### PR TITLE
Reuse existing cell execution

### DIFF
--- a/src/client/datascience/jupyter/kernels/kernelExecution.ts
+++ b/src/client/datascience/jupyter/kernels/kernelExecution.ts
@@ -332,6 +332,10 @@ export class KernelExecution implements IDisposable {
         );
     }
     private createQueuedCellExecution(cell: NotebookCell) {
+        const existingCellExecution = this.cellExecutions.get(cell);
+        if (existingCellExecution) {
+            return existingCellExecution;
+        }
         if (!this.stackOfCellsToExecuteByDocument.has(cell.notebook)) {
             this.stackOfCellsToExecuteByDocument.set(cell.notebook, []);
         }


### PR DESCRIPTION
Found a bug, run a cell, then run whole document.
We end up creating a new cell execution, when we shouldn't (potential for cell the run again)