### PR TITLE
Remove padding on >2D array elements

### DIFF
--- a/pythonFiles/vscode_datascience_helpers/dataframes/vscodeDataFrame.py
+++ b/pythonFiles/vscode_datascience_helpers/dataframes/vscodeDataFrame.py
@@ -31,7 +31,8 @@ def _VSCODE_convertNumpyArrayToDataFrame(ndarray):
                 for j in range(len(temp[i])):
                     element = temp[i][j]
                     if isinstance(element, _VSCODE_np.ndarray):
-                        stringified = _VSCODE_np.array2string(element, separator=", ")
+                        # Ensure no rjust or ljust padding is applied to stringified elements
+                        stringified = _VSCODE_np.array2string(element, separator=", ", formatter={'all':lambda x: str(x)})
                     elif isinstance(element, (list, tuple)):
                         # We can't pass lists and tuples to array2string because it expects
                         # the size attribute to be defined

--- a/pythonFiles/vscode_datascience_helpers/dataframes/vscodeDataFrame.py
+++ b/pythonFiles/vscode_datascience_helpers/dataframes/vscodeDataFrame.py
@@ -32,7 +32,9 @@ def _VSCODE_convertNumpyArrayToDataFrame(ndarray):
                     element = temp[i][j]
                     if isinstance(element, _VSCODE_np.ndarray):
                         # Ensure no rjust or ljust padding is applied to stringified elements
-                        stringified = _VSCODE_np.array2string(element, separator=", ", formatter={'all':lambda x: str(x)})
+                        stringified = _VSCODE_np.array2string(
+                            element, separator=", ", formatter={"all": lambda x: str(x)}
+                        )
                     elif isinstance(element, (list, tuple)):
                         # We can't pass lists and tuples to array2string because it expects
                         # the size attribute to be defined

--- a/src/test/datascience/dataviewer.functional.test.tsx
+++ b/src/test/datascience/dataviewer.functional.test.tsx
@@ -362,7 +362,7 @@ suite('DataScience DataViewer tests', () => {
         assert.ok(dv, 'DataViewer not created');
         await gotAllRows;
 
-        verifyRows(wrapper.wrapper, [0, '[1, 2, 3, 4, 5, 6]', '[ 7,  8,  9, 10, 11, 12]']);
+        verifyRows(wrapper.wrapper, [0, '[1, 2, 3, 4, 5, 6]', '[7, 8, 9, 10, 11, 12]']);
         wrapper.wrapper.update();
 
         // Put cell into edit mode and verify that input value is updated to be the non-truncated, stringified value
@@ -371,7 +371,7 @@ suite('DataScience DataViewer tests', () => {
 
         // Data should still be there after exiting edit mode
         cancelEdits(wrapper.wrapper);
-        verifyRows(wrapper.wrapper, [0, '[1, 2, 3, 4, 5, 6]', '[ 7,  8,  9, 10, 11, 12]']);
+        verifyRows(wrapper.wrapper, [0, '[1, 2, 3, 4, 5, 6]', '[7, 8, 9, 10, 11, 12]']);
     });
 
     runMountedTest('4D numpy ndarrays', async (wrapper) => {
@@ -384,9 +384,9 @@ suite('DataScience DataViewer tests', () => {
 
         verifyRows(wrapper.wrapper, [
             0,
-            `[[ 0,  1,  2,  3],
- [ 4,  5,  6,  7],
- [ 8,  9, 10, 11]]`,
+            `[[0, 1, 2, 3],
+ [4, 5, 6, 7],
+ [8, 9, 10, 11]]`,
             `[[12, 13, 14, 15],
  [16, 17, 18, 19],
  [20, 21, 22, 23]]`
@@ -394,15 +394,15 @@ suite('DataScience DataViewer tests', () => {
 
         // Put cell into edit mode and verify that input value is updated to be the non-truncated, stringified value
         editCell(wrapper.wrapper, 0, 1);
-        verifyInputIncludes(wrapper.wrapper, `value="[[ 0,  1,  2,  3],\n [ 4,  5,  6,  7],\n [ 8,  9, 10, 11]]"`);
+        verifyInputIncludes(wrapper.wrapper, `value="[[0, 1, 2, 3],\n [4, 5, 6, 7],\n [8, 9, 10, 11]]"`);
 
         // Data should still be there after exiting edit mode
         cancelEdits(wrapper.wrapper);
         verifyRows(wrapper.wrapper, [
             0,
-            `[[ 0,  1,  2,  3],
- [ 4,  5,  6,  7],
- [ 8,  9, 10, 11]]`,
+            `[[0, 1, 2, 3],
+ [4, 5, 6, 7],
+ [8, 9, 10, 11]]`,
             `[[12, 13, 14, 15],
  [16, 17, 18, 19],
  [20, 21, 22, 23]]`


### PR DESCRIPTION
By default numpy `array2string` zfills all elements in the array based on the length of the longest element within that array. This zfilling behavior isn't desirable in >2D data because it results in spaces that the user has to skip past within the cell. This PR ensures we don't zfill by passing a custom formatter to `array2string`.