### PR TITLE
Do not store kernel info in nb metadata for other VSC extension kernels

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -991,7 +991,6 @@ module.exports = {
         'src/client/datascience/interactive-common/intellisense/conversion.ts',
         'src/client/datascience/activation.ts',
         'src/client/datascience/jupyterUriProviderWrapper.ts',
-        'src/client/datascience/errorHandler/errorHandler.ts',
         'src/client/datascience/cellMatcher.ts',
         'src/client/datascience/notebookStorage/notebookModel.ts',
         'src/client/datascience/notebookStorage/notebookModelEditEvent.ts',

--- a/src/client/datascience/errorHandler/errorHandler.ts
+++ b/src/client/datascience/errorHandler/errorHandler.ts
@@ -27,9 +27,9 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
             // Don't show the message for self cert errors
             noop();
         } else if (err.message) {
-            this.applicationShell.showErrorMessage(err.message);
+            this.applicationShell.showErrorMessage(err.message).then(noop, noop);
         } else {
-            this.applicationShell.showErrorMessage(err.toString());
+            this.applicationShell.showErrorMessage(err.toString()).then(noop, noop);
         }
         traceError('DataScience Error', err);
     }
@@ -43,6 +43,6 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
                 if (selection === selectNewServer) {
                     this.serverSelector.selectJupyterURI(false).ignoreErrors();
                 }
-            });
+            }, noop);
     }
 }

