### PR TITLE
Use notebookIdentity instead of the notebook when handling external buttons

### DIFF
--- a/news/2 Fixes/414.md
+++ b/news/2 Fixes/414.md
@@ -1,0 +1,1 @@
+Use notebookIdentity instead of the notebook when handling external buttons. It handles the case when the user doesn't autostart the kernel.

--- a/pythonFiles/pyvsc-run-isolated.py
+++ b/pythonFiles/pyvsc-run-isolated.py
@@ -4,20 +4,14 @@
 if __name__ != "__main__":
     raise Exception("{} cannot be imported".format(__name__))
 
-import os
 import os.path
 import runpy
 import sys
 
-
-def normalize(path):
-    return os.path.normcase(os.path.normpath(path))
-
-
-# We "isolate" the script/module (sys.argv[1]) by removing current working
-# directory or '' in sys.path and then sending the target on to runpy.
-cwd = normalize(os.getcwd())
-sys.path[:] = (p for p in sys.path if p != "" and normalize(p) != cwd)
+# We "isolate" the script/module (sys.argv[1]) by
+# replacing sys.path[0] with a dummy path and then sending the target
+# on to runpy.
+sys.path[0] = os.path.join(os.path.dirname(__file__), ".does-not-exist")
 del sys.argv[0]
 module = sys.argv[0]
 if module == "-c":

--- a/pythonFiles/pyvsc-run-isolated.py
+++ b/pythonFiles/pyvsc-run-isolated.py
@@ -4,14 +4,18 @@
 if __name__ != "__main__":
     raise Exception("{} cannot be imported".format(__name__))
 
+import os
 import os.path
 import runpy
 import sys
 
-# We "isolate" the script/module (sys.argv[1]) by
-# replacing sys.path[0] with a dummy path and then sending the target
-# on to runpy.
-sys.path[0] = os.path.join(os.path.dirname(__file__), ".does-not-exist")
+def normalize(path):
+    return os.path.normcase(os.path.normpath(path))
+
+# We "isolate" the script/module (sys.argv[1]) by removing current working
+# directory or '' in sys.path and then sending the target on to runpy.
+cwd = normalize(os.getcwd())
+sys.path[:] = (p for p in sys.path if p != "" and normalize(p) != cwd)
 del sys.argv[0]
 module = sys.argv[0]
 if module == "-c":

--- a/pythonFiles/pyvsc-run-isolated.py
+++ b/pythonFiles/pyvsc-run-isolated.py
@@ -9,8 +9,10 @@ import os.path
 import runpy
 import sys
 
+
 def normalize(path):
     return os.path.normcase(os.path.normpath(path))
+
 
 # We "isolate" the script/module (sys.argv[1]) by removing current working
 # directory or '' in sys.path and then sending the target on to runpy.

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -1579,15 +1579,16 @@ export abstract class InteractiveBase extends WebviewPanelHost<IInteractiveWindo
 
     private async handleExecuteExternalCommand(payload: IExternalCommandFromWebview) {
         const button = this.externalButtons.find((b) => b.buttonId === payload.buttonId);
+        let language = PYTHON_LANGUAGE;
 
         if (this.notebook) {
-            const language = getKernelConnectionLanguage(this.notebook.getKernelConnection()) || PYTHON_LANGUAGE;
-            const id = this.notebook.identity;
-            const cell = translateCellToNative(payload.cell, language);
+            language = getKernelConnectionLanguage(this.notebook.getKernelConnection()) || PYTHON_LANGUAGE;
+        }
+        const id = this.notebookIdentity.resource;
+        const cell = translateCellToNative(payload.cell, language);
 
-            if (button && cell) {
-                await button.callback(cell as NotebookCell, this.isInteractive, id);
-            }
+        if (button && cell) {
+            await button.callback(cell as NotebookCell, this.isInteractive, id);
         }
 
         // Post message again to let the react side know the command is done executing


### PR DESCRIPTION
For #414

It handles the case when the user doesn't autostart the kernel.

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
