### PR TITLE
Update outputs API usage

### DIFF
--- a/src/client/datascience/notebook/helpers/notebookUpdater.ts
+++ b/src/client/datascience/notebook/helpers/notebookUpdater.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { workspace, WorkspaceEdit } from 'vscode';
-import { NotebookDocument, NotebookEditor } from '../../../../../types/vscode-proposed';
+import { NotebookDocument, NotebookEditor } from '../../../../../typings/vscode-proposed';
 import { createDeferred } from '../../../common/utils/async';
 import { noop } from '../../../common/utils/misc';
 

--- a/src/test/datascience/notebook/contentProvider.vscode.test.ts
+++ b/src/test/datascience/notebook/contentProvider.vscode.test.ts
@@ -9,8 +9,8 @@ import { assert } from 'chai';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import { CellErrorOutput, commands, Uri } from 'vscode';
-import { CellDisplayOutput, NotebookContentProvider } from '../../../../types/vscode-proposed';
+import { commands, Uri } from 'vscode';
+import { NotebookContentProvider } from '../../../../types/vscode-proposed';
 import { IVSCodeNotebook } from '../../../client/common/application/types';
 import { IDisposable } from '../../../client/common/types';
 import { INotebookContentProvider } from '../../../client/datascience/notebook/types';
