### PR TITLE
Add/enable tests for switching kernels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ on:
       - 'release'
       - 'release/*'
       - 'release-*'
-      - rchiodo/switching_kernels
   workflow_dispatch:
 
 env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ on:
       - 'release'
       - 'release/*'
       - 'release-*'
+      - rchiodo/switching_kernels
   workflow_dispatch:
 
 env:
@@ -267,8 +268,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Use conda for group1 and group2
-        if: matrix.test-suite == 'group1' || matrix.test-suite == 'group2'
+      - name: Use conda for group1 and group3
+        if: matrix.test-suite == 'group1' || matrix.test-suite == 'group3'
         run: |
           echo "conda_python=true" >> $GITHUB_ENV
 
@@ -396,6 +397,18 @@ jobs:
         if: env.conda_python
         run: |
           conda activate functional_test_env
+          python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r ./requirements.txt
+          python -m pip --disable-pip-version-check install -r build/debugger-install-requirements.txt
+          python ./pythonFiles/install_debugpy.py
+          conda env update --file ./build/conda-functional-requirements.yml
+          python -m pip install --upgrade -r ./build/conda-functional-requirements.txt
+
+      - name: Install secondary conda environment
+        shell: bash -l {0}
+        if: env.conda_python
+        run: |
+          conda create --name functional_test_env_2
+          conda activate functional_test_env_2
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r ./requirements.txt
           python -m pip --disable-pip-version-check install -r build/debugger-install-requirements.txt
           python ./pythonFiles/install_debugpy.py

--- a/build/ci/scripts/runFunctionalTests.js
+++ b/build/ci/scripts/runFunctionalTests.js
@@ -57,8 +57,15 @@ async function generateGroups(files) {
     });
     var lowestBucket = buckets[0];
     sorted.forEach((fs) => {
-        buckets[lowestBucket.index].totalSize += fs.size;
-        buckets[lowestBucket.index].files.push(fs.file);
+        // Index may be different if forced.
+        if (fs.file.startsWith('group')) {
+            const index = parse(fs.file.substring(5, 6), 10);
+            buckets[index].totalSize += fs.size;
+            buckets[index].files.push(fs.file);
+        } else {
+            buckets[lowestBucket.index].totalSize += fs.size;
+            buckets[lowestBucket.index].files.push(fs.file);
+        }
         lowestBucket = buckets.find((b) => b.totalSize < lowestBucket.totalSize) || lowestBucket;
     });
 

--- a/build/conda-functional-requirements.yml
+++ b/build/conda-functional-requirements.yml
@@ -1,5 +1,4 @@
 # Functional requirements using a conda environment file
-name: functional_test_env
 dependencies:
   - pandas
   - jupyter

--- a/src/client/datascience/jupyter/kernelVariables.ts
+++ b/src/client/datascience/jupyter/kernelVariables.ts
@@ -420,6 +420,7 @@ export class KernelVariables implements IJupyterVariables {
         return [];
     }
 
