### PR TITLE
Fixes to handling stream output in native notebooks

### DIFF
--- a/src/client/datascience/jupyter/kernels/cellExecution.ts
+++ b/src/client/datascience/jupyter/kernels/cellExecution.ts
@@ -32,6 +32,7 @@ import {
     cellOutputToVSCCellOutput,
     clearCellForExecution,
     getCellStatusMessageBasedOnFirstCellErrorOutput,
+    isStreamOutput,
     updateCellExecutionTimes
 } from '../../notebook/helpers/helpers';
 import { MultiCancellationTokenSource } from '../../notebook/helpers/multiCancellationToken';
@@ -564,6 +565,7 @@ export class CellExecution {
         traceInfo(`Kernel switching to ${msg.content.execution_state}`);
     }
     private async handleStreamMessage(msg: KernelMessage.IStreamMsg, clearState: RefBool) {
+        // tslint:disable-next-line: cyclomatic-complexity
         await chainWithPendingUpdates(this.editor, (edit) => {
             let exitingCellOutput = this.cell.outputs;
             // Clear output if waiting for a clear
@@ -575,17 +577,31 @@ export class CellExecution {
             // Might already have a stream message. If so, just add on to it.
             // We use Rich output for text streams (not CellStreamOutput, known VSC Issues).
             // https://github.com/microsoft/vscode-python/issues/14156
-            const lastOutput =
-                exitingCellOutput.length > 0 ? exitingCellOutput[exitingCellOutput.length - 1] : undefined;
-            const existing: CellDisplayOutput | undefined =
-                lastOutput && lastOutput.outputKind === vscodeNotebookEnums.CellOutputKind.Rich
-                    ? lastOutput
-                    : undefined;
-            if (existing && 'text/plain' in existing.data) {
+            const existing = exitingCellOutput.find((item) => item && isStreamOutput(item, msg.content.name)) as
+                | CellDisplayOutput
+                | undefined;
+
+            // Ensure we append to previous output, only if the streams as the same.
+            // Possible we have stderr first, then later we get output from stdout.
+            // Basically have one output for stderr & a seprate output for stdout.
+            // If we output stderr first, then stdout & then stderr, we should append the new stderr to the previous stderr output.
+            if (existing) {
+                let existingOutput: string = existing.data['text/plain'] || '';
+                let newContent = msg.content.text;
+                // Look for the ansi code `<char27>[A`. (this means move up)
+                // Not going to support `[2A` (not for now).
+                const moveUpCode = `${String.fromCharCode(27)}[A`;
+                if (msg.content.text.startsWith(moveUpCode)) {
+                    // Split message by lines & strip out the last n lines (where n = number of lines to move cursor up).
+                    const existingOutputLines = existingOutput.splitLines({ trim: false, removeEmptyEntries: false });
+                    if (existingOutputLines.length) {
+                        existingOutputLines.pop();
+                    }
+                    existingOutput = existingOutputLines.join('\n');
+                    newContent = newContent.substring(moveUpCode.length);
+                }
                 // tslint:disable-next-line:restrict-plus-operands
-                existing.data['text/plain'] = formatStreamText(
-                    concatMultilineString(`${existing.data['text/plain']}${msg.content.text}`)
-                );
+                existing.data['text/plain'] = formatStreamText(concatMultilineString(`${existingOutput}${newContent}`));
                 edit.replaceCellOutput(this.cell.index, [...exitingCellOutput]); // This is necessary to get VS code to update (for now)
             } else {
                 const originalText = formatStreamText(concatMultilineString(msg.content.text));

--- a/src/client/datascience/notebook/helpers/helpers.ts
+++ b/src/client/datascience/notebook/helpers/helpers.ts
@@ -584,6 +584,25 @@ function translateStreamOutput(output: nbformat.IStream, outputType: nbformat.Ou
     };
 }
 
+export function isStreamOutput(output: CellOutput, expectedStreamName: string): boolean {
+    if (output.outputKind !== vscodeNotebookEnums.CellOutputKind.Rich) {
+        return false;
+    }
+    output = (output as unknown) as CellDisplayOutput;
+    if (!('text/plain' in output.data)) {
+        return false;
+    }
+    // Logic of metadata can be found here translateStreamOutput.
+    // That function adds the vscode metadata.
+    if (output.metadata?.custom?.vscode?.outputType !== 'stream') {
+        return false;
+    }
+    if (expectedStreamName && output.metadata?.custom?.vscode?.name !== expectedStreamName) {
+        return false;
+    }
+    return true;
+}
+
 // tslint:disable-next-line: no-any
 function getSanitizedCellMetadata(metadata?: { [key: string]: any }) {
     const cloned = { ...metadata };


### PR DESCRIPTION
For #291, #292
Fixed in native notebooks only.
Doesn't work properly in Notebooks & Labs
Can fix separately for old notebooks (if we need it).


**Here is what is expected:**
![Screen Shot 2020-10-23 at 15 19 55](https://user-images.githubusercontent.com/1948812/97059059-53a1bc80-1544-11eb-9871-8f1138c8cd4c.png)


**Here is the new output (when u turn in terminal):**
![Screen Shot 2020-10-23 at 15 26 47](https://user-images.githubusercontent.com/1948812/97061726-b8611500-154c-11eb-8ca8-9ef98c2868eb.png)


**THis is what we used to get**
```
GPU available: False, used: False
TPU available: False, using: 0 TPU cores

  | Name       | Type     | Params
----------------------------------------
0 | conv1      | Conv2d   | 156   
1 | conv2      | Conv2d   | 2 K   
2 | fc1        | Linear   | 48 K  
3 | fc2        | Linear   | 10 K  
4 | classifier | Linear   | 850   
5 | accuracy   | Accuracy | 0     
Epoch 0:  92%|█████████▏| 1718/1874 [04:02<00:21,  7.09it/s, loss=2.043, v_num=7, acc=0.969]
Validating: 0it [00:00, ?it/s]A
Epoch 0:  92%|█████████▏| 1719/1874 [04:06<00:22,  6.96it/s, loss=2.043, v_num=7, acc=0.969]
Validating:   1%|▏         | 2/156 [00:05<08:46,  3.42s/it]A
Validating:   2%|▏         | 3/156 [00:05<06:17,  2.47s/it]A
Epoch 0:  92%|█████████▏| 1722/1874 [04:08<00:21,  6.94it/s, loss=2.043, v_num=7, acc=0.969]
Validating:   3%|▎         | 5/156 [00:05<03:23,  1.35s/it]A
...
Epoch 0: 100%|█████████▉| 1866/1874 [04:22<00:01,  7.11it/s, loss=2.043, v_num=7, acc=0.969]
Validating:  96%|█████████▌| 150/156 [00:20<00:00,  6.71it/s]A
Epoch 0: 100%|█████████▉| 1870/1874 [04:23<00:00,  7.11it/s, loss=2.043, v_num=7, acc=0.969]
Epoch 0: 100%|██████████| 1874/1874 [04:23<00:00,  7.10it/s, loss=2.043, v_num=7, acc=0.903]
Epoch 0: 100%|██████████| 1874/1874 [04:23<00:00,  7.10it/s, loss=2.043, v_num=7, acc=0.903]
1
```
