### PR TITLE
Try fixing npm failure on assign issue

### DIFF
--- a/.github/workflows/assignIssue.yml
+++ b/.github/workflows/assignIssue.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'microsoft/vscode-jupyter'
     steps:
+      - uses: actions/checkout@v2
       - name: Created internally
         id: internal
         env:
@@ -24,8 +25,6 @@ jobs:
         run: |
           echo ::set-output name=result::$(node -p -e "process.env.ISSUE_IS_INTERNAL === '0' && JSON.parse(process.env.ISSUE_ASSIGNEES).length === 0 && JSON.parse(process.env.ISSUE_LABELS).filter(item => item.name.indexOf('data science') >= 0).length === 1 && JSON.parse(process.env.ISSUE_LABELS).filter(item => item.name.indexOf('Epic') >= 0).length === 0 ? 1 : 0")
         shell: bash
-      - uses: actions/checkout@v2
-        if: steps.proceed.outputs.result == 1
       - name: Day of week
         if: steps.proceed.outputs.result == 1
         id: day


### PR DESCRIPTION
Assign action has been failing like this lately:

```
 Step 11/13 : RUN npm ci
   ---> Running in 94747e42d890
  npm notice 
  npm notice New patch version of npm available! 7.0.3 -> 7.0.5
  npm notice Changelog: <https://github.com/npm/cli/releases/tag/v7.0.5>
  npm notice Run `npm install -g npm@7.0.5` to update!
  npm notice 
  npm ERR! The `npm ci` command can only install with an existing package-lock.json or
  npm ERR! npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or
  npm ERR! later to generate a package-lock.json file, then try again.
```

I'm hoping this change will fix it. Not sure why this doesn't happen automatically.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
