### PR TITLE
Export as python script command will only appear on python notebooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -779,7 +779,7 @@
                     "command": "jupyter.exportAsPythonScript",
                     "title": "%jupyter.command.jupyter.exportAsPythonScript.title%",
                     "category": "Jupyter",
-                    "when": "jupyter.isnativeactive && jupyter.isnotebooktrusted"
+                    "when": "jupyter.isnativeactive && jupyter.isnotebooktrusted && jupyter.ispythonnotebook"
                 },
                 {
                     "command": "jupyter.exportToHTML",

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -158,6 +158,7 @@ export namespace EditorContexts {
     export const HaveCellSelected = 'jupyter.havecellselected';
     export const IsNotebookTrusted = 'jupyter.isnotebooktrusted';
     export const CanRestartNotebookKernel = 'jupyter.notebookeditor.canrestartNotebookkernel';
+    export const IsPythonNotebook = 'jupyter.ispythonnotebook';
 }
 
 export namespace RegExpValues {

--- a/src/client/datascience/context/activeEditorContext.ts
+++ b/src/client/datascience/context/activeEditorContext.ts
@@ -39,6 +39,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
     private isNotebookTrusted: ContextKey;
     private isPythonFileActive: boolean = false;
     private inNativeNotebookExperiment: boolean = false;
+    private isPythonNotebook: ContextKey;
     constructor(
         @inject(IInteractiveWindowProvider) private readonly interactiveProvider: IInteractiveWindowProvider,
         @inject(INotebookEditorProvider) private readonly notebookEditorProvider: INotebookEditorProvider,
@@ -71,6 +72,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
         );
         this.hasNativeNotebookCells = new ContextKey(EditorContexts.HaveNativeCells, this.commandManager);
         this.isNotebookTrusted = new ContextKey(EditorContexts.IsNotebookTrusted, this.commandManager);
+        this.isPythonNotebook = new ContextKey(EditorContexts.IsPythonNotebook, this.commandManager);
     }
     public dispose() {
         this.disposables.forEach((item) => item.dispose());
@@ -115,6 +117,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
         setSharedProperty('ds_notebookeditor', e?.type);
         this.nativeContext.set(!!e).ignoreErrors();
         this.isNotebookTrusted.set(e?.model?.isTrusted === true).ignoreErrors();
+        this.isPythonNotebook.set(e?.model?.metadata?.language_info?.name === PYTHON_LANGUAGE).ignoreErrors();
         this.updateMergedContexts();
         this.updateContextOfActiveNotebookKernel(e);
     }


### PR DESCRIPTION
For #407

The command was still appearing on the command palette, this PR fixes that.

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
