### PR TITLE
Show as much of cell contents as possible on column resize in data viewer

### DIFF
--- a/src/datascience-ui/data-explorer/cellFormatter.css
+++ b/src/datascience-ui/data-explorer/cellFormatter.css
@@ -1,9 +1,13 @@
 .number-formatter {
     text-align: right;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 
 .cell-formatter {
     /* Note: This is impacted by the RowHeightAdjustment in reactSlickGrid.tsx */
     margin: 0px 0px 0px 0px;
     text-align: right;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }

--- a/src/datascience-ui/data-explorer/cellFormatter.tsx
+++ b/src/datascience-ui/data-explorer/cellFormatter.tsx
@@ -39,7 +39,7 @@ class CellFormatter extends React.Component<ICellFormatterProps> {
         const val = this.props.value !== null ? this.props.value.toString() : '';
         return (
             <div className="cell-formatter" role="gridcell" title={val}>
-                <span>{truncate(val)}</span>
+                <span>{val}</span>
             </div>
         );
     }
@@ -56,7 +56,7 @@ class CellFormatter extends React.Component<ICellFormatterProps> {
         const val = value.toString();
         return (
             <div className="number-formatter cell-formatter" role="gridcell" title={val}>
-                <span>{truncate(val)}</span>
+                <span>{val}</span>
             </div>
         );
     }
@@ -71,13 +71,4 @@ export function cellFormatterFunc(
     _dataContext: Slick.SlickData
 ): string {
     return ReactDOMServer.renderToString(<CellFormatter value={value} columnDef={columnDef} />);
-}
-
-function truncate(value: string) {
-    // This should be based on font size and type
-    if (value.length <= 10) {
-        return value;
-    } else {
-        return value.slice(0, 7).concat('...');
-    }
 }

--- a/src/test/datascience/dataviewer.functional.test.tsx
+++ b/src/test/datascience/dataviewer.functional.test.tsx
@@ -226,7 +226,7 @@ suite('DataScience DataViewer tests', () => {
             const span = cells[i].querySelector('div.cell-formatter span') as HTMLSpanElement;
             assert.ok(span, `Span ${i} not found`);
             const val = rows[i].toString();
-            assert.equal(val, span.innerHTML, `Row ${i} not matching. ${span.innerHTML} !== ${val}`);
+            assert.equal(span.innerHTML, val, `Row ${i} not matching. ${span.innerHTML} !== ${val}`);
         }
     }
 
@@ -362,17 +362,16 @@ suite('DataScience DataViewer tests', () => {
         assert.ok(dv, 'DataViewer not created');
         await gotAllRows;
 
-        // Confirm that values are initially truncated
-        verifyRows(wrapper.wrapper, [0, '[1, 2, ...', '[ 7,  8...']);
+        verifyRows(wrapper.wrapper, [0, '[1, 2, 3, 4, 5, 6]', '[ 7,  8,  9, 10, 11, 12]']);
         wrapper.wrapper.update();
 
         // Put cell into edit mode and verify that input value is updated to be the non-truncated, stringified value
         editCell(wrapper.wrapper, 0, 1);
         verifyInputIncludes(wrapper.wrapper, 'value="[1, 2, 3, 4, 5, 6]"');
 
-        // Now cancel edit and verify the value is truncated again
+        // Data should still be there after exiting edit mode
         cancelEdits(wrapper.wrapper);
-        verifyRows(wrapper.wrapper, [0, '[1, 2, ...', '[ 7,  8...']);
+        verifyRows(wrapper.wrapper, [0, '[1, 2, 3, 4, 5, 6]', '[ 7,  8,  9, 10, 11, 12]']);
     });
 
     runMountedTest('4D numpy ndarrays', async (wrapper) => {
@@ -383,16 +382,23 @@ suite('DataScience DataViewer tests', () => {
         assert.ok(dv, 'DataViewer not created');
         await gotAllRows;
 
-        // Confirm that values are initially truncated
-        verifyRows(wrapper.wrapper, [0, `[[ 0,  ...`, `[[12, 1...`]);
+        verifyRows(wrapper.wrapper, [0, `[[ 0,  1,  2,  3],
+ [ 4,  5,  6,  7],
+ [ 8,  9, 10, 11]]`, `[[12, 13, 14, 15],
+ [16, 17, 18, 19],
+ [20, 21, 22, 23]]`]);
 
         // Put cell into edit mode and verify that input value is updated to be the non-truncated, stringified value
         editCell(wrapper.wrapper, 0, 1);
         verifyInputIncludes(wrapper.wrapper, `value="[[ 0,  1,  2,  3],\n [ 4,  5,  6,  7],\n [ 8,  9, 10, 11]]"`);
 
-        // Now cancel edit and verify the value is truncated again
+        // Data should still be there after exiting edit mode
         cancelEdits(wrapper.wrapper);
-        verifyRows(wrapper.wrapper, [0, `[[ 0,  ...`, `[[12, 1...`]);
+        verifyRows(wrapper.wrapper, [0, `[[ 0,  1,  2,  3],
+ [ 4,  5,  6,  7],
+ [ 8,  9, 10, 11]]`, `[[12, 13, 14, 15],
+ [16, 17, 18, 19],
+ [20, 21, 22, 23]]`]);
     });
 
     runMountedTest('Ragged 2D numpy array', async (wrapper) => {
@@ -411,6 +417,6 @@ suite('DataScience DataViewer tests', () => {
         const dv = await createJupyterVariableDataViewer('foo', 'ndarray');
         assert.ok(dv, 'DataViewer not created');
         await gotAllRows;
-        verifyRows(wrapper.wrapper, [0, `[1, 2, 3]`, `[4, 5]`, 1, `[6, 7, ...`, '']);
+        verifyRows(wrapper.wrapper, [0, `[1, 2, 3]`, `[4, 5]`, 1, `[6, 7, 8, 9]`, '']);
     });
 });

--- a/src/test/datascience/dataviewer.functional.test.tsx
+++ b/src/test/datascience/dataviewer.functional.test.tsx
@@ -382,11 +382,15 @@ suite('DataScience DataViewer tests', () => {
         assert.ok(dv, 'DataViewer not created');
         await gotAllRows;
 
-        verifyRows(wrapper.wrapper, [0, `[[ 0,  1,  2,  3],
+        verifyRows(wrapper.wrapper, [
+            0,
+            `[[ 0,  1,  2,  3],
  [ 4,  5,  6,  7],
- [ 8,  9, 10, 11]]`, `[[12, 13, 14, 15],
+ [ 8,  9, 10, 11]]`,
+            `[[12, 13, 14, 15],
  [16, 17, 18, 19],
- [20, 21, 22, 23]]`]);
+ [20, 21, 22, 23]]`
+        ]);
 
         // Put cell into edit mode and verify that input value is updated to be the non-truncated, stringified value
         editCell(wrapper.wrapper, 0, 1);
@@ -394,11 +398,15 @@ suite('DataScience DataViewer tests', () => {
 
         // Data should still be there after exiting edit mode
         cancelEdits(wrapper.wrapper);
-        verifyRows(wrapper.wrapper, [0, `[[ 0,  1,  2,  3],
+        verifyRows(wrapper.wrapper, [
+            0,
+            `[[ 0,  1,  2,  3],
  [ 4,  5,  6,  7],
- [ 8,  9, 10, 11]]`, `[[12, 13, 14, 15],
+ [ 8,  9, 10, 11]]`,
+            `[[12, 13, 14, 15],
  [16, 17, 18, 19],
- [20, 21, 22, 23]]`]);
+ [20, 21, 22, 23]]`
+        ]);
     });
 
     runMountedTest('Ragged 2D numpy array', async (wrapper) => {


### PR DESCRIPTION
#4416 truncated data to max 10 chars regardless of the column size, got feedback from @greazer that we should instead show as much of the cell contents as possible as the column size changes.

![resizecolumns](https://user-images.githubusercontent.com/30305945/106063903-d25f4600-60ad-11eb-96de-aea9c4a67679.gif)

