### PR TITLE
Fix focus tracking for IW

### DIFF
--- a/news/2 Fixes/1293.md
+++ b/news/2 Fixes/1293.md
@@ -1,0 +1,1 @@
+CTRL+1/CTRL+2 switching with the interactive window does not put the focus back in the edit box.

--- a/news/2 Fixes/446.md
+++ b/news/2 Fixes/446.md
@@ -1,0 +1,1 @@
+Interactive window input prompt does not allow any keyboard input.

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -559,9 +559,6 @@ export abstract class InteractiveBase extends WebviewPanelHost<IInteractiveWindo
         if (this.viewState.active && !this.documentManager.activeTextEditor) {
             // Force the webpanel to reveal and take focus.
             await super.show(false);
-
-            // Send this to the react control
-            await this.postMessage(InteractiveWindowMessages.Activate);
         }
     }
 

--- a/src/datascience-ui/history-react/index.tsx
+++ b/src/datascience-ui/history-react/index.tsx
@@ -13,6 +13,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
+import { TextAreaFocusTracker } from '../interactive-common/textAreaFocusTracker';
 import { WidgetManagerComponent } from '../ipywidgets/webViews/container';
 import { IVsCodeApi, PostOffice } from '../react-common/postOffice';
 import { detectBaseTheme } from '../react-common/themeDetector';
@@ -38,6 +39,7 @@ const ConnectedInteractiveEditor = getConnectedInteractiveEditor();
 // tslint:disable:no-typeof-undefined
 ReactDOM.render(
     <Provider store={store}>
+        <TextAreaFocusTracker />
         <ConnectedInteractiveEditor />
         <WidgetManagerComponent postOffice={postOffice} widgetContainerId={'rootWidget'} store={store} />
     </Provider>,

--- a/src/datascience-ui/history-react/redux/reducers/effects.ts
+++ b/src/datascience-ui/history-react/redux/reducers/effects.ts
@@ -7,6 +7,7 @@ import { CssMessages } from '../../../../client/datascience/messages';
 import { IJupyterExtraSettings } from '../../../../client/datascience/types';
 import { IMainState } from '../../../interactive-common/mainState';
 import { postActionToExtension } from '../../../interactive-common/redux/helpers';
+import { CommonEffects } from '../../../interactive-common/redux/reducers/commonEffects';
 import { Helpers } from '../../../interactive-common/redux/reducers/helpers';
 import { ICellAction, IScrollAction } from '../../../interactive-common/redux/reducers/types';
 import { computeEditorOptions } from '../../../react-common/settingsReactSide';
@@ -140,7 +141,7 @@ export namespace Effects {
                     focused: true
                 }
             };
