### PR TITLE
Follow up for problem on Windows with bug fix for 4006

### DIFF
--- a/src/client/datascience/jupyter/kernelVariables.ts
+++ b/src/client/datascience/jupyter/kernelVariables.ts
@@ -194,7 +194,7 @@ export class KernelVariables implements IJupyterVariables {
     // Read in a .py file and execute it silently in the given notebook
     private async runScriptFile(notebook: INotebook, scriptFile: string, token?: CancellationToken) {
         if (await this.fs.localFileExists(scriptFile)) {
-            const fileContents = await this.fs.readFile(Uri.parse(scriptFile));
+            const fileContents = await this.fs.readLocalFile(scriptFile);
             return notebook.execute(fileContents, Identifiers.EmptyFileName, 0, uuid(), token, true);
         } else {
             traceError('Cannot run non-existant script file');


### PR DESCRIPTION
For #4006

Uri.parse without a scheme fails on windows. We can use readLocalFile since we've already verified it's a local file.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
