### PR TITLE
Fix cells being run out of order

### DIFF
--- a/news/2 Fixes/4136.md
+++ b/news/2 Fixes/4136.md
@@ -1,0 +1,1 @@
+Fix notebook cells running out of order (for VS code insiders notebook editor).

--- a/package.json
+++ b/package.json
@@ -1297,6 +1297,7 @@
                         "enum": [
                             "NativeNotebookEditor",
                             "CustomEditor",
+                            "NativeVariableView",
                             "All"
                         ]
                     },

--- a/src/client/datascience/notebook/kernelWithMetadata.ts
+++ b/src/client/datascience/notebook/kernelWithMetadata.ts
@@ -8,7 +8,6 @@ import { NotebookCell, NotebookDocument, NotebookKernel as VSCNotebookKernel } f
 import { IVSCodeNotebook } from '../../common/application/types';
 import { traceInfo } from '../../common/logger';
 import { IExtensionContext } from '../../common/types';
-import { noop } from '../../common/utils/misc';
 import { getKernelConnectionId, IKernel, IKernelProvider, KernelConnectionMetadata } from '../jupyter/kernels/types';
 import { updateKernelInfoInNotebookMetadata } from './helpers/helpers';
 

--- a/src/client/datascience/notebook/kernelWithMetadata.ts
+++ b/src/client/datascience/notebook/kernelWithMetadata.ts
@@ -13,6 +13,7 @@ import { getKernelConnectionId, IKernel, IKernelProvider, KernelConnectionMetada
 import { updateKernelInfoInNotebookMetadata } from './helpers/helpers';
 
 export class VSCodeNotebookKernelMetadata implements VSCNotebookKernel {
+    private pendingExecution: Promise<void> | undefined;
     get preloads(): Uri[] {
         return [
             Uri.file(join(this.context.extensionPath, 'out', 'ipywidgets', 'dist', 'ipywidgets.js')),
@@ -36,18 +37,18 @@ export class VSCodeNotebookKernelMetadata implements VSCNotebookKernel {
         private readonly context: IExtensionContext
     ) {}
     public executeCell(doc: NotebookDocument, cell: NotebookCell) {
-        traceInfo('Execute Cell in kernelWithMetadata.ts');
+        traceInfo(`Execute Cell ${cell.document.uri.toString()} in kernelWithMetadata.ts`);
         const kernel = this.kernelProvider.getOrCreate(cell.notebook.uri, { metadata: this.selection });
         if (kernel) {
             this.updateKernelInfoInNotebookWhenAvailable(kernel, doc);
-            kernel.executeCell(cell).catch(noop);
+            return this.chainExecution(() => kernel.executeCell(cell));
         }
     }
     public executeAllCells(document: NotebookDocument) {
         const kernel = this.kernelProvider.getOrCreate(document.uri, { metadata: this.selection });
         if (kernel) {
             this.updateKernelInfoInNotebookWhenAvailable(kernel, document);
-            kernel.executeAllCells(document).catch(noop);
+            return this.chainExecution(() => kernel.executeAllCells(document));
         }
     }
     public cancelCellExecution(_: NotebookDocument, cell: NotebookCell) {
@@ -68,5 +69,11 @@ export class VSCodeNotebookKernelMetadata implements VSCNotebookKernel {
             disposable.dispose();
             updateKernelInfoInNotebookMetadata(doc, kernel.info);
         });
+    }
+
+    private chainExecution(next: () => Promise<void>): Promise<void> {
+        const prev = this.pendingExecution ?? Promise.resolve();
+        this.pendingExecution = prev.then(next);
+        return this.pendingExecution;
     }
 }


### PR DESCRIPTION
For #4136

Make sure executions wait for previous executions to complete before running the next cell.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
