### PR TITLE
Data viewer support for class instance variables

### DIFF
--- a/.github/test_plan.md
+++ b/.github/test_plan.md
@@ -141,6 +141,13 @@
     1. Verify the variables explorer window shows output not available while debugging
     1. When you get to the end of the cell, the debugger should stop
     1. Output from the cell should show up in the Interactive Window (sometimes you have to finish debugging the cell first)
+-   [ ] Verify ability to open data viewer from debugger
+    1. Open the file src/test/datascience/manualTestFiles/manualTestFileDebugger.py in VS Code
+    1. Set a breakpoint on the last line
+    1. Open the debug panel in the left sidebar of VS Code and run 'Python: Current File' debug configuration
+    1. All the variables defined in the file should appear in the debug variables window in the sidebar
+    1. Right click on each of the following variables and select the 'View Variable in Data Viewer' option from the context menu: myNparray, myDataFrame, mySeries, myList, myString, myTensor. Verify that the data viewer opens and displays them
+    1. Expand the tree view for the variable `x`. Right click on its instance member `b` and select 'View Variable in Data Viewer' from the context menu. Verify that this opens `x.b` and not `b` in the data viewer.
 -   [ ] Verify installing ipykernel in a new environment
     1. Create a brand new folder on your machine
     1. Create a new venv in that folder via command line / terminal `python3 -m venv .newEnv`

--- a/news/2 Fixes/4606.md
+++ b/news/2 Fixes/4606.md
@@ -1,0 +1,1 @@
+Allow viewing class instance variables in the data viewer.

--- a/src/client/datascience/jupyter/debuggerVariables.ts
+++ b/src/client/datascience/jupyter/debuggerVariables.ts
@@ -344,6 +344,8 @@ export class DebuggerVariables extends DebugLocationTracker
 
 export function convertDebugProtocolVariableToIJupyterVariable(variable: DebugProtocol.Variable) {
     return {
+        // If `evaluateName` is available use that. That is the name that we can eval in the debugger
+        // but it's an optional property so fallback to `variable.name`
         name: variable.evaluateName ?? variable.name,
         type: variable.type!,
         count: 0,

--- a/src/client/datascience/jupyter/debuggerVariables.ts
+++ b/src/client/datascience/jupyter/debuggerVariables.ts
@@ -344,7 +344,7 @@ export class DebuggerVariables extends DebugLocationTracker
 
 export function convertDebugProtocolVariableToIJupyterVariable(variable: DebugProtocol.Variable) {
     return {
-        name: variable.name,
+        name: variable.evaluateName ?? variable.name,
         type: variable.type!,
         count: 0,
         shape: '',

--- a/src/test/datascience/manualTestFiles/manualTestFileDebugger.py
+++ b/src/test/datascience/manualTestFiles/manualTestFileDebugger.py
@@ -1,0 +1,28 @@
+# To run this file either conda or pip install the following: jupyter, torch, numpy, matplotlib, pandas, tqdm, bokeh, vega_datasets, altair, vega, plotly
+# When installing torch please visit https://pytorch.org to identify the install instructions for your OS
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import torch
+
+
+myNparray = np.array(
+    [["Bob", 1, 2, np.inf], ["Alice", 4, np.nan, 6], ["Gina", -np.inf, 8, 9]]
+)
+myDataFrame = pd.DataFrame(myNparray, columns=["name", "b", "c", "d"])
+mySeries = myDataFrame["name"]
+myList = [x ** 2 for x in range(0, 100000)]
+myString = "testing testing testing"
+myTensor = torch.LongTensor([[[1, 2, 3], [4, 5, 6]]])
+
+
+class Foo:
+    def __init__(self):
+        self.a = 100
+        self.b = [1, 2, 3]
+
+
+b = ["not this one"]
+x = Foo()
+print(x.b)  # Should open x.b, not b


### PR DESCRIPTION
For https://github.com/microsoft/vscode-jupyter/issues/4606

Use `evaluateName` instead of `name` on the DebugProtocol.Variable we get from the context menu to eval in the debugger.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ x Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging.~
-   [x] Has telemetry for enhancements.
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
