### PR TITLE
Ensure exactly once initialization of CommonMessageCoordinator

### DIFF
--- a/src/client/datascience/ipywidgets/notebookIPyWidgetCoordinator.ts
+++ b/src/client/datascience/ipywidgets/notebookIPyWidgetCoordinator.ts
@@ -36,11 +36,12 @@ export class NotebookIPyWidgetCoordinator implements INotebookKernelResolver {
     ): Promise<void> {
         // Create a handler for this notebook if we don't already have one. Since there's one of the notebookMessageCoordinator's for the
         // entire VS code session, we have a map of notebook document to message coordinator
-        let promise = this.messageCoordinators.get(document.uri.toString());
+        const promise = this.messageCoordinators.get(document.uri.toString());
         if (!promise) {
-            const coordinator = CommonMessageCoordinator.create(document.uri, this.serviceContainer);
-            promise = coordinator.initialize().then(() => coordinator);
-            this.messageCoordinators.set(document.uri.toString(), promise);
+            this.messageCoordinators.set(
+                document.uri.toString(),
+                CommonMessageCoordinator.create(document.uri, this.serviceContainer)
+            );
         }
         return Cancellation.race(() => promise!.then(this.attachCoordinator.bind(this, document, webview)), token);
     }

--- a/src/client/datascience/ipywidgets/notebookIPyWidgetCoordinator.ts
+++ b/src/client/datascience/ipywidgets/notebookIPyWidgetCoordinator.ts
@@ -36,12 +36,10 @@ export class NotebookIPyWidgetCoordinator implements INotebookKernelResolver {
     ): Promise<void> {
         // Create a handler for this notebook if we don't already have one. Since there's one of the notebookMessageCoordinator's for the
         // entire VS code session, we have a map of notebook document to message coordinator
-        const promise = this.messageCoordinators.get(document.uri.toString());
-        if (!promise) {
-            this.messageCoordinators.set(
-                document.uri.toString(),
-                CommonMessageCoordinator.create(document.uri, this.serviceContainer)
-            );
+        let promise = this.messageCoordinators.get(document.uri.toString());
+        if (promise === undefined) {
+            promise = CommonMessageCoordinator.create(document.uri, this.serviceContainer);
+            this.messageCoordinators.set(document.uri.toString(), promise);
         }
         return Cancellation.race(() => promise!.then(this.attachCoordinator.bind(this, document, webview)), token);
     }

--- a/src/client/datascience/ipywidgets/webviewIPyWidgetCoordinator.ts
+++ b/src/client/datascience/ipywidgets/webviewIPyWidgetCoordinator.ts
@@ -62,8 +62,12 @@ export class WebviewIPyWidgetCoordinator implements IInteractiveWindowListener {
         // There should be an instance of the WebviewMessageCoordinator per notebook webview or interactive window. Create
         // the message coordinator as soon as we're sure what notebook we're in.
         this.notebookIdentity = args.resource;
-        this.messageCoordinator = CommonMessageCoordinator.create(this.notebookIdentity, this.serviceContainer);
-        this.messageCoordinatorEvent = this.messageCoordinator.postMessage((e) => {
+        const emitter = new EventEmitter<{
+            message: string;
+            // tslint:disable-next-line: no-any
+            payload: any;
+        }>();
+        this.messageCoordinatorEvent = emitter.event((e) => {
             // Special case a specific message. It must be posted to the internal class, not the webview
             if (e.message === InteractiveWindowMessages.ConvertUriForUseInWebViewRequest) {
                 this.postInternalMessageEmitter.fire(e);
@@ -71,6 +75,10 @@ export class WebviewIPyWidgetCoordinator implements IInteractiveWindowListener {
                 this.postEmitter.fire(e);
             }
         });
-        return this.messageCoordinator.initialize();
+        this.messageCoordinator = await CommonMessageCoordinator.create(
+            this.notebookIdentity,
+            this.serviceContainer,
+            emitter
+        );
     }
 }


### PR DESCRIPTION
The `CommonMessageCoordinator` requires an asynchronous initialization
step. Since constructors cannot return promises, the initialization is
delegated to the asynchronous method `initialize`.
`WebviewIPyWidgetCoordinator` takes advantage of the two-step creation
(`constructor` + `initialize`) to use the
`CommonMessageCoordinator::postEmitter` member between construction and
initialization.

This pattern requires a few safeguards to ensure correct use of
`CommonMessageCoordinator` instances by preventing prevent accidental
errors such as:
- forgetting to call `initialize`
- calling `initialize` more than once
- using the object before initialization

Use the factory method pattern to create initialized instances of
the CommonMessageCoordinator to ensure the initialization always takes
place. Make the `initialize`method private to avoid double
initialization.

Allow the caller to customize the internal `postEmitter` (an
instance of `EventEmitter<{message: string; payload: any}>`) through
dependency injection in the  constructor and factory method. This way,
the `WebviewIPyWidgetCoordinator` can interact with the emitter without
waiting for the initialization to finish.

For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [x] ~Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).~
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