@@ -128,7 +128,7 @@ suite('DataScience - VSCode Notebook - (Open)', function () {
         assert.equal(notebook.cells[1].cellKind, vscodeNotebookEnums.CellKind.Code, 'Cell2, type');
         assert.include(notebook.cells[1].document.getText(), 'pip list', 'Cell1, source');
         assert.lengthOf(notebook.cells[1].outputs, 1, 'Cell2, outputs');
-        assert.equal(notebook.cells[1].outputs[0].outputKind, vscodeNotebookEnums.CellOutputKind.Rich, 'Cell2, output');
+        // assert.equal(notebook.cells[1].outputs[0].outputKind, vscodeNotebookEnums.CellOutputKind.Rich, 'Cell2, output');
         assert.equal(notebook.cells[1].metadata.executionOrder, 3, 'Cell2, execution count');
         assert.lengthOf(Object.keys(notebook.cells[1].metadata.custom || {}), 1, 'Cell2, metadata');
         assert.deepEqual(notebook.cells[1].metadata.custom?.metadata.tags, ['WOW'], 'Cell2, metadata');
@@ -145,12 +145,12 @@ suite('DataScience - VSCode Notebook - (Open)', function () {
         assert.equal(notebook.cells[3].cellKind, vscodeNotebookEnums.CellKind.Code, 'Cell4, type');
         assert.include(notebook.cells[3].document.getText(), 'with Error', 'Cell4, source');
         assert.lengthOf(notebook.cells[3].outputs, 1, 'Cell4, outputs');
-        assert.equal(
-            notebook.cells[3].outputs[0].outputKind,
-            vscodeNotebookEnums.CellOutputKind.Error,
-            'Cell4, output'
-        );
-        const errorOutput = (notebook.cells[3].outputs[0] as unknown) as CellErrorOutput;
+        // assert.equal(
+        //     notebook.cells[3].outputs[0].outputKind,
+        //     vscodeNotebookEnums.CellOutputKind.Error,
+        //     'Cell4, output'
+        // );
+        const errorOutput = notebook.cells[3].outputs[0].outputs[0] as any;
         assert.equal(errorOutput.ename, 'SyntaxError', 'Cell4, output');
         assert.equal(errorOutput.evalue, 'invalid syntax (<ipython-input-1-8b7c24be1ec9>, line 1)', 'Cell3, output');
         assert.lengthOf(errorOutput.traceback, 1, 'Cell4, output');
@@ -164,7 +164,7 @@ suite('DataScience - VSCode Notebook - (Open)', function () {
         assert.include(notebook.cells[4].document.getText(), 'import matplotlib', 'Cell5, source');
         assert.include(notebook.cells[4].document.getText(), 'plt.show()', 'Cell5, source');
         assert.lengthOf(notebook.cells[4].outputs, 1, 'Cell5, outputs');
-        assert.equal(notebook.cells[4].outputs[0].outputKind, vscodeNotebookEnums.CellOutputKind.Rich, 'Cell5, output');
+        // assert.equal(notebook.cells[4].outputs[0].outputKind, vscodeNotebookEnums.CellOutputKind.Rich, 'Cell5, output');
         const richOutput = (notebook.cells[4].outputs[0] as unknown) as CellDisplayOutput;
         assert.containsAllKeys(
             richOutput.data,

--- a/src/test/datascience/notebook/executionService.vscode.test.ts
+++ b/src/test/datascience/notebook/executionService.vscode.test.ts
@@ -11,7 +11,7 @@ import * as dedent from 'dedent';
 import * as sinon from 'sinon';
 import { commands, Uri } from 'vscode';
 import { Common } from '../../../client/common/utils/localize';
-import { CellDisplayOutput, CellErrorOutput, NotebookCell } from '../../../../typings/vscode-proposed';
+import { NotebookCell } from '../../../../typings/vscode-proposed';
 import { IVSCodeNotebook } from '../../../client/common/application/types';
 import { traceInfo } from '../../../client/common/logger';
 import { IDisposable, Product } from '../../../client/common/types';
@@ -119,7 +119,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         await runCell(cell);
 
         await waitForExecutionCompletedSuccessfully(cell);
-        const output = (cell.outputs[0] as CellDisplayOutput).data['text/plain'];
+        const output = (cell.outputs[0].outputs.find(opit => opit.mime === 'text/plain')?.value as string);
         assert.equal(output, '\tho\n\tho\n\tho\n', 'Cell with leading whitespace has incorrect output');
     });
     test('Executed events are triggered', async () => {
@@ -224,8 +224,8 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         await waitForExecutionCompletedWithErrors(cell);
 
         assert.lengthOf(cell.outputs, 1, 'Incorrect output');
-        const errorOutput = cell.outputs[0] as CellErrorOutput;
-        assert.equal(errorOutput.outputKind, vscodeNotebookEnums.CellOutputKind.Error, 'Incorrect output');
+        const errorOutput = cell.outputs[0].outputs.find(opit => opit.mime === 'application/x.notebook.error-traceback')?.value as any;
+        // assert.equal(errorOutput.outputKind, vscodeNotebookEnums.CellOutputKind.Error, 'Incorrect output');
         assert.equal(errorOutput.ename, 'NameError', 'Incorrect ename'); // As status contains ename, we don't want this displayed again.
         assert.equal(errorOutput.evalue, "name 'abcd' is not defined", 'Incorrect evalue'); // As status contains ename, we don't want this displayed again.
         assert.isNotEmpty(errorOutput.traceback, 'Incorrect traceback');

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -14,7 +14,6 @@ import { WorkspaceEdit } from 'vscode';
 import { commands, Memento, TextDocument, Uri, window, workspace } from 'vscode';
 import { CancellationToken } from 'vscode-jsonrpc';
 import {
-    CellDisplayOutput,
     NotebookCell,
     NotebookContentProvider as VSCNotebookContentProvider,
     NotebookDocument
@@ -168,8 +167,7 @@ export async function createTemporaryNotebook(templateFile: string, disposables:
 export async function canRunNotebookTests() {
     if (!isInsiders() || !process.env.VSC_JUPYTER_RUN_NB_TEST) {
         console.log(
-            `Can't run native nb tests isInsiders() = ${isInsiders()}, process.env.VSC_JUPYTER_RUN_NB_TEST = ${
-                process.env.VSC_JUPYTER_RUN_NB_TEST
+            `Can't run native nb tests isInsiders() = ${isInsiders()}, process.env.VSC_JUPYTER_RUN_NB_TEST = ${process.env.VSC_JUPYTER_RUN_NB_TEST
             }`
         );
         return false;
@@ -469,9 +467,9 @@ export async function waitForExecutionInProgress(cell: NotebookCell, timeout: nu
         async () => {
             const result =
                 cell.metadata.runState === vscodeNotebookEnums.NotebookCellRunState.Running &&
-                cell.metadata.runStartTime &&
-                !cell.metadata.lastRunDuration &&
-                !cell.metadata.statusMessage
+                    cell.metadata.runStartTime &&
+                    !cell.metadata.lastRunDuration &&
+                    !cell.metadata.statusMessage
                     ? true
                     : false;
             return result;
@@ -487,9 +485,9 @@ export async function waitForQueuedForExecution(cell: NotebookCell, timeout: num
     await waitForCondition(
         async () =>
             cell.metadata.runState === vscodeNotebookEnums.NotebookCellRunState.Running &&
-            !cell.metadata.runStartTime &&
-            !cell.metadata.lastRunDuration &&
-            !cell.metadata.statusMessage
+                !cell.metadata.runStartTime &&
+                !cell.metadata.lastRunDuration &&
+                !cell.metadata.statusMessage
                 ? true
                 : false,
         timeout,
@@ -521,8 +519,8 @@ function assertHasExecutionCompletedWithErrors(cell: NotebookCell) {
 export function assertHasTextOutputInVSCode(cell: NotebookCell, text: string, index: number = 0, isExactMatch = true) {
     const cellOutputs = cell.outputs;
     assert.ok(cellOutputs.length, 'No output');
-    assert.equal(cellOutputs[index].outputKind, vscodeNotebookEnums.CellOutputKind.Rich, 'Incorrect output kind');
-    const outputText = (cellOutputs[index] as CellDisplayOutput).data['text/plain'].trim();
+    // assert.equal(cellOutputs[index].outputKind, vscodeNotebookEnums.CellOutputKind.Rich, 'Incorrect output kind');
+    const outputText = (cellOutputs[index].outputs.find(opit => opit.mime === 'text/plain')?.value as string).trim();
     if (isExactMatch) {
         assert.equal(outputText, text, 'Incorrect output');
     } else {
@@ -546,8 +544,8 @@ export async function waitForTextOutputInVSCode(
 export function assertNotHasTextOutputInVSCode(cell: NotebookCell, text: string, index: number, isExactMatch = true) {
     const cellOutputs = cell.outputs;
     assert.ok(cellOutputs, 'No output');
-    assert.equal(cellOutputs[index].outputKind, vscodeNotebookEnums.CellOutputKind.Rich, 'Incorrect output kind');
-    const outputText = (cellOutputs[index] as CellDisplayOutput).data['text/plain'].trim();
+    // assert.equal(cellOutputs[index].outputKind, vscodeNotebookEnums.CellOutputKind.Rich, 'Incorrect output kind');
+    const outputText = (cellOutputs[index].outputs.find(opit => opit.mime === 'text/plain')?.value as string).trim();
     if (isExactMatch) {
         assert.notEqual(outputText, text, 'Incorrect output');
     } else {
@@ -576,7 +574,7 @@ export function assertVSCCellHasErrors(cell: NotebookCell) {
 }
 export function assertVSCCellHasErrorOutput(cell: NotebookCell) {
     assert.ok(
-        cell.outputs.filter((output) => output.outputKind === vscodeNotebookEnums.CellOutputKind.Error).length,
+        cell.outputs.filter((output) => output.outputs.some(opit => opit.mime === 'application/x.notebook.error-traceback')).length,
         'No error output in cell'
     );
     return true;

--- a/src/test/datascience/notebook/helpers.unit.test.ts
+++ b/src/test/datascience/notebook/helpers.unit.test.ts
@@ -7,7 +7,7 @@ import { nbformat } from '@jupyterlab/coreutils';
 import { assert } from 'chai';
 import { cloneDeep } from 'lodash';
 import { Uri } from 'vscode';
-import { CellOutput, NotebookCellData } from '../../../../types/vscode-proposed';
+import { NotebookCellOutput, NotebookCellData, NotebookCellOutputItem } from '../../../../types/vscode-proposed';
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const vscodeNotebookEnums = require('vscode') as typeof import('vscode-proposed');
 import { MARKDOWN_LANGUAGE, PYTHON_LANGUAGE } from '../../../client/common/constants';
@@ -72,7 +72,7 @@ suite('DataScience - NativeNotebook helpers', () => {
         ]);
     });
     suite('Outputs', () => {
-        function validateCellOutputTranslation(outputs: nbformat.IOutput[], expectedOutputs: CellOutput[]) {
+        function validateCellOutputTranslation(outputs: nbformat.IOutput[], expectedOutputs: NotebookCellOutput[]) {
             const cells = [
                 {
                     cell_type: 'code',
@@ -105,10 +105,8 @@ suite('DataScience - NativeNotebook helpers', () => {
                     }
                 ],
                 [
-                    {
-                        outputKind: vscodeNotebookEnums.CellOutputKind.Rich,
-                        data: { 'text/plain': 'Error' },
-                        metadata: {
+                    new NotebookCellOutput([
+                        new NotebookCellOutputItem('text/plain', 'Error', {
                             custom: {
                                 vscode: {
                                     name: 'stderr',
@@ -116,11 +114,10 @@ suite('DataScience - NativeNotebook helpers', () => {
                                 }
                             }
                         }
-                    },
-                    {
-                        outputKind: vscodeNotebookEnums.CellOutputKind.Rich,
-                        data: { 'text/plain': 'NoError' },
-                        metadata: {
+                        )]
+                    ),
+                    new NotebookCellOutput([
+                        new NotebookCellOutputItem('text/plain', 'NoError', {
                             custom: {
                                 vscode: {
                                     name: 'stdout',
@@ -128,7 +125,8 @@ suite('DataScience - NativeNotebook helpers', () => {
                                 }
                             }
                         }
-                    }
+                        )]
+                    ),
                 ]
             );
         });
@@ -142,12 +140,8 @@ suite('DataScience - NativeNotebook helpers', () => {
                     }
                 ],
                 [
-                    {
-                        outputKind: vscodeNotebookEnums.CellOutputKind.Rich,
-                        data: {
-                            'text/plain': '\u001b[K\u001b[33m✅ \u001b[0m Loading\n'
-                        },
-                        metadata: {
+                    new NotebookCellOutput([
+                        new NotebookCellOutputItem('text/plain', '\u001b[K\u001b[33m✅ \u001b[0m Loading\n', {
                             custom: {
                                 vscode: {
                                     name: 'stderr',
@@ -155,7 +149,8 @@ suite('DataScience - NativeNotebook helpers', () => {
                                 }
                             }
                         }
-                    }
+                        )]
+                    )
                 ]
             );
         });
@@ -169,12 +164,8 @@ suite('DataScience - NativeNotebook helpers', () => {
                     }
                 ],
                 [
-                    {
-                        outputKind: vscodeNotebookEnums.CellOutputKind.Rich,
-                        data: {
-                            'text/plain': '1 is < 2'
-                        },
-                        metadata: {
+                    new NotebookCellOutput([
+                        new NotebookCellOutputItem('text/plain', '1 is < 2', {
                             custom: {
                                 vscode: {
                                     name: 'stderr',
@@ -182,7 +173,8 @@ suite('DataScience - NativeNotebook helpers', () => {
                                 }
                             }
                         }
-                    }
+                        )]
+                    )
                 ]
             );
         });
@@ -196,12 +188,8 @@ suite('DataScience - NativeNotebook helpers', () => {
                     }
                 ],
                 [
-                    {
-                        outputKind: vscodeNotebookEnums.CellOutputKind.Rich,
-                        data: {
-                            'text/plain': '1 is < 2\u001b[K\u001b[33m✅ \u001b[0m Loading\n'
-                        },
-                        metadata: {
+                    new NotebookCellOutput([
+                        new NotebookCellOutputItem('text/plain', '1 is < 2\u001b[K\u001b[33m✅ \u001b[0m Loading\n', {
                             custom: {
                                 vscode: {
                                     name: 'stderr',
@@ -209,7 +197,8 @@ suite('DataScience - NativeNotebook helpers', () => {
                                 }
                             }
                         }
-                    }
+                        )]
+                    )
                 ]
             );
         });
@@ -224,12 +213,13 @@ suite('DataScience - NativeNotebook helpers', () => {
                     }
                 ],
                 [
-                    {
-                        outputKind: vscodeNotebookEnums.CellOutputKind.Error,
-                        ename: 'Error Name',
-                        evalue: 'Error Value',
-                        traceback: ['stack1', 'stack2', 'stack3']
-                    }
+                    new NotebookCellOutput([
+                        new NotebookCellOutputItem('application/x.notebook.error-traceback', {
+                            ename: 'Error Name',
+                            evalue: 'Error Value',
+                            traceback: ['stack1', 'stack2', 'stack3']
+                        })
+                    ])
                 ]
             );
         });
@@ -247,19 +237,15 @@ suite('DataScience - NativeNotebook helpers', () => {
                             }
                         ],
                         [
-                            {
-                                outputKind: vscodeNotebookEnums.CellOutputKind.Rich,
-                                data: {
-                                    'text/plain': 'Hello World!'
-                                },
-                                metadata: {
+                            new NotebookCellOutput([
+                                new NotebookCellOutputItem('text/plain', 'Hello World!', {
                                     custom: {
                                         vscode: {
                                             outputType: output_type
                                         }
                                     }
-                                }
-                            }
+                                })
+                            ])
                         ]
                     );
                 });
@@ -276,20 +262,17 @@ suite('DataScience - NativeNotebook helpers', () => {
                             }
                         ],
                         [
-                            {
-                                outputKind: vscodeNotebookEnums.CellOutputKind.Rich,
-                                data: {
-                                    'image/png': 'base64PNG',
-                                    'image/jpeg': 'base64JPEG'
-                                },
-                                metadata: {
+                            new NotebookCellOutput([
+                                new NotebookCellOutputItem('image/png', 'base64PNG', {
                                     custom: {
                                         vscode: {
                                             outputType: output_type
                                         }
                                     }
-                                }
-                            }
+                                }),
+                                new NotebookCellOutputItem('image/jpeg', 'base64JPEG')
+
+                            ])
                         ]
                     );
                 });
@@ -307,20 +290,16 @@ suite('DataScience - NativeNotebook helpers', () => {
                             }
                         ],
                         [
-                            {
-                                outputKind: vscodeNotebookEnums.CellOutputKind.Rich,
-                                data: {
-                                    'image/png': 'base64PNG'
-                                },
-                                metadata: {
+                            new NotebookCellOutput([
+                                new NotebookCellOutputItem('image/png', 'base64PNG', {
                                     custom: {
                                         needs_background: 'light',
                                         vscode: {
                                             outputType: output_type
                                         }
                                     }
-                                }
-                            }
+                                })
+                            ])
                         ]
                     );
                 });
@@ -338,20 +317,16 @@ suite('DataScience - NativeNotebook helpers', () => {
                             }
                         ],
                         [
-                            {
-                                outputKind: vscodeNotebookEnums.CellOutputKind.Rich,
-                                data: {
-                                    'image/png': 'base64PNG'
-                                },
-                                metadata: {
+                            new NotebookCellOutput([
+                                new NotebookCellOutputItem('image/png', 'base64PNG', {
                                     custom: {
                                         needs_background: 'dark',
                                         vscode: {
                                             outputType: output_type
                                         }
                                     }
-                                }
-                            }
+                                })
+                            ])
                         ]
                     );
                 });
@@ -369,20 +344,16 @@ suite('DataScience - NativeNotebook helpers', () => {
                             }
                         ],
                         [
-                            {
-                                outputKind: vscodeNotebookEnums.CellOutputKind.Rich,
-                                data: {
-                                    'image/png': 'base64PNG'
-                                },
-                                metadata: {
+                            new NotebookCellOutput([
+                                new NotebookCellOutputItem('image/png', 'base64PNG', {
                                     custom: {
                                         'image/png': { height: '111px', width: '999px' },
                                         vscode: {
                                             outputType: output_type
                                         }
                                     }
-                                }
-                            }
+                                }),
+                            ])
                         ]
                     );
                 });
@@ -401,12 +372,8 @@ suite('DataScience - NativeNotebook helpers', () => {
                             }
                         ],
                         [
-                            {
-                                outputKind: vscodeNotebookEnums.CellOutputKind.Rich,
-                                data: {
-                                    'image/png': 'base64PNG'
-                                },
-                                metadata: {
+                            new NotebookCellOutput([
+                                new NotebookCellOutputItem('image/png', 'base64PNG', {
                                     custom: {
                                         unconfined: true,
                                         'image/png': { width: '999px' },
@@ -414,8 +381,8 @@ suite('DataScience - NativeNotebook helpers', () => {
                                             outputType: output_type
                                         }
                                     }
-                                }
-                            }
+                                }),
+                            ])
                         ]
                     );
                 });

--- a/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
@@ -5,7 +5,6 @@
 import { assert } from 'chai';
 import * as sinon from 'sinon';
 import { CancellationTokenSource, CompletionContext, CompletionTriggerKind, Position } from 'vscode';
-import { CellDisplayOutput } from '../../../../../types/vscode-proposed';
 import { IVSCodeNotebook } from '../../../../client/common/application/types';
 import { traceInfo } from '../../../../client/common/logger';
 import { IDisposable } from '../../../../client/common/types';
@@ -68,7 +67,7 @@ suite('DataScience - VSCode Notebook - (Code Completion via Jupyter) (slow)', fu
 
         // Wait till execution count changes and status is success.
         await waitForExecutionCompletedSuccessfully(cell);
-        const outputText: string = (cell.outputs[0] as CellDisplayOutput).data['text/plain'].trim();
+        const outputText: string = (cell.outputs[0].outputs.find(opit => opit.mime === 'text/plain')?.value as string).trim() || '';
         traceInfo(`Cell Output ${outputText}`);
         await insertCodeCell('a.', { index: 1 });
         const cell2 = vscodeNotebook.activeNotebookEditor!.document.cells[1];

--- a/src/test/datascience/notebook/kernelSelection.vscode.test.ts
+++ b/src/test/datascience/notebook/kernelSelection.vscode.test.ts
@@ -6,7 +6,6 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import { commands } from 'vscode';
-import { CellDisplayOutput } from '../../../../types/vscode-proposed';
 import { IPythonExtensionChecker } from '../../../client/api/types';
 import { IVSCodeNotebook } from '../../../client/common/application/types';
 import { BufferDecoder } from '../../../client/common/process/decoder';
@@ -207,7 +206,7 @@ suite('DataScience - VSCode Notebook - Kernel Selection', function () {
 
         // Confirm the executable printed is not venvkernel
         assert.ok(cell.outputs.length);
-        const outputText: string = (cell.outputs[0] as CellDisplayOutput).data['text/plain'].trim();
+        const outputText: string = (cell.outputs[0].outputs.find(opit => opit.mime === 'text/plain')?.value as string).trim();
         assert.equal(outputText.toLowerCase().indexOf(venvKernelPythonPath), -1);
 
         // Change kernel to the interpreter venvkernel
@@ -238,7 +237,7 @@ suite('DataScience - VSCode Notebook - Kernel Selection', function () {
 
         // Confirm the executable printed is not venvNoReg
         assert.ok(cell.outputs.length);
-        const outputText: string = (cell.outputs[0] as CellDisplayOutput).data['text/plain'].trim();
+        const outputText: string = (cell.outputs[0].outputs.find(opit => opit.mime === 'text/plain')?.value as string).trim();
         assert.equal(outputText.toLowerCase().indexOf(venvNoRegPythonPath), -1);
 
         // Change kernel to the interpreter venvNoReg

--- a/src/test/datascience/notebook/notebookEditor.vscode.test.ts
+++ b/src/test/datascience/notebook/notebookEditor.vscode.test.ts
@@ -4,7 +4,6 @@
 'use strict';
 
 import { assert } from 'chai';
-import { CellDisplayOutput } from 'vscode';
 import { CancellationToken } from 'vscode-jsonrpc';
 import { ICommandManager, IVSCodeNotebook } from '../../../client/common/application/types';
 import { ProductNames } from '../../../client/common/installer/productNames';
@@ -136,7 +135,7 @@ suite('Notebook Editor tests', () => {
 
         // Wait till execution count changes and status is success.
         await waitForExecutionCompletedSuccessfully(cell);
-        const originalSysPath = (cell.outputs[0] as CellDisplayOutput).data['text/plain'].toString();
+        const originalSysPath = (cell.outputs[0].outputs.find(opit => opit.mime === 'text/plain')?.value as any).toString();
 
         // Switch kernels to the other kernel
         const kernels = await kernelProvider.provideKernels(
@@ -167,7 +166,7 @@ suite('Notebook Editor tests', () => {
         assert.strictEqual(cell?.metadata.runState, vscodeNotebookEnums.NotebookCellRunState.Success);
 
         if (anotherKernel && preferredKernel) {
-            const newSysPath = (cell.outputs[0] as CellDisplayOutput).data['text/plain'].toString();
+            const newSysPath = (cell.outputs[0].outputs.find(opit => opit.mime === 'text/plain')?.value as any).toString();
             assert.notEqual(
                 newSysPath,
                 originalSysPath,

--- a/src/test/mocks/vsc/extHostedTypes.ts
+++ b/src/test/mocks/vsc/extHostedTypes.ts
@@ -547,10 +547,26 @@ export namespace vscMockExtHostedTypes {
     }
 
     export class WorkspaceEdit implements vscode.WorkspaceEdit {
+        replaceNotebookCellOutputItems(
+            _uri: vscode.Uri,
+            _index: number,
+            _outputId: string,
+            _items: vscode.NotebookCellOutputItem[],
+            _metadata?: vscode.WorkspaceEditEntryMetadata): void {
+            // Noop
+        }
+        appendNotebookCellOutputItems(
+            _uri: vscode.Uri,
+            _index: number,
+            _outputId: string,
+            _items: vscode.NotebookCellOutputItem[],
+            _metadata?: vscode.WorkspaceEditEntryMetadata): void {
+            // Noop
+        }
         appendNotebookCellOutput(
             _uri: vscode.Uri,
             _index: number,
-            _outputs: (vscode.CellOutput | vscode.NotebookCellOutput)[],
+            _outputs: vscode.NotebookCellOutput[],
             _metadata?: vscode.WorkspaceEditEntryMetadata
         ): void {
             // Noop
@@ -571,7 +587,7 @@ export namespace vscMockExtHostedTypes {
         replaceNotebookCellOutput(
             _uri: vscode.Uri,
             _index: number,
-            _outputs: vscode.CellOutput[],
+            _outputs: vscode.NotebookCellOutput[],
             _metadata?: vscode.WorkspaceEditEntryMetadata
         ): void {
             // Noop.
@@ -1054,7 +1070,7 @@ export namespace vscMockExtHostedTypes {
         public static readonly Source = CodeActionKind.Empty.append('source');
         public static readonly SourceOrganizeImports = CodeActionKind.Source.append('organizeImports');
 
-        constructor(public readonly value: string) {}
+        constructor(public readonly value: string) { }
 
         public append(parts: string): CodeActionKind {
             return new CodeActionKind(this.value ? this.value + CodeActionKind.sep + parts : parts);

--- a/types/vscode-proposed/index.d.ts
+++ b/types/vscode-proposed/index.d.ts
@@ -609,9 +609,9 @@ export class NotebookCellOutputItem {
 
     readonly mime: string;
     readonly value: unknown;
-    readonly metadata?: Record<string, string | number | boolean>;
+    readonly metadata?: Record<string, string | number | boolean | unknown>;
 
-    constructor(mime: string, value: unknown, metadata?: Record<string, string | number | boolean>);
+    constructor(mime: string, value: unknown, metadata?: Record<string, string | number | boolean | unknown>);
 }
 
 // @jrieken
@@ -917,6 +917,117 @@ export namespace notebook {
         notebook: NotebookDocument,
         selector?: DocumentSelector
     ): NotebookConcatTextDocument;
+}
+
+export class Position {
+
+    /**
+     * The zero-based line value.
+     */
+    readonly line: number;
+
+    /**
+     * The zero-based character value.
+     */
+    readonly character: number;
+
+    /**
+     * @param line A zero-based line value.
+     * @param character A zero-based character value.
+     */
+    constructor(line: number, character: number);
+
+    /**
+     * Check if this position is before `other`.
+     *
+     * @param other A position.
+     * @return `true` if position is on a smaller line
+     * or on the same line on a smaller character.
+     */
+    isBefore(other: Position): boolean;
+
+    /**
+     * Check if this position is before or equal to `other`.
+     *
+     * @param other A position.
+     * @return `true` if position is on a smaller line
+     * or on the same line on a smaller or equal character.
+     */
+    isBeforeOrEqual(other: Position): boolean;
+
+    /**
+     * Check if this position is after `other`.
+     *
+     * @param other A position.
+     * @return `true` if position is on a greater line
+     * or on the same line on a greater character.
+     */
+    isAfter(other: Position): boolean;
+
+    /**
+     * Check if this position is after or equal to `other`.
+     *
+     * @param other A position.
+     * @return `true` if position is on a greater line
+     * or on the same line on a greater or equal character.
+     */
+    isAfterOrEqual(other: Position): boolean;
+
+    /**
+     * Check if this position is equal to `other`.
+     *
+     * @param other A position.
+     * @return `true` if the line and character of the given position are equal to
+     * the line and character of this position.
+     */
+    isEqual(other: Position): boolean;
+
+    /**
+     * Compare this to `other`.
+     *
+     * @param other A position.
+     * @return A number smaller than zero if this position is before the given position,
+     * a number greater than zero if this position is after the given position, or zero when
+     * this and the given position are equal.
+     */
+    compareTo(other: Position): number;
+
+    /**
+     * Create a new position relative to this position.
+     *
+     * @param lineDelta Delta value for the line value, default is `0`.
+     * @param characterDelta Delta value for the character value, default is `0`.
+     * @return A position which line and character is the sum of the current line and
+     * character and the corresponding deltas.
+     */
+    translate(lineDelta?: number, characterDelta?: number): Position;
+
+    /**
+     * Derived a new position relative to this position.
+     *
+     * @param change An object that describes a delta to this position.
+     * @return A position that reflects the given delta. Will return `this` position if the change
+     * is not changing anything.
+     */
+    translate(change: { lineDelta?: number; characterDelta?: number; }): Position;
+
+    /**
+     * Create a new position derived from this position.
+     *
+     * @param line Value that should be used as line value, default is the [existing value](#Position.line)
+     * @param character Value that should be used as character value, default is the [existing value](#Position.character)
+     * @return A position where line and character are replaced by the given values.
+     */
+    with(line?: number, character?: number): Position;
+
+    /**
+     * Derived a new position from this position.
+     *
+     * @param change An object that describes a change to this position.
+     * @return A position that reflects the given change. Will return `this` position if the change
+     * is not changing anything.
+     */
+    with(change: { line?: number; character?: number; }): Position;
 }
 
 export interface NotebookConcatTextDocument {

--- a/types/vscode.proposed.d.ts
+++ b/types/vscode.proposed.d.ts
@@ -610,9 +610,9 @@ declare module 'vscode' {
 
         readonly mime: string;
         readonly value: unknown;
-        readonly metadata?: Record<string, string | number | boolean>;
+        readonly metadata?: Record<string, string | number | boolean | unknown>;
 
-        constructor(mime: string, value: unknown, metadata?: Record<string, string | number | boolean>);
+        constructor(mime: string, value: unknown, metadata?: Record<string, string | number | boolean | unknown>);
     }
 
     // @jrieken

--- a/typings/vscode-proposed/index.d.ts
+++ b/typings/vscode-proposed/index.d.ts
@@ -609,9 +609,9 @@ export class NotebookCellOutputItem {
 
     readonly mime: string;
     readonly value: unknown;
-    readonly metadata?: Record<string, string | number | boolean>;
+    readonly metadata?: Record<string, string | number | boolean | unknown>;
 
-    constructor(mime: string, value: unknown, metadata?: Record<string, string | number | boolean>);
+    constructor(mime: string, value: unknown, metadata?: Record<string, string | number | boolean | unknown>);
 }
 
 // @jrieken
@@ -917,6 +917,117 @@ export namespace notebook {
         notebook: NotebookDocument,
         selector?: DocumentSelector
     ): NotebookConcatTextDocument;
+}
+
+export class Position {
+
+    /**
+     * The zero-based line value.
+     */
+    readonly line: number;
+
+    /**
+     * The zero-based character value.
+     */
+    readonly character: number;
+
+    /**
+     * @param line A zero-based line value.
+     * @param character A zero-based character value.
+     */
+    constructor(line: number, character: number);
+
+    /**
+     * Check if this position is before `other`.
+     *
+     * @param other A position.
+     * @return `true` if position is on a smaller line
+     * or on the same line on a smaller character.
+     */
+    isBefore(other: Position): boolean;
+
+    /**
+     * Check if this position is before or equal to `other`.
+     *
+     * @param other A position.
+     * @return `true` if position is on a smaller line
+     * or on the same line on a smaller or equal character.
+     */
+    isBeforeOrEqual(other: Position): boolean;
+
+    /**
+     * Check if this position is after `other`.
+     *
+     * @param other A position.
+     * @return `true` if position is on a greater line
+     * or on the same line on a greater character.
+     */
+    isAfter(other: Position): boolean;
+
+    /**
+     * Check if this position is after or equal to `other`.
+     *
+     * @param other A position.
+     * @return `true` if position is on a greater line
+     * or on the same line on a greater or equal character.
+     */
+    isAfterOrEqual(other: Position): boolean;
+
+    /**
+     * Check if this position is equal to `other`.
+     *
+     * @param other A position.
+     * @return `true` if the line and character of the given position are equal to
+     * the line and character of this position.
+     */
+    isEqual(other: Position): boolean;
+
+    /**
+     * Compare this to `other`.
+     *
+     * @param other A position.
+     * @return A number smaller than zero if this position is before the given position,
+     * a number greater than zero if this position is after the given position, or zero when
+     * this and the given position are equal.
+     */
+    compareTo(other: Position): number;
+
+    /**
+     * Create a new position relative to this position.
+     *
+     * @param lineDelta Delta value for the line value, default is `0`.
+     * @param characterDelta Delta value for the character value, default is `0`.
+     * @return A position which line and character is the sum of the current line and
+     * character and the corresponding deltas.
+     */
+    translate(lineDelta?: number, characterDelta?: number): Position;
+
+    /**
+     * Derived a new position relative to this position.
+     *
+     * @param change An object that describes a delta to this position.
+     * @return A position that reflects the given delta. Will return `this` position if the change
+     * is not changing anything.
+     */
+    translate(change: { lineDelta?: number; characterDelta?: number; }): Position;
+
+    /**
+     * Create a new position derived from this position.
+     *
+     * @param line Value that should be used as line value, default is the [existing value](#Position.line)
+     * @param character Value that should be used as character value, default is the [existing value](#Position.character)
+     * @return A position where line and character are replaced by the given values.
+     */
+    with(line?: number, character?: number): Position;
+
+    /**
+     * Derived a new position from this position.
+     *
+     * @param change An object that describes a change to this position.
+     * @return A position that reflects the given change. Will return `this` position if the change
+     * is not changing anything.
+     */
+    with(change: { line?: number; character?: number; }): Position;
 }
 
 export interface NotebookConcatTextDocument {


### PR DESCRIPTION
This PR adopts the new output API (some test files are not updated properly yet), which includes following changes

* adopt the new `NotebookCellOutput`, which replaces `IErrorOutput`, `IDisplayOutput`, etc.
  * now instead of providing a object literal, we always create a `NotebookCellOutput` object and give this back to VS Code
* change how output types are validated
  * `hasErrorOutput = output.outputs.find(opit => opit.mime === 'application/x.notebook.error-traceback')`
  * `hasStreamOutput = output.outputs.find(opit => opit.mime === 'application/x.notebook.stream')`
  * others are all rich outputs

The build is not green as there are quite a few places where we check `cellKind === CellKind.Text/Error/Rich` which is no longer necessary anymore.

https://github.com/microsoft/vscode-jupyter/pull/4732/files#diff-afc015d140e9fa1b823f6e2faa3e8153bf58510b747d05e776054ba2330afce9 represents how outputs should be created with the new API. The change in this file is simple as it has good abstraction. While other files would check by

```
        assert.equal(cells[0].outputs.length, 2, 'Incorrect number of output');
        const output1 = cells[0].outputs[0] as CellDisplayOutput;
        const output2 = cells[0].outputs[1] as CellDisplayOutput;
        assert.equal(output1.metadata?.custom?.vscode?.outputType, 'stream', 'Incorrect output type');
        assert.equal(output2.metadata?.custom?.vscode?.outputType, 'stream', 'Incorrect output type');
        assert.equal(output1.metadata?.custom?.vscode?.name, 'stdout', 'Incorrect stream name');
        assert.equal(output2.metadata?.custom?.vscode?.name, 'stderr', 'Incorrect stream name');
        assert.equal(output1.outputKind, vscodeNotebookEnums.CellOutputKind.Rich, 'Incorrect output type');
        assert.equal(output2.outputKind, vscodeNotebookEnums.CellOutputKind.Rich, 'Incorrect output type');
```

I would suggest introducing helper functions similar to `validateCellOutputTranslation` https://github.com/microsoft/vscode-jupyter/pull/4732/files#diff-afc015d140e9fa1b823f6e2faa3e8153bf58510b747d05e776054ba2330afce9R75.