### PR TITLE
Handle tensorboard window.location for native notebooks

### DIFF
--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -49,6 +49,7 @@ import {
     getKernelConnectionLanguage,
     isPythonKernelConnection
 } from './kernels/helpers';
+import { handleTensorBoardDisplayDataOutput } from '../notebook/helpers/executionHelpers';
 
 class CellSubscriber {
     public get startTime(): number {
@@ -1349,24 +1350,8 @@ export class JupyterNotebookBase implements INotebook {
         }
     }
 
-    private handleTensorBoardDisplayDataOutput(data: nbformat.IMimeBundle) {
-        // After executing %tensorboard --logdir <log directory> to launch
-        // TensorBoard inline, TensorBoard sends back an IFrame to display as output.
-        // The TensorBoard app hardcodes the source URL of the IFrame to `window.location`.
-        // In the VSCode context this results in the URL taking on the internal
-        // vscode-webview:// scheme which doesn't work. Hence rewrite it to use
-        // http://localhost:<port number>.
-        if (data.hasOwnProperty('text/html')) {
-            const text = data['text/html'];
-            if (typeof text === 'string' && text.includes('<iframe id="tensorboard-frame-')) {
-                data['text/html'] = text.replace(/new URL\((.*), window.location\)/, 'new URL("http://localhost")');
-            }
-        }
-        return data;
-    }
-
     private handleDisplayData(msg: KernelMessage.IDisplayDataMsg, clearState: RefBool, cell: ICell) {
-        const newData = this.handleTensorBoardDisplayDataOutput(msg.content.data);
+        const newData = handleTensorBoardDisplayDataOutput(msg.content.data);
         const output: nbformat.IDisplayData = {
             output_type: 'display_data',
             data: newData,

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -44,12 +44,12 @@ import { PYTHON_LANGUAGE } from '../../common/constants';
 import { IFileSystem } from '../../common/platform/types';
 import { RefBool } from '../../common/refBool';
 import { PythonEnvironment } from '../../pythonEnvironments/info';
+import { handleTensorBoardDisplayDataOutput } from '../notebook/helpers/executionHelpers';
 import {
     getInterpreterFromKernelConnectionMetadata,
     getKernelConnectionLanguage,
     isPythonKernelConnection
 } from './kernels/helpers';
-import { handleTensorBoardDisplayDataOutput } from '../notebook/helpers/executionHelpers';
 
 class CellSubscriber {
     public get startTime(): number {

--- a/src/client/datascience/jupyter/kernels/cellExecution.ts
+++ b/src/client/datascience/jupyter/kernels/cellExecution.ts
@@ -24,6 +24,7 @@ import { StopWatch } from '../../../common/utils/stopWatch';
 import { sendTelemetryEvent } from '../../../telemetry';
 import { Telemetry } from '../../constants';
 import {
+    handleTensorBoardDisplayDataOutput,
     handleUpdateDisplayDataMessage,
     updateCellExecutionCount,
     updateCellWithErrorStatus
@@ -627,7 +628,7 @@ export class CellExecution {
     private async handleDisplayData(msg: KernelMessage.IDisplayDataMsg, clearState: RefBool) {
         const output: nbformat.IDisplayData = {
             output_type: 'display_data',
-            data: msg.content.data,
+            data: handleTensorBoardDisplayDataOutput(msg.content.data),
             metadata: msg.content.metadata,
             // tslint:disable-next-line: no-any
             transient: msg.content.transient as any // NOSONAR


### PR DESCRIPTION
Just figured out why this wasn't working for native notebooks. We need to handle the display data in a different spot for native notebooks. I previously fixed this for webview notebooks only.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
