### PR TITLE
Attempt to fix flaky Native Notebook tests

### DIFF
--- a/src/test/datascience/notebook/executionService.vscode.test.ts
+++ b/src/test/datascience/notebook/executionService.vscode.test.ts
@@ -12,7 +12,6 @@ import { CellErrorOutput } from '../../../../typings/vscode-proposed';
 import { IVSCodeNotebook } from '../../../client/common/application/types';
 import { traceInfo } from '../../../client/common/logger';
 import { IDisposable } from '../../../client/common/types';
-import { clearPendingChainedUpdatesForTests } from '../../../client/datascience/notebook/helpers/notebookUpdater';
 import { INotebookEditorProvider } from '../../../client/datascience/types';
 import { createEventHandler, IExtensionTestApi, sleep, waitForCondition } from '../../common';
 import { initialize } from '../../initialize';
@@ -22,7 +21,6 @@ import {
     canRunNotebookTests,
     closeNotebooks,
     closeNotebooksAndCleanUpAfterTests,
-    deleteAllCellsAndWait,
     executeActiveDocument,
     executeCell,
     insertCodeCell,

--- a/src/test/datascience/notebook/executionService.vscode.test.ts
+++ b/src/test/datascience/notebook/executionService.vscode.test.ts
@@ -21,6 +21,7 @@ import {
     canRunNotebookTests,
     closeNotebooks,
     closeNotebooksAndCleanUpAfterTests,
+    deleteAllCellsAndWait,
     executeActiveDocument,
     executeCell,
     insertCodeCell,
@@ -58,6 +59,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', () => {
         // Open a notebook and use this for all tests in this test suite.
         await editorProvider.createNew();
         await waitForKernelToGetAutoSelected();
+        await deleteAllCellsAndWait();
         assert.isOk(vscodeNotebook.activeNotebookEditor, 'No active notebook');
     });
     teardown(async () => {


### PR DESCRIPTION
For #393

Basically do not use the same notebook for the tests.
Seems like the other tests start, while the kernel is still spewing result form previous executions.
Easier to just use a new nb instead of trying to address the race conditions in the tests.