### PR TITLE
PORT: Add do not show again option to the native notebook insiders survey b…

### DIFF
--- a/news/1 Enhancements/4658.md
+++ b/news/1 Enhancements/4658.md
@@ -1,0 +1,1 @@
+Add do not show again option to the native notebook insiders survey banner.

--- a/src/client/datascience/insidersNativeNotebookSurveyBanner.ts
+++ b/src/client/datascience/insidersNativeNotebookSurveyBanner.ts
@@ -17,7 +17,8 @@ export enum InsidersNotebookSurveyStateKeys {
 
 enum DSSurveyLabelIndex {
     Yes,
-    No
+    No,
+    DontShowAgain
 }
 
 const NotebookOpenThreshold = 5;
@@ -46,6 +47,9 @@ export class InsidersNativeNotebooksSurveyBanner implements IExtensionSingleActi
         if (!this.showBannerState.value.expiry) {
             return true;
         }
+        if (this.showBannerState.value.expiry === -1) {
+            return false;
+        }
         return this.showBannerState.value.expiry! < Date.now();
     }
 
@@ -55,7 +59,8 @@ export class InsidersNativeNotebooksSurveyBanner implements IExtensionSingleActi
 
     private bannerLabels: string[] = [
         localize.DataScienceSurveyBanner.bannerLabelYes(),
-        localize.DataScienceSurveyBanner.bannerLabelNo()
+        localize.DataScienceSurveyBanner.bannerLabelNo(),
+        localize.Common.doNotShowAgain()
     ];
 
     private readonly showBannerState: IPersistentState<ShowBannerWithExpiryTime>;
@@ -106,6 +111,13 @@ export class InsidersNativeNotebooksSurveyBanner implements IExtensionSingleActi
             case this.bannerLabels[DSSurveyLabelIndex.No]: {
                 // Disable for 3 months
                 await this.disable(3);
+                break;
+            }
+            case this.bannerLabels[DSSurveyLabelIndex.DontShowAgain]: {
+                await this.showBannerState.updateValue({
+                    expiry: -1,
+                    data: true
+                });
                 break;
             }
             default:

