### PR TITLE
Add more tests for switching kernels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ on:
       - 'release'
       - 'release/*'
       - 'release-*'
-      - rchiodo/more_test_fixes
   workflow_dispatch:
 
 env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ on:
       - 'release'
       - 'release/*'
       - 'release-*'
+      - rchiodo/more_test_fixes
   workflow_dispatch:
 
 env:

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -11,7 +11,6 @@ import * as path from 'path';
 import { coerce, SemVer } from 'semver';
 import { ConfigurationTarget, Event, TextDocument, Uri } from 'vscode';
 import { IExtensionApi } from '../client/api';
-import { traceInfo } from '../client/common/logger';
 import { IProcessService } from '../client/common/process/types';
 import { IDisposable, IJupyterSettings } from '../client/common/types';
 import { IServiceContainer, IServiceManager } from '../client/ioc/types';
@@ -514,7 +513,7 @@ export async function waitForCondition(
             clearTimeout(timeout);
             // eslint-disable-next-line @typescript-eslint/no-use-before-define
             clearInterval(timer);
-            traceInfo(`Test failing --- ${errorMessage}`);
+            console.log(`Test failing --- ${errorMessage}`);
             reject(new Error(errorMessage));
         }, timeoutMs);
         const timer = setInterval(async () => {

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import { coerce, SemVer } from 'semver';
 import { ConfigurationTarget, Event, TextDocument, Uri } from 'vscode';
 import { IExtensionApi } from '../client/api';
+import { traceInfo } from '../client/common/logger';
 import { IProcessService } from '../client/common/process/types';
 import { IDisposable, IJupyterSettings } from '../client/common/types';
 import { IServiceContainer, IServiceManager } from '../client/ioc/types';
@@ -513,6 +514,7 @@ export async function waitForCondition(
             clearTimeout(timeout);
             // eslint-disable-next-line @typescript-eslint/no-use-before-define
             clearInterval(timer);
+            traceInfo(`Test failing --- ${errorMessage}`);
             reject(new Error(errorMessage));
         }, timeoutMs);
         const timer = setInterval(async () => {

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -23,7 +23,7 @@ import {
     createTemporaryNotebook,
     hijackPrompt,
     waitForExecutionCompletedSuccessfully,
-    waitForKernelToGetSelected
+    waitForKernelToChange
 } from '../../notebook/helper';
 
 /* eslint-disable no-invalid-this, , , @typescript-eslint/no-explicit-any */
@@ -125,7 +125,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
                 await openNotebook(api.serviceContainer, nbFile);
                 // If this is a native notebook, then wait for kernel to get selected.
                 if (editorProvider.activeEditor?.type === 'native') {
-                    await waitForKernelToGetSelected(kName);
+                    await waitForKernelToChange(kName);
                 }
 
                 // Run all cells

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -97,9 +97,6 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
 
     ['.venvnokernel', '.venvnoreg'].forEach((kName) =>
         test('Ensure prompt is displayed when ipykernel module is not found and it gets installed', async function () {
-            // This is pending waiting for the 'notebook.selectKernel' command to accept an id
-            this.skip();
-
             // Confirm message is displayed & we click 'Install` button.
             const prompt = await hijackPrompt(
                 'showErrorMessage',

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -19,7 +19,7 @@ import {
     NotebookDocument
 } from '../../../../typings/vscode-proposed';
 import { IApplicationEnvironment, IApplicationShell, IVSCodeNotebook } from '../../../client/common/application/types';
-import { MARKDOWN_LANGUAGE, PYTHON_LANGUAGE } from '../../../client/common/constants';
+import { JVSC_EXTENSION_ID, MARKDOWN_LANGUAGE, PYTHON_LANGUAGE } from '../../../client/common/constants';
 import { disposeAllDisposables } from '../../../client/common/helpers';
 import { traceInfo } from '../../../client/common/logger';
 import {
@@ -245,7 +245,7 @@ export async function waitForKernelToGetSelected(kernelNameSearch: string) {
     const id = kernels?.find((k) => k.label.includes(kernelNameSearch))?.id;
 
     // Send a select kernel on the active notebook editor
-    void commands.executeCommand('notebook.selectKernel', { id });
+    void commands.executeCommand('notebook.selectKernel', { id, extension: JVSC_EXTENSION_ID });
     const isRightKernel = () => {
         if (!vscodeNotebook.activeNotebookEditor) {
             return false;

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -254,9 +254,10 @@ export async function waitForKernelToChange(labelOrId: string | undefined) {
             return false;
         }
         if (vscodeNotebook.activeNotebookEditor.kernel.id === id) {
+            traceInfo(`Found selected kernel ${vscodeNotebook.activeNotebookEditor.kernel.id}`);
             return true;
         }
-        traceInfo(`Active kernel is ${vscodeNotebook.activeNotebookEditor.kernel.label}`);
+        traceInfo(`Active kernel is ${vscodeNotebook.activeNotebookEditor.kernel.id}`);
         return false;
     };
     await waitForCondition(async () => isRightKernel(), 15_000, `Kernel with label/id ${labelOrId} not selected`);

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -227,7 +227,7 @@ export async function closeNotebooks(disposables: IDisposable[] = []) {
     disposeAllDisposables(disposables);
 }
 
-export async function waitForKernelToChange(kernelNameSearch: string) {
+export async function waitForKernelToChange(labelOrId: string | undefined) {
     const { vscodeNotebook, kernelProvider } = await getServices();
 
     // Wait for the active editor to come up
@@ -242,7 +242,7 @@ export async function waitForKernelToChange(kernelNameSearch: string) {
     traceInfo(`Kernels found for wait search: ${kernels?.map((k) => k.label).join('\n')}`);
 
     // Find the kernel id that matches the name we want
-    const id = kernels?.find((k) => k.label.includes(kernelNameSearch))?.id;
+    const id = kernels?.find((k) => (labelOrId && k.label.includes(labelOrId)) || (k.id && k.id == labelOrId))?.id;
 
     // Send a select kernel on the active notebook editor
     void commands.executeCommand('notebook.selectKernel', { id, extension: JVSC_EXTENSION_ID });
@@ -259,7 +259,7 @@ export async function waitForKernelToChange(kernelNameSearch: string) {
         traceInfo(`Active kernel is ${vscodeNotebook.activeNotebookEditor.kernel.label}`);
         return false;
     };
-    await waitForCondition(async () => isRightKernel(), 15_000, `Kernel with name ${kernelNameSearch} not selected`);
+    await waitForCondition(async () => isRightKernel(), 15_000, `Kernel with label/id ${labelOrId} not selected`);
 }
 
 export async function waitForKernelToGetAutoSelected(expectedLanguage?: string, time = 100_000) {

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -227,7 +227,7 @@ export async function closeNotebooks(disposables: IDisposable[] = []) {
     disposeAllDisposables(disposables);
 }
 
-export async function waitForKernelToGetSelected(kernelNameSearch: string) {
+export async function waitForKernelToChange(kernelNameSearch: string) {
     const { vscodeNotebook, kernelProvider } = await getServices();
 
     // Wait for the active editor to come up

--- a/src/test/datascience/notebook/notebookEditor.vscode.test.ts
+++ b/src/test/datascience/notebook/notebookEditor.vscode.test.ts
@@ -142,7 +142,9 @@ suite('Notebook Editor tests', () => {
         traceInfo(`Kernels found for switch kernel: ${kernels?.map((k) => k.label).join('\n')}`);
         // Find another kernel other than the preferred kernel that is also python based
         const preferredKernel = kernels?.find((k) => k.isPreferred && k.label.toLowerCase().includes('python 3'));
-        const anotherKernel = kernels?.find((k) => !k.isPreferred && k.label.toLowerCase().includes('python 3'));
+        const anotherKernel = kernels?.find(
+            (k) => !k.isPreferred && k.label.toLowerCase().includes('python 3') && k.label !== preferredKernel?.label
+        );
         if (anotherKernel) {
             // We have multiple kernels. Try switching
             await waitForKernelToChange(anotherKernel.id);

--- a/src/test/datascience/notebook/notebookEditor.vscode.test.ts
+++ b/src/test/datascience/notebook/notebookEditor.vscode.test.ts
@@ -49,7 +49,7 @@ suite('Notebook Editor tests', () => {
         kernelProvider = api.serviceContainer.get<INotebookKernelProvider>(INotebookKernelProvider);
 
         // On conda these take longer for some reason.
-        this.timeout(30_000);
+        this.timeout(60_000);
     });
 
     setup(async function () {

--- a/src/test/datascience/notebook/notebookEditor.vscode.test.ts
+++ b/src/test/datascience/notebook/notebookEditor.vscode.test.ts
@@ -25,7 +25,7 @@ import {
     trustAllNotebooks,
     waitForExecutionCompletedSuccessfully,
     waitForKernelToGetAutoSelected,
-    waitForKernelToGetSelected
+    waitForKernelToChange
 } from './helper';
 const vscodeNotebookEnums = require('vscode') as typeof import('vscode-proposed');
 
@@ -143,7 +143,7 @@ suite('Notebook Editor tests', () => {
         traceInfo(`Kernels found for switch kernel: ${kernels?.map((k) => k.label).join('\n')}`);
         if (kernels?.length && kernels?.length > 1) {
             // We have multiple kernels. Try switching
-            await waitForKernelToGetSelected(kernels[1].label);
+            await waitForKernelToChange(kernels[1].label);
         }
 
         // Execute cell and verify output

--- a/src/test/datascience/notebook/notebookEditor.vscode.test.ts
+++ b/src/test/datascience/notebook/notebookEditor.vscode.test.ts
@@ -4,10 +4,12 @@
 'use strict';
 
 import { assert } from 'chai';
+import { CancellationToken } from 'vscode-jsonrpc';
 import { ICommandManager, IVSCodeNotebook } from '../../../client/common/application/types';
 import { traceInfo } from '../../../client/common/logger';
 import { IDisposable } from '../../../client/common/types';
 import { Commands } from '../../../client/datascience/constants';
+import { INotebookKernelProvider } from '../../../client/datascience/notebook/types';
 import { INotebookEditorProvider } from '../../../client/datascience/types';
 import { IExtensionTestApi } from '../../common';
 import { initialize } from '../../initialize';
@@ -15,12 +17,14 @@ import {
     canRunNotebookTests,
     closeNotebooksAndCleanUpAfterTests,
     deleteAllCellsAndWait,
+    executeCell,
     insertCodeCell,
     selectCell,
     startJupyterServer,
     trustAllNotebooks,
     waitForExecutionCompletedSuccessfully,
-    waitForKernelToGetAutoSelected
+    waitForKernelToGetAutoSelected,
+    waitForKernelToGetSelected
 } from './helper';
 const vscodeNotebookEnums = require('vscode') as typeof import('vscode-proposed');
 
@@ -29,6 +33,7 @@ suite('Notebook Editor tests', () => {
     let vscodeNotebook: IVSCodeNotebook;
     let editorProvider: INotebookEditorProvider;
     let commandManager: ICommandManager;
+    let kernelProvider: INotebookKernelProvider;
     const disposables: IDisposable[] = [];
 
     suiteSetup(async function () {
@@ -40,6 +45,7 @@ suite('Notebook Editor tests', () => {
         vscodeNotebook = api.serviceContainer.get<IVSCodeNotebook>(IVSCodeNotebook);
         editorProvider = api.serviceContainer.get<INotebookEditorProvider>(INotebookEditorProvider);
         commandManager = api.serviceContainer.get<ICommandManager>(ICommandManager);
+        kernelProvider = api.serviceContainer.get<INotebookKernelProvider>(INotebookKernelProvider);
 
         // On conda these take longer for some reason.
         this.timeout(30_000);
@@ -114,5 +120,32 @@ suite('Notebook Editor tests', () => {
 
         // The third cell should have a runState of Success
         assert.strictEqual(thirdCell?.metadata.runState, vscodeNotebookEnums.NotebookCellRunState.Success);
+    });
+
+    test('Switch kernels', async function () {
+        // add a cell
+        await insertCodeCell('print("0")', { index: 0 });
+
+        const cell = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
+
+        await executeCell(cell);
+
+        // Wait till execution count changes and status is success.
+        await waitForExecutionCompletedSuccessfully(cell);
+
+        // Switch kernels to the other kernel
+        const kernels = await kernelProvider.provideKernels(
+            vscodeNotebook.activeNotebookEditor!.document,
+            CancellationToken.None
+        );
+        if (kernels?.length && kernels?.length > 0) {
+            // We have multiple kernels. Try switching
+            await waitForKernelToGetSelected(kernels[0].label);
+        }
+
+        // Execute cell and verify output
+        await executeCell(cell);
+        assert.strictEqual(cell?.outputs.length, 1);
+        assert.strictEqual(cell?.metadata.runState, vscodeNotebookEnums.NotebookCellRunState.Success);
     });
 });

--- a/src/test/datascience/notebook/notebookEditor.vscode.test.ts
+++ b/src/test/datascience/notebook/notebookEditor.vscode.test.ts
@@ -138,9 +138,10 @@ suite('Notebook Editor tests', () => {
             vscodeNotebook.activeNotebookEditor!.document,
             CancellationToken.None
         );
-        if (kernels?.length && kernels?.length > 0) {
+        traceInfo(`Kernels found for switch kernel: ${kernels?.map((k) => k.label).join('\n')}`);
+        if (kernels?.length && kernels?.length > 1) {
             // We have multiple kernels. Try switching
-            await waitForKernelToGetSelected(kernels[0].label);
+            await waitForKernelToGetSelected(kernels[1].label);
         }
 
         // Execute cell and verify output

--- a/src/test/datascience/notebook/notebookEditor.vscode.test.ts
+++ b/src/test/datascience/notebook/notebookEditor.vscode.test.ts
@@ -156,7 +156,7 @@ suite('Notebook Editor tests', () => {
             assert.notEqual(
                 newSysPath,
                 originalSysPath,
-                `Kernel did not switch. New sys path is same as old ${newSysPath}`
+                `Kernel did not switch. New sys path is same as old ${newSysPath} for kernels ${kernels[0].label} && ${kernels[1].label}`
             );
         }
     });


### PR DESCRIPTION
For #4163 

Turn on more tests and use the new api provided by VS code to switch kernels. Somehow it all works? I can't believe the test run passed.

See test run here:
https://github.com/microsoft/vscode-jupyter/runs/1773425848?check_suite_focus=true

