### PR TITLE
Update execution with the true value from the UI

### DIFF
--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -248,6 +248,7 @@ export interface ISubmitNewCell {
 
 export interface IReExecuteCells {
     cellIds: string[];
+    code: string[];
 }
 
 export interface IProvideCompletionItemsRequest {

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -494,7 +494,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
                     continue;
                 }
                 cellsExecuting.add(cell);
-                await this.reexecuteCell(cell, tokenSource.token);
+                await this.reexecuteCell(cell, info.code[i], tokenSource.token);
                 cellsExecuting.delete(cell);
 
                 // Check the new state of our cell
@@ -712,14 +712,11 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         ]);
     }
 
-    private async reexecuteCell(cell: ICell, cancelToken: CancellationToken): Promise<void> {
+    private async reexecuteCell(cell: ICell, code: string, cancelToken: CancellationToken): Promise<void> {
         try {
             // If there's any payload, it has the code and the id
             if (cell.id && cell.data.cell_type !== 'messages') {
                 traceInfo(`Executing cell ${cell.id}`);
-
-                // Make sure our model is up to date
-                await this.syncCell(cell.id);
 
                 // Clear the result if we've run before
                 await this.clearResult(cell.id);
@@ -729,7 +726,6 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
                     cell.data.metadata.tags = cell.data.metadata.tags.filter((t) => t !== 'outputPrepend');
                 }
 
-                const code = concatMultilineString(cell.data.source);
                 // Send to ourselves.
                 await this.submitCode(code, Identifiers.EmptyFileName, 0, cell.id, cell.data, undefined, cancelToken);
             }

--- a/src/datascience-ui/interactive-common/redux/reducers/types.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/types.ts
@@ -102,7 +102,7 @@ export type CommonActionTypeMapping = {
     [CommonActionType.EXECUTE_CELL]: IExecuteAction;
     [CommonActionType.EXECUTE_ALL_CELLS]: never | undefined;
     [CommonActionType.EXECUTE_ABOVE]: ICellAction;
-    [CommonActionType.EXECUTE_CELL_AND_BELOW]: ICellAction;
+    [CommonActionType.EXECUTE_CELL_AND_BELOW]: IExecuteAction;
     [CommonActionType.RESTART_KERNEL]: never | undefined;
     [CommonActionType.INTERRUPT_KERNEL]: never | undefined;
     [CommonActionType.EXPORT]: never | undefined;
@@ -192,6 +192,7 @@ export interface IEditCellAction extends ICodeAction {
 // I.e. when using the operation `add`, we need the corresponding `IAddCellAction`.
 // They are mutually exclusive, if not `add`, then there's no `newCellId`.
 export type IExecuteAction = ICellAction & {
+    code: string;
     moveOp: 'select' | 'none' | 'add';
 };
 

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -455,12 +455,12 @@ export class NativeCell extends React.Component<INativeCellProps> {
 
     private runAndMove() {
         // Submit this cell
-        this.submitCell(this.props.lastCell ? 'add' : 'select');
+        this.submitCell(this.getCurrentCode(), this.props.lastCell ? 'add' : 'select');
     }
 
     private runAndAdd() {
         // Submit this cell
-        this.submitCell('add');
+        this.submitCell(this.getCurrentCode(), 'add');
     }
 
     private ctrlEnterCell = (e: IKeyboardEvent) => {
@@ -474,12 +474,12 @@ export class NativeCell extends React.Component<INativeCellProps> {
         }
 
         // Submit this cell
-        this.submitCell('none');
+        this.submitCell(this.getCurrentCode(), 'none');
         this.props.sendCommand(NativeKeyboardCommandTelemetry.Run);
     };
 
-    private submitCell = (moveOp: 'add' | 'select' | 'none') => {
-        this.props.executeCell(this.cellId, moveOp);
+    private submitCell = (code: string, moveOp: 'add' | 'select' | 'none') => {
+        this.props.executeCell(this.cellId, code, moveOp);
     };
 
     private addNewCell = () => {

--- a/src/datascience-ui/native-editor/redux/actions.ts
+++ b/src/datascience-ui/native-editor/redux/actions.ts
@@ -59,8 +59,8 @@ export const actionCreators = {
             cellId,
             newCellId: uuid()
         }),
-    executeCell: (cellId: string, moveOp: 'add' | 'select' | 'none') =>
-        createIncomingActionWithPayload(CommonActionType.EXECUTE_CELL_AND_ADVANCE, { cellId, moveOp }),
+    executeCell: (cellId: string, code: string, moveOp: 'add' | 'select' | 'none') =>
+        createIncomingActionWithPayload(CommonActionType.EXECUTE_CELL_AND_ADVANCE, { cellId, code, moveOp }),
     focusCell: (cellId: string, cursorPos: CursorPos = CursorPos.Current): CommonAction<ICellAndCursorAction> =>
         createIncomingActionWithPayload(CommonActionType.FOCUS_CELL, { cellId, cursorPos }),
     unfocusCell: (cellId: string, code: string) =>
@@ -70,8 +70,8 @@ export const actionCreators = {
     executeAllCells: (): CommonAction => createIncomingAction(CommonActionType.EXECUTE_ALL_CELLS),
     executeAbove: (cellId: string): CommonAction<ICellAction> =>
         createIncomingActionWithPayload(CommonActionType.EXECUTE_ABOVE, { cellId }),
-    executeCellAndBelow: (cellId: string): CommonAction<ICellAction> =>
-        createIncomingActionWithPayload(CommonActionType.EXECUTE_CELL_AND_BELOW, { cellId }),
+    executeCellAndBelow: (cellId: string, code: string): CommonAction<ICellAction> =>
+        createIncomingActionWithPayload(CommonActionType.EXECUTE_CELL_AND_BELOW, { cellId, code, moveOp: 'none' }),
     toggleVariableExplorer: (): CommonAction => createIncomingAction(CommonActionType.TOGGLE_VARIABLE_EXPLORER),
     setVariableExplorerHeight: (containerHeight: number, gridHeight: number): CommonAction<IVariableExplorerHeight> =>
         createIncomingActionWithPayload(CommonActionType.SET_VARIABLE_EXPLORER_HEIGHT, { containerHeight, gridHeight }),

--- a/src/datascience-ui/native-editor/toolbar.tsx
+++ b/src/datascience-ui/native-editor/toolbar.tsx
@@ -5,9 +5,11 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { NativeMouseCommandTelemetry } from '../../client/datascience/constants';
 import { IJupyterExtraSettings } from '../../client/datascience/types';
+import { concatMultilineString } from '../common';
 import { JupyterInfo } from '../interactive-common/jupyterInfo';
 import {
     getSelectedAndFocusedInfo,
+    ICellViewModel,
     IFont,
     IServerState,
     SelectionAndFocusedInfo,
@@ -30,6 +32,7 @@ type INativeEditorDataProps = {
     selectionFocusedInfo: SelectionAndFocusedInfo;
     variablesVisible: boolean;
     settings?: IJupyterExtraSettings;
+    cellVMs: ICellViewModel[];
 };
 export type INativeEditorToolbarProps = INativeEditorDataProps & {
     sendCommand: typeof actionCreators.sendCommand;
@@ -100,7 +103,13 @@ export class Toolbar extends React.PureComponent<INativeEditorToolbarProps> {
             if (selectedInfo.selectedCellId && typeof selectedInfo.selectedCellIndex === 'number') {
                 // tslint:disable-next-line: no-suspicious-comment
                 // TODO: Is the source going to be up to date during run below?
-                this.props.executeCellAndBelow(selectedInfo.selectedCellId);
+                this.props.executeCellAndBelow(
+                    selectedInfo.selectedCellId,
+                    concatMultilineString(
+                        this.props.cellVMs.find((vm) => vm.cell.id === selectedInfo.selectedCellId)?.cell.data.source ||
+                            []
+                    )
+                );
                 this.props.sendCommand(NativeMouseCommandTelemetry.RunBelow);
             }
         };

--- a/src/test/datascience/nativeEditor.toolbar.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.toolbar.functional.test.tsx
@@ -65,7 +65,8 @@ suite('DataScience Native Toolbar', () => {
             setVariableExplorerHeight: sinon.stub(),
             launchNotebookTrustPrompt: sinon.stub(),
             variablesVisible: false,
-            isNotebookTrusted: true
+            isNotebookTrusted: true,
+            cellVMs: []
         };
     });
     function mountToolbar() {
@@ -265,7 +266,8 @@ suite('DataScience Native Toolbar', () => {
                 setVariableExplorerHeight: sinon.stub(),
                 launchNotebookTrustPrompt: sinon.stub(),
                 variablesVisible: false,
-                isNotebookTrusted: false
+                isNotebookTrusted: false,
+                cellVMs: []
             };
         });
         test('All toolbar buttons are disabled unless explicitly added to allowlist', () => {


### PR DESCRIPTION
For #1701

Another way to force the code to sync, actually fetch it from Monaco during execution

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