--- a/src/test/datascience/insidersNativeNotebookSurveyBanner.vscode.test.ts
+++ b/src/test/datascience/insidersNativeNotebookSurveyBanner.vscode.test.ts
@@ -105,7 +105,7 @@ suite('Insiders Native Notebooks Survey Banner', () => {
         );
     }
     test('Confirm prompt is displayed & only once per session', async () => {
-        when(appShell.showInformationMessage(anything(), anything(), anything())).thenResolve();
+        when(appShell.showInformationMessage(anything(), anything(), anything(), anything())).thenResolve();
         await showBannerState.updateValue({ data: true });
         await executionCountState.updateValue(100);
 
@@ -113,10 +113,10 @@ suite('Insiders Native Notebooks Survey Banner', () => {
         await bannerService.showBanner();
         await bannerService.showBanner();
 
-        verify(appShell.showInformationMessage(anything(), anything(), anything())).once();
+        verify(appShell.showInformationMessage(anything(), anything(), anything(), anything())).once();
     });
     test('Confirm prompt is displayed 3 months later', async () => {
-        when(appShell.showInformationMessage(anything(), anything(), anything())).thenResolve(
+        when(appShell.showInformationMessage(anything(), anything(), anything(), anything())).thenResolve(
             localize.DataScienceSurveyBanner.bannerLabelNo() as any
         );
         await showBannerState.updateValue({ data: true });
@@ -124,31 +124,31 @@ suite('Insiders Native Notebooks Survey Banner', () => {
 
         await bannerService.showBanner();
 
-        verify(appShell.showInformationMessage(anything(), anything(), anything())).once();
+        verify(appShell.showInformationMessage(anything(), anything(), anything(), anything())).once();
         resetCalls(appShell);
 
         // Attempt to display again & it won't.
         bannerService = createBannerService();
         await bannerService.showBanner();
         verify(browser.launch(anything())).never();
-        verify(appShell.showInformationMessage(anything(), anything(), anything())).never();
+        verify(appShell.showInformationMessage(anything(), anything(), anything(), anything())).never();
 
         // Advance time by 1 month & still not displayed.
         clock.tick(MillisecondsInADay * 30);
         bannerService = createBannerService();
         await bannerService.showBanner();
         verify(browser.launch(anything())).never();
-        verify(appShell.showInformationMessage(anything(), anything(), anything())).never();
+        verify(appShell.showInformationMessage(anything(), anything(), anything(), anything())).never();
 
         // Advance time by 3.5 month & it will be displayed.
         clock.tick(MillisecondsInADay * 30 * 3.5);
         bannerService = createBannerService();
         await bannerService.showBanner();
         verify(browser.launch(anything())).never();
-        verify(appShell.showInformationMessage(anything(), anything(), anything())).once();
+        verify(appShell.showInformationMessage(anything(), anything(), anything(), anything())).once();
     });
     test('Confirm prompt is displayed 6 months later & survey displayed', async () => {
-        when(appShell.showInformationMessage(anything(), anything(), anything())).thenResolve(
+        when(appShell.showInformationMessage(anything(), anything(), anything(), anything())).thenResolve(
             localize.DataScienceSurveyBanner.bannerLabelYes() as any
         );
 
@@ -157,7 +157,7 @@ suite('Insiders Native Notebooks Survey Banner', () => {
 
         await bannerService.showBanner();
         verify(browser.launch(anything())).once();
-        verify(appShell.showInformationMessage(anything(), anything(), anything())).once();
+        verify(appShell.showInformationMessage(anything(), anything(), anything(), anything())).once();
         resetCalls(browser);
         resetCalls(appShell);
 
@@ -165,23 +165,58 @@ suite('Insiders Native Notebooks Survey Banner', () => {
         bannerService = createBannerService();
         await bannerService.showBanner();
         verify(browser.launch(anything())).never();
-        verify(appShell.showInformationMessage(anything(), anything(), anything())).never();
+        verify(appShell.showInformationMessage(anything(), anything(), anything(), anything())).never();
 
         // Advance time by 1 month & still not displayed.
         clock.tick(MillisecondsInADay * 30);
         bannerService = createBannerService();
         await bannerService.showBanner();
         verify(browser.launch(anything())).never();
-        verify(appShell.showInformationMessage(anything(), anything(), anything())).never();
+        verify(appShell.showInformationMessage(anything(), anything(), anything(), anything())).never();
 
         // Advance time by 6.5 month & it will be displayed.
         clock.tick(MillisecondsInADay * 30 * 6.5);
-        when(appShell.showInformationMessage(anything(), anything(), anything())).thenResolve(
+        when(appShell.showInformationMessage(anything(), anything(), anything(), anything())).thenResolve(
             localize.DataScienceSurveyBanner.bannerLabelNo() as any
         );
         bannerService = createBannerService();
         await bannerService.showBanner();
         verify(browser.launch(anything())).never();
-        verify(appShell.showInformationMessage(anything(), anything(), anything())).once();
+        verify(appShell.showInformationMessage(anything(), anything(), anything(), anything())).once();
+    });
+    test('Confirm prompt is not displayed again', async () => {
+        when(appShell.showInformationMessage(anything(), anything(), anything(), anything())).thenResolve(
+            localize.Common.doNotShowAgain() as any
+        );
+        await showBannerState.updateValue({ data: true });
+        await executionCountState.updateValue(100);
+
+        await bannerService.showBanner();
+
+        verify(appShell.showInformationMessage(anything(), anything(), anything(), anything())).once();
+        resetCalls(appShell);
+
+        // Attempt to display again & it won't.
+        bannerService = createBannerService();
+        await bannerService.showBanner();
+        verify(browser.launch(anything())).never();
+        verify(appShell.showInformationMessage(anything(), anything(), anything(), anything())).never();
+
+        // Advance time by 1 month & still not displayed.
+        clock.tick(MillisecondsInADay * 30);
+        bannerService = createBannerService();
+        await bannerService.showBanner();
+        verify(browser.launch(anything())).never();
+        verify(appShell.showInformationMessage(anything(), anything(), anything(), anything())).never();
+
+        // Advance time by 6.5 month & still not displayed.
+        clock.tick(MillisecondsInADay * 30 * 6.5);
+        when(appShell.showInformationMessage(anything(), anything(), anything(), anything())).thenResolve(
+            localize.DataScienceSurveyBanner.bannerLabelNo() as any
+        );
+        bannerService = createBannerService();
+        await bannerService.showBanner();
+        verify(browser.launch(anything())).never();
+        verify(appShell.showInformationMessage(anything(), anything(), anything(), anything())).never();
     });
 });


### PR DESCRIPTION
…anner. (#4729)

* Add do not show again option to the native
notebook insiders survey banner.

* fix tests

* oops

* add test

For #4658

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
