### PR TITLE
Fix julia test to pass again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ on:
       - 'release'
       - 'release/*'
       - 'release-*'
-      - rchiodo/fix_julia_test
   workflow_dispatch:
 
 env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ on:
       - 'release'
       - 'release/*'
       - 'release-*'
+      - rchiodo/fix_julia_test
   workflow_dispatch:
 
 env:

--- a/news/3 Code Health/4453.md
+++ b/news/3 Code Health/4453.md
@@ -1,0 +1,1 @@
+Fix julia test to pass

--- a/src/test/datascience/notebook/nonPythonKernels.vscode.test.ts
+++ b/src/test/datascience/notebook/nonPythonKernels.vscode.test.ts
@@ -25,6 +25,7 @@ import {
     closeNotebooksAndCleanUpAfterTests,
     createTemporaryNotebook,
     executeActiveDocument,
+    executeCell,
     insertCodeCell,
     insertMarkdownCell,
     saveActiveNotebook,
@@ -170,17 +171,13 @@ suite('DataScience - VSCode Notebook - Kernels (non-python-kernel) (slow)', () =
         }
     });
     test('Can run a Julia notebook', async function () {
-        return this.skip(); // Flakey, tracked by issue 4453
-        this.timeout(30_000); // Can be slow to start Julia kernel on CI.
+        this.timeout(60_000); // Can be slow to start Julia kernel on CI.
         await openNotebook(api.serviceContainer, testJuliaNb.fsPath);
         await insertCodeCell('123456', { language: 'julia', index: 0 });
-        await waitForKernelToGetAutoSelected('julia');
-        await executeActiveDocument();
-
         const cell = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
+        await executeCell(cell);
         // Wait till execution count changes and status is success.
-        await waitForExecutionCompletedSuccessfully(cell);
-
+        await waitForExecutionCompletedSuccessfully(cell, 60_000);
         assertHasTextOutputInVSCode(cell, '123456', 0, false);
     });
     test('Can run a CSharp notebook', async function () {


### PR DESCRIPTION
For #4453

I believe the root cause was not waiting long enough for the cell to execute. Default ```waitForExecutionCompletedSuccessfully``` is only 15 seconds.

Should be passing now. At least it did on this run here:
https://github.com/microsoft/vscode-jupyter/actions/runs/516574919