-        } else if (arg.prevState.editCellVM) {
+        } else if (arg.prevState.editCellVM && arg.payload.data.cellId !== Identifiers.EditCellId) {
             return {
                 ...arg.prevState,
                 editCellVM: {
@@ -150,7 +151,8 @@ export namespace Effects {
             };
         }
 
-        return arg.prevState;
+        // If no change, make sure focus updates
+        return CommonEffects.focusPending(arg.prevState);
     }
 
     export function unfocusCell(arg: InteractiveReducerArg<ICellAction>): IMainState {

--- a/src/datascience-ui/history-react/redux/reducers/index.ts
+++ b/src/datascience-ui/history-react/redux/reducers/index.ts
@@ -51,7 +51,6 @@ export const reducerMap: Partial<IInteractiveActionMapping> = {
     [InteractiveWindowMessages.StartCell]: Creation.startCell,
     [InteractiveWindowMessages.FinishCell]: Creation.finishCell,
     [InteractiveWindowMessages.UpdateCellWithExecutionResults]: Creation.updateCell,
-    [InteractiveWindowMessages.Activate]: CommonEffects.activate,
     [InteractiveWindowMessages.RestartKernel]: Kernel.handleRestarted,
     [CssMessages.GetCssResponse]: CommonEffects.handleCss,
     [InteractiveWindowMessages.MonacoReady]: CommonEffects.monacoReady,

--- a/src/datascience-ui/interactive-common/redux/reducers/commonEffects.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/commonEffects.ts
@@ -134,7 +134,7 @@ export namespace CommonEffects {
         };
     }
 
-    function focusPending(prevState: IMainState): IMainState {
+    export function focusPending(prevState: IMainState): IMainState {
         return {
             ...prevState,
             // This is only applicable for interactive window & not native editor.

--- a/src/datascience-ui/interactive-common/redux/store.ts
+++ b/src/datascience-ui/interactive-common/redux/store.ts
@@ -349,10 +349,14 @@ function createMiddleWare(testMode: boolean, postOffice: PostOffice): Redux.Midd
         },
         logger: testMode ? createTestLogger() : window.console
     });
+
+    // Environment variables only work in functional tests (browser doesn't have access to env). In order for logging to be present in
+    // development, you have to hardcode this
     const loggerMiddleware =
         process.env.VSC_JUPYTER_FORCE_LOGGING !== undefined && !process.env.VSC_JUPYTER_DS_NO_REDUX_LOGGING
             ? logger
             : undefined;
+    // logger;
 
     const results: Redux.Middleware<{}, IStore>[] = [];
     results.push(queueableActions);

--- a/src/datascience-ui/interactive-common/textAreaFocusTracker.tsx
+++ b/src/datascience-ui/interactive-common/textAreaFocusTracker.tsx
@@ -19,7 +19,7 @@ export class TextAreaFocusTracker extends React.Component {
 
     private onWindowGotFocus() {
         // When the window receives focus (from outside), on a delay attempt to reset our focus
-        setTimeout(this.setToLastKnown.bind(this), 100);
+        setTimeout(this.setToLastKnown.bind(this), 0);
     }
 
     private onWindowLostFocus() {

--- a/src/datascience-ui/interactive-common/textAreaFocusTracker.tsx
+++ b/src/datascience-ui/interactive-common/textAreaFocusTracker.tsx
@@ -31,6 +31,9 @@ export class TextAreaFocusTracker extends React.Component {
     }
 
     private setToLastKnown() {
+        // Try to set the focus to the last TEXTAREA if we are currently
+        // pointing at the BODY. Only do this for the BODY because the
+        // only thing that sets the focus to the BODY is the VS code focus code.
         if (
             document.activeElement &&
             document.activeElement.nodeName === document.body.nodeName &&

--- a/src/datascience-ui/interactive-common/textAreaFocusTracker.tsx
+++ b/src/datascience-ui/interactive-common/textAreaFocusTracker.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+import * as React from 'react';
+
+export class TextAreaFocusTracker extends React.Component {
+    private lastFocusedTextArea: HTMLElement | undefined;
+    public componentDidMount() {
+        window.addEventListener('focus', () => this.onWindowGotFocus(), false);
+        window.addEventListener('blur', () => this.onWindowLostFocus(), false);
+    }
+    public render() {
+        const hiddenStyle: React.CSSProperties = {
+            display: 'none'
+        };
+
+        return <div id="focus_tracker" style={hiddenStyle} />;
+    }
+
+    private onWindowGotFocus() {
+        // When the window receives focus (from outside), on a delay attempt to reset our focus
+        setTimeout(this.setToLastKnown.bind(this), 100);
+    }
+
+    private onWindowLostFocus() {
+        // When the window loses focus, remember the lost focus as long as it
+        // is a text area
+        if (document.activeElement && document.activeElement.nodeName === 'TEXTAREA') {
+            this.lastFocusedTextArea = document.activeElement as HTMLElement;
+        }
+    }
+
+    private setToLastKnown() {
+        if (
+            document.activeElement &&
+            document.activeElement.nodeName === document.body.nodeName &&
+            this.lastFocusedTextArea
+        ) {
+            this.lastFocusedTextArea.focus();
+        }
+    }
+}

--- a/src/datascience-ui/native-editor/index.tsx
+++ b/src/datascience-ui/native-editor/index.tsx
@@ -13,6 +13,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
+import { TextAreaFocusTracker } from '../interactive-common/textAreaFocusTracker';
 import { WidgetManagerComponent } from '../ipywidgets/webViews/container';
 import { IVsCodeApi, PostOffice } from '../react-common/postOffice';
 import { detectBaseTheme } from '../react-common/themeDetector';
@@ -37,6 +38,7 @@ const ConnectedNativeEditor = getConnectedNativeEditor();
 // Stick them all together
 ReactDOM.render(
     <Provider store={store}>
+        <TextAreaFocusTracker />
         <ConnectedNativeEditor />
         <WidgetManagerComponent postOffice={postOffice} widgetContainerId={'rootWidget'} store={store} />
     </Provider>,

--- a/src/datascience-ui/native-editor/redux/reducers/index.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/index.ts
@@ -85,7 +85,6 @@ export const reducerMap: Partial<INativeEditorActionMapping> = {
     [InteractiveWindowMessages.StartProgress]: CommonEffects.startProgress,
     [InteractiveWindowMessages.StopProgress]: CommonEffects.stopProgress,
     [SharedMessages.UpdateSettings]: Effects.updateSettings,
-    [InteractiveWindowMessages.Activate]: CommonEffects.activate,
     [InteractiveWindowMessages.RestartKernel]: Kernel.handleRestarted,
     [CssMessages.GetCssResponse]: CommonEffects.handleCss,
     [InteractiveWindowMessages.MonacoReady]: CommonEffects.monacoReady,

--- a/src/test/datascience/interactiveWindow.functional.test.tsx
+++ b/src/test/datascience/interactiveWindow.functional.test.tsx
@@ -259,42 +259,6 @@ for i in range(10):
     );
 
     runTest(
-        'Ctrl + 1/Ctrl + 2',
-        async () => {
-            // Create an interactive window so that it listens to the results.
-            const { mount } = await getOrCreateInteractiveWindow(ioc);
-
-            // Type in the input box
-            const editor = getInteractiveEditor(mount.wrapper);
-            typeCode(editor, 'a=1\na');
-
-            // Give focus to a random div
-            const reactDiv = mount.wrapper.find('div').first().getDOMNode();
-
-            const domDiv = reactDiv.querySelector('div');
-
-            if (domDiv && mount.wrapper) {
-                domDiv.tabIndex = -1;
-                domDiv.focus();
-
-                // send the ctrl + 1/2 message, this should put focus back on the input box
-                mount.postMessage({ type: InteractiveWindowMessages.Activate, payload: undefined });
-
-                // Then enter press shift + enter on the active element
-                const activeElement = document.activeElement;
-                if (activeElement) {
-                    await submitInput(mount, activeElement as HTMLTextAreaElement);
-                }
-            }
-
-            verifyHtmlOnInteractiveCell('1', CellPosition.Last);
-        },
-        () => {
-            return ioc;
-        }
-    );
-
-    runTest(
         'Escape/Ctrl+U',
         async () => {
             // Create an interactive window so that it listens to the results.


### PR DESCRIPTION
For #446, #1373 

Change the way we track focus from VS code activating a window. Our old 'activate' message was interfering with the focus message that VS code sends to the iframe around a webview. 

This new way actually tracks focus changes from VS code by watching focus events on the window. When the focus changes to the body element (the default) then we set the focus to the last known TEXTAREA (monaco editor). This also works for the old webview notebook editor for remembering what cell you were editing.

It should also be noted that it doesn't interfere with tabbing because tabbing doesn't put focus into the body.

I don't see an easy way to write a test for this though. David's old test relied on being able to set focus to a random div on the page and then causing an activate. Since activate isn't handled and a random div won't give focus back to the input box, the test won't work. Additionally Enzyme doesn't support adding event handlers so it wouldn't even know about the TextAreaFocusTracker. 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
