### PR TITLE
Refactor native notebook / editor out of variable view class

### DIFF
--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -186,9 +186,9 @@ import {
     ITrustService,
     IWebviewExtensibility
 } from './types';
-import { IVariableViewNotebookWatcher, IVariableViewProvider } from './variablesView/types';
+import { NotebookWatcher } from './variablesView/notebookWatcher';
+import { INotebookWatcher, IVariableViewProvider } from './variablesView/types';
 import { VariableViewActivationService } from './variablesView/variableViewActivationService';
-import { VariableViewNotebookWatcher } from './variablesView/variableViewNotebookWatcher';
 import { VariableViewProvider } from './variablesView/variableViewProvider';
 import { WebviewExtensibility } from './webviewExtensibility';
 
@@ -333,7 +333,7 @@ export function registerTypes(serviceManager: IServiceManager, inNotebookApiExpe
     serviceManager.addBinding(INotebookExtensibility, INotebookExecutionLogger);
     serviceManager.addSingleton<IWebviewExtensibility>(IWebviewExtensibility, WebviewExtensibility);
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, InsidersNativeNotebooksSurveyBanner);
-    serviceManager.addSingleton<IVariableViewNotebookWatcher>(IVariableViewNotebookWatcher, VariableViewNotebookWatcher);
+    serviceManager.addSingleton<INotebookWatcher>(INotebookWatcher, NotebookWatcher);
 
     registerNotebookTypes(serviceManager);
 }

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -186,8 +186,9 @@ import {
     ITrustService,
     IWebviewExtensibility
 } from './types';
-import { IVariableViewProvider } from './variablesView/types';
+import { IVariableViewNotebookWatcher, IVariableViewProvider } from './variablesView/types';
 import { VariableViewActivationService } from './variablesView/variableViewActivationService';
+import { VariableViewNotebookWatcher } from './variablesView/variableViewNotebookWatcher';
 import { VariableViewProvider } from './variablesView/variableViewProvider';
 import { WebviewExtensibility } from './webviewExtensibility';
 
@@ -332,6 +333,7 @@ export function registerTypes(serviceManager: IServiceManager, inNotebookApiExpe
     serviceManager.addBinding(INotebookExtensibility, INotebookExecutionLogger);
     serviceManager.addSingleton<IWebviewExtensibility>(IWebviewExtensibility, WebviewExtensibility);
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, InsidersNativeNotebooksSurveyBanner);
+    serviceManager.addSingleton<IVariableViewNotebookWatcher>(IVariableViewNotebookWatcher, VariableViewNotebookWatcher);
 
     registerNotebookTypes(serviceManager);
 }

--- a/src/client/datascience/variablesView/notebookWatcher.ts
+++ b/src/client/datascience/variablesView/notebookWatcher.ts
@@ -8,13 +8,13 @@ import { IFileSystem } from '../../common/platform/types';
 import { IDisposableRegistry } from '../../common/types';
 import { KernelState, KernelStateEventArgs } from '../notebookExtensibility';
 import { INotebook, INotebookEditor, INotebookEditorProvider, INotebookExtensibility } from '../types';
-import { IVariableViewNotebookWatcher } from './types';
+import { INotebookWatcher } from './types';
 
-// For any class that is monitoring the variables of the active notebook document, this class will update you
+// For any class that is monitoring the active notebook document, this class will update you
 // when the active notebook changes or if the execution count is updated on the active notebook
 // NOTE: Currently this class is only looking at native notebook documents
 @injectable()
