### PR TITLE
Use python API to register status bar filter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -586,6 +586,7 @@ jobs:
           python -m pip --disable-pip-version-check install -r build/debugger-install-requirements.txt
           python ./pythonFiles/install_debugpy.py
           python -m pip install numpy
+          python -m pip install nbformat==5.0.8
           python -m pip install --upgrade jupyter
           python -m pip install --upgrade -r build/test-requirements.txt
           python -m pip install --upgrade -r ./build/ipython-test-requirements.txt

--- a/build/conda-functional-requirements.yml
+++ b/build/conda-functional-requirements.yml
@@ -1,7 +1,7 @@
 # Functional requirements using a conda environment file
 dependencies:
   - pandas
-  - nbformat=5.0.8
+  - nbformat=5.0.8 # Lock down to prevent this error: https://github.com/jupyter/nbformat/issues/155
   - jupyter
   - numpy
   - matplotlib

--- a/build/conda-functional-requirements.yml
+++ b/build/conda-functional-requirements.yml
@@ -1,7 +1,7 @@
 # Functional requirements using a conda environment file
 dependencies:
   - pandas
-  - nbformat=5.0.8 # Lock down to prevent this error: https://github.com/jupyter/nbformat/issues/155
+  - nbformat=5.0.8 # Lock down to prevent this error: https://github.com/jupyter/nbformat/issues/206
   - jupyter
   - numpy
   - matplotlib

--- a/build/conda-functional-requirements.yml
+++ b/build/conda-functional-requirements.yml
@@ -1,6 +1,7 @@
 # Functional requirements using a conda environment file
 dependencies:
   - pandas
+  - nbformat=5.0.8
   - jupyter
   - numpy
   - matplotlib

--- a/src/client/api/serviceRegistry.ts
+++ b/src/client/api/serviceRegistry.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import { InterpreterStatusBarVisibility } from '../../test/interpreters/visibilityFilter';
+import { InterpreterStatusBarVisibility } from '../interpreter/display/visibilityFilter';
 import { IExtensionSingleActivationService } from '../activation/types';
 import { IEnvironmentActivationService } from '../interpreter/activation/types';
 import { IInterpreterSelector } from '../interpreter/configuration/types';

--- a/src/client/api/serviceRegistry.ts
+++ b/src/client/api/serviceRegistry.ts
@@ -3,6 +3,8 @@
 
 'use strict';
 
+import { InterpreterStatusBarVisibility } from '../../test/interpreters/visibilityFilter';
+import { IExtensionSingleActivationService } from '../activation/types';
 import { IEnvironmentActivationService } from '../interpreter/activation/types';
 import { IInterpreterSelector } from '../interpreter/configuration/types';
 import { IInterpreterService } from '../interpreter/contracts';
@@ -32,6 +34,10 @@ export function registerTypes(serviceManager: IServiceManager): void {
     serviceManager.addSingleton<IPythonExtensionChecker>(IPythonExtensionChecker, PythonExtensionChecker);
     serviceManager.addSingleton<IInterpreterService>(IInterpreterService, InterpreterService);
     serviceManager.addSingleton<IInterpreterSelector>(IInterpreterSelector, InterpreterSelector);
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSingleActivationService,
+        InterpreterStatusBarVisibility
+    );
     serviceManager.addSingleton<IWindowsStoreInterpreter>(IWindowsStoreInterpreter, WindowsStoreInterpreter);
     serviceManager.addSingleton<IPythonDebuggerPathProvider>(IPythonDebuggerPathProvider, PythonDebuggerPathProvider);
     serviceManager.addSingleton<ILanguageServerProvider>(ILanguageServerProvider, LanguageServerProvider);

--- a/src/client/api/serviceRegistry.ts
+++ b/src/client/api/serviceRegistry.ts
@@ -3,11 +3,11 @@
 
 'use strict';
 
-import { InterpreterStatusBarVisibility } from '../interpreter/display/visibilityFilter';
 import { IExtensionSingleActivationService } from '../activation/types';
 import { IEnvironmentActivationService } from '../interpreter/activation/types';
 import { IInterpreterSelector } from '../interpreter/configuration/types';
 import { IInterpreterService } from '../interpreter/contracts';
