### PR TITLE
Fix smoke tests on mac

### DIFF
--- a/.github/actions/set-python/action.yml
+++ b/.github/actions/set-python/action.yml
@@ -13,11 +13,6 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Use Python ${{inputs.PYTHON_VERSION}}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{inputs.PYTHON_VERSION}}
-
     - name: Output python path
       id: python_run
       shell: bash

--- a/.github/actions/set-python/action.yml
+++ b/.github/actions/set-python/action.yml
@@ -1,0 +1,28 @@
+name: 'Set Python'
+description: "Sets python to a specific version"
+
+inputs: 
+  PYTHON_VERSION:
+     description: 'Version of python'
+     required: true
+     default: ${{env.PYTHON_VERSION}}
+outputs:
+  CI_PYTHON_PATH:
+    description: 'Path to the python'
+    value: ${{ steps.python_run.outputs.python_path }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Use Python ${{inputs.PYTHON_VERSION}}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{inputs.PYTHON_VERSION}}
+
+    - name: Output python path
+      id: python_run
+      shell: bash
+      run: python -c "import sys;print('::set-output name=python_path::' + sys.executable)"
+
+    - name: Push to environment
+      shell: bash
+      run: echo "CI_PYTHON_PATH=${{ steps.python_run.outputs.python_path }}" >> $GITHUB_ENV

--- a/.github/actions/set-python/action.yml
+++ b/.github/actions/set-python/action.yml
@@ -5,7 +5,7 @@ inputs:
   PYTHON_VERSION:
      description: 'Version of python'
      required: true
-     default: ${{env.PYTHON_VERSION}}
+     default: python
 outputs:
   CI_PYTHON_PATH:
     description: 'Path to the python'

--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -125,6 +125,12 @@ jobs:
         with:
           python-version: ${{matrix.python}}
 
+      - name: Set CI Path
+        uses: ./.github/actions/set-python
+        id: set-python
+        with: 
+          PYTHON_VERSION: ${{env.PYTHON_VERSION}}
+
       - name: Run Black on Python code
         run: |
           python -m pip install -U black

--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -544,7 +544,7 @@ jobs:
         if: (steps.test_notebook_vscode.outcome == 'failure' || steps.test_notebook_vscode.outcome == 'failure') && failure()
 
   smoke-tests:
-    timeout: 30
+    timeout-minutes: 30
     name: Smoke tests
     # The value of runs-on is the OS of the current job (specified in the strategy matrix below) instead of being hardcoded.
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - rchiodo/smoke_tests_mac
   workflow_dispatch:
 
 env:
@@ -544,7 +543,7 @@ jobs:
         if: (steps.test_notebook_vscode.outcome == 'failure' || steps.test_notebook_vscode.outcome == 'failure') && failure()
 
   smoke-tests:
-    timeout-minutes: 10
+    timeout-minutes: 30
     name: Smoke tests
     # The value of runs-on is the OS of the current job (specified in the strategy matrix below) instead of being hardcoded.
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -544,6 +544,7 @@ jobs:
         if: (steps.test_notebook_vscode.outcome == 'failure' || steps.test_notebook_vscode.outcome == 'failure') && failure()
 
   smoke-tests:
+    timeout: 30
     name: Smoke tests
     # The value of runs-on is the OS of the current job (specified in the strategy matrix below) instead of being hardcoded.
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -42,10 +42,9 @@ jobs:
           node-version: ${{env.NODE_VERSION}}
 
       - name: Use Python ${{env.PYTHON_VERSION}}
-        uses: ./.github/actions/set-python
-        id: set-python
-        with: 
-          PYTHON_VERSION: ${{env.PYTHON_VERSION}}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{env.PYTHON_VERSION}}
 
       # Caching of npm packages (https://github.com/actions/cache/blob/main/examples.md#node---npm)
       - name: Cache npm on linux/mac
@@ -120,16 +119,10 @@ jobs:
       - name: Run prettier on JavaScript code
         run: npx prettier 'build/**/*.js' --check
 
