### PR TITLE
Jupyter lab's default URI doesn't seem to work

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1034,7 +1034,6 @@ module.exports = {
         'src/client/datascience/jupyter/jupyterInvalidKernelError.ts',
         'src/client/datascience/jupyter/notebookStarter.ts',
         'src/client/datascience/jupyter/jupyterZMQBinariesNotFoundError.ts',
-        'src/client/datascience/jupyter/jupyterUtils.ts',
         'src/client/datascience/jupyter/jupyterDataRateLimitError.ts',
         'src/client/datascience/jupyter/variableScriptLoader.ts',
         'src/client/datascience/jupyter/jupyterImporter.ts',

--- a/news/2 Fixes/4751.md
+++ b/news/2 Fixes/4751.md
@@ -1,0 +1,1 @@
+Allow connecting to jupyterlab uris (example: http://localhost:8080/lab?token=ffffffffffff).

--- a/src/client/datascience/jupyter/jupyterUtils.ts
+++ b/src/client/datascience/jupyter/jupyterUtils.ts
@@ -49,6 +49,13 @@ export function createRemoteConnectionInfo(
     let url: URL;
     try {
         url = new URL(uri);
+
+        // Special case for URI's ending with 'lab'. Remove this from the URI. This is not
+        // the location for connecting to jupyterlab
+        if (url.pathname === '/lab') {
+            uri = uri.replace('lab', '');
+        }
+        url = new URL(uri);
     } catch (err) {
         // This should already have been parsed when set, so just throw if it's not right here
         throw err;


### PR DESCRIPTION
For #4751

Not sure if this changed in jupyterlab recently or not, but if you make jupyter requests against the URI that jupyter lab puts out when you start it, it doesn't work.

Example:

```
http://localhost:8888/lab?token=3333d8e1a0dfe7556a7addf2082cda8a14b46ef157f97da
```

has to instead be:
```
http://localhost:8888/?token=3333d8e1a0dfe7556a7addf2082cda8a14b46ef157f97da
```

Also skipped using the contents api if it doesn't work. This is kind of a red herring when stuff falls down. 

I was investigating the bug and ended up fixing it to see what the problem was so figured I'd just submit this fix.