### PR TITLE
Correctly hide old interpreters registered as kernelspecs from kernel selection

### DIFF
--- a/news/2 Fixes/4632.md
+++ b/news/2 Fixes/4632.md
@@ -1,0 +1,1 @@
+Correctly hide old interpreters registered as kernels from the selector.

--- a/src/client/datascience/jupyter/kernels/kernelSelections.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelections.ts
@@ -15,7 +15,7 @@ import { noop } from '../../../common/utils/misc';
 import { IInterpreterSelector } from '../../../interpreter/configuration/types';
 import { IInterpreterService } from '../../../interpreter/contracts';
 import { IKernelFinder } from '../../kernel-launcher/types';
-import { IJupyterSessionManager, IJupyterSessionManagerFactory } from '../../types';
+import { IJupyterSessionManager, IJupyterSessionManagerFactory, IRawNotebookSupportedService } from '../../types';
 import { isPythonKernelConnection } from './helpers';
 import { KernelService } from './kernelService';
 import { ActiveJupyterSessionKernelSelectionListProvider } from './providers/activeJupyterSessionKernelProvider';
@@ -64,8 +64,8 @@ export class KernelSelectionProvider {
         @inject(IKernelFinder) private readonly kernelFinder: IKernelFinder,
         @inject(IPythonExtensionChecker) private readonly extensionChecker: IPythonExtensionChecker,
         @inject(IDisposableRegistry) disposableRegistry: IDisposableRegistry,
-
-        @inject(IJupyterSessionManagerFactory) private jupyterSessionManagerFactory: IJupyterSessionManagerFactory
+        @inject(IJupyterSessionManagerFactory) private jupyterSessionManagerFactory: IJupyterSessionManagerFactory,
+        @inject(IRawNotebookSupportedService) private rawNotebookSupportedService: IRawNotebookSupportedService
     ) {
         disposableRegistry.push(
             this.jupyterSessionManagerFactory.onRestartSessionCreated(this.addKernelToIgnoreList.bind(this))
@@ -136,7 +136,8 @@ export class KernelSelectionProvider {
             const installedKernelsPromise = new InstalledLocalKernelSelectionListProvider(
                 this.kernelFinder,
                 this.pathUtils,
-                this.kernelService
+                this.kernelService,
+                this.rawNotebookSupportedService
             ).getKernelSelections(resource, cancelToken);
             const interpretersPromise = this.extensionChecker.isPythonExtensionInstalled
                 ? new InterpreterKernelSelectionListProvider(this.interpreterSelector).getKernelSelections(

--- a/src/client/datascience/jupyter/kernels/providers/installedLocalKernelProvider.ts
+++ b/src/client/datascience/jupyter/kernels/providers/installedLocalKernelProvider.ts
@@ -39,11 +39,8 @@ export class InstalledLocalKernelSelectionListProvider
                         // If it is, then no need to display that (selecting kernels registered is done by selecting the corresponding interpreter).
                         // Hence we can hide such kernels.
                         // Kernels we create will end with a uuid (with - stripped), & will have interpreter info in the metadata.
-                        if (
-                            item.metadata?.interpreter &&
-                            item.name.length > 32 &&
-                            item.name.slice(-32).toLowerCase() === item.name
-                        ) {
+                        const guidRegEx = /[a-f0-9]{32}$/;
+                        if (item.metadata?.interpreter && item.name.toLowerCase().search(guidRegEx)) {
                             return false;
                         }
 

--- a/src/client/datascience/jupyter/kernels/providers/installedLocalKernelProvider.ts
+++ b/src/client/datascience/jupyter/kernels/providers/installedLocalKernelProvider.ts
@@ -28,7 +28,7 @@ export class InstalledLocalKernelSelectionListProvider
         resource: Resource,
         cancelToken?: CancellationToken
     ): Promise<IKernelSpecQuickPickItem<KernelSpecConnectionMetadata>[]> {
-        const rawNotebookSupported = this.rawNotebookSupportedService.isSupportedForLocalLaunch();
+        const rawNotebookSupported = await this.rawNotebookSupportedService.supported();
         const items = await this.kernelFinder.listKernelSpecs(resource);
         const selections = await Promise.all(
             items

--- a/src/client/datascience/jupyter/kernels/providers/installedLocalKernelProvider.ts
+++ b/src/client/datascience/jupyter/kernels/providers/installedLocalKernelProvider.ts
@@ -9,6 +9,7 @@ import { IPathUtils, Resource, ReadWrite } from '../../../../common/types';
 import { sendTelemetryEvent } from '../../../../telemetry';
 import { Telemetry } from '../../../constants';
 import { IKernelFinder } from '../../../kernel-launcher/types';
+import { IRawNotebookSupportedService } from '../../../types';
 import { detectDefaultKernelName, isPythonKernelConnection } from '../helpers';
 import { KernelService } from '../kernelService';
 import { IKernelSelectionListProvider, KernelSpecConnectionMetadata, IKernelSpecQuickPickItem } from '../types';
@@ -20,12 +21,14 @@ export class InstalledLocalKernelSelectionListProvider
     constructor(
         private readonly kernelFinder: IKernelFinder,
         private readonly pathUtils: IPathUtils,
-        private readonly kernelService: KernelService
+        private readonly kernelService: KernelService,
+        private readonly rawNotebookSupportedService: IRawNotebookSupportedService
     ) {}
     public async getKernelSelections(
         resource: Resource,
         cancelToken?: CancellationToken
     ): Promise<IKernelSpecQuickPickItem<KernelSpecConnectionMetadata>[]> {
+        const rawNotebookSupported = this.rawNotebookSupportedService.isSupportedForLocalLaunch();
         const items = await this.kernelFinder.listKernelSpecs(resource);
         const selections = await Promise.all(
             items
@@ -39,8 +42,13 @@ export class InstalledLocalKernelSelectionListProvider
                         // If it is, then no need to display that (selecting kernels registered is done by selecting the corresponding interpreter).
                         // Hence we can hide such kernels.
                         // Kernels we create will end with a uuid (with - stripped), & will have interpreter info in the metadata.
+                        // Only do this for raw kernel scenarios
                         const guidRegEx = /[a-f0-9]{32}$/;
-                        if (item.metadata?.interpreter && item.name.toLowerCase().search(guidRegEx)) {
+                        if (
+                            rawNotebookSupported &&
+                            item.metadata?.interpreter &&
+                            item.name.toLowerCase().search(guidRegEx)
+                        ) {
                             return false;
                         }
 

--- a/src/test/datascience/jupyter/kernels/kernelSelections.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSelections.unit.test.ts
@@ -22,7 +22,12 @@ import { KernelSelectionProvider } from '../../../../client/datascience/jupyter/
 import { KernelService } from '../../../../client/datascience/jupyter/kernels/kernelService';
 import { IKernelSpecQuickPickItem } from '../../../../client/datascience/jupyter/kernels/types';
 import { IKernelFinder } from '../../../../client/datascience/kernel-launcher/types';
-import { IJupyterKernel, IJupyterKernelSpec, IJupyterSessionManager } from '../../../../client/datascience/types';
+import {
+    IJupyterKernel,
+    IJupyterKernelSpec,
+    IJupyterSessionManager,
+    IRawNotebookSupportedService
+} from '../../../../client/datascience/types';
 import { IInterpreterQuickPickItem, IInterpreterSelector } from '../../../../client/interpreter/configuration/types';
 import { IInterpreterService } from '../../../../client/interpreter/contracts';
 
@@ -149,6 +154,8 @@ suite('DataScience - KernelSelections', () => {
         when(extensionChecker.isPythonExtensionInstalled).thenReturn(true);
         const interpreterService = mock<IInterpreterService>();
         when(interpreterService.getActiveInterpreter(anything())).thenResolve();
+        const rawSupportedService = mock<IRawNotebookSupportedService>();
+        when(rawSupportedService.isSupportedForLocalLaunch()).thenResolve(true);
         kernelSelectionProvider = new KernelSelectionProvider(
             instance(kernelService),
             instance(interpreterSelector),
@@ -158,7 +165,8 @@ suite('DataScience - KernelSelections', () => {
             instance(kernelFinder),
             instance(extensionChecker),
             disposableRegistry,
-            instance(jupyterSessionManagerFactory)
+            instance(jupyterSessionManagerFactory),
+            instance(rawSupportedService)
         );
     });
     teardown(() => disposeAllDisposables(disposableRegistry));

--- a/src/test/datascience/jupyter/kernels/kernelSelector.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSelector.unit.test.ts
@@ -25,7 +25,11 @@ import { KernelSelector } from '../../../../client/datascience/jupyter/kernels/k
 import { KernelService } from '../../../../client/datascience/jupyter/kernels/kernelService';
 import { LiveKernelModel } from '../../../../client/datascience/jupyter/kernels/types';
 import { IKernelFinder } from '../../../../client/datascience/kernel-launcher/types';
-import { IJupyterSessionManager, KernelInterpreterDependencyResponse } from '../../../../client/datascience/types';
+import {
+    IJupyterSessionManager,
+    IRawNotebookSupportedService,
+    KernelInterpreterDependencyResponse
+} from '../../../../client/datascience/types';
 import { IInterpreterService } from '../../../../client/interpreter/contracts';
 import { PythonEnvironment } from '../../../../client/pythonEnvironments/info';
 import { PreferredRemoteKernelIdProvider } from '../../../../client/datascience/notebookStorage/preferredRemoteKernelIdProvider';
@@ -224,6 +228,8 @@ suite('DataScience - KernelSelector', () => {
             sinon
                 .stub(ActiveJupyterSessionKernelSelectionListProvider.prototype, 'getKernelSelections')
                 .resolves(quickPickItems);
+            const rawSupportedService = mock<IRawNotebookSupportedService>();
+            when(rawSupportedService.isSupportedForLocalLaunch()).thenResolve(true);
             const provider = new KernelSelectionProvider(
                 instance(kernelService),
                 instance(mock<IInterpreterSelector>()),
@@ -233,7 +239,8 @@ suite('DataScience - KernelSelector', () => {
                 instance(kernelFinder),
                 instance(mock<IPythonExtensionChecker>()),
                 disposableRegistry,
-                instance(jupyterSessionManagerFactory)
+                instance(jupyterSessionManagerFactory),
+                instance(rawSupportedService)
             );
             when(appShell.showQuickPick(anything(), anything(), anything())).thenResolve(undefined);
 


### PR DESCRIPTION
For #4632

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