-      - name: Use Python ${{matrix.python}}
+      - name: Use Python ${{env.PYTHON_VERSION}}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{matrix.python}}
-
-      - name: Set CI Path
-        uses: ./.github/actions/set-python
-        id: set-python
-        with: 
-          PYTHON_VERSION: ${{env.PYTHON_VERSION}}
+          python-version: ${{env.PYTHON_VERSION}}
 
       - name: Run Black on Python code
         run: |
@@ -245,7 +238,7 @@ jobs:
         uses: ./.github/actions/set-python
         id: set-python
         with: 
-          PYTHON_VERSION: ${{env.PYTHON_VERSION}}
+          PYTHON_VERSION: ${{matrix.python}}
 
       - name: Upgrade pip
         run: python -m pip install -U pip
@@ -397,7 +390,7 @@ jobs:
         uses: ./.github/actions/set-python
         id: set-python
         with: 
-          PYTHON_VERSION: ${{env.PYTHON_VERSION}}
+          PYTHON_VERSION: ${{matrix.python}}
 
       - name: Upgrade pip
         run: python -m pip install -U pip
@@ -576,7 +569,7 @@ jobs:
         uses: ./.github/actions/set-python
         id: set-python
         with: 
-          PYTHON_VERSION: ${{env.PYTHON_VERSION}}
+          PYTHON_VERSION: ${{matrix.python}}
 
       - name: Upgrade pip
         run: python -m pip install -U pip

--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -22,7 +22,6 @@ env:
   VSIX_NAME: ms-toolsai-jupyter-insiders.vsix
   VSIX_NAME_UPLOADED_TO_BLOB: ms-toolsai-jupyter-insiders.vsix
   COVERAGE_REPORTS: tests-coverage-reports
-  CI_PYTHON_PATH: python
   TEST_RESULTS_DIRECTORY: .
   TEST_RESULTS_GLOB: '**/test-results*.xml'
   IPYWIDGET_SCREENSHOT_PATH: '*-screenshot.png'
@@ -43,9 +42,10 @@ jobs:
           node-version: ${{env.NODE_VERSION}}
 
       - name: Use Python ${{env.PYTHON_VERSION}}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{env.PYTHON_VERSION}}
+        uses: ./.github/actions/set-python
+        id: set-python
+        with: 
+          PYTHON_VERSION: ${{env.PYTHON_VERSION}}
 
       # Caching of npm packages (https://github.com/actions/cache/blob/main/examples.md#node---npm)
       - name: Cache npm on linux/mac
@@ -601,7 +601,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: smoke-test.log
+          name: smoke-test-${{matrix.os}}.log
           path: './smoke-test.log'
 
   upload:

--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -544,7 +544,7 @@ jobs:
         if: (steps.test_notebook_vscode.outcome == 'failure' || steps.test_notebook_vscode.outcome == 'failure') && failure()
 
   smoke-tests:
-    timeout-minutes: 30
+    timeout-minutes: 10
     name: Smoke tests
     # The value of runs-on is the OS of the current job (specified in the strategy matrix below) instead of being hardcoded.
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -120,10 +120,10 @@ jobs:
       - name: Run prettier on JavaScript code
         run: npx prettier 'build/**/*.js' --check
 
-      - name: Use Python ${{env.PYTHON_VERSION}}
+      - name: Use Python ${{matrix.python}}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{env.PYTHON_VERSION}}
+          python-version: ${{matrix.python}}
 
       - name: Run Black on Python code
         run: |
@@ -234,6 +234,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.python}}
+
+      - name: Set CI Path
+        uses: ./.github/actions/set-python
+        id: set-python
+        with: 
+          PYTHON_VERSION: ${{env.PYTHON_VERSION}}
 
       - name: Upgrade pip
         run: python -m pip install -U pip
@@ -380,6 +386,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.python}}
+
+      - name: Set CI Path
+        uses: ./.github/actions/set-python
+        id: set-python
+        with: 
+          PYTHON_VERSION: ${{env.PYTHON_VERSION}}
 
       - name: Upgrade pip
         run: python -m pip install -U pip
