### PR TITLE
remove variable view experiement and enable along with native notebook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1264,6 +1264,12 @@
                     "command": "jupyter.opennotebookInPreviewEditor",
                     "when": "false",
                     "category": "Jupyter"
+                },
+                {
+                    "command": "jupyter.openVariableView",
+                    "title": "%jupyter.command.jupyter.openVariableView.title%",
+                    "category": "Jupyter",
+                    "when": "jupyter.isnativeactive"
                 }
             ],
             "debug/variables/context": [
@@ -1304,7 +1310,6 @@
                         "enum": [
                             "NativeNotebookEditor",
                             "CustomEditor",
-                            "NativeVariableView",
                             "All"
                         ]
                     },
@@ -1799,7 +1804,7 @@
                     "type": "webview",
                     "id": "jupyterViewVariables",
                     "name": "Variables",
-                    "when": "jupyter.nativevariableview"
+                    "when": "jupyter.isnativeactive"
                 }
             ]
         }

--- a/src/client/common/experiments/groups.ts
+++ b/src/client/common/experiments/groups.ts
@@ -5,7 +5,5 @@ export enum Experiments {
     // Experiment to turn on custom editor or VS Code Native Notebook API support.
     CustomEditor = 'CustomEditor',
     // Experiment to turn on custom editor or VS Code Native Notebook API support.
-    NativeNotebook = 'NativeNotebookEditor',
-    // Experiment to show native notebook variable in a separate VS Code View.
-    NativeVariableView = 'NativeVariableView'
+    NativeNotebook = 'NativeNotebookEditor'
 }

--- a/src/client/datascience/variablesView/variableViewActivationService.ts
+++ b/src/client/datascience/variablesView/variableViewActivationService.ts
@@ -1,8 +1,6 @@
 import { inject, injectable } from 'inversify';
 import { window } from 'vscode';
 import { IExtensionSingleActivationService } from '../../activation/types';
-import { ICommandManager } from '../../common/application/types';
-import { ContextKey } from '../../common/contextKey';
 import { Experiments } from '../../common/experiments/groups';
 import { IExperimentService, IExtensionContext } from '../../common/types';
 import { IVariableViewProvider } from './types';
@@ -13,22 +11,18 @@ export class VariableViewActivationService implements IExtensionSingleActivation
     constructor(
         @inject(IExtensionContext) private extensionContext: IExtensionContext,
         @inject(IVariableViewProvider) private variableViewProvider: IVariableViewProvider,
-        @inject(IExperimentService) private experimentService: IExperimentService,
-        @inject(ICommandManager) private commandManager: ICommandManager
+        @inject(IExperimentService) private experimentService: IExperimentService
     ) {}
 
     public async activate() {
-        const context = new ContextKey('jupyter.nativevariableview', this.commandManager);
-        if (await this.experimentService.inExperiment(Experiments.NativeVariableView)) {
-            context.set(true).ignoreErrors();
+        // Only activate this when in the NativeNotebook experiment
+        if (await this.experimentService.inExperiment(Experiments.NativeNotebook)) {
             this.extensionContext.subscriptions.push(
                 // Consider not using retainContext here? This will save the context of our view, but take more memory in VS Code.
                 window.registerWebviewViewProvider(this.variableViewProvider.viewType, this.variableViewProvider, {
                     webviewOptions: { retainContextWhenHidden: true }
                 })
             );
-        } else {
-            context.set(false).ignoreErrors();
         }
     }
 }

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -631,6 +631,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         globalState.update(trustDirectoryMigrated, true);
         mockExtensionContext.setup((m) => m.globalState).returns(() => globalState);
         mockExtensionContext.setup((m) => m.extensionPath).returns(() => this.extensionRootPath || os.tmpdir());
+        mockExtensionContext.setup((m) => m.subscriptions).returns(() => []);
         this.serviceManager.addSingletonInstance<IExtensionContext>(IExtensionContext, mockExtensionContext.object);
 
         const mockServerSelector = mock(JupyterServerSelector);


### PR DESCRIPTION
Just breaking up the test work bits that are independent into smaller PRs

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
