### PR TITLE
Fixes cooridnation of cell executions/cancellation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -887,7 +887,6 @@ module.exports = {
         'src/client/linters/linterCommands.ts',
         'src/client/linters/flake8.ts',
         'src/client/linters/errorHandlers/baseErrorHandler.ts',
-        'src/client/linters/errorHandlers/errorHandler.ts',
         'src/client/linters/errorHandlers/notInstalled.ts',
         'src/client/linters/errorHandlers/standard.ts',
         'src/client/linters/types.ts',

--- a/src/client/common/utils/async.ts
+++ b/src/client/common/utils/async.ts
@@ -240,9 +240,6 @@ export async function flattenIterator<T>(iterator: AsyncIterator<T, void>): Prom
 
 export class ChainedExecutions<T> {
     private pendingCellExecution?: Promise<T> | undefined;
-    public clear() {
-        this.pendingCellExecution = undefined;
-    }
     public async chainExecution(next: () => Promise<T>): Promise<T> {
         if (this.pendingCellExecution) {
             const previous = this.pendingCellExecution;

--- a/src/client/common/utils/async.ts
+++ b/src/client/common/utils/async.ts
@@ -242,7 +242,9 @@ export class ChainedExecutions<T> {
     private pendingCellExecution?: Promise<T> | undefined;
     public async chainExecution(next: () => Promise<T>): Promise<T> {
         if (this.pendingCellExecution) {
-            await this.pendingCellExecution;
+            const previous = this.pendingCellExecution;
+            this.pendingCellExecution = undefined;
+            await previous;
         }
         const promise = next();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/client/common/utils/async.ts
+++ b/src/client/common/utils/async.ts
@@ -3,8 +3,6 @@
 
 'use strict';
 
-import { traceError } from '../logger';
-
 /**
  * Error type thrown when a timeout occurs
  */
@@ -242,15 +240,9 @@ export async function flattenIterator<T>(iterator: AsyncIterator<T, void>): Prom
 
 export class ChainedExecutions<T> {
     private pendingCellExecution?: Promise<T> | undefined;
-    constructor(private readonly messageForErrorTracing: string) {}
     public async chainExecution(next: () => Promise<T>): Promise<T> {
         if (this.pendingCellExecution) {
-            try {
-                await this.pendingCellExecution;
-            } catch (ex) {
-                traceError(this.messageForErrorTracing, ex);
-                throw ex;
-            }
+            await this.pendingCellExecution;
         }
         const promise = next();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/client/common/utils/async.ts
+++ b/src/client/common/utils/async.ts
@@ -240,21 +240,21 @@ export async function flattenIterator<T>(iterator: AsyncIterator<T, void>): Prom
 
 export class ChainedExecutions<T> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private pendingCellExecution: Promise<any> = Promise.resolve();
+    private pendingExecution: Promise<any> = Promise.resolve();
     /**
      * Clears the chained promises.
      */
     public clear() {
-        this.pendingCellExecution = Promise.resolve();
+        this.pendingExecution = Promise.resolve();
     }
     public async chainExecution(next: () => Promise<T>): Promise<T> {
         const deferred = createDeferred<T>();
-        const chainedPromise = this.pendingCellExecution.then(() => {
+        const chainedPromise = this.pendingExecution.then(() => {
             const nextPromise = next();
             nextPromise.then((result) => deferred.resolve(result)).catch((ex) => deferred.reject(ex));
             return nextPromise;
         });
-        this.pendingCellExecution = chainedPromise;
+        this.pendingExecution = chainedPromise;
 
         return Promise.race([deferred.promise, chainedPromise]);
     }

--- a/src/client/common/utils/async.ts
+++ b/src/client/common/utils/async.ts
@@ -239,27 +239,23 @@ export async function flattenIterator<T>(iterator: AsyncIterator<T, void>): Prom
 }
 
 export class ChainedExecutions<T> {
-    private pendingCellExecution?: Promise<T> | undefined;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private pendingCellExecution: Promise<any> = Promise.resolve();
+    /**
+     * Clears the chained promises.
+     */
+    public clear() {
+        this.pendingCellExecution = Promise.resolve();
+    }
     public async chainExecution(next: () => Promise<T>): Promise<T> {
-        if (this.pendingCellExecution) {
-            const previous = this.pendingCellExecution;
-            // Clear in case this promise fails.
-            this.pendingCellExecution = undefined;
-            await previous;
-        }
-        const promise = next();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        this.pendingCellExecution = promise;
-        promise
-            .finally(() => {
-                // Clear in case this next promise fails.
-                if (this.pendingCellExecution === promise) {
-                    this.pendingCellExecution = undefined;
-                }
-            })
-            .catch(() => {
-                //
-            });
-        return promise;
+        const deferred = createDeferred<T>();
+        const chainedPromise = this.pendingCellExecution.then(() => {
+            const nextPromise = next();
+            nextPromise.then((result) => deferred.resolve(result)).catch((ex) => deferred.reject(ex));
+            return nextPromise;
+        });
+        this.pendingCellExecution = chainedPromise;
+
+        return Promise.race([deferred.promise, chainedPromise]);
     }
 }

--- a/src/client/datascience/errorHandler/errorHandler.ts
+++ b/src/client/datascience/errorHandler/errorHandler.ts
@@ -9,6 +9,7 @@ import { JupyterInstallError } from '../jupyter/jupyterInstallError';
 import { JupyterSelfCertsError } from '../jupyter/jupyterSelfCertsError';
 import { JupyterZMQBinariesNotFoundError } from '../jupyter/jupyterZMQBinariesNotFoundError';
 import { JupyterServerSelector } from '../jupyter/serverSelector';
+import { IpyKernelNotInstalledError } from '../kernel-launcher/types';
 import { IDataScienceErrorHandler, IJupyterInterpreterDependencyManager } from '../types';
 @injectable()
 export class DataScienceErrorHandler implements IDataScienceErrorHandler {
@@ -25,6 +26,9 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
             await this.showZMQError(err);
         } else if (err instanceof JupyterSelfCertsError) {
             // Don't show the message for self cert errors
+            noop();
+        } else if (err instanceof IpyKernelNotInstalledError) {
+            // Don't show the message, as user decided not to install IPyKernel.
             noop();
         } else if (err.message) {
             this.applicationShell.showErrorMessage(err.message).then(noop, noop);

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -504,7 +504,7 @@ export class JupyterNotebookBase implements INotebook {
 
             // Tell our loggers
             this.loggers.forEach((l) => l.onKernelRestarted(this.getNotebookId()));
-
+            traceInfo(`Time to restart kernel is ${(Date.now() - this.sessionStartTime) / 1000}s`);
             this.kernelRestarted.fire();
             return;
         }

--- a/src/client/datascience/jupyter/kernels/cellExecution.ts
+++ b/src/client/datascience/jupyter/kernels/cellExecution.ts
@@ -195,6 +195,13 @@ export class CellExecution {
     public async cancel() {
         await this.cancelInternal(false);
     }
+    /**
+     * @param {boolean} [forced=false]
+     * If `true`, then dequeue this & do not wait for execution to complete (basically kill it).
+     * This is used when we restart the kernel (either as a result of kernel interrupt or user initiated).
+     * When restarted, the execution needs to stop as jupyter will not send more messages.
+     * Thus `forced=true` is more like a hard kill.
+     */
     private async cancelInternal(forced = false) {
         if (this.started && !forced) {
             // At this point the cell execution can only be stopped from kernel & we should not

--- a/src/client/datascience/jupyter/kernels/cellExecution.ts
+++ b/src/client/datascience/jupyter/kernels/cellExecution.ts
@@ -198,7 +198,7 @@ export class CellExecution {
     public async cancel() {
         await this.cancelInternal(false);
     }
-    public async cancelInternal(forced = false) {
+    private async cancelInternal(forced = false) {
         if (this.started && !forced) {
             // At this point the cell execution can only be stopped from kernel & we should not
             // stop handling execution results & the like from the kernel.

--- a/src/client/datascience/jupyter/kernels/cellExecution.ts
+++ b/src/client/datascience/jupyter/kernels/cellExecution.ts
@@ -87,10 +87,6 @@ export class CellExecution {
     public get result(): Promise<NotebookCellRunState | undefined> {
         return this._result.promise;
     }
-
-    public get completed() {
-        return this._completed;
-    }
     /**
      * To be used only in tests.
      */

--- a/src/client/datascience/jupyter/kernels/cellExecution.ts
+++ b/src/client/datascience/jupyter/kernels/cellExecution.ts
@@ -190,6 +190,7 @@ export class CellExecution {
     /**
      * Cancel execution.
      * If execution has commenced, then wait for execution to complete or kernel to start.
+     * If execution has not commenced, then ensure dequeue it & revert the status to not-queued (remove spinner, etc).
      */
     public async cancel() {
         await this.cancelInternal(false);

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -254,9 +254,17 @@ export class Kernel implements IKernel {
                 this._onDisposed.fire();
             });
             this.notebook.onKernelRestarted(() => {
+                traceInfo(`Notebook Kernel restarted ${this.notebook?.identity}`);
                 this._onRestarted.fire();
             });
-            this.notebook.onSessionStatusChanged((e) => this._onStatusChanged.fire(e), this, this.disposables);
+            this.notebook.onSessionStatusChanged(
+                (e) => {
+                    traceInfo(`Notebook Session status ${this.notebook?.identity} # ${e}`);
+                    this._onStatusChanged.fire(e);
+                },
+                this,
+                this.disposables
+            );
         }
         if (isPythonKernelConnection(this.kernelConnectionMetadata)) {
             await this.notebook.setLaunchingFile(this.uri.fsPath);

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -9,9 +9,9 @@ import { Subject } from 'rxjs/Subject';
 import * as uuid from 'uuid/v4';
 import { CancellationTokenSource, Event, EventEmitter, NotebookCell, NotebookDocument, Uri } from 'vscode';
 import { ServerStatus } from '../../../../datascience-ui/interactive-common/mainState';
-import { IApplicationShell, ICommandManager, IVSCodeNotebook } from '../../../common/application/types';
+import { IApplicationShell, IVSCodeNotebook } from '../../../common/application/types';
 import { WrappedError } from '../../../common/errors/errorUtils';
-import { traceError, traceWarning } from '../../../common/logger';
+import { traceError, traceInfo, traceWarning } from '../../../common/logger';
 import { IFileSystem } from '../../../common/platform/types';
 import { IDisposableRegistry, IExtensionContext } from '../../../common/types';
 import { createDeferred, Deferred } from '../../../common/utils/async';
@@ -45,9 +45,6 @@ export class Kernel implements IKernel {
     get onDisposed(): Event<void> {
         return this._onDisposed.event;
     }
-    get onInterruptTimedOut(): Event<void> {
-        return this._onInterruptTimedOut.event;
-    }
     private _info?: KernelMessage.IInfoReplyMsg['content'];
     get info(): KernelMessage.IInfoReplyMsg['content'] | undefined {
         return this._info;
@@ -68,7 +65,6 @@ export class Kernel implements IKernel {
     private readonly _onStatusChanged = new EventEmitter<ServerStatus>();
     private readonly _onRestarted = new EventEmitter<void>();
     private readonly _onDisposed = new EventEmitter<void>();
-    private readonly _onInterruptTimedOut = new EventEmitter<void>();
     private _notebookPromise?: Promise<INotebook>;
     private readonly hookedNotebookForEvents = new WeakSet<INotebook>();
     private restarting?: Deferred<void>;
@@ -81,8 +77,7 @@ export class Kernel implements IKernel {
         private readonly notebookProvider: INotebookProvider,
         private readonly disposables: IDisposableRegistry,
         private readonly launchTimeout: number,
-        private readonly interruptTimeout: number,
-        commandManager: ICommandManager,
+        interruptTimeout: number,
         private readonly errorHandler: IDataScienceErrorHandler,
         private readonly editorProvider: INotebookEditorProvider,
         private readonly kernelProvider: IKernelProvider,
@@ -95,7 +90,6 @@ export class Kernel implements IKernel {
     ) {
         this.kernelExecution = new KernelExecution(
             kernelProvider,
-            commandManager,
             errorHandler,
             editorProvider,
             kernelSelectionUsage,
@@ -103,7 +97,8 @@ export class Kernel implements IKernel {
             vscNotebook,
             kernelConnectionMetadata,
             rawNotebookSupported,
-            context
+            context,
+            interruptTimeout
         );
     }
     public async executeCell(cell: NotebookCell): Promise<void> {
@@ -114,42 +109,21 @@ export class Kernel implements IKernel {
         const notebookPromise = this.startNotebook({ disableUI: false });
         await this.kernelExecution.executeAllCells(notebookPromise, document);
     }
-    public async cancelCell(cell: NotebookCell) {
-        this.startCancellation.cancel();
-        await this.kernelExecution.cancelCell(cell);
-    }
-    public async cancelAllCells(document: NotebookDocument) {
-        this.startCancellation.cancel();
-        await this.kernelExecution.cancelAllCells(document);
-    }
     public async start(options?: { disableUI?: boolean }): Promise<void> {
         await this.startNotebook(options);
     }
-    public async interruptCell(cell: NotebookCell): Promise<InterruptResult> {
+    public async interrupt(document: NotebookDocument): Promise<InterruptResult> {
         if (this.restarting) {
+            traceInfo(`Interrupt requested & currently restarting ${document.uri}`);
             await this.restarting.promise;
         }
-        if (!this.notebook) {
-            throw new Error('No notebook to interrupt');
+        traceInfo(`Interrupt requested ${document.uri}`);
+        this.startCancellation.cancel();
+        if (!this._notebookPromise) {
+            traceInfo('Interrupt requested even before a notebook has been created');
+            return InterruptResult.Success;
         }
-        const result = await this.kernelExecution.interruptCell(cell, this.interruptTimeout);
-        if (result === InterruptResult.TimedOut) {
-            this._onInterruptTimedOut.fire();
-        }
-        return result;
-    }
-    public async interruptAllCells(document: NotebookDocument): Promise<InterruptResult> {
-        if (this.restarting) {
-            await this.restarting.promise;
-        }
-        if (!this.notebook) {
-            throw new Error('No notebook to interrupt');
-        }
-        const result = await this.kernelExecution.interruptAllCells(document, this.interruptTimeout);
-        if (result === InterruptResult.TimedOut) {
-            this._onInterruptTimedOut.fire();
-        }
-        return result;
+        return this.kernelExecution.interrupt(this._notebookPromise, document);
     }
     public async dispose(): Promise<void> {
         this.restarting = undefined;

--- a/src/client/datascience/jupyter/kernels/kernelExecution.ts
+++ b/src/client/datascience/jupyter/kernels/kernelExecution.ts
@@ -280,7 +280,7 @@ export class KernelExecution implements IDisposable {
                 await this.cancelAllCells(notebookPromise, document);
                 break;
             }
-            // Remove the item that was processed.
+            // Remove the item that was processed, possible it got automatically removed (see `createCellExecution`)
             if (stackOfCellsToExecute[0] === cellToExecute) {
                 stackOfCellsToExecute.shift();
             }

--- a/src/client/datascience/jupyter/kernels/kernelExecution.ts
+++ b/src/client/datascience/jupyter/kernels/kernelExecution.ts
@@ -242,6 +242,7 @@ export class KernelExecution implements IDisposable {
             const kernel = this.getKernel(document);
             stackOfCellsToExecute.forEach((exec) => traceCellMessage(exec.cell, 'Ready to execute'));
             while (stackOfCellsToExecute.length) {
+                // Stack of cells to be executed, this way we maintain order of cell executions.
                 const cellToExecute = stackOfCellsToExecute[0];
                 if (!cellToExecute) {
                     continue;

--- a/src/client/datascience/jupyter/kernels/kernelExecution.ts
+++ b/src/client/datascience/jupyter/kernels/kernelExecution.ts
@@ -196,11 +196,11 @@ export class KernelExecution implements IDisposable {
         const restartHandlerToken = session.onSessionStatusChanged(restartHandler);
 
         // Start our interrupt. If it fails, indicate a restart
-        // session.interrupt(this.interruptTimeout).catch((exc) => {
-        //     traceWarning(`Error during interrupt: ${exc}`);
-        //     restarted.resolve(true);
-        // });
-        setTimeout(() => restarted.resolve(true), 5_000);
+        session.interrupt(this.interruptTimeout).catch((exc) => {
+            traceWarning(`Error during interrupt: ${exc}`);
+            restarted.resolve(true);
+        });
+
         try {
             // Wait for all of the pending cells to finish or the timeout to fire
             const result = await waitForPromise(Promise.race([pendingCells, restarted.promise]), this.interruptTimeout);

--- a/src/client/datascience/jupyter/kernels/kernelExecution.ts
+++ b/src/client/datascience/jupyter/kernels/kernelExecution.ts
@@ -41,10 +41,8 @@ export class KernelExecution implements IDisposable {
 
     private readonly executionFactory: CellExecutionFactory;
     private readonly disposables: IDisposable[] = [];
-    private readonly pendingExecution = new ChainedExecutions<void>('Kernel execution failure');
-    private readonly pendingCellExecution = new ChainedExecutions<NotebookCellRunState | undefined>(
-        'Kernel execution previous cell failure'
-    );
+    private readonly pendingExecution = new ChainedExecutions<void>();
+    private readonly pendingCellExecution = new ChainedExecutions<NotebookCellRunState | undefined>();
     private isRawNotebookSupported?: Promise<boolean>;
     private _interruptPromise?: Promise<InterruptResult>;
     constructor(

--- a/src/client/datascience/jupyter/kernels/kernelExecution.ts
+++ b/src/client/datascience/jupyter/kernels/kernelExecution.ts
@@ -74,9 +74,7 @@ export class KernelExecution implements IDisposable {
         }
         const cellExecution = this.createCellExecution(cell);
         try {
-            await this.pendingExecution.chainExecution(async () =>
-                this.executeQueuedCells(notebookPromise, cell.notebook)
-            );
+            await this.pendingExecution.chainExecution(() => this.executeQueuedCells(notebookPromise, cell.notebook));
         } catch (ex) {
             // Possible one cell failed, we need to stop everything else.
             traceError(`Failed to execute a cell ${cell.index}, hence cancelling all`, ex);

--- a/src/client/datascience/jupyter/kernels/kernelExecution.ts
+++ b/src/client/datascience/jupyter/kernels/kernelExecution.ts
@@ -323,6 +323,7 @@ export class KernelExecution implements IDisposable {
                 if (kernel !== this.kernelProvider.get(document.uri)) {
                     return;
                 }
+                this.documentExecutions.get(document)?.cancel(); // NOSONAR
                 traceInfo('Cancel all executions as Kernel was restarted');
                 return this.cancelAllPendingCells(document, true);
             },

--- a/src/client/datascience/jupyter/kernels/kernelExecution.ts
+++ b/src/client/datascience/jupyter/kernels/kernelExecution.ts
@@ -66,6 +66,8 @@ export class KernelExecution implements IDisposable {
     public async executeCell(notebookPromise: Promise<INotebook>, cell: NotebookCell): Promise<void> {
         // Return current execution.
         if (this.cellExecutions.get(cell)) {
+            // It is impossible for a cell to be re-executed multiple times.
+            // Hence log this error.
             traceError(`Cell already executing/queued for execution, requested re-execution of ${cell.index}`);
             await this.cellExecutions.get(cell)!.result;
             return;

--- a/src/client/datascience/jupyter/kernels/kernelExecution.ts
+++ b/src/client/datascience/jupyter/kernels/kernelExecution.ts
@@ -270,9 +270,7 @@ export class KernelExecution implements IDisposable {
                 continue;
             }
             traceCellMessage(cellToExecute.cell, 'Before Execute individual cell');
-            const result = this.executeIndividualCell(kernel, cellToExecute, notebook);
-            result.finally(() => this.cellExecutions.delete(cellToExecute.cell)).catch(noop);
-            const executionResult = await result;
+            const executionResult = await this.executeIndividualCell(kernel, cellToExecute, notebook);
             traceCellMessage(cellToExecute.cell, `After Execute individual cell ${executionResult}`);
             // If a cell has failed or execution cancelled, the get out.
             if (token?.isCancellationRequested || executionResult === vscodeNotebookEnums.NotebookCellRunState.Error) {
@@ -300,6 +298,7 @@ export class KernelExecution implements IDisposable {
             if (index >= 0) {
                 stackOfCellsToExecute.splice(index, 1);
             }
+            this.cellExecutions.delete(cellExecution.cell);
         });
         return cellExecution;
     }

--- a/src/client/datascience/jupyter/kernels/types.ts
+++ b/src/client/datascience/jupyter/kernels/types.ts
@@ -160,7 +160,6 @@ export interface IKernel extends IAsyncDisposable {
     readonly onStatusChanged: Event<ServerStatus>;
     readonly onDisposed: Event<void>;
     readonly onRestarted: Event<void>;
-    readonly onInterruptTimedOut: Event<void>;
     readonly status: ServerStatus;
     readonly disposed: boolean;
     /**
@@ -170,8 +169,7 @@ export interface IKernel extends IAsyncDisposable {
     readonly info?: KernelMessage.IInfoReplyMsg['content'];
     readonly kernelSocket: Observable<KernelSocketInformation | undefined>;
     start(options?: { disableUI?: boolean }): Promise<void>;
-    interruptCell(cell: NotebookCell): Promise<InterruptResult>;
-    interruptAllCells(document: NotebookDocument): Promise<InterruptResult>;
+    interrupt(document: NotebookDocument): Promise<InterruptResult>;
     restart(): Promise<void>;
     executeCell(cell: NotebookCell): Promise<void>;
     executeAllCells(document: NotebookDocument): Promise<void>;
@@ -180,10 +178,6 @@ export interface IKernel extends IAsyncDisposable {
 export type KernelOptions = { metadata: KernelConnectionMetadata };
 export const IKernelProvider = Symbol('IKernelProvider');
 export interface IKernelProvider extends IAsyncDisposable {
-    /**
-     * Event fired when an interrupt event times out for any kernel
-     */
-    readonly onInterruptTimedOut: Event<IKernel>;
     /**
      * Get hold of the active kernel for a given Uri (Notebook or other file).
      */

--- a/src/client/datascience/notebook/helpers/notebookUpdater.ts
+++ b/src/client/datascience/notebook/helpers/notebookUpdater.ts
@@ -31,7 +31,8 @@ export async function chainWithPendingUpdates(
     const aggregatedPromise = pendingUpdates
         // We need to ensure the update operation gets invoked after previous updates have been completed.
         // This way, the callback making references to cell metadata will have the latest information.
-        .then(async () =>
+        // Even if previous update fails, we should not fail this current update.
+        .finally(async () =>
             editor.edit(update).then(
                 (result) => deferred.resolve(result),
                 (ex) => deferred.reject(ex)

--- a/src/client/datascience/notebook/kernelProvider.ts
+++ b/src/client/datascience/notebook/kernelProvider.ts
@@ -9,7 +9,7 @@ import {
     NotebookDocument,
     NotebookKernel as VSCNotebookKernel
 } from '../../../../types/vscode-proposed';
-import { IVSCodeNotebook } from '../../common/application/types';
+import { ICommandManager, IVSCodeNotebook } from '../../common/application/types';
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import { IConfigurationService, IDisposableRegistry, IExtensionContext } from '../../common/types';
 import { noop } from '../../common/utils/misc';
@@ -70,7 +70,8 @@ export class VSCodeKernelPickerProvider implements INotebookKernelProvider {
         @inject(IJupyterSessionManagerFactory)
         private readonly jupyterSessionManagerFactory: IJupyterSessionManagerFactory,
         @inject(PreferredRemoteKernelIdProvider)
-        private readonly preferredRemoteKernelIdProvider: PreferredRemoteKernelIdProvider
+        private readonly preferredRemoteKernelIdProvider: PreferredRemoteKernelIdProvider,
+        @inject(ICommandManager) private readonly commandManager: ICommandManager
     ) {
         this.kernelSelectionProvider.onDidChangeSelections(
             (e) => {
@@ -130,7 +131,8 @@ export class VSCodeKernelPickerProvider implements INotebookKernelProvider {
                     this.kernelProvider,
                     this.notebook,
                     this.context,
-                    this.preferredRemoteKernelIdProvider
+                    this.preferredRemoteKernelIdProvider,
+                    this.commandManager
                 );
             })
             .filter((item) => {
@@ -173,7 +175,8 @@ export class VSCodeKernelPickerProvider implements INotebookKernelProvider {
                         this.kernelProvider,
                         this.notebook,
                         this.context,
-                        this.preferredRemoteKernelIdProvider
+                        this.preferredRemoteKernelIdProvider,
+                        this.commandManager
                     )
                 );
             }
@@ -268,7 +271,8 @@ export class VSCodeKernelPickerProvider implements INotebookKernelProvider {
                 this.kernelProvider,
                 this.notebook,
                 this.context,
-                this.preferredRemoteKernelIdProvider
+                this.preferredRemoteKernelIdProvider,
+                this.commandManager
             );
         } else if (preferredKernel.kind === 'connectToLiveKernel') {
             return new VSCodeNotebookKernelMetadata(
@@ -280,7 +284,8 @@ export class VSCodeKernelPickerProvider implements INotebookKernelProvider {
                 this.kernelProvider,
                 this.notebook,
                 this.context,
-                this.preferredRemoteKernelIdProvider
+                this.preferredRemoteKernelIdProvider,
+                this.commandManager
             );
         } else {
             return new VSCodeNotebookKernelMetadata(
@@ -292,7 +297,8 @@ export class VSCodeKernelPickerProvider implements INotebookKernelProvider {
                 this.kernelProvider,
                 this.notebook,
                 this.context,
-                this.preferredRemoteKernelIdProvider
+                this.preferredRemoteKernelIdProvider,
+                this.commandManager
             );
         }
     }

--- a/src/test/datascience/notebook/emptyCellWithOutput.ipynb
+++ b/src/test/datascience/notebook/emptyCellWithOutput.ipynb
@@ -1,0 +1,38 @@
+{
+    "cells": [
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": "Hello World"
+                    },
+                    "execution_count": 1,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": []
+        }
+    ],
+    "nbformat": 4,
+    "nbformat_minor": 2,
+    "metadata": {
+        "language_info": {
+            "name": "python",
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            }
+        },
+        "orig_nbformat": 2,
+        "file_extension": ".py",
+        "mimetype": "text/x-python",
+        "name": "python",
+        "npconvert_exporter": "python",
+        "pygments_lexer": "ipython3",
+        "version": 3
+    }
+}

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -379,6 +379,12 @@ function assertHasExecutionCompletedSuccessfully(cell: NotebookCell) {
         cell.metadata.runState === vscodeNotebookEnums.NotebookCellRunState.Success
     );
 }
+function assertHasEmptyCellExecutionCompleted(cell: NotebookCell) {
+    return (
+        (cell.metadata.executionOrder ?? 0) === 0 &&
+        cell.metadata.runState === vscodeNotebookEnums.NotebookCellRunState.Idle
+    );
+}
 /**
  *  Wait for VSC to perform some last minute clean up of cells.
  * In tests we can end up deleting cells. However if extension is still dealing with the cells, we need to give it some time to finish.
@@ -401,6 +407,14 @@ export async function waitForExecutionCompletedSuccessfully(cell: NotebookCell, 
         async () => assertHasExecutionCompletedSuccessfully(cell),
         timeout,
         `Cell ${cell.index + 1} did not complete successfully`
+    );
+    await waitForCellExecutionToComplete(cell);
+}
+export async function waitForEmptyCellExecutionCompleted(cell: NotebookCell, timeout: number = 15_000) {
+    await waitForCondition(
+        async () => assertHasEmptyCellExecutionCompleted(cell),
+        timeout,
+        `Cell ${cell.index + 1} did not complete (this is an empty cell)`
     );
     await waitForCellExecutionToComplete(cell);
 }

--- a/src/test/datascience/notebook/interrupRestart.vscode.test.ts
+++ b/src/test/datascience/notebook/interrupRestart.vscode.test.ts
@@ -169,7 +169,7 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
                 traceInfo(`Step 8 Cell Status = ${cell.metadata.runState}`);
                 return assertVSCCellIsNotRunning(cell);
             },
-            15_000,
+            30_000, // Could be slow with remote jupyter (on CI).
             'Execution not cancelled first time.'
         );
 


### PR DESCRIPTION
For #4514
**Summary of changes**
* Moved interrupt from CellExecution to KernelExecution (as we need a single interrupt for kernel, not for each cell)
* Cells cannot cancel them selves, we cancel a kernel & kernel stops execution of cells.
	* Previously we'd cancel a kernel via the cancelMethod or cancellation Token and then the cellExecution would propagate that message upto KernelExecution asking that to interrupt the kernel... 
	* **I.e was backwards, cell should not have to ask the Kernel to interrupt itself.**
* Ensure we order the executions (moved from kernel layer to KernelExecution, closer to where we queue executions)
	* Else sometimes cells that are queued don't look queued at all (until previous cells finish execution)
* Remove interruptEvent

**Fix a number of bugs:**
* Things running out of order
	* Run multiple cells one after the other
	* Run whole notebook & then run another cell
* Run multiple cells, and the timers seem to indicate things are running out of order or longer than necessary
* Run all cells, then stop & it doesn't stop properly (document seems to be running)
* Run cells with empty cells and cell status isn't updated
* Issues with cancellation/interrupts (not able to re-run after).


**Will require a lot of tests**
Writing test is still a WIP