### PR TITLE
Open variables view command and remove the test OPEN button from it

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
         "onCommand:jupyter.exportfileandoutputasnotebook",
         "onCommand:jupyter.selectJupyterInterpreter",
         "onCommand:jupyter.selectjupytercommandline",
+        "onCommand:jupyter.openVariableView",
         "onNotebook:jupyter-notebook",
         "onCustomEditor:jupyter.notebook.ipynb"
     ],
@@ -697,6 +698,11 @@
             {
                 "command": "jupyter.clearSavedJupyterUris",
                 "title": "%jupyter.command.jupyter.clearSavedJupyterUris.title%",
+                "category": "Jupyter"
+            },
+            {
+                "command": "jupyter.openVariableView",
+                "title": "%jupyter.command.jupyter.openVariableView.title%",
                 "category": "Jupyter"
             }
         ],

--- a/package.nls.json
+++ b/package.nls.json
@@ -107,6 +107,7 @@
     "jupyter.command.jupyter.showDataViewer.title": "View Value in Data Viewer",
     "jupyter.command.jupyter.viewOutput.title": "Show Output",
     "jupyter.command.jupyter.clearSavedJupyterUris.title": "Clear Jupyter server list",
+    "jupyter.command.jupyter.openVariableView.title": "Open Jupyter Variable View",
     "Datascience.currentlySelectedJupyterInterpreterForPlaceholder": "current: {0}",
     "jupyter.command.jupyter.analysis.clearCache.title": "Clear Module Analysis Cache",
     "jupyter.command.jupyter.analysis.restartLanguageServer.title": "Restart Language Server",

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -33,6 +33,7 @@ interface ICommandNameWithoutArgumentTypeMapping {
     ['editor.action.formatDocument']: [];
     ['editor.action.rename']: [];
     ['jupyter.selectJupyterInterpreter']: [];
+    ['jupyterViewVariables.focus']: [];
     [DSCommands.RunCurrentCell]: [];
     [DSCommands.RunCurrentCellAdvance]: [];
     [DSCommands.ExecSelectionInInteractiveWindow]: [];
@@ -58,6 +59,7 @@ interface ICommandNameWithoutArgumentTypeMapping {
     [DSCommands.CreateNewNotebook]: [];
     [DSCommands.EnableDebugLogging]: [];
     [DSCommands.ResetLoggingLevel]: [];
+    [DSCommands.OpenVariableView]: [];
 }
 
 /**

--- a/src/client/datascience/commands/commandRegistry.ts
+++ b/src/client/datascience/commands/commandRegistry.ts
@@ -116,6 +116,7 @@ export class CommandRegistry implements IDisposable {
             this.enableLoadingWidgetScriptsFromThirdParty
         );
         this.registerCommand(Commands.ClearSavedJupyterUris, this.clearJupyterUris);
+        this.registerCommand(Commands.OpenVariableView, this.openVariableView);
         if (this.commandListeners) {
             this.commandListeners.forEach((listener: IDataScienceCommandListener) => {
                 listener.register(this.commandManager);
@@ -487,6 +488,10 @@ export class CommandRegistry implements IDisposable {
         env.openExternal(Uri.parse(`https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter`));
     }
 
+    // Open up our variable viewer using the command that VS Code provides for this
+    private async openVariableView(): Promise<void> {
+        this.commandManager.executeCommand('jupyterViewVariables.focus');
+    }
     private async onVariablePanelShowDataViewerRequest(request: IShowDataViewerFromVariablePanel) {
         sendTelemetryEvent(EventName.OPEN_DATAVIEWER_FROM_VARIABLE_WINDOW_REQUEST);
         if (this.debugService.activeDebugSession) {

--- a/src/client/datascience/commands/commandRegistry.ts
+++ b/src/client/datascience/commands/commandRegistry.ts
@@ -490,6 +490,8 @@ export class CommandRegistry implements IDisposable {
 
     // Open up our variable viewer using the command that VS Code provides for this
     private async openVariableView(): Promise<void> {
+        // For all contributed views vscode creates a command with the format [view ID].focus to focus that view
+        // It's the given way to focus a single view so using that here, note that it needs to match the view ID
         this.commandManager.executeCommand('jupyterViewVariables.focus');
     }
     private async onVariablePanelShowDataViewerRequest(request: IShowDataViewerFromVariablePanel) {

--- a/src/client/datascience/commands/commandRegistry.ts
+++ b/src/client/datascience/commands/commandRegistry.ts
@@ -492,7 +492,7 @@ export class CommandRegistry implements IDisposable {
     private async openVariableView(): Promise<void> {
         // For all contributed views vscode creates a command with the format [view ID].focus to focus that view
         // It's the given way to focus a single view so using that here, note that it needs to match the view ID
-        this.commandManager.executeCommand('jupyterViewVariables.focus');
+        return this.commandManager.executeCommand('jupyterViewVariables.focus');
     }
     private async onVariablePanelShowDataViewerRequest(request: IShowDataViewerFromVariablePanel) {
         sendTelemetryEvent(EventName.OPEN_DATAVIEWER_FROM_VARIABLE_WINDOW_REQUEST);

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -131,6 +131,7 @@ export namespace Commands {
     export const SubmitGitHubIssue = 'jupyter.submitGitHubIssue';
     export const ShowDataViewer = 'jupyter.showDataViewer';
     export const ClearSavedJupyterUris = 'jupyter.clearSavedJupyterUris';
+    export const OpenVariableView = 'jupyter.openVariableView';
 }
 
 export namespace CodeLensCommands {

--- a/src/datascience-ui/variable-view/variableViewPanel.tsx
+++ b/src/datascience-ui/variable-view/variableViewPanel.tsx
@@ -22,6 +22,9 @@ export class VariableViewPanel extends React.Component<IVariableViewPanelProps> 
 
     constructor(props: IVariableViewPanelProps) {
         super(props);
+
+        // For the variable view we want to start toggled open
+        this.props.toggleVariableExplorer();
     }
 
     public componentDidMount() {
@@ -48,7 +51,6 @@ export class VariableViewPanel extends React.Component<IVariableViewPanelProps> 
         // we can size and host it differently from the variable panel in the interactive window or native editor
         return (
             <div id="variable-view-main-panel" role="Main" style={dynamicFont}>
-                <button onClick={this.props.toggleVariableExplorer}>OPEN</button>
                 {this.renderVariablePanel(this.props.baseTheme)}
             </div>
         ); // NOTE: Currently the OPEN, button just exists to mimic the toggling of the variable view, make it easier to test when working


### PR DESCRIPTION
Stalled a little bit on the test work, so checking in a couple of small tweaks that I made separate from the test work to keep things flowing.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
