### PR TITLE
remove old kernel picker setting and always enable in IW

### DIFF
--- a/package.json
+++ b/package.json
@@ -1404,12 +1404,6 @@
                     "description": "Automatically scroll the interactive window to show the output of the last statement executed. If false, the interactive window will only automatically scroll if the bottom of the prior cell is visible.",
                     "scope": "resource"
                 },
-                "jupyter.showKernelSelectionOnInteractiveWindow": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "When set to true, enables the kernel selector in the Interactive Window. By default, the Interactive Window will use your Python Interpreters kernel.",
-                    "scope": "resource"
-                },
                 "jupyter.enableScrollingForCellOutputs": {
                     "type": "boolean",
                     "default": true,

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -91,7 +91,6 @@ export class JupyterSettings implements IWatchableJupyterSettings {
     public jupyterCommandLineArguments: string[] = [];
     public widgetScriptSources: WidgetCDNs[] = [];
     public alwaysScrollOnNewCell: boolean = false;
-    public showKernelSelectionOnInteractiveWindow: boolean = false;
     public interactiveWindowMode: InteractiveWindowMode = 'multiple';
     // Hidden settings not surfaced in package.json
     public disableZMQSupport: boolean = false;

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -161,7 +161,6 @@ export interface IJupyterSettings {
     readonly jupyterCommandLineArguments: string[];
     readonly widgetScriptSources: WidgetCDNs[];
     readonly alwaysScrollOnNewCell: boolean;
-    readonly showKernelSelectionOnInteractiveWindow: boolean;
     readonly interactiveWindowMode: InteractiveWindowMode;
     readonly disableZMQSupport: boolean;
 }

--- a/src/datascience-ui/history-react/interactivePanel.tsx
+++ b/src/datascience-ui/history-react/interactivePanel.tsx
@@ -223,14 +223,6 @@ ${buildSettingsCss(this.props.settings)}`}</style>
     }
 
     private renderKernelSelection() {
-        // Skip showing the kernel picker when local and python extension is installed (as it interferes with the interpreter picker)
-        if (
-            this.props.kernel.serverName === getLocString('DataScience.localJupyterServer', 'local') &&
-            this.props.settings?.extraSettings.hasPythonExtension
-        ) {
-            return;
-        }
-
         return (
             <JupyterInfo
                 baseTheme={this.props.baseTheme}

--- a/src/test/activation/migrateDataScienceSettingsService.unit.test.ts
+++ b/src/test/activation/migrateDataScienceSettingsService.unit.test.ts
@@ -70,7 +70,6 @@ suite('Migrate data science settings', () => {
         "python.dataScience.disableJupyterAutoStart": true,
         "python.dataScience.jupyterCommandLineArguments": ["foo", "bar"],
         "python.dataScience.alwaysScrollOnNewCell": true,
-        "python.dataScience.showKernelSelectionOnInteractiveWindow": true,
         "python.languageServer": "Pylance",
         "python.linting.enabled": false,
         "python.experiments.optOutFrom": [
@@ -130,7 +129,6 @@ suite('Migrate data science settings', () => {
         "jupyter.disableJupyterAutoStart": true,
         "jupyter.jupyterCommandLineArguments": ["foo", "bar"],
         "jupyter.alwaysScrollOnNewCell": true,
-        "jupyter.showKernelSelectionOnInteractiveWindow": true,
         "python.languageServer": "Pylance",
         "python.linting.enabled": false,
         "python.experiments.optOutFrom": [


### PR DESCRIPTION
For #411 

Per Jim. Re-enable and no need for setting. Removed the old setting that wasn't hooked up anyways. 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
