### PR TITLE
Use interpreter service not InterrpeterLocator

### DIFF
--- a/src/client/datascience/kernel-launcher/kernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/kernelFinder.ts
@@ -3,7 +3,7 @@
 'use strict';
 
 import type { nbformat } from '@jupyterlab/coreutils';
-import { inject, injectable, named } from 'inversify';
+import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { CancellationToken, CancellationTokenSource } from 'vscode';
 import { IWorkspaceService } from '../../common/application/types';
@@ -13,7 +13,7 @@ import { IPlatformService } from '../../common/platform/types';
 import { IPythonExecutionFactory } from '../../common/process/types';
 import { IExtensionContext, IInstaller, InstallerResponse, IPathUtils, Product, Resource } from '../../common/types';
 import { IEnvironmentVariablesProvider } from '../../common/variables/types';
-import { IInterpreterLocatorService, IInterpreterService, KNOWN_PATH_SERVICE } from '../../interpreter/contracts';
+import { IInterpreterService } from '../../interpreter/contracts';
 import { captureTelemetry } from '../../telemetry';
 import { getRealPath } from '../common';
 import { Telemetry } from '../constants';
@@ -50,9 +50,6 @@ export class KernelFinder implements IKernelFinder {
 
     constructor(
         @inject(IInterpreterService) private interpreterService: IInterpreterService,
-        @inject(IInterpreterLocatorService)
-        @named(KNOWN_PATH_SERVICE)
-        private readonly interpreterLocator: IInterpreterLocatorService,
         @inject(IPlatformService) private platformService: IPlatformService,
         @inject(IDataScienceFileSystem) private fs: IDataScienceFileSystem,
         @inject(IPathUtils) private readonly pathUtils: IPathUtils,
@@ -217,7 +214,7 @@ export class KernelFinder implements IKernelFinder {
     }
 
     private async getInterpreterPaths(resource: Resource): Promise<string[]> {
-        const interpreters = await this.interpreterLocator.getInterpreters(resource, { ignoreCache: false });
+        const interpreters = await this.interpreterService.getInterpreters(resource);
         const interpreterPrefixPaths = interpreters.map((interpreter) => interpreter.sysPrefix);
         // We can get many duplicates here, so de-dupe the list
         const uniqueInterpreterPrefixPaths = [...new Set(interpreterPrefixPaths)];

--- a/src/test/datascience/kernelFinder.unit.test.ts
+++ b/src/test/datascience/kernelFinder.unit.test.ts
@@ -19,12 +19,11 @@ import { JupyterKernelSpec } from '../../client/datascience/jupyter/kernels/jupy
 import { KernelFinder } from '../../client/datascience/kernel-launcher/kernelFinder';
 import { IKernelFinder } from '../../client/datascience/kernel-launcher/types';
 import { IDataScienceFileSystem, IJupyterKernelSpec } from '../../client/datascience/types';
-import { IInterpreterLocatorService, IInterpreterService } from '../../client/interpreter/contracts';
+import { IInterpreterService } from '../../client/interpreter/contracts';
 import { EnvironmentType, PythonEnvironment } from '../../client/pythonEnvironments/info';
 
 suite('Kernel Finder', () => {
     let interpreterService: typemoq.IMock<IInterpreterService>;
-    let interpreterLocator: typemoq.IMock<IInterpreterLocatorService>;
     let fileSystem: typemoq.IMock<IDataScienceFileSystem>;
     let platformService: typemoq.IMock<IPlatformService>;
     let pathUtils: typemoq.IMock<IPathUtils>;
@@ -139,9 +138,8 @@ suite('Kernel Finder', () => {
                 .returns(() => Promise.resolve(activeInterpreter));
 
             // Set our workspace interpreters
-            interpreterLocator = typemoq.Mock.ofType<IInterpreterLocatorService>();
-            interpreterLocator
-                .setup((il) => il.getInterpreters(typemoq.It.isAny(), typemoq.It.isAny()))
+            interpreterService
+                .setup((il) => il.getInterpreters(typemoq.It.isAny()))
                 .returns(() => Promise.resolve(interpreters));
 
             activeKernelA = {
@@ -321,7 +319,6 @@ suite('Kernel Finder', () => {
 
             kernelFinder = new KernelFinder(
                 interpreterService.object,
-                interpreterLocator.object,
                 platformService.object,
                 fileSystem.object,
                 pathUtils.object,
@@ -369,10 +366,8 @@ suite('Kernel Finder', () => {
             interpreterService
                 .setup((is) => is.getInterpreterDetails(typemoq.It.isAny()))
                 .returns(() => Promise.resolve(activeInterpreter));
-
-            interpreterLocator = typemoq.Mock.ofType<IInterpreterLocatorService>();
-            interpreterLocator
-                .setup((il) => il.getInterpreters(typemoq.It.isAny(), typemoq.It.isAny()))
+            interpreterService
+                .setup((il) => il.getInterpreters(typemoq.It.isAny()))
                 .returns(() => Promise.resolve(interpreters));
 
             fileSystem = typemoq.Mock.ofType<IDataScienceFileSystem>();
@@ -404,7 +399,6 @@ suite('Kernel Finder', () => {
 
             kernelFinder = new KernelFinder(
                 interpreterService.object,
-                interpreterLocator.object,
                 platformService.object,
                 fileSystem.object,
                 pathUtils.object,


### PR DESCRIPTION
Reducing Python core interfaces used, so we can use the Python Extension API
**Note: Local unit tests passed**