### PR TITLE
Ignore windows tests as compilation times out on windows

### DIFF
--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -143,7 +143,7 @@ jobs:
       matrix:
         # We're not running CI on macOS for now because it's one less matrix entry to lower the number of runners used,
         # macOS runners are expensive, and we assume that Ubuntu is enough to cover the UNIX case.
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         test-suite: [ts-unit]
     steps:
       - name: Checkout


### PR DESCRIPTION
Compilation is timing out on CI for windows unit tests, disabling as this blocks Insiders from getting uploaded.