@@ -550,13 +562,15 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.python}}
+
+      - name: Set CI Path
+        uses: ./.github/actions/set-python
+        id: set-python
+        with: 
+          PYTHON_VERSION: ${{env.PYTHON_VERSION}}
+
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Use Python ${{matrix.python}}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{matrix.python}}
 
       - name: Upgrade pip
         run: python -m pip install -U pip

--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -558,6 +558,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python: [3.8]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Use Python ${{matrix.python}}
         uses: actions/setup-python@v2
         with:
@@ -568,9 +571,6 @@ jobs:
         id: set-python
         with: 
           PYTHON_VERSION: ${{env.PYTHON_VERSION}}
-
-      - name: Checkout
-        uses: actions/checkout@v2
 
       - name: Upgrade pip
         run: python -m pip install -U pip

--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - rchiodo/smoke_tests_mac
   workflow_dispatch:
 
 env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,6 @@ env:
   CACHE_PYTHONFILES: cache-pvsc-pythonFiles
   VSIX_NAME: ms-toolsai-jupyter-insiders.vsix
   COVERAGE_REPORTS: tests-coverage-reports
-  CI_PYTHON_PATH: python
   TEST_RESULTS_DIRECTORY: .
   TEST_RESULTS_GLOB: '**/test-results*.xml'
   IPYWIDGET_SCREENSHOT_PATH: '*-screenshot.png'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ env:
   VSIX_NAME: ms-toolsai-jupyter-release.vsix
   VSIX_NAME_UPLOADED_TO_BLOB: ms-toolsai-jupyter-release.vsix
   COVERAGE_REPORTS: tests-coverage-reports
-  CI_PYTHON_PATH: python
   TEST_RESULTS_DIRECTORY: .
   TEST_RESULTS_GLOB: '**/test-results*.xml'
   IPYWIDGET_SCREENSHOT_PATH: '*-screenshot.png'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -546,6 +546,7 @@ jobs:
 
 
   smoke-tests:
+    timeout-minutes: 30
     name: Smoke tests
     # The value of runs-on is the OS of the current job (specified in the strategy matrix below) instead of being hardcoded.
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,6 +235,12 @@ jobs:
         with:
           python-version: ${{matrix.python}}
 
+      - name: Set CI Path
+        uses: ./.github/actions/set-python
+        id: set-python
+        with: 
+          PYTHON_VERSION: ${{matrix.python}}
+
       - name: Upgrade pip
         run: python -m pip install -U pip
 
@@ -380,6 +386,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.python}}
+
+      - name: Set CI Path
+        uses: ./.github/actions/set-python
+        id: set-python
+        with: 
+          PYTHON_VERSION: ${{matrix.python}}
 
       - name: Upgrade pip
         run: python -m pip install -U pip
@@ -547,10 +559,6 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python: [3.8]
     steps:
-      - name: Use Python ${{matrix.python}}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{matrix.python}}
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -558,6 +566,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.python}}
+
+      - name: Set CI Path
+        uses: ./.github/actions/set-python
+        id: set-python
+        with: 
+          PYTHON_VERSION: ${{matrix.python}}
 
       - name: Upgrade pip
         run: python -m pip install -U pip
@@ -602,7 +616,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: smoke-test.log
+          name: smoke-test-${{matrix.os}}.log
           path: './smoke-test.log'
 
 

--- a/package.json
+++ b/package.json
@@ -1775,7 +1775,7 @@
         "testNativeNotebooksWithoutPythonInVSCode": "cross-env CODE_TESTS_WORKSPACE=src/test/datascience VSC_JUPYTER_CI_TEST_VSC_CHANNEL=insiders VSC_JUPYTER_RUN_NB_TEST=true TEST_FILES_SUFFIX=vscode.test VSC_JUPYTER_FORCE_LOGGING=1 VSC_JUPYTER_LOAD_EXPERIMENTS_FROM_FILE=true VSC_JUPYTER_CI_TEST_GREP=non-python-kernel VSC_JUPYTER_CI_TEST_DO_NOT_INSTALL_PYTHON_EXT=true node ./out/test/testBootstrap.js ./out/test/standardTest.js",
         "testPerformance": "node ./out/test/testBootstrap.js ./out/test/performanceTest.js",
         "testSmoke": "node ./out/test/testBootstrap.js ./out/test/smokeTest.js",