-export class VariableViewNotebookWatcher implements IVariableViewNotebookWatcher {
+export class NotebookWatcher implements INotebookWatcher {
     public get onDidChangeActiveVariableViewNotebook(): Event<INotebook | undefined> {
         return this._onDidChangeActiveVariableViewNotebook.event;
     }
@@ -47,7 +47,7 @@ export class VariableViewNotebookWatcher implements IVariableViewNotebookWatcher
             kernelStateEvent.state === KernelState.executed &&
             kernelStateEvent.cell &&
             kernelStateEvent.cell.metadata.executionOrder &&
-            kernelStateEvent.silent !== true
+            !kernelStateEvent.silent
         ) {
             // We only want to update the variable view execution count when it's the active document executing
             if (

--- a/src/client/datascience/variablesView/types.ts
+++ b/src/client/datascience/variablesView/types.ts
@@ -29,8 +29,8 @@ export class IVariableViewPanelMapping {
     public [InteractiveWindowMessages.UpdateVariableViewExecutionCount]: { executionCount: number };
 }
 
-export const IVariableViewNotebookWatcher = Symbol('IVariableViewNotebookWatcher');
-export interface IVariableViewNotebookWatcher {
+export const INotebookWatcher = Symbol('INotebookWatcher');
+export interface INotebookWatcher {
     readonly activeVariableViewNotebook?: INotebook;
     readonly onDidChangeActiveVariableViewNotebook: Event<INotebook | undefined>;
     readonly onDidExecuteActiveVariableViewNotebook: Event<{ executionCount: number }>;

--- a/src/client/datascience/variablesView/types.ts
+++ b/src/client/datascience/variablesView/types.ts
@@ -1,3 +1,4 @@
+import { Event } from 'vscode';
 import { IVariableExplorerHeight } from '../../../datascience-ui/interactive-common/redux/reducers/types';
 import {
     IFinishCell,
@@ -5,7 +6,7 @@ import {
     IShowDataViewer
 } from '../../datascience/interactive-common/interactiveWindowTypes';
 import { CssMessages, IGetCssRequest, IGetCssResponse, SharedMessages } from '../messages';
-import { IJupyterVariablesRequest, IJupyterVariablesResponse, IVSCWebviewViewProvider } from '../types';
+import { IJupyterVariablesRequest, IJupyterVariablesResponse, INotebook, IVSCWebviewViewProvider } from '../types';
 
 // Mapping of Message to payload that our VariableViewPanel needs to support
 export class IVariableViewPanelMapping {
@@ -26,6 +27,13 @@ export class IVariableViewPanelMapping {
     public [SharedMessages.LocInit]: string;
     public [InteractiveWindowMessages.FinishCell]: IFinishCell;
     public [InteractiveWindowMessages.UpdateVariableViewExecutionCount]: { executionCount: number };
+}
+
+export const IVariableViewNotebookWatcher = Symbol('IVariableViewNotebookWatcher');
+export interface IVariableViewNotebookWatcher {
+    readonly activeVariableViewNotebook?: INotebook;
+    readonly onDidChangeActiveVariableViewNotebook: Event<INotebook | undefined>;
+    readonly onDidExecuteActiveVariableViewNotebook: Event<{ executionCount: number }>;
 }
 
 export const IVariableViewProvider = Symbol('IVariableViewProvider');

--- a/src/client/datascience/variablesView/variableView.ts
+++ b/src/client/datascience/variablesView/variableView.ts
@@ -10,7 +10,6 @@ import { WebviewView as vscodeWebviewView } from 'vscode';
 import { IApplicationShell, IWebviewViewProvider, IWorkspaceService } from '../../common/application/types';
 import { EXTENSION_ROOT_DIR } from '../../common/constants';
 import { traceError } from '../../common/logger';
-import { IFileSystem } from '../../common/platform/types';
 import { IConfigurationService, IDisposable, IDisposableRegistry, Resource } from '../../common/types';
 import * as localize from '../../common/utils/localize';
 import {
@@ -21,16 +20,12 @@ import { sendTelemetryEvent } from '../../telemetry';
 import { Telemetry } from '../constants';
 import { IDataViewerFactory } from '../data-viewing/types';
 import { DataViewerChecker } from '../interactive-common/dataViewerChecker';
-import { KernelState, KernelStateEventArgs } from '../notebookExtensibility';
 import {
     ICodeCssGenerator,
     IJupyterVariableDataProviderFactory,
     IJupyterVariables,
     IJupyterVariablesRequest,
     INotebook,
-    INotebookEditor,
-    INotebookEditorProvider,
-    INotebookExtensibility,
     IThemeFinder
 } from '../types';
 import { WebviewViewHost } from '../webviews/webviewViewHost';
@@ -40,8 +35,8 @@ import { VariableViewMessageListener } from './variableViewMessageListener';
 const variableViewDir = path.join(EXTENSION_ROOT_DIR, 'out', 'datascience-ui', 'viewers');
 
 // This is the client side host for the native notebook variable view webview
-// It handles passing messages to and from the react view as well as tracking
-// code execution changes and active editor switches
+// It handles passing messages to and from the react view as well as the connection
+// to execution and changing of the active notebook
 @injectable()
 export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> implements IDisposable {
     private dataViewerChecker: DataViewerChecker;
@@ -55,13 +50,10 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
         @unmanaged() workspaceService: IWorkspaceService,
         @unmanaged() provider: IWebviewViewProvider,
         @unmanaged() private readonly variables: IJupyterVariables,
-        @unmanaged() private readonly notebookEditorProvider: INotebookEditorProvider,
-        @unmanaged() private readonly notebookExtensibility: INotebookExtensibility,
         @unmanaged() private readonly disposables: IDisposableRegistry,
         @unmanaged() private readonly appShell: IApplicationShell,
         @unmanaged() private readonly jupyterVariableDataProviderFactory: IJupyterVariableDataProviderFactory,
         @unmanaged() private readonly dataViewerFactory: IDataViewerFactory,
-        @unmanaged() private readonly fileSystem: IFileSystem,
         @unmanaged() private readonly variableViewNotebookWatcher: IVariableViewNotebookWatcher
     ) {
         super(
@@ -75,9 +67,7 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
             [path.join(variableViewDir, 'commons.initial.bundle.js'), path.join(variableViewDir, 'variableView.js')]
         );
 
-        // We need to know if kernel state changes or if the active notebook editor is changed
-        //this.notebookExtensibility.onKernelStateChange(this.kernelStateChanged, this, this.disposables);
-        //this.notebookEditorProvider.onDidChangeActiveNotebookEditor(this.activeEditorChanged, this, this.disposables);
+        // Sign up if the active variable view notebook is changed or updated
         this.variableViewNotebookWatcher.onDidExecuteActiveVariableViewNotebook(
             this.activeNotebookExecuted,
             this,
@@ -133,11 +123,6 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
     // Handle a request from the react UI to show our data viewer
     private async showDataViewer(request: IShowDataViewer): Promise<void> {
         try {
-            //if (
-            //this.notebookEditorProvider.activeEditor &&
-            //this.notebookEditorProvider.activeEditor.notebook &&
-            //(await this.dataViewerChecker.isRequestedColumnSizeAllowed(request.columnSize, this.owningResource))
-            //) {
             if (
                 this.variableViewNotebookWatcher.activeVariableViewNotebook &&
                 (await this.dataViewerChecker.isRequestedColumnSizeAllowed(request.columnSize, this.owningResource))
@@ -146,7 +131,6 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
                 const jupyterVariableDataProvider = await this.jupyterVariableDataProviderFactory.create(
                     request.variable,
                     this.variableViewNotebookWatcher.activeVariableViewNotebook
-                    //this.notebookEditorProvider.activeEditor.notebook
                 );
                 const title: string = `${localize.DataScience.dataExplorerTitle()} - ${request.variable.name}`;
                 await this.dataViewerFactory.create(jupyterVariableDataProvider, title);
@@ -158,12 +142,10 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
         }
     }
 
-    // Variables for the current active editor are being requested, check that we have a valid active editor
+    // Variables for the current active editor are being requested, check that we have a valid active notebook
     // and use the variables interface to fetch them and pass them to the variable view UI
     private async requestVariables(args: IJupyterVariablesRequest): Promise<void> {
-        //if (this.notebookEditorProvider.activeEditor && this.notebookEditorProvider.activeEditor.notebook) {
         if (this.variableViewNotebookWatcher.activeVariableViewNotebook) {
-            //const response = await this.variables.getVariables(args, this.notebookEditorProvider.activeEditor.notebook);
             const response = await this.variables.getVariables(
                 args,
                 this.variableViewNotebookWatcher.activeVariableViewNotebook
@@ -173,41 +155,15 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
         }
     }
 
+    // The active variable view notebook has executed a new cell so update the execution count in the variable view
     private async activeNotebookExecuted(args: { executionCount: number }) {
         this.postMessage(InteractiveWindowMessages.UpdateVariableViewExecutionCount, {
             executionCount: args.executionCount
         }).ignoreErrors();
     }
 
+    // The active variable new notebook has changed, so force a refresh on the view to pick up the new info
     private async activeNotebookChanged(_notebook: INotebook | undefined) {
-        // When the active editor changes we want to force a refresh of variables
-        this.postMessage(InteractiveWindowMessages.ForceVariableRefresh).ignoreErrors();
-    }
-
-    // When the kernel state is changed we need to see if it's a cell from the active document that finished execution
-    // If so update the execution count on the variable view to refresh variables
-    private async kernelStateChanged(kernelStateEvent: KernelStateEventArgs) {
-        // Check for non-silent executes from the current cell that have an execution order
-        if (
-            kernelStateEvent.state === KernelState.executed &&
-            kernelStateEvent.cell &&
-            kernelStateEvent.cell.metadata.executionOrder &&
-            kernelStateEvent.silent !== true
-        ) {
-            // We only want to update the variable view execution count when it's the active document executing
-            if (
-                this.notebookEditorProvider.activeEditor &&
-                this.fileSystem.arePathsSame(this.notebookEditorProvider.activeEditor.file, kernelStateEvent.resource)
-            ) {
-                this.postMessage(InteractiveWindowMessages.UpdateVariableViewExecutionCount, {
-                    executionCount: kernelStateEvent.cell.metadata.executionOrder
-                }).ignoreErrors();
-            }
-        }
-    }
-
-    private async activeEditorChanged(_editor: INotebookEditor | undefined) {
-        // When the active editor changes we want to force a refresh of variables
         this.postMessage(InteractiveWindowMessages.ForceVariableRefresh).ignoreErrors();
     }
 }

--- a/src/client/datascience/variablesView/variableViewNotebookWatcher.ts
+++ b/src/client/datascience/variablesView/variableViewNotebookWatcher.ts
@@ -10,13 +10,9 @@ import { KernelState, KernelStateEventArgs } from '../notebookExtensibility';
 import { INotebook, INotebookEditor, INotebookEditorProvider, INotebookExtensibility } from '../types';
 import { IVariableViewNotebookWatcher } from './types';
 
+// IANHU: Class comment
 @injectable()
 export class VariableViewNotebookWatcher implements IVariableViewNotebookWatcher {
-    //public readonly activeVariableViewNotebook?: INotebook | undefined;
-    //public readonly onDidChangeActiveVariableViewNotebook: Event<INotebook>;
-    //public readonly onDidExecuteActiveVariableViewNotebook: Event<{ executionCount: number }>;
-    //protected readonly _onDidChangeActiveNotebookEditor = new EventEmitter<INotebookEditor | undefined>();
-    //protected readonly _onDidOpenNotebookEditor = new EventEmitter<INotebookEditor>();
     public get onDidChangeActiveVariableViewNotebook(): Event<INotebook | undefined> {
         return this._onDidChangeActiveVariableViewNotebook.event;
     }

--- a/src/client/datascience/variablesView/variableViewNotebookWatcher.ts
+++ b/src/client/datascience/variablesView/variableViewNotebookWatcher.ts
@@ -10,7 +10,9 @@ import { KernelState, KernelStateEventArgs } from '../notebookExtensibility';
 import { INotebook, INotebookEditor, INotebookEditorProvider, INotebookExtensibility } from '../types';
 import { IVariableViewNotebookWatcher } from './types';
 
-// IANHU: Class comment
+// For any class that is monitoring the variables of the active notebook document, this class will update you
+// when the active notebook changes or if the execution count is updated on the active notebook
+// NOTE: Currently this class is only looking at native notebook documents
 @injectable()
 export class VariableViewNotebookWatcher implements IVariableViewNotebookWatcher {
     public get onDidChangeActiveVariableViewNotebook(): Event<INotebook | undefined> {

--- a/src/client/datascience/variablesView/variableViewNotebookWatcher.ts
+++ b/src/client/datascience/variablesView/variableViewNotebookWatcher.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+import { inject, injectable } from 'inversify';
+import { Event, EventEmitter } from 'vscode';
+import '../../common/extensions';
+import { IFileSystem } from '../../common/platform/types';
+import { IDisposableRegistry } from '../../common/types';
+import { KernelState, KernelStateEventArgs } from '../notebookExtensibility';
+import { INotebook, INotebookEditor, INotebookEditorProvider, INotebookExtensibility } from '../types';
+import { IVariableViewNotebookWatcher } from './types';
+
+@injectable()
+export class VariableViewNotebookWatcher implements IVariableViewNotebookWatcher {
+    //public readonly activeVariableViewNotebook?: INotebook | undefined;
+    //public readonly onDidChangeActiveVariableViewNotebook: Event<INotebook>;
+    //public readonly onDidExecuteActiveVariableViewNotebook: Event<{ executionCount: number }>;
+    //protected readonly _onDidChangeActiveNotebookEditor = new EventEmitter<INotebookEditor | undefined>();
+    //protected readonly _onDidOpenNotebookEditor = new EventEmitter<INotebookEditor>();
+    public get onDidChangeActiveVariableViewNotebook(): Event<INotebook | undefined> {
+        return this._onDidChangeActiveVariableViewNotebook.event;
+    }
+    public get onDidExecuteActiveVariableViewNotebook(): Event<{ executionCount: number }> {
+        return this._onDidExecuteActiveVariableViewNotebook.event;
+    }
+    public get activeVariableViewNotebook(): INotebook | undefined {
+        return this.notebookEditorProvider.activeEditor?.notebook;
+    }
+
+    private readonly _onDidExecuteActiveVariableViewNotebook = new EventEmitter<{ executionCount: number }>();
+    private readonly _onDidChangeActiveVariableViewNotebook = new EventEmitter<INotebook | undefined>();
+
+    constructor(
+        @inject(INotebookEditorProvider) private readonly notebookEditorProvider: INotebookEditorProvider,
+        @inject(INotebookExtensibility) private readonly notebookExtensibility: INotebookExtensibility,
+        @inject(IFileSystem) private readonly fileSystem: IFileSystem,
+        @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry
+    ) {
+        // We need to know if kernel state changes or if the active notebook editor is changed
+        this.notebookExtensibility.onKernelStateChange(this.kernelStateChanged, this, this.disposables);
+        this.notebookEditorProvider.onDidChangeActiveNotebookEditor(this.activeEditorChanged, this, this.disposables);
+    }
+
+    // When the kernel state is changed we need to see if it's a cell from the active document that finished execution
+    // If so update the execution count on the variable view to refresh variables
+    private async kernelStateChanged(kernelStateEvent: KernelStateEventArgs) {
+        // Check for non-silent executes from the current cell that have an execution order
+        if (
+            kernelStateEvent.state === KernelState.executed &&
+            kernelStateEvent.cell &&
+            kernelStateEvent.cell.metadata.executionOrder &&
+            kernelStateEvent.silent !== true
+        ) {
+            // We only want to update the variable view execution count when it's the active document executing
+            if (
+                this.notebookEditorProvider.activeEditor &&
+                this.fileSystem.arePathsSame(this.notebookEditorProvider.activeEditor.file, kernelStateEvent.resource)
+            ) {
+                // Notify any listeners that the active notebook has updated execution order
+                this._onDidExecuteActiveVariableViewNotebook.fire({
+                    executionCount: kernelStateEvent.cell.metadata.executionOrder
+                });
+            }
+        }
+    }
+
+    private async activeEditorChanged(editor: INotebookEditor | undefined) {
+        // When the active editor changes we want to force a refresh of variables
+        this._onDidChangeActiveVariableViewNotebook.fire(editor?.notebook);
+    }
+}

--- a/src/client/datascience/variablesView/variableViewProvider.ts
+++ b/src/client/datascience/variablesView/variableViewProvider.ts
@@ -9,7 +9,7 @@ import { IConfigurationService, IDisposableRegistry } from '../../common/types';
 import { Identifiers } from '../constants';
 import { IDataViewerFactory } from '../data-viewing/types';
 import { ICodeCssGenerator, IJupyterVariableDataProviderFactory, IJupyterVariables, IThemeFinder } from '../types';
-import { IVariableViewNotebookWatcher, IVariableViewProvider } from './types';
+import { INotebookWatcher, IVariableViewProvider } from './types';
 import { VariableView } from './variableView';
 
 // This class creates our UI for our variable view and links it to the vs code webview view
@@ -31,7 +31,7 @@ export class VariableViewProvider implements IVariableViewProvider {
         @inject(IJupyterVariableDataProviderFactory)
         private readonly jupyterVariableDataProviderFactory: IJupyterVariableDataProviderFactory,
         @inject(IDataViewerFactory) private readonly dataViewerFactory: IDataViewerFactory,
-        @inject(IVariableViewNotebookWatcher) private readonly variableViewNotebookWatcher: IVariableViewNotebookWatcher
+        @inject(INotebookWatcher) private readonly notebookWatcher: INotebookWatcher
     ) {}
 
     public async resolveWebviewView(
@@ -53,7 +53,7 @@ export class VariableViewProvider implements IVariableViewProvider {
             this.appShell,
             this.jupyterVariableDataProviderFactory,
             this.dataViewerFactory,
-            this.variableViewNotebookWatcher
+            this.notebookWatcher
         );
 
         await this.variableView.load(webviewView);

--- a/src/client/datascience/variablesView/variableViewProvider.ts
+++ b/src/client/datascience/variablesView/variableViewProvider.ts
@@ -17,7 +17,7 @@ import {
     INotebookExtensibility,
     IThemeFinder
 } from '../types';
-import { IVariableViewProvider } from './types';
+import { IVariableViewNotebookWatcher, IVariableViewProvider } from './types';
 import { VariableView } from './variableView';
 
 // This class creates our UI for our variable view and links it to the vs code webview view
@@ -41,7 +41,8 @@ export class VariableViewProvider implements IVariableViewProvider {
         @inject(IJupyterVariableDataProviderFactory)
         private readonly jupyterVariableDataProviderFactory: IJupyterVariableDataProviderFactory,
         @inject(IDataViewerFactory) private readonly dataViewerFactory: IDataViewerFactory,
-        @inject(IFileSystem) private readonly fileSystem: IFileSystem
+        @inject(IFileSystem) private readonly fileSystem: IFileSystem,
+        @inject(IVariableViewNotebookWatcher) private readonly variableViewNotebookWatcher: IVariableViewNotebookWatcher
     ) {}
 
     public async resolveWebviewView(
@@ -65,7 +66,8 @@ export class VariableViewProvider implements IVariableViewProvider {
             this.appShell,
             this.jupyterVariableDataProviderFactory,
             this.dataViewerFactory,
-            this.fileSystem
+            this.fileSystem,
+            this.variableViewNotebookWatcher
         );
 
         await this.variableView.load(webviewView);

--- a/src/client/datascience/variablesView/variableViewProvider.ts
+++ b/src/client/datascience/variablesView/variableViewProvider.ts
@@ -5,18 +5,10 @@
 import { inject, injectable, named } from 'inversify';
 import { CancellationToken, WebviewView, WebviewViewResolveContext } from 'vscode';
 import { IApplicationShell, IWebviewViewProvider, IWorkspaceService } from '../../common/application/types';
-import { IFileSystem } from '../../common/platform/types';
 import { IConfigurationService, IDisposableRegistry } from '../../common/types';
 import { Identifiers } from '../constants';
 import { IDataViewerFactory } from '../data-viewing/types';
-import {
-    ICodeCssGenerator,
-    IJupyterVariableDataProviderFactory,
-    IJupyterVariables,
-    INotebookEditorProvider,
-    INotebookExtensibility,
-    IThemeFinder
-} from '../types';
+import { ICodeCssGenerator, IJupyterVariableDataProviderFactory, IJupyterVariables, IThemeFinder } from '../types';
 import { IVariableViewNotebookWatcher, IVariableViewProvider } from './types';
 import { VariableView } from './variableView';
 
@@ -34,14 +26,11 @@ export class VariableViewProvider implements IVariableViewProvider {
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IWebviewViewProvider) private readonly webviewViewProvider: IWebviewViewProvider,
         @inject(IJupyterVariables) @named(Identifiers.ALL_VARIABLES) private variables: IJupyterVariables,
-        @inject(INotebookEditorProvider) private readonly notebookEditorProvider: INotebookEditorProvider,
-        @inject(INotebookExtensibility) private readonly notebookExtensibility: INotebookExtensibility,
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(IJupyterVariableDataProviderFactory)
         private readonly jupyterVariableDataProviderFactory: IJupyterVariableDataProviderFactory,
         @inject(IDataViewerFactory) private readonly dataViewerFactory: IDataViewerFactory,
-        @inject(IFileSystem) private readonly fileSystem: IFileSystem,
         @inject(IVariableViewNotebookWatcher) private readonly variableViewNotebookWatcher: IVariableViewNotebookWatcher
     ) {}
 
@@ -60,13 +49,10 @@ export class VariableViewProvider implements IVariableViewProvider {
             this.workspaceService,
             this.webviewViewProvider,
             this.variables,
-            this.notebookEditorProvider,
-            this.notebookExtensibility,
             this.disposables,
             this.appShell,
             this.jupyterVariableDataProviderFactory,
             this.dataViewerFactory,
-            this.fileSystem,
             this.variableViewNotebookWatcher
         );
 

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -873,7 +873,10 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.addSingleton<ILanguageServerProvider>(ILanguageServerProvider, MockLanguageServerProvider);
         this.serviceManager.addSingleton<IEncryptedStorage>(IEncryptedStorage, MockEncryptedStorage);
         this.serviceManager.addSingleton<IJupyterServerUriStorage>(IJupyterServerUriStorage, JupyterServerUriStorage);
-        this.serviceManager.addSingleton<IVariableViewNotebookWatcher>(IVariableViewNotebookWatcher, VariableViewNotebookWatcher);
+        this.serviceManager.addSingleton<IVariableViewNotebookWatcher>(
+            IVariableViewNotebookWatcher,
+            VariableViewNotebookWatcher
+        );
 
         when(this.applicationShell.showErrorMessage(anyString())).thenReturn(Promise.resolve(''));
         when(this.applicationShell.showErrorMessage(anyString(), anything())).thenReturn(Promise.resolve(''));

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -256,7 +256,7 @@ import {
     ITrustService,
     IWebviewExtensibility
 } from '../../client/datascience/types';
-import { IVariableViewNotebookWatcher, IVariableViewProvider } from '../../client/datascience/variablesView/types';
+import { INotebookWatcher, IVariableViewProvider } from '../../client/datascience/variablesView/types';
 import { VariableViewActivationService } from '../../client/datascience/variablesView/variableViewActivationService';
 import { VariableViewProvider } from '../../client/datascience/variablesView/variableViewProvider';
 import { WebviewExtensibility } from '../../client/datascience/webviewExtensibility';
@@ -309,7 +309,7 @@ import { WebviewIPyWidgetCoordinator } from '../../client/datascience/ipywidgets
 import { WebviewViewProvider } from '../../client/common/application/webviewViews/webviewViewProvider';
 import { SystemPseudoRandomNumberGenerator } from '../../client/datascience/interactive-ipynb/randomBytes';
 import { KernelEnvironmentVariablesService } from '../../client/datascience/kernel-launcher/kernelEnvVarsService';
-import { VariableViewNotebookWatcher } from '../../client/datascience/variablesView/variableViewNotebookWatcher';
+import { NotebookWatcher } from '../../client/datascience/variablesView/notebookWatcher';
 
 export class DataScienceIocContainer extends UnitTestIocContainer {
     public get workingInterpreter() {
@@ -873,10 +873,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.addSingleton<ILanguageServerProvider>(ILanguageServerProvider, MockLanguageServerProvider);
         this.serviceManager.addSingleton<IEncryptedStorage>(IEncryptedStorage, MockEncryptedStorage);
         this.serviceManager.addSingleton<IJupyterServerUriStorage>(IJupyterServerUriStorage, JupyterServerUriStorage);
-        this.serviceManager.addSingleton<IVariableViewNotebookWatcher>(
-            IVariableViewNotebookWatcher,
-            VariableViewNotebookWatcher
-        );
+        this.serviceManager.addSingleton<INotebookWatcher>(INotebookWatcher, NotebookWatcher);
 
         when(this.applicationShell.showErrorMessage(anyString())).thenReturn(Promise.resolve(''));
         when(this.applicationShell.showErrorMessage(anyString(), anything())).thenReturn(Promise.resolve(''));

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -256,7 +256,7 @@ import {
     ITrustService,
     IWebviewExtensibility
 } from '../../client/datascience/types';
-import { IVariableViewProvider } from '../../client/datascience/variablesView/types';
+import { IVariableViewNotebookWatcher, IVariableViewProvider } from '../../client/datascience/variablesView/types';
 import { VariableViewActivationService } from '../../client/datascience/variablesView/variableViewActivationService';
 import { VariableViewProvider } from '../../client/datascience/variablesView/variableViewProvider';
 import { WebviewExtensibility } from '../../client/datascience/webviewExtensibility';
@@ -309,6 +309,7 @@ import { WebviewIPyWidgetCoordinator } from '../../client/datascience/ipywidgets
 import { WebviewViewProvider } from '../../client/common/application/webviewViews/webviewViewProvider';
 import { SystemPseudoRandomNumberGenerator } from '../../client/datascience/interactive-ipynb/randomBytes';
 import { KernelEnvironmentVariablesService } from '../../client/datascience/kernel-launcher/kernelEnvVarsService';
+import { VariableViewNotebookWatcher } from '../../client/datascience/variablesView/variableViewNotebookWatcher';
 
 export class DataScienceIocContainer extends UnitTestIocContainer {
     public get workingInterpreter() {
@@ -872,6 +873,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.addSingleton<ILanguageServerProvider>(ILanguageServerProvider, MockLanguageServerProvider);
         this.serviceManager.addSingleton<IEncryptedStorage>(IEncryptedStorage, MockEncryptedStorage);
         this.serviceManager.addSingleton<IJupyterServerUriStorage>(IJupyterServerUriStorage, JupyterServerUriStorage);
+        this.serviceManager.addSingleton<IVariableViewNotebookWatcher>(IVariableViewNotebookWatcher, VariableViewNotebookWatcher);
 
         when(this.applicationShell.showErrorMessage(anyString())).thenReturn(Promise.resolve(''));
         when(this.applicationShell.showErrorMessage(anyString(), anything())).thenReturn(Promise.resolve(''));


### PR DESCRIPTION
For #4341 

I think that @DonJayamanne suggested something like this on the PR and looking at the code more I agreed.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
