### PR TITLE
Attempt to fix test by not including two classes in same file

### DIFF
--- a/src/client/datascience/notebook/helpers/helpers.ts
+++ b/src/client/datascience/notebook/helpers/helpers.ts
@@ -35,7 +35,7 @@ import { KernelMessage } from '@jupyterlab/services';
 // tslint:disable-next-line: no-require-imports
 import cloneDeep = require('lodash/cloneDeep');
 import { Uri } from 'vscode';
-import { VSCodeNotebookKernelMetadata } from '../kernelProvider';
+import { VSCodeNotebookKernelMetadata } from '../kernelWithMetadata';
 import { chainWithPendingUpdates } from './notebookUpdater';
 
 // This is the custom type we are adding into nbformat.IBaseCellMetadata

--- a/src/client/datascience/notebook/kernelProvider.ts
+++ b/src/client/datascience/notebook/kernelProvider.ts
@@ -3,17 +3,14 @@
 
 import { inject, injectable } from 'inversify';
 // tslint:disable-next-line: no-require-imports
-import { join } from 'path';
-import { CancellationToken, Event, EventEmitter, Uri } from 'vscode';
+import { CancellationToken, Event, EventEmitter } from 'vscode';
 import {
-    NotebookCell,
     NotebookCommunication,
     NotebookDocument,
     NotebookKernel as VSCNotebookKernel
 } from '../../../../types/vscode-proposed';
 import { IVSCodeNotebook } from '../../common/application/types';
 import { PYTHON_LANGUAGE } from '../../common/constants';
-import { traceInfo } from '../../common/logger';
 import { IDisposableRegistry, IExtensionContext } from '../../common/types';
 import { noop } from '../../common/utils/misc';
 import { captureTelemetry } from '../../telemetry';
@@ -23,76 +20,17 @@ import { areKernelConnectionsEqual } from '../jupyter/kernels/helpers';
 import { KernelSelectionProvider } from '../jupyter/kernels/kernelSelections';
 import { KernelSelector } from '../jupyter/kernels/kernelSelector';
 import { KernelSwitcher } from '../jupyter/kernels/kernelSwitcher';
-import { getKernelConnectionId, IKernel, IKernelProvider, KernelConnectionMetadata } from '../jupyter/kernels/types';
+import { IKernelProvider, KernelConnectionMetadata } from '../jupyter/kernels/types';
 import { INotebookStorageProvider } from '../notebookStorage/notebookStorageProvider';
 import { INotebook, INotebookProvider, IRawNotebookSupportedService } from '../types';
 import {
     getNotebookMetadata,
     isJupyterKernel,
     isJupyterNotebook,
-    updateKernelInfoInNotebookMetadata,
     updateKernelInNotebookMetadata
 } from './helpers/helpers';
+import { VSCodeNotebookKernelMetadata } from './kernelWithMetadata';
 import { INotebookKernelProvider, INotebookKernelResolver } from './types';
