### PR TITLE
Default native notebook editor as the default in VSCode Insiders

### DIFF
--- a/src/client/application/serviceRegistry.ts
+++ b/src/client/application/serviceRegistry.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-'use strict';
-
 import { IExtensionSingleActivationService } from '../activation/types';
 import { IServiceManager } from '../ioc/types';
 import { JoinMailingListPrompt } from './misc/joinMailingListPrompt';


### PR DESCRIPTION
Tests are consistently failing in https://github.com/microsoft/vscode-jupyter/pull/344/files
Hence this new PR.