### PR TITLE
Always hide Submit GitHub issue command in command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -1200,9 +1200,13 @@
                 },
                 {
                     "command": "jupyter.createGitHubIssue",
-                    "title": "%jupyter.command.jupyter.createGitHubIssue.title%",
                     "category": "Jupyter",
                     "when": "config.jupyter.logging.level == debug && config.noExists"
+                },
+                {
+                    "command": "jupyter.submitGitHubIssue",
+                    "category": "Jupyter",
+                    "when": "false"
                 },
                 {
                     "command": "jupyter.showDataViewer",


### PR DESCRIPTION
For https://github.com/microsoft/vscode-jupyter/pull/351

Was trying to validate this but it still shows up in the command palette in the latest vsix from https://github.com/microsoft/vscode-jupyter/suites/1428768698/artifacts/24053176

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
