### PR TITLE
Bump plotly.js-dist from v1.57.1 to v1.58.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19002,9 +19002,9 @@
             }
         },
         "plotly.js-dist": {
-            "version": "1.57.1",
-            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.57.1.tgz",
-            "integrity": "sha512-tOOFxNc6PvdDkOUgWCSYc+CcxQULTpaGTROxrtmmF8NuZghcT3EInsToEzhPH3PcGM6bu61fKo73ZiFqxwYtlg=="
+            "version": "1.58.0",
+            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.58.0.tgz",
+            "integrity": "sha512-MXhZ0rWe0LoDkU3N6T/pJF14zJxGROInlqjZ1OEl+6uyfE0TdK5zYMCef96CVuW5mvOjaIPPydFvInVGLSH7bA=="
         },
         "plugin-error": {
             "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -1827,7 +1827,7 @@
         "node-stream-zip": "^1.6.0",
         "onigasm": "^2.2.2",
         "pdfkit": "^0.11.0",
-        "plotly.js-dist": "^1.57.1",
+        "plotly.js-dist": "^1.58.0",
         "portfinder": "^1.0.25",
         "react": "^16.5.2",
         "react-data-grid": "^6.0.2-0",


### PR DESCRIPTION
Bumping `plotly.js-dist` module
https://github.com/plotly/plotly.js/releases/tag/v1.58.0

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).

Similar to #1083.

@rchiodo
cc: @nicolaskruchten 
