### PR TITLE
Add cell indicator for pre-execution

### DIFF
--- a/src/test/datascience/notebook/interrupRestart.vscode.test.ts
+++ b/src/test/datascience/notebook/interrupRestart.vscode.test.ts
@@ -186,8 +186,8 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
         await waitForTextOutputInVSCode(cell, '1', 0, false, 15_000); // Wait for 15 seconds for it to start (possibly kernel is still starting).
         traceInfo(`Step 13. Cell output`);
 
-        // Don't have to wait for interrupt, as sometimes interrupt can timeout & we switch to a new kernel.
-        // Stop execution of the cell (if possible).
+        // Don't have to wait for interrupt, as sometimes interrupt can timeout & we get a prompt to restart.
+        // Stop execution of the cell (if possible) in kernel.
         commands.executeCommand('jupyter.notebookeditor.interruptkernel').then(noop, noop);
         // Stop the cell (cleaner way to tear down this test, else VS Code can hang due to the fact that we delete/close notebooks & rest of the code is trying to access it).
         vscEditor.kernel!.cancelAllCellsExecution(vscEditor.document);

--- a/src/test/datascience/notebook/interrupRestart.vscode.test.ts
+++ b/src/test/datascience/notebook/interrupRestart.vscode.test.ts
@@ -37,7 +37,7 @@ import {
  * We will not use actual kernels, just ensure the appropriate methods are invoked on the appropriate classes.
  * This is done by stubbing out some methods.
  */
-suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)xxx', function () {
+suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', function () {
     this.timeout(60_000);
 
     let api: IExtensionTestApi;

--- a/src/test/datascience/notebook/interrupRestart.vscode.test.ts
+++ b/src/test/datascience/notebook/interrupRestart.vscode.test.ts
@@ -15,7 +15,7 @@ import { DataScience } from '../../../client/common/utils/localize';
 import { noop } from '../../../client/common/utils/misc';
 import { IKernelProvider } from '../../../client/datascience/jupyter/kernels/types';
 import { INotebookEditorProvider } from '../../../client/datascience/types';
-import { IExtensionTestApi, waitForCondition } from '../../common';
+import { IExtensionTestApi, sleep, waitForCondition } from '../../common';
 import { initialize } from '../../initialize';
 import {
     assertVSCCellIsNotRunning,
@@ -37,7 +37,7 @@ import {
  * We will not use actual kernels, just ensure the appropriate methods are invoked on the appropriate classes.
  * This is done by stubbing out some methods.
  */
-suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', function () {
+suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)xxx', function () {
     this.timeout(60_000);
 
     let api: IExtensionTestApi;
@@ -173,7 +173,13 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
         // Wait before we execute cells again.
         traceInfo('Step 9 Wait for restart');
         await restartPromise;
-        traceInfo('Step 10 Restarted');
+        traceInfo('Step 9.1 Restarted');
+
+        // Unfortunately the code is still busy restarting a few things like restart session etc.
+        // Hence add a slight delay for tests to pass (else its flaky).
+        await sleep(3_000);
+
+        traceInfo('Step 10 Before execute document');
 
         // Confirm we can execute a cell (using the new kernel session).
         await executeActiveDocument();

--- a/src/test/datascience/notebook/interrupRestart.vscode.test.ts
+++ b/src/test/datascience/notebook/interrupRestart.vscode.test.ts
@@ -15,7 +15,7 @@ import { DataScience } from '../../../client/common/utils/localize';
 import { noop } from '../../../client/common/utils/misc';
 import { IKernelProvider } from '../../../client/datascience/jupyter/kernels/types';
 import { INotebookEditorProvider } from '../../../client/datascience/types';
-import { IExtensionTestApi, sleep, waitForCondition } from '../../common';
+import { IExtensionTestApi, waitForCondition } from '../../common';
 import { initialize } from '../../initialize';
 import {
     assertVSCCellIsNotRunning,

--- a/src/test/datascience/notebook/interrupRestart.vscode.test.ts
+++ b/src/test/datascience/notebook/interrupRestart.vscode.test.ts
@@ -196,7 +196,10 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)xxx
         const interruptPromise = commands.executeCommand('jupyter.notebookeditor.interruptkernel');
         traceInfo('Step 14 Executed interrupt');
         await waitForCondition(
-            async () => assertVSCCellIsNotRunning(cell),
+            async () => {
+                traceInfo(`Step 14.1 Cell Status = ${cell.metadata.runState}`);
+                return assertVSCCellIsNotRunning(cell);
+            },
             15_000,
             'Execution not cancelled second time.'
         );

--- a/src/test/datascience/notebook/interrupRestart.vscode.test.ts
+++ b/src/test/datascience/notebook/interrupRestart.vscode.test.ts
@@ -173,13 +173,7 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)xxx
         // Wait before we execute cells again.
         traceInfo('Step 9 Wait for restart');
         await restartPromise;
-        traceInfo('Step 9.1 Restarted');
-
-        // Unfortunately the code is still busy restarting a few things like restart session etc.
-        // Hence add a slight delay for tests to pass (else its flaky).
-        await sleep(3_000);
-
-        traceInfo('Step 10 Before execute document');
+        traceInfo('Step 10 Restarted');
 
         // Confirm we can execute a cell (using the new kernel session).
         await executeActiveDocument();

--- a/src/test/datascience/notebook/interrupRestart.vscode.test.ts
+++ b/src/test/datascience/notebook/interrupRestart.vscode.test.ts
@@ -186,19 +186,10 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)xxx
         await waitForTextOutputInVSCode(cell, '1', 0, false, 15_000); // Wait for 15 seconds for it to start (possibly kernel is still starting).
         traceInfo(`Step 13. Cell output`);
 
+        // Don't have to wait for interrupt, as sometimes interrupt can timeout & we switch to a new kernel.
+        // Stop execution of the cell (if possible).
+        commands.executeCommand('jupyter.notebookeditor.interruptkernel').then(noop, noop);
         // Stop the cell (cleaner way to tear down this test, else VS Code can hang due to the fact that we delete/close notebooks & rest of the code is trying to access it).
-        const interruptPromise = commands.executeCommand('jupyter.notebookeditor.interruptkernel');
-        traceInfo('Step 14 Executed interrupt');
-        await waitForCondition(
-            async () => {
-                traceInfo(`Step 14.1 Cell Status = ${cell.metadata.runState}`);
-                return assertVSCCellIsNotRunning(cell);
-            },
-            15_000,
-            'Execution not cancelled second time.'
-        );
-        traceInfo('Step 15 execution cancelled');
-        await interruptPromise;
-        traceInfo('Step 16 Interrupted');
+        vscEditor.kernel!.cancelAllCellsExecution(vscEditor.document);
     });
 });

--- a/src/test/datascience/notebook/remoteNotebookEditor.vscode.test.ts
+++ b/src/test/datascience/notebook/remoteNotebookEditor.vscode.test.ts
@@ -31,7 +31,7 @@ import { PYTHON_LANGUAGE } from '../../../client/common/constants';
 import { PreferredRemoteKernelIdProvider } from '../../../client/datascience/notebookStorage/preferredRemoteKernelIdProvider';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, no-invalid-this */
-suite('DataScience - VSCode Notebook - (Remote) (Execution) (slow)xxx', function () {
+suite('DataScience - VSCode Notebook - (Remote) (Execution) (slow)', function () {
     this.timeout(920_000);
     let api: IExtensionTestApi;
     const disposables: IDisposable[] = [];


### PR DESCRIPTION
For #4409
The solution is to wait for notebook to start after a cell execution has been queued (this happens by creating an instance of CellExecution).
Previously it was the other way around.