-        "testSmokeLogged": "cross-env VSC_JUPYTER_FORCE_LOGGING=true VSC_JUPYTER_LOG_FILE=smoke-test.log node --no-force-async-hooks-checks ./out/test/smokeTest.js",
+        "testSmokeLogged": "cross-env VSC_JUPYTER_FORCE_LOGGING=true VSC_JUPYTER_LOG_FILE=smoke-test.log node --no-force-async-hooks-checks ./out/test/testBootstrap.js ./out/test/smokeTest.js",
         "lint-staged": "node gulpfile.js",
         "lint": "tslint src/**/*.ts -t verbose",
         "prettier-fix": "prettier 'src/**/*.ts*' --write && prettier 'build/**/*.js' --write",

--- a/package.json
+++ b/package.json
@@ -1763,7 +1763,7 @@
         "testNativeNotebooksWithoutPythonInVSCode": "cross-env CODE_TESTS_WORKSPACE=src/test/datascience VSC_JUPYTER_CI_TEST_VSC_CHANNEL=insiders VSC_JUPYTER_RUN_NB_TEST=true TEST_FILES_SUFFIX=vscode.test VSC_JUPYTER_FORCE_LOGGING=1 VSC_JUPYTER_LOAD_EXPERIMENTS_FROM_FILE=true VSC_JUPYTER_CI_TEST_GREP=non-python-kernel VSC_JUPYTER_CI_TEST_DO_NOT_INSTALL_PYTHON_EXT=true node ./out/test/testBootstrap.js ./out/test/standardTest.js",
         "testPerformance": "node ./out/test/testBootstrap.js ./out/test/performanceTest.js",
         "testSmoke": "node ./out/test/testBootstrap.js ./out/test/smokeTest.js",
-        "testSmokeLogged": "cross-env VSC_JUPYTER_FORCE_LOGGING=true VSC_JUPYTER_LOG_FILE=smoke-test-%OS%.log node --no-force-async-hooks-checks ./out/test/smokeTest.js",
+        "testSmokeLogged": "cross-env VSC_JUPYTER_FORCE_LOGGING=true VSC_JUPYTER_LOG_FILE=smoke-test.log node --no-force-async-hooks-checks ./out/test/smokeTest.js",
         "lint-staged": "node gulpfile.js",
         "lint": "tslint src/**/*.ts -t verbose",
         "prettier-fix": "prettier 'src/**/*.ts*' --write && prettier 'build/**/*.js' --write",

--- a/package.json
+++ b/package.json
@@ -1763,7 +1763,7 @@
         "testNativeNotebooksWithoutPythonInVSCode": "cross-env CODE_TESTS_WORKSPACE=src/test/datascience VSC_JUPYTER_CI_TEST_VSC_CHANNEL=insiders VSC_JUPYTER_RUN_NB_TEST=true TEST_FILES_SUFFIX=vscode.test VSC_JUPYTER_FORCE_LOGGING=1 VSC_JUPYTER_LOAD_EXPERIMENTS_FROM_FILE=true VSC_JUPYTER_CI_TEST_GREP=non-python-kernel VSC_JUPYTER_CI_TEST_DO_NOT_INSTALL_PYTHON_EXT=true node ./out/test/testBootstrap.js ./out/test/standardTest.js",
         "testPerformance": "node ./out/test/testBootstrap.js ./out/test/performanceTest.js",
         "testSmoke": "node ./out/test/testBootstrap.js ./out/test/smokeTest.js",
