### PR TITLE
only check kernelspec on kernel provider comparison for kernelspec connections

### DIFF
--- a/news/2 Fixes/4109.md
+++ b/news/2 Fixes/4109.md
@@ -1,0 +1,1 @@
+When comparing to existing running kernel only consider the kernelspec when launched via kernelspec.

--- a/src/client/datascience/jupyter/kernels/kernelProvider.ts
+++ b/src/client/datascience/jupyter/kernels/kernelProvider.ts
@@ -42,8 +42,21 @@ export class KernelProvider implements IKernelProvider {
     }
     public getOrCreate(uri: Uri, options: KernelOptions): IKernel | undefined {
         const existingKernelInfo = this.kernelsByUri.get(uri.toString());
-        if (existingKernelInfo && fastDeepEqual(existingKernelInfo.options.metadata, options.metadata)) {
-            return existingKernelInfo.kernel;
+        if (existingKernelInfo) {
+            if (
+                existingKernelInfo.options.metadata.kind === 'startUsingKernelSpec' &&
+                options.metadata.kind === 'startUsingKernelSpec'
+            ) {
+                // When using a specific kernelspec, just compare the actual kernel specs
+                if (fastDeepEqual(existingKernelInfo.options.metadata.kernelSpec, options.metadata.kernelSpec)) {
+                    return existingKernelInfo.kernel;
+                }
+            } else {
+                // If not launching via kernelspec, compare the entire metadata
+                if (fastDeepEqual(existingKernelInfo.options.metadata, options.metadata)) {
+                    return existingKernelInfo.kernel;
+                }
+            }
         }
 
         this.disposeOldKernel(uri);


### PR DESCRIPTION
For #4109

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
