### PR TITLE
Only install insiders in insiders

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -800,7 +800,6 @@ module.exports = {
         'src/client/common/process/decoder.ts',
         'src/client/common/process/pythonExecutionFactory.ts',
         'src/client/common/insidersBuild/insidersExtensionPrompt.ts',
-        'src/client/common/insidersBuild/insidersExtensionService.ts',
         'src/client/common/insidersBuild/types.ts',
         'src/client/common/insidersBuild/downloadChannelService.ts',
         'src/client/common/insidersBuild/downloadChannelRules.ts',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -163,7 +163,6 @@ module.exports = {
         'src/test/common/insidersBuild/downloadChannelRules.unit.test.ts',
         'src/test/common/insidersBuild/insidersExtensionPrompt.unit.test.ts',
         'src/test/common/insidersBuild/downloadChannelService.unit.test.ts',
-        'src/test/common/insidersBuild/insidersExtensionService.unit.test.ts',
         'src/test/pythonFiles/formatting/dummy.ts',
         'src/test/format/extension.dispatch.test.ts',
         'src/test/format/extension.format.native.vscode.test.ts',

--- a/src/client/common/insidersBuild/insidersExtensionService.ts
+++ b/src/client/common/insidersBuild/insidersExtensionService.ts
@@ -71,7 +71,7 @@ export class InsidersExtensionService implements IExtensionSingleActivationServi
     @traceDecorators.error('Handling channel failed')
     public async handleChannel(installChannel: ExtensionChannels, didChannelChange: boolean = false): Promise<void> {
         const channelRule = this.serviceContainer.get<IExtensionChannelRule>(IExtensionChannelRule, installChannel);
-        const shouldInstall = await channelRule.shouldLookForInsidersBuild(didChannelChange);
+        const shouldInstall = this.appEnvironment.channel === 'insiders' && await channelRule.shouldLookForInsidersBuild(didChannelChange);
         if (!shouldInstall) {
             return;
         }

--- a/src/client/common/insidersBuild/insidersExtensionService.ts
+++ b/src/client/common/insidersBuild/insidersExtensionService.ts
@@ -71,7 +71,9 @@ export class InsidersExtensionService implements IExtensionSingleActivationServi
     @traceDecorators.error('Handling channel failed')
     public async handleChannel(installChannel: ExtensionChannels, didChannelChange: boolean = false): Promise<void> {
         const channelRule = this.serviceContainer.get<IExtensionChannelRule>(IExtensionChannelRule, installChannel);
-        const shouldInstall = this.appEnvironment.channel === 'insiders' && await channelRule.shouldLookForInsidersBuild(didChannelChange);
+        const shouldInstall =
+            this.appEnvironment.channel === 'insiders' &&
+            (await channelRule.shouldLookForInsidersBuild(didChannelChange));
         if (!shouldInstall) {
             return;
         }

--- a/src/test/common/insidersBuild/insidersExtensionService.unit.test.ts
+++ b/src/test/common/insidersBuild/insidersExtensionService.unit.test.ts
@@ -57,6 +57,7 @@ suite('Insiders Extension', () => {
         setup(() => {
             extensionChannelService = mock(ExtensionChannelService);
             appEnvironment = mock(ApplicationEnvironment);
+            when(appEnvironment.channel).thenReturn('insiders');
             cmdManager = mock(CommandManager);
             serviceContainer = mock(ServiceContainer);
             insidersPrompt = mock(InsidersExtensionPrompt);


### PR DESCRIPTION
For #4700 

Only install insiders in insiders versions of VS code. Othewise breaking API changes as VS code changes their API won't work in stable.

