### PR TITLE
Bump plotly.js-dist from v1.55.2 to v1.57.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18912,9 +18912,9 @@
             }
         },
         "plotly.js-dist": {
-            "version": "1.55.2",
-            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.55.2.tgz",
-            "integrity": "sha512-1QBBIPnh/G+8w9h/6pr7DQGm3t/XZptskUxJQsqTJJ1uth4xsDj2ltkmzujI5cG4lZadurJnfrJbFof+LHiyHg=="
+            "version": "1.57.1",
+            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.57.1.tgz",
+            "integrity": "sha512-tOOFxNc6PvdDkOUgWCSYc+CcxQULTpaGTROxrtmmF8NuZghcT3EInsToEzhPH3PcGM6bu61fKo73ZiFqxwYtlg=="
         },
         "plugin-error": {
             "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -1809,7 +1809,7 @@
         "node-stream-zip": "^1.6.0",
         "onigasm": "^2.2.2",
         "pdfkit": "^0.11.0",
-        "plotly.js-dist": "^1.55.2",
+        "plotly.js-dist": "^1.57.1",
         "portfinder": "^1.0.25",
         "react": "^16.5.2",
         "react-data-grid": "^6.0.2-0",


### PR DESCRIPTION
Bumping `plotly.js-dist` module
https://github.com/plotly/plotly.js/releases/tag/v1.56.0
https://github.com/plotly/plotly.js/releases/tag/v1.57.0
https://github.com/plotly/plotly.js/releases/tag/v1.57.1

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).

Follow up of https://github.com/microsoft/vscode-python/pull/14413

@rchiodo
cc: @nicolaskruchten 