+    // tslint:disable-next-line: cyclomatic-complexity
     private async getVariableValueFromKernel(
         targetVariable: IJupyterVariable,
         notebook: INotebook,
@@ -462,10 +463,10 @@ export class KernelVariables implements IJupyterVariables {
             }
 
             // Otherwise look for the appropriate entries
-            if (output.type) {
+            if (output && output.type) {
                 result.type = output.type.toString();
             }
-            if (output.value) {
+            if (output && output.value) {
                 result.value = output.value.toString();
             }
 

--- a/src/test/datascience/group1.nonConda.functional.test.tsx
+++ b/src/test/datascience/group1.nonConda.functional.test.tsx
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+import * as assert from 'assert';
+import { Disposable } from 'vscode';
+
+import { InteractiveWindowMessages } from '../../client/datascience/interactive-common/interactiveWindowTypes';
+import { DataScienceIocContainer } from './dataScienceIocContainer';
+import { takeSnapshot, writeDiffSnapshot } from './helpers';
+import {
+    addCode,
+    getOrCreateInteractiveWindow,
+    runTest
+} from './interactiveWindowTestHelpers';
+import {
+    CellPosition,
+    verifyHtmlOnCell} from './testHelpers';
+// tslint:disable-next-line: no-require-imports no-var-requires
+
+// tslint:disable:max-func-body-length trailing-comma no-any no-multiline-string
+suite('DataScience Interactive Window output tests', () => {
+    const disposables: Disposable[] = [];
+    let ioc: DataScienceIocContainer;
+    let snapshot: any;
+
+    suiteSetup(() => {
+        snapshot = takeSnapshot();
+    });
+    setup(async () => {
+        ioc = new DataScienceIocContainer();
+        ioc.registerDataScienceTypes();
+        return ioc.activate();
+    });
+
+    suiteTeardown(() => {
+        writeDiffSnapshot(snapshot, 'Interactive Window');
+    });
+
+    teardown(async () => {
+        for (const disposable of disposables) {
+            if (!disposable) {
+                continue;
+            }
+            // tslint:disable-next-line:no-any
+            const promise = disposable.dispose() as Promise<any>;
+            if (promise) {
+                await promise;
+            }
+        }
+        await ioc.dispose();
+    });
+
+
+
+    function verifyHtmlOnInteractiveCell(html: string | undefined | RegExp, cellIndex: number | CellPosition) {
+        const iw = ioc.getInteractiveWebPanel(undefined).wrapper;
+        iw.update();
+        verifyHtmlOnCell(iw, 'InteractiveCell', html, cellIndex);
+    }
+
+    runTest(
+        'Simple text with no python extension',
+        async (c) => {
+            // Interactive window will attempt to connect so we can only
+            // run this test with raw kernel
+            if (ioc.isRawKernel) {
+                ioc.setPythonExtensionState(false);
+                await getOrCreateInteractiveWindow(ioc);
+
+                await addCode(ioc, 'a=1\na');
+                verifyHtmlOnInteractiveCell('1', CellPosition.Last);
+
+                assert.ok(
+                    !ioc.attemptedPythonExtension,
+                    'Python extension installation should not happen on simple open'
+                );
+            } else {
+                c.skip();
+            }
+        },
+        () => {
+            return ioc;
+        }
+    );
+
+    runTest(
+        'Saving without python extension',
+        async (c) => {
+            if (ioc.isRawKernel) {
+                ioc.setPythonExtensionState(false);
+
+                await addCode(ioc, 'a=1\na');
+
+                const { window, mount } = await getOrCreateInteractiveWindow(ioc);
+
+                const exportPromise = mount.waitForMessage(InteractiveWindowMessages.ReturnAllCells);
+                window.exportCells();
+                await exportPromise;
+
+                assert.ok(ioc.attemptedPythonExtension, 'Export should warn user about installing');
+            } else {
+                c.skip();
+            }
+        },
+        () => {
+            return ioc;
+        }
+    );
+
+});

--- a/src/test/datascience/group1.nonConda.functional.test.tsx
+++ b/src/test/datascience/group1.nonConda.functional.test.tsx
@@ -7,14 +7,8 @@ import { Disposable } from 'vscode';
 import { InteractiveWindowMessages } from '../../client/datascience/interactive-common/interactiveWindowTypes';
 import { DataScienceIocContainer } from './dataScienceIocContainer';
 import { takeSnapshot, writeDiffSnapshot } from './helpers';
-import {
-    addCode,
-    getOrCreateInteractiveWindow,
-    runTest
-} from './interactiveWindowTestHelpers';
-import {
-    CellPosition,
-    verifyHtmlOnCell} from './testHelpers';
+import { addCode, getOrCreateInteractiveWindow, runTest } from './interactiveWindowTestHelpers';
+import { CellPosition, verifyHtmlOnCell } from './testHelpers';
 // tslint:disable-next-line: no-require-imports no-var-requires
 
 // tslint:disable:max-func-body-length trailing-comma no-any no-multiline-string
@@ -49,8 +43,6 @@ suite('DataScience Interactive Window output tests', () => {
         }
         await ioc.dispose();
     });
-
-
 
     function verifyHtmlOnInteractiveCell(html: string | undefined | RegExp, cellIndex: number | CellPosition) {
         const iw = ioc.getInteractiveWebPanel(undefined).wrapper;
@@ -106,5 +98,4 @@ suite('DataScience Interactive Window output tests', () => {
             return ioc;
         }
     );
-
 });

--- a/src/test/datascience/group1.nonConda.functional.test.tsx
+++ b/src/test/datascience/group1.nonConda.functional.test.tsx
@@ -20,7 +20,7 @@ suite('DataScience Interactive Window output tests', () => {
     suiteSetup(function () {
         snapshot = takeSnapshot();
         if (process.env.CI_PYTHON_PATH?.includes('conda')) {
-            console.log('This test should only run without conda installed')
+            console.log('This test should only run without conda installed');
             this.skip();
         }
     });

--- a/src/test/datascience/group1.nonConda.functional.test.tsx
+++ b/src/test/datascience/group1.nonConda.functional.test.tsx
@@ -17,8 +17,12 @@ suite('DataScience Interactive Window output tests', () => {
     let ioc: DataScienceIocContainer;
     let snapshot: any;
 
-    suiteSetup(() => {
+    suiteSetup(function () {
         snapshot = takeSnapshot();
+        if (process.env.CI_PYTHON_PATH?.includes('conda')) {
+            console.log('This test should only run without conda installed')
+            this.skip();
+        }
     });
     setup(async () => {
         ioc = new DataScienceIocContainer();

--- a/src/test/datascience/interactiveWindow.functional.test.tsx
+++ b/src/test/datascience/interactiveWindow.functional.test.tsx
@@ -139,55 +139,6 @@ suite('DataScience Interactive Window output tests', () => {
     );
 
     runTest(
-        'Simple text with no python extension',
-        async (c) => {
-            // Interactive window will attempt to connect so we can only
-            // run this test with raw kernel
-            if (ioc.isRawKernel) {
-                ioc.setPythonExtensionState(false);
-                await getOrCreateInteractiveWindow(ioc);
-
-                await addCode(ioc, 'a=1\na');
-                verifyHtmlOnInteractiveCell('1', CellPosition.Last);
-
-                assert.ok(
-                    !ioc.attemptedPythonExtension,
-                    'Python extension installation should not happen on simple open'
-                );
-            } else {
-                c.skip();
-            }
-        },
-        () => {
-            return ioc;
-        }
-    );
-
-    runTest(
-        'Saving without python extension',
-        async (c) => {
-            if (ioc.isRawKernel) {
-                ioc.setPythonExtensionState(false);
-
-                await addCode(ioc, 'a=1\na');
-
-                const { window, mount } = await getOrCreateInteractiveWindow(ioc);
-
-                const exportPromise = mount.waitForMessage(InteractiveWindowMessages.ReturnAllCells);
-                window.exportCells();
-                await exportPromise;
-
-                assert.ok(ioc.attemptedPythonExtension, 'Export should warn user about installing');
-            } else {
-                c.skip();
-            }
-        },
-        () => {
-            return ioc;
-        }
-    );
-
-    runTest(
         'Clear output',
         async () => {
             const text = `from IPython.display import clear_output

--- a/src/test/datascience/notebook/notebookEditor.vscode.test.ts
+++ b/src/test/datascience/notebook/notebookEditor.vscode.test.ts
@@ -7,7 +7,6 @@ import { assert } from 'chai';
 import { ICommandManager, IVSCodeNotebook } from '../../../client/common/application/types';
 import { IDisposable } from '../../../client/common/types';
 import { Commands } from '../../../client/datascience/constants';
-import { INotebookKernelProvider } from '../../../client/datascience/notebook/types';
 import { INotebookEditorProvider } from '../../../client/datascience/types';
 import { IExtensionTestApi } from '../../common';
 import { initialize } from '../../initialize';
@@ -28,7 +27,6 @@ suite('Notebook Editor tests', () => {
     let vscodeNotebook: IVSCodeNotebook;
     let editorProvider: INotebookEditorProvider;
     let commandManager: ICommandManager;
-    let kernelProvider: INotebookKernelProvider;
     const disposables: IDisposable[] = [];
 
     suiteSetup(async function () {
@@ -39,7 +37,6 @@ suite('Notebook Editor tests', () => {
         vscodeNotebook = api.serviceContainer.get<IVSCodeNotebook>(IVSCodeNotebook);
         editorProvider = api.serviceContainer.get<INotebookEditorProvider>(INotebookEditorProvider);
         commandManager = api.serviceContainer.get<ICommandManager>(ICommandManager);
-        kernelProvider = api.serviceContainer.get<INotebookKernelProvider>(INotebookKernelProvider);
     });
 
     setup(async function () {

--- a/src/test/datascience/notebook/notebookEditor.vscode.test.ts
+++ b/src/test/datascience/notebook/notebookEditor.vscode.test.ts
@@ -4,7 +4,6 @@
 'use strict';
 
 import { assert } from 'chai';
-import { CancellationToken } from 'vscode-languageclient';
 import { ICommandManager, IVSCodeNotebook } from '../../../client/common/application/types';
 import { IDisposable } from '../../../client/common/types';
 import { Commands } from '../../../client/datascience/constants';
@@ -17,7 +16,6 @@ import {
     closeNotebooks,
     closeNotebooksAndCleanUpAfterTests,
     deleteAllCellsAndWait,
-    executeCell,
     insertCodeCell,
     selectCell,
     waitForExecutionCompletedSuccessfully,

--- a/src/test/datascience/notebook/notebookEditor.vscode.test.ts
+++ b/src/test/datascience/notebook/notebookEditor.vscode.test.ts
@@ -4,9 +4,11 @@
 'use strict';
 
 import { assert } from 'chai';
+import { CancellationToken } from 'vscode-languageclient';
 import { ICommandManager, IVSCodeNotebook } from '../../../client/common/application/types';
 import { IDisposable } from '../../../client/common/types';
 import { Commands } from '../../../client/datascience/constants';
+import { INotebookKernelProvider } from '../../../client/datascience/notebook/types';
 import { INotebookEditorProvider } from '../../../client/datascience/types';
 import { IExtensionTestApi } from '../../common';
 import { initialize } from '../../initialize';
@@ -15,6 +17,7 @@ import {
     closeNotebooks,
     closeNotebooksAndCleanUpAfterTests,
     deleteAllCellsAndWait,
+    executeCell,
     insertCodeCell,
     selectCell,
     waitForExecutionCompletedSuccessfully,
@@ -27,6 +30,7 @@ suite('Notebook Editor tests', () => {
     let vscodeNotebook: IVSCodeNotebook;
     let editorProvider: INotebookEditorProvider;
     let commandManager: ICommandManager;
+    let kernelProvider: INotebookKernelProvider;
     const disposables: IDisposable[] = [];
 
     suiteSetup(async function () {
@@ -37,6 +41,7 @@ suite('Notebook Editor tests', () => {
         vscodeNotebook = api.serviceContainer.get<IVSCodeNotebook>(IVSCodeNotebook);
         editorProvider = api.serviceContainer.get<INotebookEditorProvider>(INotebookEditorProvider);
         commandManager = api.serviceContainer.get<ICommandManager>(ICommandManager);
+        kernelProvider = api.serviceContainer.get<INotebookKernelProvider>(INotebookKernelProvider);
     });
 
     setup(async function () {
@@ -103,5 +108,30 @@ suite('Notebook Editor tests', () => {
 
         // The third cell should have a runState of Success
         assert.strictEqual(thirdCell?.metadata.runState, vscodeNotebookEnums.NotebookCellRunState.Success);
+    });
+    test('Switch kernels', async function () {
+        this.skip();
+        // Do this after talking with VS code team
+        // // add a cell
+        // await insertCodeCell('print("0")', { index: 0 });
+
+        // const cell = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
+
+        // await executeCell(cell);
+
+        // // Wait till execution count changes and status is success.
+        // await waitForExecutionCompletedSuccessfully(cell);
+
+        // // Switch kernels to the other kernel
+        // const kernels = await kernelProvider.provideKernels(
+        //     vscodeNotebook.activeNotebookEditor!.document,
+        //     CancellationToken.None
+        // );
+        // if (kernels?.length && kernels?.length > 0) {
+        //     // We have multiple kernels. Try switching
+        //     await commandManager.executeCommand(
+        //         'notebook.selectKernel',
+        //     );
+        // }
     });
 });


### PR DESCRIPTION
For #4163 (must fix bug)

Turn on tests for switching kernels. We already had a functional test for this. It runs if there's more than one kernel (so I added a second interpreter in the conda case).

Did not add tests for native though. This is pending https://github.com/microsoft/vscode/issues/114289

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
