### PR TITLE
Improved handling of  failures in Kernell Daemon

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -810,7 +810,6 @@ module.exports = {
         'src/client/common/process/pythonDaemonFactory.ts',
         'src/client/common/process/types.ts',
         'src/client/common/process/logger.ts',
-        'src/client/common/process/baseDaemon.ts',
         'src/client/common/process/constants.ts',
         'src/client/common/process/pythonProcess.ts',
         'src/client/common/process/proc.ts',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -783,7 +783,6 @@ module.exports = {
         'src/client/common/application/commands/reloadCommand.ts',
         'src/client/common/application/terminalManager.ts',
         'src/client/common/application/applicationEnvironment.ts',
-        'src/client/common/errors/errorUtils.ts',
         'src/client/common/errors/moduleNotInstalledError.ts',
         'src/client/common/installer/serviceRegistry.ts',
         'src/client/common/installer/productNames.ts',

--- a/src/client/common/errors/errorUtils.ts
+++ b/src/client/common/errors/errorUtils.ts
@@ -25,3 +25,24 @@ export class WrappedError extends Error {
         this.stack = `${new Error('').stack}${EOL}${EOL}${originalException.stack}`;
     }
 }
+
+/**
+ * Given a python traceback, attempt to get the Python error message.
+ * Generally Python error messages are at the bottom of the traceback.
+ */
+export function getErrorMessageFromPythonTraceback(traceback: string) {
+    if (!traceback) {
+        return;
+    }
+    // Look for something like `NameError: name 'XYZ' is not defined` in the last line.
+    const pythonErrorMessageRegExp = /\S+Error: /g;
+    const reversedLines = traceback
+        .split('\n')
+        .filter((item) => item.trim().length)
+        .reverse();
+    if (reversedLines.length === 0) {
+        return;
+    }
+    const lastLine = reversedLines[0];
+    return lastLine.match(pythonErrorMessageRegExp) ? lastLine : undefined;
+}

--- a/src/client/common/process/baseDaemon.ts
+++ b/src/client/common/process/baseDaemon.ts
@@ -39,7 +39,7 @@ export abstract class BasePythonDaemon {
     public get isAlive(): boolean {
         return this.connectionClosedMessage === '';
     }
-    protected outputObservale = new Subject<Output<string>>();
+    protected outputObservable = new Subject<Output<string>>();
     private connectionClosedMessage: string = '';
     protected get closed() {
         return this.connectionClosedDeferred.promise;
@@ -243,7 +243,7 @@ export abstract class BasePythonDaemon {
         let stdErr = '';
         this.proc.stderr.on('data', (output: string | Buffer) => (stdErr += output.toString()));
         // Wire up stdout/stderr.
-        const subscription = this.outputObservale.subscribe((out) => {
+        const subscription = this.outputObservable.subscribe((out) => {
             if (out.source === 'stderr' && options.throwOnStdErr) {
                 subject.error(new StdErrError(out.out));
             } else if (out.source === 'stderr' && options.mergeStdOutErr) {
@@ -360,8 +360,8 @@ export abstract class BasePythonDaemon {
         // this.proc.on('error', error => logConnectionStatus('Daemon Processed died with error', error));
         this.proc.on('exit', (code) => logConnectionStatus('Daemon Processed died with exit code', code));
         // Wire up stdout/stderr.
-        const OuputNotification = new NotificationType<Output<string>, void>('output');
-        this.connection.onNotification(OuputNotification, (output) => this.outputObservale.next(output));
+        const OutputNotification = new NotificationType<Output<string>, void>('output');
+        this.connection.onNotification(OutputNotification, (output) => this.outputObservable.next(output));
         const logNotification = new NotificationType<
             { level: 'WARN' | 'WARNING' | 'INFO' | 'DEBUG' | 'NOTSET'; msg: string; pid?: string },
             void


### PR DESCRIPTION
Related to #4540

The kernel dies pretty much immediately but we need to wait for 3 minutes for a timeout.
The problem is we're erroring out in the Rx Subject, & the assumption was that Rx Subjects can be errored multiple times.


Here's what it looks like now (no timeout error & better error message)
![Screen Shot 2021-02-01 at 10 42 48](https://user-images.githubusercontent.com/1948812/106504340-a95afe80-647b-11eb-836e-fd2bf44b2b7e.png)


