### PR TITLE
Fix hover regression in webview editor

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -339,20 +339,6 @@ jobs:
       - name: Install dependencies (npm ci)
         run: npm ci --prefer-offline
 
-      - name: Install Dot.net
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{env.DOTNET_VERSION}}
-        if: matrix.test-suite != 'notebookWithoutPythonExt'
-
-      - name: Install .NET Interactive
-        run: dotnet tool install -g --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" Microsoft.dotnet-interactive
-        if: matrix.test-suite != 'notebookWithoutPythonExt'
-
-      - name: Install .NET Kernel
-        run: dotnet interactive jupyter install
-        if: matrix.test-suite != 'notebookWithoutPythonExt'
-
         # This step is slow.
       - name: Install Julia
         uses: julia-actions/setup-julia@v1

--- a/news/2 Fixes/4218.md
+++ b/news/2 Fixes/4218.md
@@ -1,0 +1,1 @@
+Fix hover tips on notebooks (and the interactive window).

--- a/src/client/datascience/interactive-common/intellisense/conversion.ts
+++ b/src/client/datascience/interactive-common/intellisense/conversion.ts
@@ -262,14 +262,16 @@ function convertToMonacoMarkdown(
         | vscode.MarkedString
         | vscode.MarkedString[]
 ): monacoEditor.IMarkdownString[] {
-    if (strings.hasOwnProperty('kind')) {
+    // tslint:disable-next-line: no-any
+    if (strings.hasOwnProperty('kind') || (strings as any).kind) {
         const content = strings as vscodeLanguageClient.MarkupContent;
         return [
             {
                 value: content.value
             }
         ];
-    } else if (strings.hasOwnProperty('value')) {
+        // tslint:disable-next-line: no-any
+    } else if (strings.hasOwnProperty('value') || (strings as any).value) {
         // tslint:disable-next-line: no-any
         const content = strings as any;
         return [

--- a/src/client/datascience/interactive-common/intellisense/conversion.ts
+++ b/src/client/datascience/interactive-common/intellisense/conversion.ts
@@ -263,7 +263,7 @@ function convertToMonacoMarkdown(
         | vscode.MarkedString[]
 ): monacoEditor.IMarkdownString[] {
     // tslint:disable-next-line: no-any
-    if (strings.hasOwnProperty('kind') || (strings as any).kind) {
+    if ('kind' in (strings as any)) {
         const content = strings as vscodeLanguageClient.MarkupContent;
         return [
             {
@@ -271,7 +271,7 @@ function convertToMonacoMarkdown(
             }
         ];
         // tslint:disable-next-line: no-any
-    } else if (strings.hasOwnProperty('value') || (strings as any).value) {
+    } else if ('value' in (strings as any)) {
         // tslint:disable-next-line: no-any
         const content = strings as any;
         return [


### PR DESCRIPTION
For #4218 

Root cause was the structure returned by the language server did not show 'hasOwnProperty' as true even though the field was present.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
