### PR TITLE
Fix handling of 1D/2D ndarrays and tensors

### DIFF
--- a/pythonFiles/vscode_datascience_helpers/dataframes/vscodeDataFrame.py
+++ b/pythonFiles/vscode_datascience_helpers/dataframes/vscodeDataFrame.py
@@ -7,68 +7,48 @@ import pandas.io.json as _VSCODE_pd_json
 # PyTorch and TensorFlow tensors which can be converted to numpy arrays
 _VSCODE_allowedTensorTypes = ["Tensor", "EagerTensor"]
 
-# Convert numpy array to DataFrame
+
+def _VSCODE_stringifyElement(element):
+    if isinstance(element, _VSCODE_np.ndarray):
+        # Ensure no rjust or ljust padding is applied to stringified elements
+        stringified = _VSCODE_np.array2string(
+            element, separator=", ", formatter={"all": lambda x: str(x)}
+        )
+    elif isinstance(element, (list, tuple)):
+        # We can't pass lists and tuples to array2string because it expects
+        # the size attribute to be defined
+        stringified = str(element)
+    else:
+        stringified = element
+    return stringified
+
+
 def _VSCODE_convertNumpyArrayToDataFrame(ndarray):
     # Save the user's current setting
     current_options = _VSCODE_np.get_printoptions()
     # Ask for the full string. Without this numpy truncates to 3 leading and 3 trailing by default
     _VSCODE_np.set_printoptions(threshold=99999)
-    temp = ndarray
 
+    flattened = None
     try:
-        x_len = temp.shape[0]
-        # Figure out if we're dealing with ragged data
-        row_lengths = [
-            len(temp[i])
-            if isinstance(temp[i], (list, tuple, _VSCODE_np.ndarray))
-            else 1
-            for i in range(x_len)
-        ]
-        max_y_len = max(row_lengths)
-        is_ragged_or_ndimensional = hasattr(temp, "ndim") and (
-            (temp.ndim == 1 and max_y_len > 1) or temp.ndim > 2
-        )
-
-        if not is_ragged_or_ndimensional:
-            return _VSCODE_pd.DataFrame(temp)
-
-        # Handle ragged arrays by making a container where the number of
-        # columns is the max length of all rows. Missing elements are
-        # represented as empty strings.
-        flattened = _VSCODE_np.full((x_len, max_y_len), "", dtype="object")
-
-        def _VSCODE_stringifyElement(element):
-            if isinstance(element, _VSCODE_np.ndarray):
-                # Ensure no rjust or ljust padding is applied to stringified elements
-                stringified = _VSCODE_np.array2string(
-                    element, separator=", ", formatter={"all": lambda x: str(x)}
-                )
-            elif isinstance(element, (list, tuple)):
-                # We can't pass lists and tuples to array2string because it expects
-                # the size attribute to be defined
-                stringified = str(element)
-            else:
-                stringified = element
-            return stringified
-
-        for i in range(x_len):
-            row = temp[i]
-            row_length = row_lengths[i]
-            for j in range(row_length):
-                cell = row if row_length == 1 else row[j]
-                flattened[i][j] = _VSCODE_stringifyElement(cell)
-
-        ndarray = flattened
-        del flattened
-        del is_ragged_or_ndimensional
-        del x_len
-        del max_y_len
-        del row_lengths
-        del temp
-        return _VSCODE_pd.DataFrame(ndarray)
+        if ndarray.ndim < 3 and str(ndarray.dtype) != "object":
+            pass
+        elif ndarray.ndim == 1 and str(ndarray.dtype) == "object":
+            flattened = _VSCODE_np.empty(ndarray.shape[:2], dtype="object")
+            for i in range(len(flattened)):
+                flattened[i] = _VSCODE_stringifyElement(ndarray[i])
+            ndarray = flattened
+        else:
+            flattened = _VSCODE_np.empty(ndarray.shape[:2], dtype="object")
+            for i in range(len(flattened)):
+                for j in range(len(flattened[i])):
+                    flattened[i][j] = _VSCODE_stringifyElement(ndarray[i][j])
+            ndarray = flattened
     finally:
         # Restore the user's printoptions
         _VSCODE_np.set_printoptions(threshold=current_options["threshold"])
+        del flattened
+        return _VSCODE_pd.DataFrame(ndarray)
 
 
 # Function that converts tensors to DataFrames

--- a/src/datascience-ui/data-explorer/cellFormatter.css
+++ b/src/datascience-ui/data-explorer/cellFormatter.css
@@ -1,5 +1,5 @@
 .number-formatter {
-    text-align: right;
+    text-align: left;
     text-overflow: ellipsis;
     overflow: hidden;
 }
