### PR TITLE
Fix security bugs in yargs-parser and jpeg-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11195,6 +11195,48 @@
                 }
             }
         },
+        "extract-zip": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+            "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+            "dev": true,
+            "requires": {
+                "@types/yauzl": "^2.9.1",
+                "debug": "^4.1.1",
+                "get-stream": "^5.1.0",
+                "yauzl": "^2.10.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                    "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "get-stream": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "pump": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+                    "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                }
+            }
+        },
         "extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -12924,6 +12966,17 @@
                         "which-module": "^1.0.0",
                         "y18n": "^3.2.1",
                         "yargs-parser": "^5.0.0"
+                    },
+                    "dependencies": {
+                        "yargs-parser": {
+                            "version": "5.0.0",
+                            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+                            "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+                            "dev": true,
+                            "requires": {
+                                "camelcase": "^3.0.0"
+                            }
+                        }
                     }
                 }
             }
@@ -14936,9 +14989,9 @@
             }
         },
         "jpeg-js": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.7.tgz",
-            "integrity": "sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==",
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
+            "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==",
             "dev": true
         },
         "jquery": {
@@ -18460,87 +18513,55 @@
             }
         },
         "playwright-chromium": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/playwright-chromium/-/playwright-chromium-0.13.0.tgz",
-            "integrity": "sha512-Ex9y563Vn8cnoBgMOcYLGdAVVC1xrBk/aWZ66AmOD77lk6v0x0cthLcbPX9h+tfkcWCFQQz1OWQR6V3+c3KUFA==",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/playwright-chromium/-/playwright-chromium-1.4.2.tgz",
+            "integrity": "sha512-Yj4QKRL0TB1oZ1InAhqmqoVgu1MeeYnKgwCyaEnA1+tjhYYcieINq4HO8bMMgUDHa/ccMWyHA8qyP9WEdz8v0A==",
             "dev": true,
             "requires": {
-                "playwright-core": "=0.13.0"
-            }
-        },
-        "playwright-core": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-0.13.0.tgz",
-            "integrity": "sha512-bH9cOQhmbdXJnHX22PRZ79IdXv5wmLc9tHob2PmkT5qFilopT3INAIJcKkaLN1E/GqIDp0xGdB88Vr5f86g8pQ==",
-            "dev": true,
-            "requires": {
-                "debug": "^4.1.0",
-                "extract-zip": "^2.0.0",
-                "https-proxy-agent": "^3.0.0",
-                "jpeg-js": "^0.3.6",
-                "mime": "^2.4.4",
-                "pngjs": "^3.4.0",
+                "debug": "^4.1.1",
+                "extract-zip": "^2.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "jpeg-js": "^0.4.2",
+                "mime": "^2.4.6",
+                "pngjs": "^5.0.0",
                 "progress": "^2.0.3",
                 "proxy-from-env": "^1.1.0",
                 "rimraf": "^3.0.2",
-                "ws": "^6.1.0"
+                "ws": "^7.3.1"
             },
             "dependencies": {
+                "agent-base": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+                    "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "4"
+                    }
+                },
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                    "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "extract-zip": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.0.tgz",
-                    "integrity": "sha512-i42GQ498yibjdvIhivUsRslx608whtGoFIhF26Z7O4MYncBxp8CwalOs1lnHy21A9sIohWO2+uiE4SRtC9JXDg==",
-                    "dev": true,
-                    "requires": {
-                        "@types/yauzl": "^2.9.1",
-                        "debug": "^4.1.1",
-                        "get-stream": "^5.1.0",
-                        "yauzl": "^2.10.0"
-                    }
-                },
-                "get-stream": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-                    "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-                    "dev": true,
-                    "requires": {
-                        "pump": "^3.0.0"
+                        "ms": "2.1.2"
                     }
                 },
                 "https-proxy-agent": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-                    "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+                    "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
                     "dev": true,
                     "requires": {
-                        "agent-base": "^4.3.0",
-                        "debug": "^3.1.0"
-                    },
-                    "dependencies": {
-                        "debug": {
-                            "version": "3.2.6",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                            "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-                            "dev": true,
-                            "requires": {
-                                "ms": "^2.1.1"
-                            }
-                        }
+                        "agent-base": "6",
+                        "debug": "4"
                     }
                 },
                 "mime": {
-                    "version": "2.4.4",
-                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-                    "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+                    "version": "2.4.6",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+                    "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
                     "dev": true
                 },
                 "progress": {
@@ -18549,15 +18570,11 @@
                     "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
                     "dev": true
                 },
-                "pump": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-                    "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-                    "dev": true,
-                    "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
-                    }
+                "ws": {
+                    "version": "7.3.1",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+                    "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+                    "dev": true
                 }
             }
         },
@@ -18662,9 +18679,9 @@
             "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
         },
         "pngjs": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-            "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+            "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
             "dev": true
         },
         "polygon-offset": {
@@ -26739,9 +26756,9 @@
             "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         },
         "yargs": {
-            "version": "15.3.1",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-            "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+            "version": "15.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
             "dev": true,
             "requires": {
                 "cliui": "^6.0.0",
@@ -26754,7 +26771,7 @@
                 "string-width": "^4.2.0",
                 "which-module": "^2.0.0",
                 "y18n": "^4.0.0",
-                "yargs-parser": "^18.1.1"
+                "yargs-parser": "^18.1.2"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -26907,21 +26924,10 @@
             }
         },
         "yargs-parser": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-            "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-            "dev": true,
-            "requires": {
-                "camelcase": "^3.0.0"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-                    "dev": true
-                }
-            }
+            "version": "20.2.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.1.tgz",
+            "integrity": "sha512-yYsjuSkjbLMBp16eaOt7/siKTjNVjMm3SoJnIg3sEh/JsvqVVDyjRKmaJV4cl+lNIgq6QEco2i3gDebJl7/vLA==",
+            "dev": true
         },
         "yargs-unparser": {
             "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -1915,7 +1915,7 @@
         "node-has-native-dependencies": "^1.0.2",
         "node-html-parser": "^1.1.13",
         "nyc": "^15.0.0",
-        "playwright-chromium": "^0.13.0",
+        "playwright-chromium": "^1.4.2",
         "postcss": "^7.0.27",
         "postcss-cssnext": "^3.1.0",
         "postcss-import": "^12.0.1",
@@ -1969,6 +1969,7 @@
         "webpack-cli": "^3.1.2",
         "webpack-fix-default-import-plugin": "^1.0.3",
         "why-is-node-running": "^2.0.3",
-        "yargs": "^15.3.1"
+        "yargs": "^15.4.1",
+        "yargs-parser": ">=13.1.2"
     }
 }


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-jupyter/issues/171

Upgrade playwright-chromium to pull in a newer version of jpeg-js without the security bug, and pin yargs-parser via devDependencies.

Note, gulp v4.0.2 indirectly requires yargs-parser 5.0.0, and we are already on the latest gulp (updated in 2019), so I pinned the version of yargs-parser in devDependencies to force yargs-parser onto a newer version.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).


**Optional tests to run**:
Select one or more of the following tests to run as part of the CI for the current PR. If multiple tests are selected and one of them fails, then the rest will not run.
* [ ] Run single-workspace tests (with VS Code, without Python extension & without Jupyter)
* [ ] Run functional-with-jupyter tests (mocked VS Code, without Python extension & with Jupyter)
* [ ] Run vscode tests (with VS Code, with Python extension & with Jupyter)
