### PR TITLE
Add azure telemetry for remote server URIs

### DIFF
--- a/src/client/datascience/jupyter/serverSelector.ts
+++ b/src/client/datascience/jupyter/serverSelector.ts
@@ -17,7 +17,7 @@ import {
     InputStep,
     IQuickPickParameters
 } from '../../common/utils/multiStepInput';
-import { captureTelemetry } from '../../telemetry';
+import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { getSavedUriList } from '../common';
 import { Identifiers, Settings, Telemetry } from '../constants';
 import { IJupyterUriProvider, IJupyterUriProviderRegistration, JupyterServerUriHandle } from '../types';
@@ -145,10 +145,14 @@ export class JupyterServerSelector {
         }
     }
 
-    @captureTelemetry(Telemetry.SetJupyterURIToUserSpecified)
     private async setJupyterURIToRemote(userURI: string): Promise<void> {
         const previousValue = this.configuration.getSettings(undefined).jupyterServerURI;
         await this.configuration.updateSetting('jupyterServerURI', userURI, undefined, ConfigurationTarget.Workspace);
+
+        // Indicate setting a jupyter URI to a remote setting. Check if an azure remote or not
+        sendTelemetryEvent(Telemetry.SetJupyterURIToUserSpecified, undefined, {
+            azure: userURI.toLowerCase().includes('azure')
+        });
 
         // Reload if there's a change
         if (previousValue !== userURI) {

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -688,7 +688,9 @@ export interface IEventNamePropertyMapping {
     [Telemetry.UserDidNotInstallJupyter]: never | undefined;
     [Telemetry.UserDidNotInstallPandas]: never | undefined;
     [Telemetry.SetJupyterURIToLocal]: never | undefined;
-    [Telemetry.SetJupyterURIToUserSpecified]: never | undefined;
+    [Telemetry.SetJupyterURIToUserSpecified]: {
+        azure: boolean;
+    };
     [Telemetry.ShiftEnterBannerShown]: never | undefined;
     [Telemetry.ShowDataViewer]: { rows: number | undefined; columns: number | undefined };
     [Telemetry.CreateNewInteractive]: never | undefined;


### PR DESCRIPTION
For #280

If a server URI has 'azure' in it, assume it's an azure box.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
