### PR TITLE
Check and prompt to install missing dependencies

### DIFF
--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -533,7 +533,11 @@ export class KernelSelector implements IKernelSelectionUsage {
             };
             // Install missing dependencies only if we're dealing with a Python kernel.
             if (interpreterStoredInKernelSpec && isPythonKernelConnection(connectionInfo)) {
-                await this.installDependenciesIntoInterpreter(interpreterStoredInKernelSpec, ignoreDependencyCheck, cancelToken);
+                await this.installDependenciesIntoInterpreter(
+                    interpreterStoredInKernelSpec,
+                    ignoreDependencyCheck,
+                    cancelToken
+                );
             }
             return connectionInfo;
         }

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -527,10 +527,15 @@ export class KernelSelector implements IKernelSelectionUsage {
             notebookMetadata
         );
         if (interpreterStoredInKernelSpec) {
-            return {
+            const connectionInfo: PythonKernelConnectionMetadata = {
                 kind: 'startUsingPythonInterpreter',
                 interpreter: interpreterStoredInKernelSpec
             };
+            // Install missing dependencies only if we're dealing with a Python kernel.
+            if (interpreterStoredInKernelSpec && isPythonKernelConnection(connectionInfo)) {
+                await this.installDependenciesIntoInterpreter(interpreterStoredInKernelSpec, ignoreDependencyCheck, cancelToken);
+            }
+            return connectionInfo;
         }
 
         // First use our kernel finder to locate a kernelspec on disk


### PR DESCRIPTION
While working on another task came across this bug.
Basically if the kernel spec contains the interpreter information then we don't check if ipykernel is installed.

