### PR TITLE
Remove export to python script for other languages

### DIFF
--- a/news/2 Fixes/407.md
+++ b/news/2 Fixes/407.md
@@ -1,0 +1,1 @@
+Only offer to export to python script when the metadata specifies python as its language.

--- a/src/client/datascience/commands/exportCommands.ts
+++ b/src/client/datascience/commands/exportCommands.ts
@@ -8,6 +8,7 @@ import { QuickPickItem, QuickPickOptions, Uri } from 'vscode';
 import { getLocString } from '../../../datascience-ui/react-common/locReactSide';
 import { ICommandNameArgumentTypeMapping } from '../../common/application/commands';
 import { IApplicationShell, ICommandManager } from '../../common/application/types';
+import { PYTHON_LANGUAGE } from '../../common/constants';
 import { IFileSystem } from '../../common/platform/types';
 
 import { IDisposable } from '../../common/types';
@@ -114,8 +115,10 @@ export class ExportCommands implements IDisposable {
         defaultFileName?: string,
         interpreter?: PythonEnvironment
     ): IExportQuickPickItem[] {
-        return [
-            {
+        const items: IExportQuickPickItem[] = [];
+
+        if (model.metadata && model.metadata.language_info && model.metadata.language_info.name === PYTHON_LANGUAGE) {
+            items.push({
                 label: DataScience.exportPythonQuickPickLabel(),
                 picked: true,
                 handler: () => {
@@ -124,28 +127,35 @@ export class ExportCommands implements IDisposable {
                     });
                     this.commandManager.executeCommand(Commands.ExportAsPythonScript, model, interpreter);
                 }
-            },
-            {
-                label: DataScience.exportHTMLQuickPickLabel(),
-                picked: false,
-                handler: () => {
-                    sendTelemetryEvent(Telemetry.ClickedExportNotebookAsQuickPick, undefined, {
-                        format: ExportFormat.html
-                    });
-                    this.commandManager.executeCommand(Commands.ExportToHTML, model, defaultFileName, interpreter);
+            });
+        }
+
+        items.push(
+            ...[
+                {
+                    label: DataScience.exportHTMLQuickPickLabel(),
+                    picked: false,
+                    handler: () => {
+                        sendTelemetryEvent(Telemetry.ClickedExportNotebookAsQuickPick, undefined, {
+                            format: ExportFormat.html
+                        });
+                        this.commandManager.executeCommand(Commands.ExportToHTML, model, defaultFileName, interpreter);
+                    }
+                },
+                {
+                    label: DataScience.exportPDFQuickPickLabel(),
+                    picked: false,
+                    handler: () => {
+                        sendTelemetryEvent(Telemetry.ClickedExportNotebookAsQuickPick, undefined, {
+                            format: ExportFormat.pdf
+                        });
+                        this.commandManager.executeCommand(Commands.ExportToPDF, model, defaultFileName, interpreter);
+                    }
                 }
-            },
-            {
-                label: DataScience.exportPDFQuickPickLabel(),
-                picked: false,
-                handler: () => {
-                    sendTelemetryEvent(Telemetry.ClickedExportNotebookAsQuickPick, undefined, {
-                        format: ExportFormat.pdf
-                    });
-                    this.commandManager.executeCommand(Commands.ExportToPDF, model, defaultFileName, interpreter);
-                }
-            }
-        ];
+            ]
+        );
+
+        return items;
     }
 
     private async showExportQuickPickMenu(


### PR DESCRIPTION
Only offer to export to python script when the metadata specifies python as its language

For #407

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