--- a/src/client/datascience/notebook/helpers/helpers.ts
+++ b/src/client/datascience/notebook/helpers/helpers.ts
@@ -120,8 +120,12 @@ export function isPythonNotebook(metadata?: nbformat.INotebookMetadata) {
  * Similarly, if you open an existing notebook, it is marked as dirty.
  *
  * Solution: Store the metadata in some place, when saving, take the metadata & store in the file.
+ * Thus this method doesn't update it, we merely keep track of the kernel information, and when saving we retrieve the information from the tracked location (map).
+ *
+ * If `kernelConnection` is empty, then when saving the notebook we will not update the
+ * metadata in the notebook with any kernel information (we can't as its empty).
  */
-export function updateKernelInNotebookMetadata(
+export function trackKernelInNotebookMetadata(
     document: NotebookDocument,
     kernelConnection: KernelConnectionMetadata | undefined
 ) {
@@ -129,7 +133,12 @@ export function updateKernelInNotebookMetadata(
     data.metadata = kernelConnection;
     kernelInformationForNotebooks.set(document, data);
 }
-export function updateKernelInfoInNotebookMetadata(
+/**
+ * Thus this method doesn't update it the notebook metadata, we merely keep track of the information.
+ * When saving we retrieve the information from the tracked location (map).
+ * @see {trackKernelInNotebookMetadata} That function does something similar.
+ */
+export function trackKernelInfoInNotebookMetadata(
     document: NotebookDocument,
     kernelInfo: KernelMessage.IInfoReplyMsg['content']
 ) {

--- a/src/client/datascience/notebook/helpers/helpers.ts
+++ b/src/client/datascience/notebook/helpers/helpers.ts
@@ -124,6 +124,11 @@ export function isPythonNotebook(metadata?: nbformat.INotebookMetadata) {
  *
  * If `kernelConnection` is empty, then when saving the notebook we will not update the
  * metadata in the notebook with any kernel information (we can't as its empty).
+ *
+ * @param {(KernelConnectionMetadata | undefined)} kernelConnection
+ * This can be undefined when a kernels contributed by other VSC extensions is selected.
+ * E.g. .NET extension can contribute their own extension. At this point they could
+ * end up updating the notebook metadata themselves. We should not blow this metadata away. The way we achieve that is by clearing this stored kernel information & not updating the metadata.
  */
 export function trackKernelInNotebookMetadata(
     document: NotebookDocument,

--- a/src/client/datascience/notebook/kernelProvider.ts
+++ b/src/client/datascience/notebook/kernelProvider.ts
@@ -41,7 +41,7 @@ import {
     getNotebookMetadata,
     isJupyterKernel,
     isJupyterNotebook,
-    updateKernelInNotebookMetadata
+    trackKernelInNotebookMetadata
 } from './helpers/helpers';
 import { VSCodeNotebookKernelMetadata } from './kernelWithMetadata';
 import { INotebookKernelProvider, INotebookKernelResolver } from './types';
@@ -350,7 +350,7 @@ export class VSCodeKernelPickerProvider implements INotebookKernelProvider {
     }) {
         // We're only interested in our Jupyter Notebooks & our kernels.
         if (!isJupyterKernel(kernel) || !isJupyterNotebook(document)) {
-            updateKernelInNotebookMetadata(document, undefined);
+            trackKernelInNotebookMetadata(document, undefined);
             return;
         }
         const selectedKernelConnectionMetadata = kernel.selection;
@@ -422,7 +422,7 @@ export class VSCodeKernelPickerProvider implements INotebookKernelProvider {
                         if (notebook.disposed) {
                             return;
                         }
-                        updateKernelInNotebookMetadata(document, e);
+                        trackKernelInNotebookMetadata(document, e);
                     },
                     this,
                     this.disposables
@@ -435,7 +435,7 @@ export class VSCodeKernelPickerProvider implements INotebookKernelProvider {
             // Adding comment here, so we have context for the requirement.
             this.kernelSwitcher.switchKernelWithRetry(notebook, selectedKernelConnectionMetadata).catch(noop);
         } else {
-            updateKernelInNotebookMetadata(document, selectedKernelConnectionMetadata);
+            trackKernelInNotebookMetadata(document, selectedKernelConnectionMetadata);
         }
     }
 }

--- a/src/client/datascience/notebook/kernelProvider.ts
+++ b/src/client/datascience/notebook/kernelProvider.ts
@@ -350,6 +350,7 @@ export class VSCodeKernelPickerProvider implements INotebookKernelProvider {
     }) {
         // We're only interested in our Jupyter Notebooks & our kernels.
         if (!isJupyterKernel(kernel) || !isJupyterNotebook(document)) {
+            updateKernelInNotebookMetadata(document, undefined);
             return;
         }
         const selectedKernelConnectionMetadata = kernel.selection;

--- a/src/client/datascience/notebook/kernelWithMetadata.ts
+++ b/src/client/datascience/notebook/kernelWithMetadata.ts
@@ -13,7 +13,7 @@ import { noop } from '../../common/utils/misc';
 import { getKernelConnectionId, IKernel, IKernelProvider, KernelConnectionMetadata } from '../jupyter/kernels/types';
 import { PreferredRemoteKernelIdProvider } from '../notebookStorage/preferredRemoteKernelIdProvider';
 import { KernelSocketInformation } from '../types';
-import { updateKernelInfoInNotebookMetadata } from './helpers/helpers';
+import { trackKernelInfoInNotebookMetadata } from './helpers/helpers';
 
 export class VSCodeNotebookKernelMetadata implements VSCNotebookKernel {
     private pendingExecution: Promise<void> | undefined;
@@ -88,7 +88,7 @@ export class VSCodeNotebookKernelMetadata implements VSCNotebookKernel {
             if (!editor || editor.kernel?.id !== this.id) {
                 return;
             }
-            updateKernelInfoInNotebookMetadata(doc, kernel.info);
+            trackKernelInfoInNotebookMetadata(doc, kernel.info);
             if (kernel.info.status === 'ok' && this.selection.kind === 'startUsingKernelSpec') {
                 saveKernelInfo();
             }


### PR DESCRIPTION
For https://github.com/microsoft/vscode-jupyter/issues/4423#issuecomment-763903125

This way we don't set the kernel metadata when a non-jupyter kernel is selected.
Allowing others to update the notebook metadata without us blowing it away.