### PR TITLE
Fix remote native nb, starting right kernel when opening nb

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1054,7 +1054,6 @@ module.exports = {
         'src/client/datascience/jupyter/jupyterExecutionFactory.ts',
         'src/client/datascience/jupyter/serverPreload.ts',
         'src/client/datascience/jupyter/jupyterRequest.ts',
-        'src/client/datascience/jupyter/jupyterNotebookProvider.ts',
         'src/client/datascience/jupyter/commandLineSelector.ts',
         'src/client/datascience/jupyter/jupyterVariables.ts',
         'src/client/datascience/jupyter/jupyterDebugger.ts',

--- a/.github/actions/create-venv-for-tests/action.yml
+++ b/.github/actions/create-venv-for-tests/action.yml
@@ -14,6 +14,7 @@ runs:
     # These tests are slow hence will only run on linux.
     # This env will be used to install ipykernel & test for prompts if ipykernel is missing & imilar tests.
     # Ensure this is registered as a kernel.
+    # Use specific version of Jedi https://github.com/ipython/ipython/issues/12740
     - name: Create virtual environment without ipykernel
       run: |
         python -m venv .venvnoreg
@@ -22,11 +23,15 @@ runs:
         source .venvkernel/bin/activate
         python -m pip install ipykernel
         python -m ipykernel install --user --name .venvkernel --display-name .venvkernel
+        python -m pip uninstall jedi --yes
+        python -m pip install jedi==0.17.2
 
         python -m venv .venvnokernel
         source .venvnokernel/bin/activate
         python -m pip install ipykernel
         python -m ipykernel install --user --name .venvnokernel --display-name .venvnokernel
+        python -m pip uninstall jedi --yes
+        python -m pip install jedi==0.17.2
         python -m pip uninstall ipykernel --yes
       working-directory: src/test/datascience
       shell: bash

--- a/.github/actions/create-venv-for-tests/action.yml
+++ b/.github/actions/create-venv-for-tests/action.yml
@@ -17,6 +17,12 @@ runs:
     - name: Create virtual environment without ipykernel
       run: |
         python -m venv .venvnoreg
+
+        python -m venv .venvkernel
+        source .venvkernel/bin/activate
+        python -m pip install ipykernel
+        python -m ipykernel install --user --name .venvkernel --display-name .venvkernel
+
         python -m venv .venvnokernel
         source .venvnokernel/bin/activate
         python -m pip install ipykernel

--- a/src/client/common/application/authenticationService.ts
+++ b/src/client/common/application/authenticationService.ts
@@ -52,8 +52,8 @@ export class AuthenticationService implements IAuthenticationService {
         return Promise.resolve(undefined);
     }
     public setPassword(key: string, value: string): Thenable<void> {
-        if (this.useProposedApi && this.env.channel === 'insiders' && this.context.secrets?.set) {
-            return this.context.secrets.set(key, value);
+        if (this.useProposedApi && this.env.channel === 'insiders' && this.context.secrets?.store) {
+            return this.context.secrets.store(key, value);
         }
         return Promise.resolve();
     }

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -134,10 +134,10 @@ export class JupyterExecutionBase implements IJupyterExecution {
         return Cancellation.race(async () => {
             let result: INotebookServer | undefined;
             let connection: IJupyterConnection | undefined;
-            let kernelConnectionMetadata: KernelConnectionMetadata | undefined;
+            let kernelConnectionMetadata = options?.kernelConnection;
             let kernelConnectionMetadataPromise: Promise<KernelConnectionMetadata | undefined> = Promise.resolve<
                 KernelConnectionMetadata | undefined
-            >(undefined);
+            >(kernelConnectionMetadata);
             traceInfo(`Connecting to ${options ? options.purpose : 'unknown type of'} server`);
             const allowUI = !options || options.allowUI();
             const kernelSpecCancelSource = new CancellationTokenSource();
@@ -148,7 +148,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
             }
             const isLocalConnection = !options || !options.uri;
 
-            if (isLocalConnection) {
+            if (isLocalConnection && !options?.kernelConnection) {
                 // Get hold of the kernelspec and corresponding (matching) interpreter that'll be used as the spec.
                 // We can do this in parallel, while starting the server (faster).
                 traceInfo(`Getting kernel specs for ${options ? options.purpose : 'unknown type of'} server`);

--- a/src/client/datascience/jupyter/jupyterNotebookProvider.ts
+++ b/src/client/datascience/jupyter/jupyterNotebookProvider.ts
@@ -55,7 +55,9 @@ export class JupyterNotebookProvider implements IJupyterNotebookProvider {
         const server = await this.serverProvider.getOrCreateServer({
             getOnly: options.getOnly,
             disableUI: options.disableUI,
-            token: options.token
+            token: options.token,
+            metadata: options.metadata,
+            kernelConnection: options.kernelConnection
         });
         if (server) {
             return server.getNotebook(options.identity, options.token);

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -295,12 +295,11 @@ export class KernelSelector implements IKernelSelectionUsage {
                     score += 16;
                 }
 
-                if (
-                    score === 0 &&
-                    isPythonNotebook(notebookMetadata) &&
-                    spec.language?.toLowerCase() === PYTHON_LANGUAGE.toLowerCase()
-                ) {
-                    // Find a kernel spec that matches the language.
+                // Find a kernel spec that matches the language in the notebook metadata.
+                const nbMetadataLanguage = isPythonNotebook(notebookMetadata)
+                    ? PYTHON_LANGUAGE
+                    : (notebookMetadata?.kernelspec?.language as string) || notebookMetadata?.language_info?.name;
+                if (score === 0 && spec.language?.toLowerCase() === (nbMetadataLanguage || '').toLowerCase()) {
                     score = 1;
                 }
             }

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -294,6 +294,15 @@ export class KernelSelector implements IKernelSelectionUsage {
                 if (spec.display_name && spec.display_name === notebookMetadata?.kernelspec?.display_name) {
                     score += 16;
                 }
+
+                if (
+                    score === 0 &&
+                    isPythonNotebook(notebookMetadata) &&
+                    spec.language?.toLowerCase() === PYTHON_LANGUAGE.toLowerCase()
+                ) {
+                    // Find a kernel spec that matches the language.
+                    score = 1;
+                }
             }
 
             if (score > bestScore) {

--- a/src/client/datascience/jupyter/kernels/types.ts
+++ b/src/client/datascience/jupyter/kernels/types.ts
@@ -168,7 +168,7 @@ export interface IKernel extends IAsyncDisposable {
      */
     readonly info?: KernelMessage.IInfoReplyMsg['content'];
     readonly kernelSocket: Observable<KernelSocketInformation | undefined>;
-    start(options?: { disableUI?: boolean }): Promise<void>;
+    start(options?: { disableUI?: boolean; document: NotebookDocument }): Promise<void>;
     interrupt(document: NotebookDocument): Promise<InterruptResult>;
     restart(): Promise<void>;
     executeCell(cell: NotebookCell): Promise<void>;

--- a/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
+++ b/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
@@ -337,6 +337,8 @@ export class HostJupyterServer extends LiveShareParticipantHost(JupyterServerBas
                 kernelInfo = kernelConnection;
             } else if (!launchInfo.connectionInfo.localLaunch && kernelConnection?.kind === 'connectToLiveKernel') {
                 kernelInfo = kernelConnection;
+            } else if (!launchInfo.connectionInfo.localLaunch && kernelConnection?.kind === 'startUsingKernelSpec') {
+                kernelInfo = kernelConnection;
             } else {
                 kernelInfo = await (launchInfo.connectionInfo.localLaunch
                     ? this.kernelSelector.getPreferredKernelForLocalConnection(

--- a/src/client/datascience/notebook/intellisense/completionProvider.ts
+++ b/src/client/datascience/notebook/intellisense/completionProvider.ts
@@ -10,8 +10,9 @@ import {
     Position,
     TextDocument
 } from 'vscode';
+import { IS_CI_SERVER } from '../../../../test/initialize';
 import { IVSCodeNotebook } from '../../../common/application/types';
-import { traceError } from '../../../common/logger';
+import { traceError, traceInfoIf } from '../../../common/logger';
 import { IFileSystem } from '../../../common/platform/types';
 import { sleep } from '../../../common/utils/async';
 import { isNotebookCell } from '../../../common/utils/misc';
@@ -50,6 +51,7 @@ export class NotebookCompletionProvider implements CompletionItemProvider {
             getOnly: true
         });
         if (token.isCancellationRequested) {
+            traceInfoIf(IS_CI_SERVER, `Getting completions cancelled for ${notebookDocument.uri.toString()}`);
             return [];
         }
         if (!notebook) {
@@ -62,7 +64,10 @@ export class NotebookCompletionProvider implements CompletionItemProvider {
             parseInt(process.env.VSC_JUPYTER_IntellisenseTimeout || '0', 10) || Settings.IntellisenseTimeout;
         const result = await Promise.race([
             notebook.getCompletion(document.getText(), document.offsetAt(position), token),
-            sleep(timeout).then(() => emptyResult)
+            sleep(timeout).then(() => {
+                traceInfoIf(IS_CI_SERVER, `Notebook completions request timed out for Cell ${document.uri.toString()}`);
+                return emptyResult;
+            })
         ]);
         return result.matches.map((item) => {
             const completion: CompletionItem = {

--- a/src/client/datascience/notebook/kernelProvider.ts
+++ b/src/client/datascience/notebook/kernelProvider.ts
@@ -408,7 +408,7 @@ export class VSCodeKernelPickerProvider implements INotebookKernelProvider {
 
         // Auto start the local kernels.
         if (newKernel && !this.configuration.getSettings(undefined).disableJupyterAutoStart && this.isLocalLaunch()) {
-            newKernel.start({ disableUI: true }).catch(noop);
+            newKernel.start({ disableUI: true, document }).catch(noop);
         }
 
         // Change kernel and update metadata (this can return `undefined`).

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -258,6 +258,7 @@ export interface INotebookServerOptions {
     workingDir?: string;
     purpose: string;
     metadata?: nbformat.INotebookMetadata;
+    kernelConnection?: KernelConnectionMetadata;
     skipSearchingForKernel?: boolean;
     allowUI(): boolean;
 }
@@ -1161,6 +1162,8 @@ export type GetServerOptions = {
     disableUI?: boolean;
     localOnly?: boolean;
     token?: CancellationToken;
+    metadata?: nbformat.INotebookMetadata;
+    kernelConnection?: KernelConnectionMetadata;
     onConnectionMade?(): void; // Optional callback for when the first connection is made
 };
 

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -125,7 +125,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
                 await openNotebook(api.serviceContainer, nbFile);
                 // If this is a native notebook, then wait for kernel to get selected.
                 if (editorProvider.activeEditor?.type === 'native') {
-                    await waitForKernelToChange(kName);
+                    await waitForKernelToChange({ labelOrId: kName });
                 }
 
                 // Run all cells

--- a/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
@@ -68,7 +68,7 @@ suite('DataScience - VSCode Notebook - (Code Completion via Jupyter) (slow)', fu
         await waitForKernelToGetAutoSelected(undefined);
         await deleteAllCellsAndWait();
         assert.isOk(vscodeNotebook.activeNotebookEditor, 'No active notebook');
-        process.env.VSC_JUPYTER_IntellisenseTimeout = '30000';
+        process.env.VSC_JUPYTER_IntellisenseTimeout = '10000';
         traceInfo(`Start Test (completed) ${this.currentTest?.title}`);
     });
     teardown(async function () {
@@ -79,8 +79,7 @@ suite('DataScience - VSCode Notebook - (Code Completion via Jupyter) (slow)', fu
     });
     suiteTeardown(() => closeNotebooksAndCleanUpAfterTests(disposables));
     test('Execute cell and get completions for variable', async () => {
-        // Print sys.executable for debugging purposes (some times on CI we weren't using the right kernel).
-        await insertCodeCell('import sys\nprint(sys.executable)\na = 1', { index: 0 });
+        await insertCodeCell('na = 1', { index: 0 });
         const cell = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
 
         await executeCell(cell);

--- a/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import { CancellationTokenSource, CompletionContext, CompletionTriggerKind, Position, Uri } from 'vscode';
-import { CellDisplayOutput } from '../../../../../types/vscode-proposed';
 import { IVSCodeNotebook } from '../../../../client/common/application/types';
 import { traceInfo } from '../../../../client/common/logger';
 import { IDisposable } from '../../../../client/common/types';

--- a/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
@@ -6,6 +6,7 @@ import { assert } from 'chai';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import { CancellationTokenSource, CompletionContext, CompletionTriggerKind, Position, Uri } from 'vscode';
+import { CellDisplayOutput } from '../../../../../types/vscode-proposed';
 import { IVSCodeNotebook } from '../../../../client/common/application/types';
 import { traceInfo } from '../../../../client/common/logger';
 import { IDisposable } from '../../../../client/common/types';
@@ -67,7 +68,7 @@ suite('DataScience - VSCode Notebook - (Code Completion via Jupyter) (slow)', fu
         await waitForKernelToGetAutoSelected(undefined);
         await deleteAllCellsAndWait();
         assert.isOk(vscodeNotebook.activeNotebookEditor, 'No active notebook');
-        process.env.VSC_JUPYTER_IntellisenseTimeout = '10000';
+        process.env.VSC_JUPYTER_IntellisenseTimeout = '30000';
         traceInfo(`Start Test (completed) ${this.currentTest?.title}`);
     });
     teardown(async function () {
@@ -78,14 +79,15 @@ suite('DataScience - VSCode Notebook - (Code Completion via Jupyter) (slow)', fu
     });
     suiteTeardown(() => closeNotebooksAndCleanUpAfterTests(disposables));
     test('Execute cell and get completions for variable', async () => {
-        await insertCodeCell('na = 1', { index: 0 });
+        await insertCodeCell('import sys\nprint(sys.executable)\na = 1', { index: 0 });
         const cell = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
 
         await executeCell(cell);
 
         // Wait till execution count changes and status is success.
         await waitForExecutionCompletedSuccessfully(cell);
-
+        const outputText: string = (cell.outputs[0] as CellDisplayOutput).data['text/plain'].trim();
+        traceInfo(`Cell Output ${outputText}`);
         await insertCodeCell('a.', { index: 1 });
         const cell2 = vscodeNotebook.activeNotebookEditor!.document.cells[1];
 

--- a/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
@@ -6,6 +6,7 @@ import { assert } from 'chai';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import { CancellationTokenSource, CompletionContext, CompletionTriggerKind, Position, Uri } from 'vscode';
+import { CellDisplayOutput } from '../../../../../types/vscode-proposed';
 import { IVSCodeNotebook } from '../../../../client/common/application/types';
 import { traceInfo } from '../../../../client/common/logger';
 import { IDisposable } from '../../../../client/common/types';
@@ -78,13 +79,16 @@ suite('DataScience - VSCode Notebook - (Code Completion via Jupyter) (slow)', fu
     });
     suiteTeardown(() => closeNotebooksAndCleanUpAfterTests(disposables));
     test('Execute cell and get completions for variable', async () => {
-        await insertCodeCell('a = 1', { index: 0 });
+        // Print sys.executable for debugging purposes (some times on CI we weren't using the right kernel).
+        await insertCodeCell('import sys\nprint(sys.executable)\na = 1', { index: 0 });
         const cell = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
 
         await executeCell(cell);
 
         // Wait till execution count changes and status is success.
         await waitForExecutionCompletedSuccessfully(cell);
+        const outputText: string = (cell.outputs[0] as CellDisplayOutput).data['text/plain'].trim();
+        traceInfo(`Cell Output ${outputText}`);
 
         await insertCodeCell('a.', { index: 1 });
         const cell2 = vscodeNotebook.activeNotebookEditor!.document.cells[1];

--- a/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
@@ -57,7 +57,7 @@ suite('DataScience - VSCode Notebook - (Code Completion via Jupyter) (slow)', fu
         await waitForKernelToGetAutoSelected(undefined);
         await deleteAllCellsAndWait();
         assert.isOk(vscodeNotebook.activeNotebookEditor, 'No active notebook');
-        process.env.VSC_JUPYTER_IntellisenseTimeout = '10000';
+        process.env.VSC_JUPYTER_IntellisenseTimeout = '30000';
         traceInfo(`Start Test (completed) ${this.currentTest?.title}`);
     });
     teardown(async function () {

--- a/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
@@ -86,8 +86,6 @@ suite('DataScience - VSCode Notebook - (Code Completion via Jupyter) (slow)', fu
 
         // Wait till execution count changes and status is success.
         await waitForExecutionCompletedSuccessfully(cell);
-        const outputText: string = (cell.outputs[0] as CellDisplayOutput).data['text/plain'].trim();
-        traceInfo(`Cell Output ${outputText}`);
 
         await insertCodeCell('a.', { index: 1 });
         const cell2 = vscodeNotebook.activeNotebookEditor!.document.cells[1];

--- a/src/test/datascience/notebook/kernelSelection.vscode.test.ts
+++ b/src/test/datascience/notebook/kernelSelection.vscode.test.ts
@@ -164,7 +164,7 @@ suite('DataScience - VSCode Notebook - Kernel Selection', function () {
         // Confirm the executable printed as a result of code in cell `import sys;sys.executable`
         assertHasTextOutputInVSCode(cell, venvNoKernelPythonPath, 0, false);
     });
-    test('Switch kernel to a registered kernelspec', async function () {
+    test('User kernelspec in notebook metadata', async function () {
         await openNotebook(api.serviceContainer, nbFile1);
         await waitForKernelToGetAutoSelected(undefined);
 
@@ -189,8 +189,8 @@ suite('DataScience - VSCode Notebook - Kernel Selection', function () {
         assertHasTextOutputInVSCode(cell, venvKernelPythonPath, 0, false);
     });
     test('Switch kernel to an interpreter that is registered as a kernel', async function () {
-        // Test only applies for Raw & Jupyter notebooks.
-        if (IS_REMOTE_NATIVE_TEST) {
+        // Test only applies for Raw notebooks.
+        if (IS_REMOTE_NATIVE_TEST || IS_NON_RAW_NATIVE_TEST) {
             return this.skip();
         }
         await editorProvider.open(Uri.file(emptyPythonNb));

--- a/src/test/datascience/notebook/kernelSelection.vscode.test.ts
+++ b/src/test/datascience/notebook/kernelSelection.vscode.test.ts
@@ -1,0 +1,256 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { assert } from 'chai';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import { commands, Uri } from 'vscode';
+import { CellDisplayOutput } from '../../../../types/vscode-proposed';
+import { IPythonExtensionChecker } from '../../../client/api/types';
+import { IVSCodeNotebook } from '../../../client/common/application/types';
+import { BufferDecoder } from '../../../client/common/process/decoder';
+import { ProcessService } from '../../../client/common/process/proc';
+import { IDisposable } from '../../../client/common/types';
+import { INotebookEditorProvider } from '../../../client/datascience/types';
+import { IInterpreterService } from '../../../client/interpreter/contracts';
+import { getOSType, IExtensionTestApi, OSType, waitForCondition } from '../../common';
+import { EXTENSION_ROOT_DIR_FOR_TESTS, IS_NON_RAW_NATIVE_TEST, IS_REMOTE_NATIVE_TEST } from '../../constants';
+import { closeActiveWindows, initialize, IS_CI_SERVER } from '../../initialize';
+import { openNotebook } from '../helpers';
+import {
+    assertHasTextOutputInVSCode,
+    canRunNotebookTests,
+    closeNotebooksAndCleanUpAfterTests,
+    createTemporaryNotebook,
+    deleteAllCellsAndWait,
+    executeActiveDocument,
+    insertCodeCell,
+    startJupyterServer,
+    trustAllNotebooks,
+    waitForExecutionCompletedSuccessfully,
+    waitForKernelToChange,
+    waitForKernelToGetAutoSelected
+} from './helper';
+
+/* eslint-disable no-invalid-this, , , @typescript-eslint/no-explicit-any */
+suite('DataScience - VSCode Notebook - Kernel Selection', function () {
+    const disposables: IDisposable[] = [];
+    const templateIPynbFile = path.join(
+        EXTENSION_ROOT_DIR_FOR_TESTS,
+        'src/test/datascience/notebook/nbWithKernel.ipynb'
+    );
+    const templateEmptyPython = path.join(
+        EXTENSION_ROOT_DIR_FOR_TESTS,
+        'src/test/datascience/notebook/emptyPython.ipynb'
+    );
+    const executable = getOSType() === OSType.Windows ? 'Scripts/python.exe' : 'bin/python'; // If running locally on Windows box.
+    const venvNoKernelPython = path.join(
+        EXTENSION_ROOT_DIR_FOR_TESTS,
+        'src/test/datascience/.venvnokernel',
+        executable
+    );
+    const venvKernelPython = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src/test/datascience/.venvkernel', executable);
+    const venvNoRegPath = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src/test/datascience/.venvnoreg', executable);
+
+    let nbFile1: string;
+    let emptyPythonNb: string;
+    let api: IExtensionTestApi;
+    let editorProvider: INotebookEditorProvider;
+    let activeInterpreterPath: string;
+    let venvNoKernelPythonPath: string;
+    let venvKernelPythonPath: string;
+    let venvNoRegPythonPath: string;
+    let vscodeNotebook: IVSCodeNotebook;
+    this.timeout(60_000); // Slow test, we need to uninstall/install ipykernel.
+    /*
+    This test requires a virtual environment to be created & registered as a kernel.
+    It also needs to have ipykernel installed in it.
+    */
+    suiteSetup(async function () {
+        this.timeout(120_000);
+        // These are slow tests, hence lets run only on linux on CI.
+        if (
+            (IS_CI_SERVER && getOSType() !== OSType.Linux) ||
+            !fs.pathExistsSync(venvNoKernelPython) ||
+            !fs.pathExistsSync(venvKernelPython) ||
+            !fs.pathExistsSync(venvNoRegPath)
+        ) {
+            // Virtual env does not exist.
+            return this.skip();
+        }
+        api = await initialize();
+        if (!(await canRunNotebookTests())) {
+            return this.skip();
+        }
+
+        const pythonChecker = api.serviceContainer.get<IPythonExtensionChecker>(IPythonExtensionChecker);
+        editorProvider = api.serviceContainer.get<INotebookEditorProvider>(INotebookEditorProvider);
+        vscodeNotebook = api.serviceContainer.get<IVSCodeNotebook>(IVSCodeNotebook);
+
+        if (!pythonChecker.isPythonExtensionInstalled) {
+            return this.skip();
+        }
+
+        const interpreterService = api.serviceContainer.get<IInterpreterService>(IInterpreterService);
+        const [activeInterpreter, interpreter1, interpreter2, interpreter3] = await Promise.all([
+            interpreterService.getActiveInterpreter(),
+            interpreterService.getInterpreterDetails(venvNoKernelPython),
+            interpreterService.getInterpreterDetails(venvKernelPython),
+            interpreterService.getInterpreterDetails(venvNoRegPath)
+        ]);
+        if (!activeInterpreter || !interpreter1 || !interpreter2 || !interpreter3) {
+            throw new Error('Unable to get information for interpreter 1');
+        }
+        activeInterpreterPath = activeInterpreter?.path;
+        venvNoKernelPythonPath = interpreter1.path;
+        venvKernelPythonPath = interpreter2.path;
+        venvNoRegPythonPath = interpreter3.path;
+
+        await trustAllNotebooks();
+        await startJupyterServer();
+        sinon.restore();
+    });
+
+    setup(async function () {
+        console.log(`Start test ${this.currentTest?.title}`);
+        // Don't use same file (due to dirty handling, we might save in dirty.)
+        // Coz we won't save to file, hence extension will backup in dirty file and when u re-open it will open from dirty.
+        nbFile1 = await createTemporaryNotebook(templateIPynbFile, disposables);
+        emptyPythonNb = await createTemporaryNotebook(templateEmptyPython, disposables);
+        // Ensure IPykernel is in all environments.
+        const proc = new ProcessService(new BufferDecoder());
+        await Promise.all([
+            proc.exec(venvNoKernelPython, ['-m', 'pip', 'install', 'ipykernel']),
+            proc.exec(venvKernelPython, ['-m', 'pip', 'install', 'ipykernel']),
+            proc.exec(venvNoRegPythonPath, ['-m', 'pip', 'install', 'ipykernel']),
+            closeActiveWindows()
+        ]);
+        sinon.restore();
+        console.log(`Start Test completed ${this.currentTest?.title}`);
+    });
+    teardown(async function () {
+        console.log(`End test ${this.currentTest?.title}`);
+        await closeNotebooksAndCleanUpAfterTests(disposables);
+        console.log(`End test completed ${this.currentTest?.title}`);
+    });
+
+    test('Ensure we select active interpreter as kernel (when Raw Kernels)', async function () {
+        if (IS_NON_RAW_NATIVE_TEST || IS_REMOTE_NATIVE_TEST) {
+            return this.skip();
+        }
+        await editorProvider.open(Uri.file(emptyPythonNb));
+        await waitForKernelToGetAutoSelected(undefined);
+        await deleteAllCellsAndWait();
+        await insertCodeCell('import sys\nsys.executable', { index: 0 });
+
+        // Run all cells
+        await executeActiveDocument();
+        const cell = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
+        await waitForExecutionCompletedSuccessfully(cell);
+
+        // Confirm the executable printed as a result of code in cell `import sys;sys.executable`
+        assertHasTextOutputInVSCode(cell, activeInterpreterPath, 0, false);
+    });
+    test('Ensure kernel is auto selected and interpreter is as expected', async function () {
+        await openNotebook(api.serviceContainer, nbFile1);
+        await waitForKernelToGetAutoSelected(undefined);
+
+        // Run all cells
+        await executeActiveDocument();
+        const cell = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
+        await waitForExecutionCompletedSuccessfully(cell);
+
+        // Confirm the executable printed as a result of code in cell `import sys;sys.executable`
+        assertHasTextOutputInVSCode(cell, venvNoKernelPythonPath, 0, false);
+    });
+    test('Switch kernel to a registered kernelspec', async function () {
+        await openNotebook(api.serviceContainer, nbFile1);
+        await waitForKernelToGetAutoSelected(undefined);
+
+        // Run all cells
+        await executeActiveDocument();
+        const cell = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
+        await waitForExecutionCompletedSuccessfully(cell);
+
+        // Confirm the executable printed as a result of code in cell `import sys;sys.executable`
+        assertHasTextOutputInVSCode(cell, venvNoKernelPythonPath, 0, false);
+
+        // Change kernel
+        await waitForKernelToChange({ labelOrId: '.venvkernel' });
+
+        // Clear the cells & execute again
+        await commands.executeCommand('notebook.clearAllCellsOutputs');
+        await waitForCondition(async () => cell.outputs.length === 0, 5_000, 'Cell did not get cleared');
+        await executeActiveDocument();
+        await waitForExecutionCompletedSuccessfully(cell);
+
+        // Confirm the executable printed as a result of code in cell `import sys;sys.executable`
+        assertHasTextOutputInVSCode(cell, venvKernelPythonPath, 0, false);
+    });
+    test('Switch kernel to an interpreter that is registered as a kernel', async function () {
+        // Test only applies for Raw & Jupyter notebooks.
+        if (IS_REMOTE_NATIVE_TEST) {
+            return this.skip();
+        }
+        await editorProvider.open(Uri.file(emptyPythonNb));
+        await waitForKernelToGetAutoSelected(undefined);
+        await deleteAllCellsAndWait();
+        await insertCodeCell('import sys\nsys.executable', { index: 0 });
+
+        // Run all cells
+        await executeActiveDocument();
+        const cell = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
+        await waitForExecutionCompletedSuccessfully(cell);
+
+        // Confirm the executable printed is not venvkernel
+        assert.ok(cell.outputs.length);
+        const outputText: string = (cell.outputs[0] as CellDisplayOutput).data['text/plain'].trim();
+        assert.equal(outputText.toLowerCase().indexOf(venvKernelPythonPath), -1);
+
+        // Change kernel to the interpreter venvkernel
+        await waitForKernelToChange({ interpreterPath: venvKernelPythonPath });
+
+        // Clear the cells & execute again
+        await commands.executeCommand('notebook.clearAllCellsOutputs');
+        await waitForCondition(async () => cell.outputs.length === 0, 5_000, 'Cell did not get cleared');
+        await executeActiveDocument();
+        await waitForExecutionCompletedSuccessfully(cell);
+
+        // Confirm the executable printed as a result of code in cell `import sys;sys.executable`
+        assertHasTextOutputInVSCode(cell, venvKernelPythonPath, 0, false);
+    });
+    test('Switch kernel to an interpreter that is not registered as a kernel', async function () {
+        // Test only applies for raw notebooks.
+        if (IS_NON_RAW_NATIVE_TEST || IS_REMOTE_NATIVE_TEST) {
+            return this.skip();
+        }
+        await editorProvider.open(Uri.file(emptyPythonNb));
+        await waitForKernelToGetAutoSelected(undefined);
+        await deleteAllCellsAndWait();
+        await insertCodeCell('import sys\nsys.executable', { index: 0 });
+
+        // Run all cells
+        await executeActiveDocument();
+
+        const cell = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
+        await waitForExecutionCompletedSuccessfully(cell);
+
+        // Confirm the executable printed is not venvNoReg
+        assert.ok(cell.outputs.length);
+        const outputText: string = (cell.outputs[0] as CellDisplayOutput).data['text/plain'].trim();
+        assert.equal(outputText.toLowerCase().indexOf(venvNoRegPythonPath), -1);
+
+        // Change kernel to the interpreter venvNoReg
+        await waitForKernelToChange({ interpreterPath: venvNoRegPythonPath });
+
+        // Clear the cells & execute again
+        await commands.executeCommand('notebook.clearAllCellsOutputs');
+        await waitForCondition(async () => cell.outputs.length === 0, 5_000, 'Cell did not get cleared');
+        await executeActiveDocument();
+        await waitForExecutionCompletedSuccessfully(cell);
+
+        // Confirm the executable printed as a result of code in cell `import sys;sys.executable`
+        assertHasTextOutputInVSCode(cell, venvNoRegPythonPath, 0, false);
+    });
+});

--- a/src/test/datascience/notebook/kernelSelection.vscode.test.ts
+++ b/src/test/datascience/notebook/kernelSelection.vscode.test.ts
@@ -164,6 +164,23 @@ suite('DataScience - VSCode Notebook - Kernel Selection', function () {
         // Confirm the executable printed as a result of code in cell `import sys;sys.executable`
         assertHasTextOutputInVSCode(cell, venvNoKernelPythonPath, 0, false);
     });
+    test('Ensure we select a Python kernel for a nb with python language information', async function () {
+        await editorProvider.open(Uri.file(emptyPythonNb));
+        await waitForKernelToGetAutoSelected(undefined);
+
+        // Run all cells
+        await deleteAllCellsAndWait();
+        await insertCodeCell('import sys\nsys.executable', { index: 0 });
+        await insertCodeCell('print("Hello World")', { index: 1 });
+        await executeActiveDocument();
+
+        const cell1 = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
+        const cell2 = vscodeNotebook.activeNotebookEditor?.document.cells![1]!;
+
+        // If it was successfully selected, then we know a Python kernel was correctly selected & managed to run the code.
+        await Promise.all([waitForExecutionCompletedSuccessfully(cell1), waitForExecutionCompletedSuccessfully(cell2)]);
+        assertHasTextOutputInVSCode(cell2, 'Hello World', 0, false);
+    });
     test('User kernelspec in notebook metadata', async function () {
         await openNotebook(api.serviceContainer, nbFile1);
         await waitForKernelToGetAutoSelected(undefined);

--- a/src/test/datascience/notebook/nbWithKernel.ipynb
+++ b/src/test/datascience/notebook/nbWithKernel.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.executable\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venvnokernel",
+   "name": ".venvnokernel"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2-final"
+  },
+  "orig_nbformat": 2
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/test/datascience/notebook/notebookEditor.vscode.test.ts
+++ b/src/test/datascience/notebook/notebookEditor.vscode.test.ts
@@ -162,7 +162,7 @@ suite('Notebook Editor tests', () => {
         );
         if (anotherKernel) {
             // We have multiple kernels. Try switching
-            await waitForKernelToChange(anotherKernel.id);
+            await waitForKernelToChange({ labelOrId: anotherKernel.id });
         }
 
         // Execute cell and verify output

--- a/types/vscode.proposed.d.ts
+++ b/types/vscode.proposed.d.ts
@@ -882,7 +882,7 @@ declare module 'vscode' {
          * @param key The key to store the password under.
          * @param value The password.
          */
-        set(key: string, value: string): Thenable<void>;
+        store(key: string, value: string): Thenable<void>;
 
         /**
          * Remove a secret from storage.


### PR DESCRIPTION
For #4556

* Fixed remote support in native notebook
* Fixed starting right kernel in webview & native when opening notebook with Jupyter (non-raw)
	As part of passing kernel connection metadata (prevent searching for kernel spec all over again instead of using what was provided), i ended up removing the nb metadata.

	This fixes that by passing kernelConnectionMetadata for `getServer` as well, used in non-raw kernels (that code path is used only in non-raw).

* Added tests to cover all of the scenarios (found another bug while adding tests)
	* Switching kernels
	* Starting kernel defined in nb when opening an nb
	* Ensure interpreter matches the kernel in all scenarios
	* Tests for remote, native & raw 


