### PR TITLE
Fixes to for escaping of output in native notebooks (#14159)

### DIFF
--- a/src/client/datascience/jupyter/kernels/cellExecution.ts
+++ b/src/client/datascience/jupyter/kernels/cellExecution.ts
@@ -38,8 +38,6 @@ import {
 import { IKernel } from './types';
 // tslint:disable-next-line: no-var-requires no-require-imports
 const vscodeNotebookEnums = require('vscode') as typeof import('vscode-proposed');
-// tslint:disable-next-line: no-require-imports
-import escape = require('lodash/escape');
 
 export class CellExecutionFactory {
     constructor(
@@ -458,11 +456,6 @@ export class CellExecution {
     // See this for docs on the messages:
     // https://jupyter-client.readthedocs.io/en/latest/messaging.html#messaging-in-jupyter
     private async handleExecuteResult(msg: KernelMessage.IExecuteResultMsg, clearState: RefBool) {
-        // Escape text output
-        if (msg.content.data && msg.content.data.hasOwnProperty('text/plain')) {
-            msg.content.data['text/plain'] = escape(msg.content.data['text/plain'] as string);
-        }
-
         await this.addToCellData(
             {
                 output_type: 'execute_result',
@@ -487,7 +480,7 @@ export class CellExecution {
                                 // Mark as stream output so the text is formatted because it likely has ansi codes in it.
                                 output_type: 'stream',
                                 // tslint:disable-next-line: no-any
-                                text: escape((o.data as any)['text/plain'].toString()),
+                                text: (o.data as any)['text/plain'].toString(),
                                 name: 'stdout',
                                 metadata: {},
                                 execution_count: reply.execution_count
@@ -528,11 +521,11 @@ export class CellExecution {
             if (existing && 'text/plain' in existing.data) {
                 // tslint:disable-next-line:restrict-plus-operands
                 existing.data['text/plain'] = formatStreamText(
-                    concatMultilineString(`${existing.data['text/plain']}${escape(msg.content.text)}`)
+                    concatMultilineString(`${existing.data['text/plain']}${msg.content.text}`)
                 );
                 edit.replaceCellOutput(this.cellIndex, [...exitingCellOutput]); // This is necessary to get VS code to update (for now)
             } else {
-                const originalText = formatStreamText(concatMultilineString(escape(msg.content.text)));
+                const originalText = formatStreamText(concatMultilineString(msg.content.text));
                 // Create a new stream entry
                 const output: nbformat.IStream = {
                     output_type: 'stream',
@@ -545,11 +538,6 @@ export class CellExecution {
     }
 
     private async handleDisplayData(msg: KernelMessage.IDisplayDataMsg, clearState: RefBool) {
-        // Escape text output
-        if (msg.content.data && msg.content.data.hasOwnProperty('text/plain')) {
-            msg.content.data['text/plain'] = escape(msg.content.data['text/plain'] as string);
-        }
-
         const output: nbformat.IDisplayData = {
             output_type: 'display_data',
             data: msg.content.data,


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/14088
Basically remove code related to escaping of output & let the UI do the necessary escaping.

**Merged from Python repo**