### PR TITLE
Eliminate unnecessary dupe files and map files in VSIX

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,12 +1,6 @@
 **/*.map
 **/*.analyzer.html
 !out/datascience-ui/common/node_modules/**/*
-!out/datascience-ui/notebook/commons.initial.bundle.js.map
-!out/datascience-ui/notebook/interactiveWindow.js.map
-!out/datascience-ui/notebook/nativeEditor.js.map
-!out/datascience-ui/viewers/commons.initial.bundle.js.map
-!out/datascience-ui/viewers/dataExplorer.js.map
-!out/datascience-ui/viewers/plotViewer.js.map
 !out/BCryptGenRandom/BCryptGenRandom.exe
 images/**
 docs/**
@@ -113,3 +107,5 @@ test/**
 tmp/**
 typings/**
 types/**
+test-results*
+*.zip

--- a/news/2 Fixes/4551.md
+++ b/news/2 Fixes/4551.md
@@ -1,0 +1,1 @@
+Remove unnecessary files from the VSIX that just take up space.

--- a/src/datascience-ui/history-react/redux/store.ts
+++ b/src/datascience-ui/history-react/redux/store.ts
@@ -5,8 +5,19 @@
 import * as ReduxCommon from '../../interactive-common/redux/store';
 import { PostOffice } from '../../react-common/postOffice';
 import { reducerMap } from './reducers';
+import { forceLoad } from '../../interactive-common/transforms';
 
 // This special version uses the reducer map from the IInteractiveWindowMapping
 export function createStore(skipDefault: boolean, baseTheme: string, testMode: boolean, postOffice: PostOffice) {
-    return ReduxCommon.createStore(skipDefault, baseTheme, testMode, false, false, false, reducerMap, postOffice);
+    return ReduxCommon.createStore(
+        skipDefault,
+        baseTheme,
+        testMode,
+        false,
+        false,
+        false,
+        reducerMap,
+        postOffice,
+        forceLoad
+    );
 }

--- a/src/datascience-ui/native-editor/redux/store.ts
+++ b/src/datascience-ui/native-editor/redux/store.ts
@@ -5,8 +5,19 @@
 import * as ReduxCommon from '../../interactive-common/redux/store';
 import { PostOffice } from '../../react-common/postOffice';
 import { reducerMap } from './reducers';
+import { forceLoad } from '../../interactive-common/transforms';
 
 // This special version uses the reducer map from the INativeEditorMapping
 export function createStore(skipDefault: boolean, baseTheme: string, testMode: boolean, postOffice: PostOffice) {
-    return ReduxCommon.createStore(skipDefault, baseTheme, testMode, true, true, false, reducerMap, postOffice);
+    return ReduxCommon.createStore(
+        skipDefault,
+        baseTheme,
+        testMode,
+        true,
+        true,
+        false,
+        reducerMap,
+        postOffice,
+        forceLoad
+    );
 }

--- a/src/datascience-ui/variable-view/redux/store.ts
+++ b/src/datascience-ui/variable-view/redux/store.ts
@@ -16,6 +16,7 @@ export function createStore(skipDefault: boolean, baseTheme: string, testMode: b
         false,
         true /* Start with variable view open */,
         reducerMap,
-        postOffice
+        postOffice,
+        () => Promise.resolve()
     );
 }


### PR DESCRIPTION
For #4551 

Map files aren't needed in the vsix.

Additionally the 'forceLoad' function for test code was forcing the transforms.tsx file to get pulled in which brings in a whole host of other imports. This is only necessary for the webview editors.

