### PR TITLE
Wait for DS code to activate as part of extension activation

### DIFF
--- a/news/2 Fixes/4295.md
+++ b/news/2 Fixes/4295.md
@@ -1,0 +1,1 @@
+Wait for datascience code to activate when activating the extension.

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -129,13 +129,13 @@ async function activateLegacy(
     context.subscriptions.push(manager);
     const activationPromise = manager.activate();
 
-    // Activate data science features
+    // Activate data science features after base features.
     const dataScience = serviceManager.get<IDataScience>(IDataScience);
-    dataScience.activate().ignoreErrors();
+    const dsActivationPromise = dataScience.activate();
 
     const deprecationMgr = serviceContainer.get<IFeatureDeprecationManager>(IFeatureDeprecationManager);
     deprecationMgr.initialize();
     context.subscriptions.push(deprecationMgr);
 
-    return { activationPromise };
+    return { activationPromise: activationPromise.then(() => dsActivationPromise) };
 }


### PR DESCRIPTION
For #4295
@IanMatthewHuff  I ran into this issue this morning with a new workspace.
I think when DS extension activates first without any Python extension then you might be able to replicate this issue.
I had accidentally deleted the python extension (trying to remove an older version) & then ran into this this morning.