### PR TITLE
Bump plotly.js-dist v1.58.3 in vscode-jupyter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18918,9 +18918,9 @@
             }
         },
         "plotly.js-dist": {
-            "version": "1.58.2",
-            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.58.2.tgz",
-            "integrity": "sha512-IJG1Lubiv6wwOM+fIXD5FaufAMbMvP1J7ppiwfQkutXx6AGeRbS8dIBqcrJS5Lmh3/NOWIzjeQD7XkraVW+Trg=="
+            "version": "1.58.3",
+            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.58.3.tgz",
+            "integrity": "sha512-V45HUbFfqPb6JIuUJFMVfe25Q7CO8DTxJOOXt7SNdOXGplnK6uGdhTmrJzm+9zhKE0yo/Cjisy/XuMPkzNnM7A=="
         },
         "plugin-error": {
             "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -1823,7 +1823,7 @@
         "node-stream-zip": "^1.6.0",
         "onigasm": "^2.2.2",
         "pdfkit": "^0.11.0",
-        "plotly.js-dist": "^1.58.2",
+        "plotly.js-dist": "^1.58.3",
         "portfinder": "^1.0.25",
         "react": "^16.5.2",
         "react-data-grid": "^6.0.2-0",


### PR DESCRIPTION
Bumping `plotly.js-dist` module
https://github.com/plotly/plotly.js/releases/tag/v1.58.3

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).

Similar to #4178.

@rchiodo
cc: @nicolaskruchten 
