### PR TITLE
Run smoke tests with 64-bit VSCode

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,8 +7,8 @@
 !out/datascience-ui/viewers/commons.initial.bundle.js.map
 !out/datascience-ui/viewers/dataExplorer.js.map
 !out/datascience-ui/viewers/plotViewer.js.map
-images
-docs
+images/**
+docs/**
 *.vsix
 .appveyor.yml
 .editorconfig

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,6 +7,8 @@
 !out/datascience-ui/viewers/commons.initial.bundle.js.map
 !out/datascience-ui/viewers/dataExplorer.js.map
 !out/datascience-ui/viewers/plotViewer.js.map
+images
+docs
 *.vsix
 .appveyor.yml
 .editorconfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -14107,9 +14107,9 @@
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "version": "3.2.7",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
                     "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
@@ -26229,9 +26229,9 @@
             }
         },
         "vscode-test": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.2.3.tgz",
-            "integrity": "sha512-mKRTNso33NaUULiPBFg6zRjyntjcCpIgkrogyPQuKlvoQREQR8jLKN5UD4L5rkTSD+oBhcKtaLR2/g34FexURw==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.4.1.tgz",
+            "integrity": "sha512-Ls7+JyC06cUCuomlTYk4aNJI00Rri09hgtkNl3zfQ1bj6meXglpSPpuzJ/RPNetlUHFMm4eGs0Xr/H5pFPVwfQ==",
             "dev": true,
             "requires": {
                 "http-proxy-agent": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -2037,7 +2037,7 @@
         "unicode-properties": "^1.3.1",
         "url-loader": "^1.1.2",
         "vsce": "^1.59.0",
-        "vscode-test": "^1.2.3",
+        "vscode-test": "^1.4.0",
         "webpack": "^4.37.0",
         "webpack-bundle-analyzer": "^3.6.0",
         "webpack-cli": "^3.1.2",

--- a/src/test/standardTest.ts
+++ b/src/test/standardTest.ts
@@ -29,6 +29,18 @@ const channel = (process.env.VSC_JUPYTER_CI_TEST_VSC_CHANNEL || '').toLowerCase(
     ? 'insiders'
     : 'stable';
 
+function computePlatform() {
+    switch (process.platform) {
+        case 'darwin':
+            return 'darwin';
+        case 'win32':
+            return process.arch === 'x32' || process.arch === 'ia32' ? 'win32-archive' : 'win32-x64-archive';
+        default:
+            return 'linux-x64';
+    }
+}
+const platform = computePlatform();
+
 /**
  * Smoke tests & tests running in VSCode require Python extension to be installed.
  */
@@ -48,7 +60,7 @@ async function installPythonExtension(vscodeExecutablePath: string) {
 async function start() {
     console.log('*'.repeat(100));
     console.log('Start Standard tests');
-    const vscodeExecutablePath = await downloadAndUnzipVSCode(channel);
+    const vscodeExecutablePath = await downloadAndUnzipVSCode(channel, platform);
     const baseLaunchArgs = requiresPythonExtensionToBeInstalled() ? [] : ['--disable-extensions'];
     await installPythonExtension(vscodeExecutablePath);
     await runTests({


### PR DESCRIPTION
By default it used to download 32-bit.
Also ensure that we don't ship the images or docs directories.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
