### PR TITLE
Set session name for the remote sessions created

### DIFF
--- a/src/client/datascience/jupyter/jupyterServer.ts
+++ b/src/client/datascience/jupyter/jupyterServer.ts
@@ -97,6 +97,7 @@ export class JupyterServerBase implements INotebookServer {
         session = await this.sessionManager.startNew(
             launchInfo.kernelConnectionMetadata,
             launchInfo.connectionInfo.rootDirectory,
+            launchInfo.uri,
             cancelToken
         );
         const idleTimeout = this.configService.getSettings().jupyterLaunchTimeout;

--- a/src/client/datascience/jupyter/jupyterSessionManager.ts
+++ b/src/client/datascience/jupyter/jupyterSessionManager.ts
@@ -69,6 +69,7 @@ export class JupyterSessionManager implements IJupyterSessionManager {
     public async startNew(
         kernelConnection: KernelConnectionMetadata | undefined,
         workingDirectory: string,
+        uri?: string,
         cancelToken?: CancellationToken
     ): Promise<IJupyterSession> {
         if (!this.connInfo || !this._sessionManager || !this._contentsManager || !this.serverSettings) {
@@ -85,7 +86,8 @@ export class JupyterSessionManager implements IJupyterSessionManager {
             this.restartSessionCreatedEvent.fire.bind(this.restartSessionCreatedEvent),
             this.restartSessionUsedEvent.fire.bind(this.restartSessionUsedEvent),
             workingDirectory,
-            this.configService.getSettings().jupyterLaunchTimeout
+            this.configService.getSettings().jupyterLaunchTimeout,
+            uri
         );
         try {
             await session.connect(this.configService.getSettings().jupyterLaunchTimeout, cancelToken);

--- a/src/client/datascience/jupyter/liveshare/guestJupyterSessionManager.ts
+++ b/src/client/datascience/jupyter/liveshare/guestJupyterSessionManager.ts
@@ -37,9 +37,10 @@ export class GuestJupyterSessionManager implements IJupyterSessionManager {
     public startNew(
         kernelConnection: KernelConnectionMetadata | undefined,
         workingDirectory: string,
+        uri: string,
         cancelToken?: CancellationToken
     ): Promise<IJupyterSession> {
-        return this.realSessionManager.startNew(kernelConnection, workingDirectory, cancelToken);
+        return this.realSessionManager.startNew(kernelConnection, workingDirectory, uri, cancelToken);
     }
 
     public async getKernelSpecs(): Promise<IJupyterKernelSpec[]> {

--- a/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
+++ b/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
@@ -231,7 +231,12 @@ export class HostJupyterServer extends LiveShareParticipantHost(JupyterServerBas
             const session =
                 possibleSession && this.fs.areLocalPathsSame(possibleSession.workingDirectory, workingDirectory)
                     ? possibleSession
-                    : await sessionManager.startNew(info.kernelConnectionMetadata, workingDirectory, cancelToken);
+                    : await sessionManager.startNew(
+                          info.kernelConnectionMetadata,
+                          workingDirectory,
+                          resource?.toString(),
+                          cancelToken
+                      );
             traceInfo(`Started session ${this.id}`);
             return { info, session };
         };

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -378,6 +378,7 @@ export interface IJupyterSessionManager extends IAsyncDisposable {
     startNew(
         kernelConnection: KernelConnectionMetadata | undefined,
         workingDirectory: string,
+        uri?: string,
         cancelToken?: CancellationToken
     ): Promise<IJupyterSession>;
     getKernelSpecs(): Promise<IJupyterKernelSpec[]>;

--- a/src/test/datascience/mockJupyterManager.ts
+++ b/src/test/datascience/mockJupyterManager.ts
@@ -435,6 +435,7 @@ export class MockJupyterManager implements IJupyterSessionManager {
     public startNew(
         _kernelConnection: KernelConnectionMetadata | undefined,
         _workingDirectory: string,
+        _uri?: string,
         cancelToken?: CancellationToken
     ): Promise<IJupyterSession> {
         if (this.sessionTimeout && cancelToken) {


### PR DESCRIPTION
For https://github.com/microsoft/vscode-jupyter/issues/254#issuecomment-721993186

Will add tests separately (updated above todo list).
Currently there are other issues in this branch & would like to get things working before I add tests.
Apologies, please approve even if there are no tests (will add later)

* Classic Jupyter Notebook always displays paths in sessions.
Hence this change makes no different in classic jupyter.
* Jupyter Lab will display the new names, see below
![Screen Shot 2020-11-10 at 16 25 49](https://user-images.githubusercontent.com/1948812/98750834-c21fb080-2373-11eb-87a8-c66811bb4d9d.png)