@@ -7,7 +7,7 @@
 .cell-formatter {
     /* Note: This is impacted by the RowHeightAdjustment in reactSlickGrid.tsx */
     margin: 0px 0px 0px 0px;
-    text-align: right;
+    text-align: left;
     text-overflow: ellipsis;
     overflow: hidden;
 }

--- a/src/datascience-ui/data-explorer/reactSlickGrid.css
+++ b/src/datascience-ui/data-explorer/reactSlickGrid.css
@@ -100,7 +100,7 @@ input.editor-text {
     border-right-style: solid;
     background-color: var(--vscode-button-background);
     color: var(--vscode-button-foreground);
-    text-align: right;
+    text-align: left;
     /* input does not inherit font from body */
     font-family: var(--vscode-editor-font-family);
     font-weight: var(--vscode-editor-font-weight);

--- a/src/test/datascience/dataviewer.functional.test.tsx
+++ b/src/test/datascience/dataviewer.functional.test.tsx
@@ -372,9 +372,7 @@ suite('DataScience DataViewer tests', () => {
     });
 
     runMountedTest('Filter 2D PyTorch tensors', async (wrapper) => {
-        await injectCode(
-            "import torch\r\nfoo = torch.tensor([0, 1, 2, 3, 4, 5])"
-        );
+        await injectCode('import torch\r\nfoo = torch.tensor([0, 1, 2, 3, 4, 5])');
         const gotAllRows = getCompletedPromise(wrapper);
         const dv = await createJupyterVariableDataViewer('foo', 'Tensor');
         assert.ok(dv, 'DataViewer not created');

--- a/src/test/datascience/dataviewer.functional.test.tsx
+++ b/src/test/datascience/dataviewer.functional.test.tsx
@@ -465,7 +465,7 @@ suite('DataScience DataViewer tests', () => {
         const dv = await createJupyterVariableDataViewer('foo', 'ndarray');
         assert.ok(dv, 'DataViewer not created');
         await gotAllRows;
-        verifyRows(wrapper.wrapper, [0, 'hello', '', 1, 42, '', 2, 'hi', 'hey']);
+        verifyRows(wrapper.wrapper, [0, 'hello', 1, 42, 2, "['hi', 'hey']"]);
     });
 
     runMountedTest('Ragged 2D numpy array', async (wrapper) => {
@@ -474,7 +474,7 @@ suite('DataScience DataViewer tests', () => {
         const dv = await createJupyterVariableDataViewer('foo', 'ndarray');
         assert.ok(dv, 'DataViewer not created');
         await gotAllRows;
-        verifyRows(wrapper.wrapper, [0, 1, 2, 3, 'inf', 1, 4, 'nan', 5]);
+        verifyRows(wrapper.wrapper, [0, '[1, 2, 3, inf]', 1, '[4, nan, 5]']);
     });
 
     runMountedTest('Ragged 3D numpy array', async (wrapper) => {
@@ -484,6 +484,6 @@ suite('DataScience DataViewer tests', () => {
         const dv = await createJupyterVariableDataViewer('foo', 'ndarray');
         assert.ok(dv, 'DataViewer not created');
         await gotAllRows;
-        verifyRows(wrapper.wrapper, [0, `[1, 2, 3]`, `[4, 5]`, 1, `[[6, 7, 8, 9]]`, '']);
+        verifyRows(wrapper.wrapper, [0, `[[1, 2, 3], [4, 5]]`, 1, '[[6, 7, 8, 9]]']);
     });
 });

--- a/src/test/datascience/dataviewer.functional.test.tsx
+++ b/src/test/datascience/dataviewer.functional.test.tsx
@@ -371,6 +371,19 @@ suite('DataScience DataViewer tests', () => {
         }
     });
 
+    runMountedTest('Filter 2D PyTorch tensors', async (wrapper) => {
+        await injectCode(
+            "import torch\r\nfoo = torch.tensor([0, 1, 2, 3, 4, 5])"
+        );
+        const gotAllRows = getCompletedPromise(wrapper);
+        const dv = await createJupyterVariableDataViewer('foo', 'Tensor');
+        assert.ok(dv, 'DataViewer not created');
+        await gotAllRows;
+
+        await filterRows(wrapper.wrapper, '0', '> 0');
+        verifyRows(wrapper.wrapper, [1, 1, 2, 2, 3, 3, 4, 4, 5, 5]);
+    });
+
     runMountedTest('2D PyTorch tensors', async (wrapper) => {
         await injectCode(
             "import torch\r\nimport numpy as np\r\nfoo = torch.tensor([0, 1, np.inf, float('-inf'), np.nan])"


### PR DESCRIPTION
Was testing and noticed #298 regressed ndarray handling--all elements were automatically stringified, so filtering stopped working. Same goes for tensors.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] ~Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).~
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