-        "testSmokeLogged": "cross-env VSC_JUPYTER_FORCE_LOGGING=true VSC_JUPYTER_LOG_FILE=smoke-test.log node --no-force-async-hooks-checks ./out/test/smokeTest.js",
+        "testSmokeLogged": "cross-env VSC_JUPYTER_FORCE_LOGGING=true VSC_JUPYTER_LOG_FILE=smoke-test-%OS%.log node --no-force-async-hooks-checks ./out/test/smokeTest.js",
         "lint-staged": "node gulpfile.js",
         "lint": "tslint src/**/*.ts -t verbose",
         "prettier-fix": "prettier 'src/**/*.ts*' --write && prettier 'build/**/*.js' --write",

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -623,7 +623,9 @@ export class KernelSelector implements IKernelSelectionUsage {
                 KernelInterpreterDependencyResponse.ok
             ) {
                 throw new Error(
-                    localize.DataScience.ipykernelNotInstalled().format(interpreter.displayName || interpreter.path)
+                    localize.DataScience.ipykernelNotInstalled().format(
+                        `${interpreter.displayName || interpreter.path}:${interpreter.path}`
+                    )
                 );
             }
         }

--- a/src/test/common/exitCIAfterTestReporter.ts
+++ b/src/test/common/exitCIAfterTestReporter.ts
@@ -47,7 +47,7 @@ function notifyCompleted(hasFailures: boolean, reconnectCount: number) {
         console.error(`No client to write from ${client}. Attempting reconnect`);
         // Try reconnecting.
         if (reconnectCount <= 0) {
-            connectToServer().then(notifyCompleted.bind(undefined, hasFailures, reconnectCount+1));
+            connectToServer().then(notifyCompleted.bind(undefined, hasFailures, reconnectCount + 1));
         }
         return;
     }

--- a/src/test/common/exitCIAfterTestReporter.ts
+++ b/src/test/common/exitCIAfterTestReporter.ts
@@ -42,13 +42,9 @@ async function connectToServer() {
         }
     });
 }
-function notifyCompleted(hasFailures: boolean, reconnectCount: number) {
+function notifyCompleted(hasFailures: boolean) {
     if (!client || client.destroyed || !client.writable) {
-        console.error(`No client to write from ${client}. Attempting reconnect`);
-        // Try reconnecting.
-        if (reconnectCount <= 0) {
-            connectToServer().then(notifyCompleted.bind(undefined, hasFailures, reconnectCount + 1));
-        }
+        console.error(`No client to write from ${client}.`);
         return;
     }
     try {
@@ -73,7 +69,7 @@ class ExitReporter {
                 console.info('Start Exit Reporter for Mocha.');
             })
             .once(EVENT_RUN_END, async () => {
-                notifyCompleted(stats.failures > 0, 0);
+                notifyCompleted(stats.failures > 0);
                 console.info('End Exit Reporter for Mocha.');
             });
     }

--- a/src/test/common/exitCIAfterTestReporter.ts
+++ b/src/test/common/exitCIAfterTestReporter.ts
@@ -44,6 +44,7 @@ async function connectToServer() {
 function notifyCompleted(hasFailures: boolean) {
     if (!client || client.destroyed || !client.writable) {
         console.error('No client to write from');
+        process.exit(hasFailures ? 1 : 0);
         return;
     }
     try {

--- a/src/test/testBootstrap.ts
+++ b/src/test/testBootstrap.ts
@@ -7,7 +7,6 @@ import { ChildProcess, spawn, SpawnOptions } from 'child_process';
 import * as fs from 'fs-extra';
 import { AddressInfo, createServer, Server } from 'net';
 import * as path from 'path';
-import { EXTENSION_ROOT_DIR } from '../client/constants';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from './constants';
 import { noop, sleep } from './core';
 import { initializeLogger } from './testLogger';


### PR DESCRIPTION
For #372

Smoke tests were not using the testBootstrapper and on mac the python path was set incorrectly.

Added a new action to set CI_PYTHON_PATH based on what 'python' in the path is set to.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
