### PR TITLE
Fixes to coverage and generate HTML report

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -208,7 +208,9 @@
                 "VSC_JUPYTER_CI_RUN_NON_PYTHON_NB_TEST": "", // Initialize this to run tests again Julia & other kernels.
                 "VSC_JUPYTER_RUN_NB_TEST": "true", // Initialize this to run notebook tests (must be using VSC Insiders).
                 "VSC_JUPYTER_LOAD_EXPERIMENTS_FROM_FILE": "true",
-                "TEST_FILES_SUFFIX": "vscode.test"
+                "TEST_FILES_SUFFIX": "vscode.test",
+                "XVSC_JUPYTER_INSTRUMENT_CODE_FOR_COVERAGE": "1",
+                "XVSC_JUPYTER_INSTRUMENT_CODE_FOR_COVERAGE_HTML": "1" //Enable to get full coverage repor (in coverage folder).
             },
             "stopOnEntry": false,
             "sourceMaps": true,
@@ -250,9 +252,10 @@
             },
             "env": {
                 // Remove 'X' prefix to run with coverage
-                "XVSC_JUPYTER_INSTRUMENT_CODE_FOR_COVERAGE": "1"
+                "XVSC_JUPYTER_INSTRUMENT_CODE_FOR_COVERAGE": "1",
+                "XVSC_JUPYTER_INSTRUMENT_CODE_FOR_COVERAGE_HTML": "1" //Enable to get full coverage repor (in coverage folder).
             },
-            
+
         },
         {
             "name": "Functional Tests (without VS Code, *.functional.test.ts)",

--- a/src/test/coverage.ts
+++ b/src/test/coverage.ts
@@ -13,7 +13,8 @@ export function setupCoverage() {
     if (!process.env.VSC_JUPYTER_INSTRUMENT_CODE_FOR_COVERAGE) {
         return;
     }
-    const reports = ['text', 'text-summary'];
+    const htmlReport = process.env.VSC_JUPYTER_INSTRUMENT_CODE_FOR_COVERAGE_HTML ? ['html'] : [];
+    const reports = htmlReport.concat(['text', 'text-summary']);
     const NYC = require('nyc');
     const nyc = new NYC({
         cwd: path.join(EXTENSION_ROOT_DIR_FOR_TESTS),
@@ -21,6 +22,7 @@ export function setupCoverage() {
         include: ['**/src/client/**/*.ts', '**/out/client/**/*.js'],
         exclude: ['**/test/**', '.vscode-test/**', '**/ipywidgets/**', '**/node_modules/**'],
         reporter: reports,
+        'report-dir': path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'coverage'),
         all: true,
         instrument: true,
         hookRequire: true,
@@ -33,5 +35,5 @@ export function setupCoverage() {
     nyc.reset();
     nyc.wrap();
 
-    return nyc as { writeCoverageFile: Function; report: Function };
+    return nyc as { writeCoverageFile: Function; report: () => Promise<void> };
 }

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -10,6 +10,10 @@ require('./common/exitCIAfterTestReporter');
 if ((Reflect as any).metadata === undefined) {
     require('reflect-metadata');
 }
+// Always place at top, must be done before we import any of the files from src/client folder.
+// We need to ensure nyc gets a change to setup necessary hooks before files are loaded.
+const { setupCoverage } = require('./coverage');
+const nyc = setupCoverage();
 
 import * as glob from 'glob';
 import * as Mocha from 'mocha';
@@ -24,7 +28,6 @@ import {
 } from './constants';
 import { initialize } from './initialize';
 import { initializeLogger } from './testLogger';
-import { setupCoverage } from './coverage';
 
 initializeLogger();
 
@@ -135,7 +138,6 @@ function activateExtensionScript() {
  * @returns {Promise<void>}
  */
 export async function run(): Promise<void> {
-    const nyc = setupCoverage();
     const options = configure();
     const mocha = new Mocha(options);
     const testsRoot = path.join(__dirname);
@@ -201,7 +203,7 @@ export async function run(): Promise<void> {
     } finally {
         if (nyc) {
             nyc.writeCoverageFile();
-            nyc.report();
+            await nyc.report(); // This is async.
         }
     }
 }


### PR DESCRIPTION
* Generate HTML coverage report (optional)
* Fixes
	* Ensure coverage code runs first (we need to instrument & setup hooks before loading any of the other modules. I.e. src/client/**/*.ts files cannot be loaded until we have setup nyc.
	* Hence moved nyc to the very top so its obvious.
	* Also ensured we wait for report to finish (its async)