+import { InterpreterStatusBarVisibility } from '../interpreter/display/visibilityFilter';
 import { IWindowsStoreInterpreter } from '../interpreter/locators/types';
 import { IServiceManager } from '../ioc/types';
 import {

--- a/src/client/api/types.ts
+++ b/src/client/api/types.ts
@@ -42,6 +42,14 @@ export enum JupyterProductToInstall {
     pandas = 'pandas'
 }
 
+/**
+ * Implement this interface to control the visibility of the interpreter statusbar.
+ */
+export interface IInterpreterStatusbarVisibilityFilter {
+    readonly changed?: Event<void>;
+    readonly hidden: boolean;
+}
+
 export type PythonApi = {
     /**
      * IInterpreterService
@@ -94,6 +102,10 @@ export type PythonApi = {
      * @param resource file that determines which connection to return
      */
     getLanguageServer(resource?: InterpreterUri): Promise<ILanguageServer | undefined>;
+    /**
+     * Registers a visibility filter for the interpreter status bar.
+     */
+    registerInterpreterStatusFilter(filter: IInterpreterStatusbarVisibilityFilter): void;
 };
 
 export const IPythonInstaller = Symbol('IPythonInstaller');

--- a/src/client/interpreter/display/visibilityFilter.ts
+++ b/src/client/interpreter/display/visibilityFilter.ts
@@ -3,15 +3,11 @@
 
 import { inject, injectable } from 'inversify';
 import { Event, EventEmitter } from 'vscode';
-import { IExtensionSingleActivationService } from '../../client/activation/types';
-import {
-    IInterpreterStatusbarVisibilityFilter,
-    IPythonApiProvider,
-    IPythonExtensionChecker
-} from '../../client/api/types';
-import { IVSCodeNotebook } from '../../client/common/application/types';
-import { IDisposableRegistry, IExtensions } from '../../client/common/types';
-import { isJupyterNotebook } from '../../client/datascience/notebook/helpers/helpers';
+import { IExtensionSingleActivationService } from '../../activation/types';
+import { IInterpreterStatusbarVisibilityFilter, IPythonApiProvider, IPythonExtensionChecker } from '../../api/types';
+import { IVSCodeNotebook } from '../../common/application/types';
+import { IDisposableRegistry, IExtensions } from '../../common/types';
+import { isJupyterNotebook } from '../../datascience/notebook/helpers/helpers';
 
 @injectable()
 export class InterpreterStatusBarVisibility

--- a/src/client/interpreter/display/visibilityFilter.ts
+++ b/src/client/interpreter/display/visibilityFilter.ts
@@ -35,12 +35,15 @@ export class InterpreterStatusBarVisibility
         // Tell the python extension about our filter
         if (this.extensionChecker.isPythonExtensionInstalled) {
             this._registered = true;
-            this.pythonApi.getApi().then((a) => {
-                // Python API may not have the register function yet.
-                if (a.registerInterpreterStatusFilter) {
-                    a.registerInterpreterStatusFilter(this);
-                }
-            });
+            this.pythonApi
+                .getApi()
+                .then((a) => {
+                    // Python API may not have the register function yet.
+                    if (a.registerInterpreterStatusFilter) {
+                        a.registerInterpreterStatusFilter(this);
+                    }
+                })
+                .ignoreErrors();
         }
     }
     public get changed(): Event<void> {

--- a/src/test/interpreters/visibilityFilter.ts
+++ b/src/test/interpreters/visibilityFilter.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { inject, injectable } from 'inversify';
+import { Event, EventEmitter } from 'vscode';
+import { IExtensionSingleActivationService } from '../../client/activation/types';
+import {
+    IInterpreterStatusbarVisibilityFilter,
+    IPythonApiProvider,
+    IPythonExtensionChecker
+} from '../../client/api/types';
+import { IVSCodeNotebook } from '../../client/common/application/types';
+import { IDisposableRegistry, IExtensions } from '../../client/common/types';
+import { isJupyterNotebook } from '../../client/datascience/notebook/helpers/helpers';
+
+@injectable()
+export class InterpreterStatusBarVisibility
+    implements IInterpreterStatusbarVisibilityFilter, IExtensionSingleActivationService {
+    private _changed = new EventEmitter<void>();
+    private _registered = false;
+
+    constructor(
+        @inject(IVSCodeNotebook) private readonly vscNotebook: IVSCodeNotebook,
+        @inject(IDisposableRegistry) disposables: IDisposableRegistry,
+        @inject(IPythonExtensionChecker) private extensionChecker: IPythonExtensionChecker,
+        @inject(IPythonApiProvider) private pythonApi: IPythonApiProvider,
+        @inject(IExtensions) readonly extensions: IExtensions
+    ) {
+        vscNotebook.onDidChangeActiveNotebookEditor(
+            () => {
+                this._changed.fire();
+            },
+            this,
+            disposables
+        );
+        extensions.onDidChange(this.extensionsChanged, this, disposables);
+    }
+    public async activate(): Promise<void> {
+        // Tell the python extension about our filter
+        if (this.extensionChecker.isPythonExtensionInstalled) {
+            this._registered = true;
+            this.pythonApi.getApi().then((a) => {
+                // Python API may not have the register function yet.
+                if (a.registerInterpreterStatusFilter) {
+                    a.registerInterpreterStatusFilter(this);
+                }
+            });
+        }
+    }
+    public get changed(): Event<void> {
+        return this._changed.event;
+    }
+    public get hidden() {
+        return this.vscNotebook.activeNotebookEditor &&
+            isJupyterNotebook(this.vscNotebook.activeNotebookEditor.document)
+            ? true
+            : false;
+    }
+    private extensionsChanged() {
+        // See if the python extension was suddenly registered
+        if (this.extensionChecker.isPythonExtensionInstalled && this._registered) {
+            this.activate().ignoreErrors();
+        }
+    }
+}


### PR DESCRIPTION
For #3979 

Corresponding PR in python is here:
https://github.com/microsoft/vscode-python/pull/15149

Register an interpreter status bar filter to allow us to disable the interpreter when showing notebook files.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
