### PR TITLE
Revert change until VSC API is fixed

### DIFF
--- a/src/client/datascience/notebook/serviceRegistry.ts
+++ b/src/client/datascience/notebook/serviceRegistry.ts
@@ -12,7 +12,6 @@ import { KernelProvider } from '../jupyter/kernels/kernelProvider';
 import { IKernelProvider } from '../jupyter/kernels/types';
 import { NotebookContentProvider } from './contentProvider';
 import { NotebookCellLanguageService } from './defaultCellLanguageService';
-import { EmptyNotebookCellLanguageService } from './emptyNotebookCellLanguageService';
 import { NotebookIntegration } from './integration';
 import { VSCodeKernelPickerProvider } from './kernelProvider';
 import { NotebookDisposeService } from './notebookDisposeService';
@@ -34,10 +33,10 @@ export function registerTypes(serviceManager: IServiceManager) {
         IExtensionSingleActivationService,
         RendererExtension
     );
-    serviceManager.addSingleton<IExtensionSingleActivationService>(
-        IExtensionSingleActivationService,
-        EmptyNotebookCellLanguageService
-    );
+    // serviceManager.addSingleton<IExtensionSingleActivationService>(
+    //     IExtensionSingleActivationService,
+    //     EmptyNotebookCellLanguageService
+    // );
     serviceManager.addSingleton<RendererExtensionDownloader>(RendererExtensionDownloader, RendererExtensionDownloader);
     serviceManager.addSingleton<NotebookIntegration>(NotebookIntegration, NotebookIntegration);
     serviceManager.addSingleton<IKernelProvider>(IKernelProvider, KernelProvider);

--- a/src/client/datascience/notebook/serviceRegistry.ts
+++ b/src/client/datascience/notebook/serviceRegistry.ts
@@ -33,6 +33,7 @@ export function registerTypes(serviceManager: IServiceManager) {
         IExtensionSingleActivationService,
         RendererExtension
     );
+    // Disabled temporarily due to upstream VSC bug, see https://github.com/microsoft/vscode-jupyter/pull/4069
     // serviceManager.addSingleton<IExtensionSingleActivationService>(
     //     IExtensionSingleActivationService,
     //     EmptyNotebookCellLanguageService


### PR DESCRIPTION
Disables the change introduced in #398 until the VSC API is fixed (or we know how to use it).
Else we end up making things worse by adding new cells when switching kernels.
