### PR TITLE
Track the interpreter that owns kernelspec in kernelspec info

### DIFF
--- a/src/client/datascience/jupyter/kernels/jupyterKernelSpec.ts
+++ b/src/client/datascience/jupyter/kernels/jupyterKernelSpec.ts
@@ -17,19 +17,21 @@ export class JupyterKernelSpec implements IJupyterKernelSpec {
     public name: string;
     public language: string;
     public path: string;
-    public specFile: string | undefined;
     public readonly env: NodeJS.ProcessEnv | undefined;
     public display_name: string;
     public argv: string[];
 
     // tslint:disable-next-line: no-any
     public metadata?: Record<string, any> & { interpreter?: Partial<PythonEnvironment> };
-    constructor(specModel: Kernel.ISpecModel, file?: string) {
+    constructor(
+        specModel: Kernel.ISpecModel,
+        public readonly specFile?: string,
+        public readonly interpreterPath?: string
+    ) {
         this.name = specModel.name;
         this.argv = specModel.argv;
         this.language = specModel.language;
         this.path = specModel.argv && specModel.argv.length > 0 ? specModel.argv[0] : '';
-        this.specFile = file;
         this.display_name = specModel.display_name;
         this.metadata = specModel.metadata;
         // tslint:disable-next-line: no-any

--- a/src/client/datascience/kernel-launcher/kernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/kernelFinder.ts
@@ -438,7 +438,7 @@ export class KernelFinder implements IKernelFinder {
         if (
             !this.cache.find(
                 (item) =>
-                    item.interpreterPath === newPath.interpreterPath && item.kernelSpecFile === item.kernelSpecFile
+                    item.interpreterPath === newPath.interpreterPath && item.kernelSpecFile === newPath.kernelSpecFile
             )
         ) {
             this.cache.push(newPath);

--- a/src/client/datascience/kernel-launcher/kernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/kernelFinder.ts
@@ -21,8 +21,6 @@ import { Telemetry } from '../constants';
 import { JupyterKernelSpec } from '../jupyter/kernels/jupyterKernelSpec';
 import { IJupyterKernelSpec } from '../types';
 import { IKernelFinder } from './types';
-// tslint:disable-next-line:no-require-imports no-var-requires
-const flatten = require('lodash/flatten') as typeof import('lodash/flatten');
 
 const winJupyterPath = path.join('AppData', 'Roaming', 'jupyter', 'kernels');
 const linuxJupyterPath = path.join('.local', 'share', 'jupyter', 'kernels');
@@ -31,6 +29,8 @@ const baseKernelPath = path.join('share', 'jupyter', 'kernels');
 
 const cacheFile = 'kernelSpecPathCache.json';
 
+type KernelSpecFileWithContainingInterpreter = { interpreterPath?: string; kernelSpecFile: string };
+
 // This class searches for a kernel that matches the given kernel name.
 // First it searches on a global persistent state, then on the installed python interpreters,
 // and finally on the default locations that jupyter installs kernels on.
@@ -38,7 +38,7 @@ const cacheFile = 'kernelSpecPathCache.json';
 // Before returning the IJupyterKernelSpec it makes sure that ipykernel is installed into the kernel spec interpreter
 @injectable()
 export class KernelFinder implements IKernelFinder {
-    private cache?: string[];
+    private cache?: KernelSpecFileWithContainingInterpreter[];
     private cacheDirty = false;
 
     // Store our results when listing all possible kernelspecs for a resource
@@ -131,9 +131,9 @@ export class KernelFinder implements IKernelFinder {
             }
 
             const diskSearch = this.findDiskPath(kernelSpecMetadata);
-            const interpreterSearch = this.getInterpreterPaths(resource).then((interpreterPaths) => {
-                return this.findInterpreterPath(interpreterPaths, kernelSpecMetadata);
-            });
+            const interpreterSearch = this.getInterpreterPaths(resource).then((interpreterPaths) =>
+                this.findInterpreterPath(interpreterPaths, kernelSpecMetadata)
+            );
 
             let result = await Promise.race([diskSearch, interpreterSearch]);
             if (!result) {
@@ -164,7 +164,7 @@ export class KernelFinder implements IKernelFinder {
             searchResults.map(async (resultPath) => {
                 // Add these into our path cache to speed up later finds
                 this.updateCache(resultPath);
-                const kernelspec = await this.getKernelSpec(resultPath);
+                const kernelspec = await this.getKernelSpec(resultPath.kernelSpecFile, resultPath.interpreterPath);
 
                 if (kernelspec) {
                     results.push(kernelspec);
@@ -176,10 +176,10 @@ export class KernelFinder implements IKernelFinder {
     }
 
     // Load the IJupyterKernelSpec for a given spec path, check the ones that we have already loaded first
-    private async getKernelSpec(specPath: string): Promise<IJupyterKernelSpec | undefined> {
+    private async getKernelSpec(specPath: string, interpreterPath?: string): Promise<IJupyterKernelSpec | undefined> {
         // If we have not already loaded this kernel spec, then load it
         if (!this.pathToKernelSpec.has(specPath)) {
-            this.pathToKernelSpec.set(specPath, this.loadKernelSpec(specPath));
+            this.pathToKernelSpec.set(specPath, this.loadKernelSpec(specPath, interpreterPath));
         }
 
         // ! as the has and set above verify that we have a return here
@@ -190,13 +190,13 @@ export class KernelFinder implements IKernelFinder {
 
             // If we failed to get a kernelspec pull path from our cache and loaded list
             this.pathToKernelSpec.delete(specPath);
-            this.cache = this.cache?.filter((itempath) => itempath !== specPath);
+            this.cache = this.cache?.filter((itempath) => itempath.kernelSpecFile !== specPath);
             return undefined;
         });
     }
 
     // Load kernelspec json from disk
-    private async loadKernelSpec(specPath: string): Promise<IJupyterKernelSpec | undefined> {
+    private async loadKernelSpec(specPath: string, interpreterPath?: string): Promise<IJupyterKernelSpec | undefined> {
         let kernelJson;
         try {
             kernelJson = JSON.parse(await this.fs.readLocalFile(specPath));
@@ -204,7 +204,7 @@ export class KernelFinder implements IKernelFinder {
             traceError(`Failed to parse kernelspec ${specPath}`);
             return undefined;
         }
-        const kernelSpec: IJupyterKernelSpec = new JupyterKernelSpec(kernelJson, specPath);
+        const kernelSpec: IJupyterKernelSpec = new JupyterKernelSpec(kernelJson, specPath, interpreterPath);
 
         // Some registered kernel specs do not have a name, in this case use the last part of the path
         kernelSpec.name = kernelJson?.name || path.basename(path.dirname(specPath));
@@ -215,7 +215,7 @@ export class KernelFinder implements IKernelFinder {
     private async findAllResourcePossibleKernelPaths(
         resource: Resource,
         _cancelToken?: CancellationToken
-    ): Promise<string[]> {
+    ): Promise<(string | { interpreter: PythonEnvironment; kernelSearchPath: string })[]> {
         const [activePath, interpreterPaths, diskPaths] = await Promise.all([
             this.getActiveInterpreterPath(resource),
             this.getInterpreterPaths(resource),
@@ -234,15 +234,28 @@ export class KernelFinder implements IKernelFinder {
         return [];
     }
 
-    private async getInterpreterPaths(resource: Resource): Promise<string[]> {
+    private async getInterpreterPaths(
+        resource: Resource
+    ): Promise<{ interpreter: PythonEnvironment; kernelSearchPath: string }[]> {
         if (this.extensionChecker.isPythonExtensionInstalled) {
             const interpreters = await this.interpreterService.getInterpreters(resource);
             // tslint:disable-next-line: no-console
             console.debug(`Search all interpreters ${interpreters.map((item) => item.path).join(', ')}`);
-            const interpreterPrefixPaths = interpreters.map((interpreter) => interpreter.sysPrefix);
-            // We can get many duplicates here, so de-dupe the list
-            const uniqueInterpreterPrefixPaths = [...new Set(interpreterPrefixPaths)];
-            return uniqueInterpreterPrefixPaths.map((prefixPath) => path.join(prefixPath, baseKernelPath));
+            const interpreterPaths = new Set<string>();
+            return interpreters
+                .filter((interpreter) => {
+                    if (interpreterPaths.has(interpreter.path)) {
+                        return false;
+                    }
+                    interpreterPaths.add(interpreter.path);
+                    return true;
+                })
+                .map((interpreter) => {
+                    return {
+                        interpreter,
+                        kernelSearchPath: path.join(interpreter.sysPrefix, baseKernelPath)
+                    };
+                });
         }
         return [];
     }
@@ -332,20 +345,29 @@ export class KernelFinder implements IKernelFinder {
     }
 
     // Given a set of paths, search for kernel.json files and return back the full paths of all of them that we find
-    private async kernelGlobSearch(paths: string[]): Promise<string[]> {
-        const promises = paths.map((kernelPath) => this.fs.searchLocal(`**/kernel.json`, kernelPath, true));
-        const searchResults = await Promise.all(promises);
-
-        // Append back on the start of each path so we have the full path in the results
-        const fullPathResults = searchResults
-            .filter((f) => f)
-            .map((result, index) => {
-                return result.map((partialSpecPath) => {
-                    return path.join(paths[index], partialSpecPath);
+    private async kernelGlobSearch(
+        paths: (string | { interpreter: PythonEnvironment; kernelSearchPath: string })[]
+    ): Promise<KernelSpecFileWithContainingInterpreter[]> {
+        const searchResults = await Promise.all(
+            paths.map((searchItem) => {
+                const searchPath = typeof searchItem === 'string' ? searchItem : searchItem.kernelSearchPath;
+                return this.fs.searchLocal(`**/kernel.json`, searchPath, true).then((kernelSpecFilesFound) => {
+                    return {
+                        interpreter: typeof searchItem === 'string' ? undefined : searchItem.interpreter,
+                        kernelSpecFiles: kernelSpecFilesFound.map((item) => path.join(searchPath, item))
+                    };
                 });
-            });
+            })
+        );
 
-        return flatten(fullPathResults);
+        const kernelSpecFiles: { interpreter?: PythonEnvironment; kernelSpecFile: string }[] = [];
+        searchResults.forEach((item) => {
+            for (const kernelSpecFile of item.kernelSpecFiles) {
+                kernelSpecFiles.push({ interpreter: item.interpreter, kernelSpecFile });
+            }
+        });
+
+        return kernelSpecFiles;
     }
 
     private async getKernelSpecFromActiveInterpreter(
@@ -357,13 +379,23 @@ export class KernelFinder implements IKernelFinder {
     }
 
     private async findInterpreterPath(
-        interpreterPaths: string[],
+        interpreterPaths: { interpreter: PythonEnvironment; kernelSearchPath: string }[],
         kernelSpecMetadata?: nbformat.IKernelspecMetadata
     ): Promise<IJupyterKernelSpec | undefined> {
-        const promises = interpreterPaths.map((intPath) => this.getKernelSpecFromDisk([intPath], kernelSpecMetadata));
+        const kernelSpecs = await Promise.all(
+            interpreterPaths.map(async (item) => {
+                const kernelSpec = await this.getKernelSpecFromDisk([item.kernelSearchPath], kernelSpecMetadata);
+                if (!kernelSpec) {
+                    return;
+                }
+                return {
+                    ...kernelSpec,
+                    interpreterPath: item.interpreter.path
+                };
+            })
+        );
 
-        const specs = await Promise.all(promises);
-        return specs.find((sp) => sp !== undefined);
+        return kernelSpecs.find((item) => item !== undefined);
     }
 
     // Jupyter looks for kernels in these paths:
@@ -394,16 +426,21 @@ export class KernelFinder implements IKernelFinder {
                 return;
             }
             this.cache = JSON.parse(
-                await this.fs.readLocalFile(path.join(this.context.globalStoragePath, cacheFile))
-            ) as string[];
+                await this.fs.readLocalFile(path.join(this.context.globalStorageUri.fsPath, cacheFile))
+            );
         } catch {
             traceInfo('No kernelSpec cache found.');
         }
     }
 
-    private updateCache(newPath: string) {
+    private updateCache(newPath: KernelSpecFileWithContainingInterpreter) {
         this.cache = Array.isArray(this.cache) ? this.cache : [];
-        if (!this.cache.includes(newPath)) {
+        if (
+            !this.cache.find(
+                (item) =>
+                    item.interpreterPath === newPath.interpreterPath && item.kernelSpecFile === item.kernelSpecFile
+            )
+        ) {
             this.cache.push(newPath);
             this.cacheDirty = true;
         }
@@ -412,7 +449,7 @@ export class KernelFinder implements IKernelFinder {
     private async writeCache() {
         if (this.cacheDirty && Array.isArray(this.cache)) {
             await this.fs.writeLocalFile(
-                path.join(this.context.globalStoragePath, cacheFile),
+                path.join(this.context.globalStorageUri.fsPath, cacheFile),
                 JSON.stringify(this.cache)
             );
             this.cacheDirty = false;
@@ -429,13 +466,15 @@ export class KernelFinder implements IKernelFinder {
             this.cache
                 .filter((kernelPath) => {
                     try {
-                        return path.basename(path.dirname(kernelPath)) === kernelSpecMetadata.name;
+                        return path.basename(path.dirname(kernelPath.kernelSpecFile)) === kernelSpecMetadata.name;
                     } catch (e) {
                         traceInfo('KernelSpec path in cache is not a string.', e);
                         return false;
                     }
                 })
-                .map((kernelJsonFile) => this.getKernelSpec(kernelJsonFile))
+                .map((kernelJsonFile) =>
+                    this.getKernelSpec(kernelJsonFile.kernelSpecFile, kernelJsonFile.interpreterPath)
+                )
         );
         const kernelSpecsWithSameName = items.filter((item) => !!item).map((item) => item!);
         switch (kernelSpecsWithSameName.length) {

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -420,6 +420,18 @@ export interface IJupyterKernelSpec {
     // tslint:disable-next-line: no-any
     readonly metadata?: Record<string, any> & { interpreter?: Partial<PythonEnvironment> };
     readonly argv: string[];
+    /**
+     * Optionally where this kernel spec json is located on the local FS.
+     */
+    specFile?: string;
+    /**
+     * Optionally the Interpreter this kernel spec belongs to.
+     * You can have kernel specs that are scoped to an interpreter.
+     * E.g. if you have Python in `c:\Python\Python3.8`
+     * Then you could have kernels in `<sys.prefix folder for this interpreter>\share\jupyter\kernels`
+     * Plenty of conda packages ship kernels in this manner (beakerx, etc).
+     */
+    interpreterPath?: string;
 }
 
 export const INotebookImporter = Symbol('INotebookImporter');

--- a/src/test/datascience/kernel-launcher/kernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/kernelFinder.unit.test.ts
@@ -322,6 +322,7 @@ suite('Kernel Finder', () => {
         });
 
         test('Basic listKernelSpecs', async () => {
+            setupFileSystem();
             setupFindFileSystem();
             const specs = await kernelFinder.listKernelSpecs(resource);
             expect(specs[0]).to.deep.include(activeKernelA);
@@ -335,6 +336,7 @@ suite('Kernel Finder', () => {
         });
 
         test('listKernelSpecs load error', async () => {
+            setupFileSystem();
             setupFindFileSystem();
             loadError = true;
             const specs = await kernelFinder.listKernelSpecs(resource);
@@ -411,7 +413,12 @@ suite('Kernel Finder', () => {
                 kernelspec: testKernelMetadata,
                 orig_nbformat: 4
             });
-            assert.deepEqual(spec, kernel, 'The found kernel spec is not the same.');
+            // Ignore some properties when comparing.
+            assert.deepEqual(
+                { ...spec, specFile: '', interpreterPath: '' },
+                { ...kernel, specFile: '', interpreterPath: '' },
+                'The found kernel spec is not the same.'
+            );
             fileSystem.reset();
         });
 
@@ -557,9 +564,9 @@ suite('Kernel Finder', () => {
                     if (pathParam.includes(cacheFile)) {
                         return Promise.resolve(
                             JSON.stringify([
-                                path.join('kernels', kernel.name, 'kernel.json'),
-                                path.join('kernels', 'kernelA', 'kernel.json'),
-                                path.join('kernels', 'kernelB', 'kernel.json')
+                                { kernelSpecFile: path.join('kernels', kernel.name, 'kernel.json') },
+                                { kernelSpecFile: path.join('kernels', 'kernelA', 'kernel.json') },
+                                { kernelSpecFile: path.join('kernels', 'kernelB', 'kernel.json') }
                             ])
                         );
                     } else if (pathParam.includes('kernelB')) {


### PR DESCRIPTION
Part of #365
With Jupyter kernels in Conda environments, we need to inherit the environment variabels of the conda environment.
This means, if we start a kernel, we need to first chekc if it belongs to a conda or python environment & then inherit the variables from that (for now, plan is to do this just for conda environments).

Steps:
* User select a kernel
* Before we start a kernel, check if it belongs to conda env
* Get corresponding conda env that owns this kernel
* Get env variabels of that conda env
* When starting the kernel, use those env variables instead of the current `process.env`.


This PR merely allows us to identify easily the python environment that a kernel belongs to.
* Not a fan of adding `interpreterPath` to kernel Spec, but this makes it easier than querying this information all over again.

Optionally:
* I could add a method to kernel Finder that returns the corresopnding interpreter
* Behind the scenes (private variable) i'd hold this mapping in some dict
* I'm ok with either change or alternatives
I.e `KernelFinder.getOwningInterpreter(kernelSpecName: string): Promoise<PythonEnvironment | undefined>`