### PR TITLE
Fix server uri storage to support having no workspace

### DIFF
--- a/news/2 Fixes/4037.md
+++ b/news/2 Fixes/4037.md
@@ -1,0 +1,1 @@
+Fix error with selecting jupyter server URI when no workspace open.

--- a/package.json
+++ b/package.json
@@ -1377,7 +1377,7 @@
                         "remote"
                     ],
                     "description": "Determines the type of connection for talking to jupyter. Local will start kernels locally. Remote allows for connections to remote servers",
-                    "scope": "resource"
+                    "scope": "application"
                 },
                 "jupyter.jupyterCommandLineArguments": {
                     "type": "array",

--- a/package.json
+++ b/package.json
@@ -1377,7 +1377,7 @@
                         "remote"
                     ],
                     "description": "Determines the type of connection for talking to jupyter. Local will start kernels locally. Remote allows for connections to remote servers",
-                    "scope": "application"
+                    "scope": "resource"
                 },
                 "jupyter.jupyterCommandLineArguments": {
                     "type": "array",

--- a/src/client/datascience/jupyter/serverUriStorage.ts
+++ b/src/client/datascience/jupyter/serverUriStorage.ts
@@ -124,24 +124,22 @@ export class JupyterServerUriStorage implements IJupyterServerUriStorage {
 
         if (uri === Settings.JupyterServerLocalLaunch) {
             // Just save directly into the settings
-            await this.configService.updateSetting(
-                'jupyterServerType',
-                Settings.JupyterServerLocalLaunch,
-                undefined,
-                ConfigurationTarget.Workspace
-            );
+            await this.updateServerType(Settings.JupyterServerLocalLaunch);
         } else {
             // This is a remote setting. Save in the settings as remote
-            await this.configService.updateSetting(
-                'jupyterServerType',
-                Settings.JupyterServerRemoteLaunch,
-                undefined,
-                ConfigurationTarget.Workspace
-            );
+            await this.updateServerType(Settings.JupyterServerRemoteLaunch);
 
             // Save in the storage (unique account per workspace)
             const key = this.getUriAccountKey();
             await this.encryptedStorage.store(Settings.JupyterServerRemoteLaunchService, key, uri);
+        }
+    }
+
+    private async updateServerType(val: string): Promise<void> {
+        if (this.workspaceService.hasWorkspaceFolders) {
+            return this.configService.updateSetting('jupyterServerType', val, undefined, ConfigurationTarget.Workspace);
+        } else {
+            return this.configService.updateSetting('jupyterServerType', val, undefined, ConfigurationTarget.Global);
         }
     }
 


### PR DESCRIPTION
For #4037 

The JupyterServerUriStorage class would throw an exception while trying to save the 'serverType' setting if the user doesn't have a workspace open. This makes the enter key actually not close the quick pick dialog.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
