### PR TITLE
Ensure data viewer doesn't fail on dataframe replace errors

### DIFF
--- a/pythonFiles/vscode_datascience_helpers/dataframes/vscodeDataFrame.py
+++ b/pythonFiles/vscode_datascience_helpers/dataframes/vscodeDataFrame.py
@@ -125,13 +125,16 @@ def _VSCODE_getDataFrameRows(df, start, end):
     df = _VSCODE_convertToDataFrame(df)
     # Turn into JSON using pandas. We use pandas because it's about 3 orders of magnitude faster to turn into JSON
     rows = df.iloc[start:end]
-    rows = rows.replace(
-        {
-            _VSCODE_np.inf: "inf",
-            -_VSCODE_np.inf: "-inf",
-            _VSCODE_np.nan: "nan",
-        }
-    )
+    try:
+        rows = rows.replace(
+            {
+                _VSCODE_np.inf: "inf",
+                -_VSCODE_np.inf: "-inf",
+                _VSCODE_np.nan: "nan",
+            }
+        )
+    except:
+        pass
     return _VSCODE_pd_json.to_json(None, rows, orient="table", date_format="iso")
 
 

--- a/src/test/datascience/dataviewer.functional.test.tsx
+++ b/src/test/datascience/dataviewer.functional.test.tsx
@@ -486,4 +486,19 @@ suite('DataScience DataViewer tests', () => {
         await gotAllRows;
         verifyRows(wrapper.wrapper, [0, `[[1, 2, 3], [4, 5]]`, 1, '[[6, 7, 8, 9]]']);
     });
+
+    // https://github.com/microsoft/vscode-jupyter/issues/4706
+    // Disabled for now. Root cause is that pd.replace isn't recursive over objects in DataFrames,
+    // so our current inf/nan handling does not work for DataFrames whose cells are Series, ndarray, or list
+    // runMountedTest('Inf/NaN in DataFrame', async (wrapper) => {
+    //     await injectCode(
+    //         'import pandas as pd\r\nimport numpy as np\r\ndf = pd.DataFrame([], columns=["foo", "bar", "baz"])\r\ndf = df.append({"foo": [0, 1, np.inf], "bar": [-np.inf, 0, 1], "baz": [1, np.nan, 0]}, ignore_index=True)'
+    //     );
+    //     const gotAllRows = getCompletedPromise(wrapper);
+    //     const dv = await createJupyterVariableDataViewer('df', 'DataFrame');
+    //     assert.ok(dv, 'DataViewer not created');
+    //     await gotAllRows;
+
+    //     verifyRows(wrapper.wrapper, [0, '[0,1,inf]', '[-inf,0,1]', '[1,nan,0]']);
+    // });
 });


### PR DESCRIPTION
For https://github.com/microsoft/vscode-jupyter/issues/4706

Temporary fix to avoid regressing ahead of February release while I dig into pandas documentation to figure out how to handle inf/-inf/nan in DataFrames which contain cells that are objects (list, ndarray, Series) ideally without having to iterate over the DataFrame

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
