### PR TITLE
Switch ipywidget tests to use raw

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -210,7 +210,6 @@ module.exports = {
         'src/test/datascience/uiTests/webBrowserPanelProvider.ts',
         'src/test/datascience/uiTests/recorder.ts',
         'src/test/datascience/uiTests/notebookHelpers.ts',
-        'src/test/datascience/uiTests/ipywidget.ui.functional.test.ts',
         'src/test/datascience/mockWorkspaceConfiguration.ts',
         'src/test/datascience/mockTextEditor.ts',
         'src/test/datascience/mockLanguageServerAnalysisOptions.ts',

--- a/src/test/datascience/uiTests/ipywidget.ui.functional.test.ts
+++ b/src/test/datascience/uiTests/ipywidget.ui.functional.test.ts
@@ -61,7 +61,7 @@ use(chaiAsPromised);
             // Make sure we force auto start (we wait for kernel idle before running)
             ioc.forceDataScienceSettingsChanged({
                 disableJupyterAutoStart: false,
-                disableZMQSupport: true
+                disableZMQSupport: !useRawKernel
             });
 
             await ioc.activate();


### PR DESCRIPTION
Seems we were still using jupyter for ipywidget tests. Jupyter is flakey at shutting down (at least during functional tests). Hopefully this will resolve some flakiness in tests timing out.

