### PR TITLE
Default to python kernel if none found

### DIFF
--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -22,6 +22,7 @@ import { captureTelemetry, IEventNamePropertyMapping, sendTelemetryEvent } from 
 import { sendNotebookOrKernelLanguageTelemetry } from '../../common';
 import { Commands, Settings, Telemetry } from '../../constants';
 import { IKernelFinder } from '../../kernel-launcher/types';
+import { isPythonNotebook } from '../../notebook/helpers/helpers';
 import { getInterpreterInfoStoredInMetadata } from '../../notebookStorage/baseModel';
 import { reportAction } from '../../progress/decorator';
 import { ReportableAction } from '../../progress/types';
@@ -568,7 +569,8 @@ export class KernelSelector implements IKernelSelectionUsage {
             const kernelSpecs = await this.kernelFinder.listKernelSpecs(resource);
 
             // Do a bit of hack and pick a python one first if the resource is a python file
-            if (resource?.fsPath && resource.fsPath.endsWith('.py')) {
+            // Or if its a python notebook.
+            if (isPythonNotebook(notebookMetadata) || (resource?.fsPath && resource.fsPath.endsWith('.py'))) {
                 const firstPython = kernelSpecs.find((k) => k.language === 'python');
                 if (firstPython) {
                     return { kind: 'startUsingKernelSpec', kernelSpec: firstPython, interpreter: undefined };


### PR DESCRIPTION
While testing Survey with Native notebook came across a bug & submitting PR for a simple quick fix.

Basically I opened an old Python notebook without a workspace, the kernel defaulted to `Java`
* If we know its a Python notebook & we don't have a kernel, then we should provide a default kernel
We did this for Python files, extended that code for Notebooks.