### PR TITLE
port isolated fix to jupyter ext

### DIFF
--- a/src/client/common/process/internal/python.ts
+++ b/src/client/common/process/internal/python.ts
@@ -28,7 +28,7 @@ export function execCode(code: string, isolated = true): string[] {
 export function execModule(name: string, moduleArgs: string[], isolated = true): string[] {
     const args = ['-m', name, ...moduleArgs];
     if (isolated) {
-        args[0] = ISOLATED.fileToCommandArgument();
+        args[0] = ISOLATED; // replace
     }
     // "code" isn't specific enough to know how to parse it,
     // so we only return the args.

--- a/src/client/common/process/internal/scripts/index.ts
+++ b/src/client/common/process/internal/scripts/index.ts
@@ -305,7 +305,7 @@ export function shell_exec(command: string, lockfile: string, shellArgs: string[
     // We don't bother with a "parse" function since the output
     // could be anything.
     return [
-        ISOLATED.fileToCommandArgument(),
+        ISOLATED,
         script,
         command.fileToCommandArgument(),
         // The shell args must come after the command

--- a/src/test/common/process/pythonProcess.unit.test.ts
+++ b/src/test/common/process/pythonProcess.unit.test.ts
@@ -12,7 +12,7 @@ import { IProcessService, StdErrError } from '../../../client/common/process/typ
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../constants';
 import { noop } from '../../core';
 
-const isolated = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'pyvsc-run-isolated.py').replace(/\\/g, '/');
+const isolated = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'pyvsc-run-isolated.py');
 
 use(chaiAsPromised);
 


### PR DESCRIPTION
For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).


**Optional tests to run**:
Select one or more of the following tests to run as part of the CI for the current PR. If multiple tests are selected and one of them fails, then the rest will not run.
* [ ] Run single-workspace tests (with VS Code, without Python extension & without Jupyter)
* [ ] Run functional-with-jupyter tests (mocked VS Code, without Python extension & with Jupyter)
* [ ] Run vscode tests (with VS Code, with Python extension & with Jupyter)