-
-export class VSCodeNotebookKernelMetadata implements VSCNotebookKernel {
-    get preloads(): Uri[] {
-        return [
-            Uri.file(join(this.context.extensionPath, 'out', 'ipywidgets', 'dist', 'ipywidgets.js')),
-            Uri.file(
-                join(this.context.extensionPath, 'out', 'datascience-ui', 'ipywidgetsKernel', 'ipywidgetsKernel.js')
-            ),
-            Uri.file(join(this.context.extensionPath, 'out', 'datascience-ui', 'ipywidgetsKernel', 'require.js'))
-        ];
-    }
-    get id() {
-        return getKernelConnectionId(this.selection);
-    }
-    constructor(
-        public readonly label: string,
-        public readonly description: string,
-        public readonly detail: string,
-        public readonly selection: Readonly<KernelConnectionMetadata>,
-        public readonly isPreferred: boolean,
-        private readonly kernelProvider: IKernelProvider,
-        private readonly notebook: IVSCodeNotebook,
-        private readonly context: IExtensionContext
-    ) {}
-    public executeCell(doc: NotebookDocument, cell: NotebookCell) {
-        traceInfo('Execute Cell in KernelProvider.ts');
-        const kernel = this.kernelProvider.getOrCreate(cell.notebook.uri, { metadata: this.selection });
-        if (kernel) {
-            this.updateKernelInfoInNotebookWhenAvailable(kernel, doc);
-            kernel.executeCell(cell).catch(noop);
-        }
-    }
-    public executeAllCells(document: NotebookDocument) {
-        const kernel = this.kernelProvider.getOrCreate(document.uri, { metadata: this.selection });
-        if (kernel) {
-            this.updateKernelInfoInNotebookWhenAvailable(kernel, document);
-            kernel.executeAllCells(document).catch(noop);
-        }
-    }
-    public cancelCellExecution(_: NotebookDocument, cell: NotebookCell) {
-        this.kernelProvider.get(cell.notebook.uri)?.interrupt(); // NOSONAR
-    }
-    public cancelAllCellsExecution(document: NotebookDocument) {
-        this.kernelProvider.get(document.uri)?.interrupt(); // NOSONAR
-    }
-    private updateKernelInfoInNotebookWhenAvailable(kernel: IKernel, doc: NotebookDocument) {
-        const disposable = kernel.onStatusChanged(() => {
-            if (!kernel.info) {
-                return;
-            }
-            const editor = this.notebook.notebookEditors.find((item) => item.document === doc);
-            if (!editor || editor.kernel?.id !== this.id) {
-                return;
-            }
-            disposable.dispose();
-            updateKernelInfoInNotebookMetadata(doc, kernel.info);
-        });
-    }
-}
 
 @injectable()
 export class VSCodeKernelPickerProvider implements INotebookKernelProvider {

--- a/src/client/datascience/notebook/kernelWithMetadata.ts
+++ b/src/client/datascience/notebook/kernelWithMetadata.ts
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// tslint:disable-next-line: no-require-imports
+import { join } from 'path';
+import { Uri } from 'vscode';
+import { NotebookCell, NotebookDocument, NotebookKernel as VSCNotebookKernel } from '../../../../types/vscode-proposed';
+import { IVSCodeNotebook } from '../../common/application/types';
+import { traceInfo } from '../../common/logger';
+import { IExtensionContext } from '../../common/types';
+import { noop } from '../../common/utils/misc';
+import { getKernelConnectionId, IKernel, IKernelProvider, KernelConnectionMetadata } from '../jupyter/kernels/types';
+import { updateKernelInfoInNotebookMetadata } from './helpers/helpers';
+
+export class VSCodeNotebookKernelMetadata implements VSCNotebookKernel {
+    get preloads(): Uri[] {
+        return [
+            Uri.file(join(this.context.extensionPath, 'out', 'ipywidgets', 'dist', 'ipywidgets.js')),
+            Uri.file(
+                join(this.context.extensionPath, 'out', 'datascience-ui', 'ipywidgetsKernel', 'ipywidgetsKernel.js')
+            ),
+            Uri.file(join(this.context.extensionPath, 'out', 'datascience-ui', 'ipywidgetsKernel', 'require.js'))
+        ];
+    }
+    get id() {
+        return getKernelConnectionId(this.selection);
+    }
+    constructor(
+        public readonly label: string,
+        public readonly description: string,
+        public readonly detail: string,
+        public readonly selection: Readonly<KernelConnectionMetadata>,
+        public readonly isPreferred: boolean,
+        private readonly kernelProvider: IKernelProvider,
+        private readonly notebook: IVSCodeNotebook,
+        private readonly context: IExtensionContext
+    ) {}
+    public executeCell(doc: NotebookDocument, cell: NotebookCell) {
+        traceInfo('Execute Cell in kernelWithMetadata.ts');
+        const kernel = this.kernelProvider.getOrCreate(cell.notebook.uri, { metadata: this.selection });
+        if (kernel) {
+            this.updateKernelInfoInNotebookWhenAvailable(kernel, doc);
+            kernel.executeCell(cell).catch(noop);
+        }
+    }
+    public executeAllCells(document: NotebookDocument) {
+        const kernel = this.kernelProvider.getOrCreate(document.uri, { metadata: this.selection });
+        if (kernel) {
+            this.updateKernelInfoInNotebookWhenAvailable(kernel, document);
+            kernel.executeAllCells(document).catch(noop);
+        }
+    }
+    public cancelCellExecution(_: NotebookDocument, cell: NotebookCell) {
+        this.kernelProvider.get(cell.notebook.uri)?.interrupt(); // NOSONAR
+    }
+    public cancelAllCellsExecution(document: NotebookDocument) {
+        this.kernelProvider.get(document.uri)?.interrupt(); // NOSONAR
+    }
+    private updateKernelInfoInNotebookWhenAvailable(kernel: IKernel, doc: NotebookDocument) {
+        const disposable = kernel.onStatusChanged(() => {
+            if (!kernel.info) {
+                return;
+            }
+            const editor = this.notebook.notebookEditors.find((item) => item.document === doc);
+            if (!editor || editor.kernel?.id !== this.id) {
+                return;
+            }
+            disposable.dispose();
+            updateKernelInfoInNotebookMetadata(doc, kernel.info);
+        });
+    }
+}

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -1267,9 +1267,13 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
 
     private getResourceKey(resource: Resource): string {
         if (!this.disposed) {
-            const workspace = this.serviceManager.get<IWorkspaceService>(IWorkspaceService);
-            const workspaceFolderUri = JupyterSettings.getSettingsUriAndTarget(resource, workspace).uri;
-            return workspaceFolderUri ? workspaceFolderUri.fsPath : '';
+            try {
+                const workspace = this.serviceManager.get<IWorkspaceService>(IWorkspaceService);
+                const workspaceFolderUri = JupyterSettings.getSettingsUriAndTarget(resource, workspace).uri;
+                return workspaceFolderUri ? workspaceFolderUri.fsPath : '';
+            } catch {
+                // May as well be disposed
+            }
         }
         return '';
     }


### PR DESCRIPTION
For #4079 

Inversify is failing when loading the helpers.ts file. Seems weird. Trying by removing the class helpers is using into a separate file.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
