### PR TITLE
Migrate when clauses

### DIFF
--- a/src/test/activation/migrateDataScienceSettingsService.unit.test.ts
+++ b/src/test/activation/migrateDataScienceSettingsService.unit.test.ts
@@ -154,11 +154,11 @@ suite('Migrate data science settings', () => {
     const originalKeybindings = `[
     {
         "key": "ctrl+shift+enter",
-        "command": "python.dataScience.runallcells"
+        "command": "python.datascience.runallcells"
     },
     {
         "key": "ctrl+shift+enter",
-        "command": "python.dataScience.foo"
+        "command": "python.datascience.foo"
     },
     {
         "key": "ctrl+shift+enter",
@@ -166,7 +166,8 @@ suite('Migrate data science settings', () => {
     },
     {
         "key": "ctrl+shift+enter",
-        "command": "python.datascience.foobar"
+        "command": "python.datascience.foobar",
+        "when": "python.datascience.hascodecells"
     },
     {
         "key": "ctrl+shift+alt",
@@ -184,7 +185,8 @@ suite('Migrate data science settings', () => {
     },
     {
         "key": "ctrl+shift+enter",
-        "command": "jupyter.foobar"
+        "command": "jupyter.foobar",
+        "when": "jupyter.hascodecells"
     },
     {
         "key": "ctrl+shift+alt",


### PR DESCRIPTION
Also ensure we migrate the keybindings where the command property is prefixed with '-'

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
