### PR TITLE
Add new editor context for just if native notebook is active

### DIFF
--- a/news/2 Fixes/4761.md
+++ b/news/2 Fixes/4761.md
@@ -1,0 +1,1 @@
+Allow options to show native variable view only when looking at native notebooks.

--- a/package.json
+++ b/package.json
@@ -728,7 +728,7 @@
                     "dark": "resources/dark/variable_explorer.svg"
                 },
                 "category": "Jupyter",
-                "enablement": "jupyter.isvscodenotebookactive && !jupyter.variableViewVisible"
+                "enablement": "notebookViewType == jupyter-notebook && !jupyter.variableViewVisible"
             }
         ],
         "menus": {
@@ -1294,7 +1294,7 @@
                     "command": "jupyter.openVariableView",
                     "title": "%jupyter.command.jupyter.openVariableView.title%",
                     "category": "Jupyter",
-                    "when": "jupyter.isvscodenotebookactive"
+                    "when": "notebookViewType == jupyter-notebook"
                 },
                 {
                     "command": "jupyter.selectNativeJupyterUriFromToolBar",

--- a/package.json
+++ b/package.json
@@ -728,7 +728,7 @@
                     "dark": "resources/dark/variable_explorer.svg"
                 },
                 "category": "Jupyter",
-                "enablement": "!jupyter.variableViewVisible"
+                "enablement": "jupyter.isvscodenotebookactive && !jupyter.variableViewVisible"
             }
         ],
         "menus": {
@@ -1294,7 +1294,7 @@
                     "command": "jupyter.openVariableView",
                     "title": "%jupyter.command.jupyter.openVariableView.title%",
                     "category": "Jupyter",
-                    "when": "jupyter.isnativeactive"
+                    "when": "jupyter.isvscodenotebookactive"
                 },
                 {
                     "command": "jupyter.selectNativeJupyterUriFromToolBar",
@@ -1839,7 +1839,7 @@
                     "type": "webview",
                     "id": "jupyterViewVariables",
                     "name": "Variables",
-                    "when": "jupyter.isnativeactive"
+                    "when": "jupyter.isvscodenotebookactive"
                 }
             ]
         }

--- a/src/client/datascience/commands/activeEditorContext.ts
+++ b/src/client/datascience/commands/activeEditorContext.ts
@@ -40,6 +40,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
     private isNotebookTrusted: ContextKey;
     private isPythonFileActive: boolean = false;
     private isPythonNotebook: ContextKey;
+    private isVSCodeNotebookActive: ContextKey;
     constructor(
         @inject(IInteractiveWindowProvider) private readonly interactiveProvider: IInteractiveWindowProvider,
         @inject(INotebookEditorProvider) private readonly notebookEditorProvider: INotebookEditorProvider,
@@ -82,6 +83,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
         this.hasNativeNotebookCells = new ContextKey(EditorContexts.HaveNativeCells, this.commandManager);
         this.isNotebookTrusted = new ContextKey(EditorContexts.IsNotebookTrusted, this.commandManager);
         this.isPythonNotebook = new ContextKey(EditorContexts.IsPythonNotebook, this.commandManager);
+        this.isVSCodeNotebookActive = new ContextKey(EditorContexts.IsVSCodeNotebookActive, this.commandManager);
     }
     public dispose() {
         this.disposables.forEach((item) => item.dispose());
@@ -122,6 +124,14 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
     }
     private onDidChangeActiveNotebookEditor(e?: INotebookEditor) {
         this.nativeContext.set(!!e).ignoreErrors();
+
+        // jupyter.isnativeactive is set above, but also set jupyter.isvscodenotebookactive
+        // if the active document is also a vscode document
+        if (e && e.type === 'native') {
+            this.isVSCodeNotebookActive.set(true).ignoreErrors();
+        } else {
+            this.isVSCodeNotebookActive.set(false).ignoreErrors();
+        }
         this.isNotebookTrusted.set(e?.model?.isTrusted === true).ignoreErrors();
         this.isPythonNotebook.set(isPythonNotebook(e?.model?.metadata)).ignoreErrors();
         this.updateMergedContexts();

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -166,6 +166,7 @@ export namespace EditorContexts {
     export const CanRestartNotebookKernel = 'jupyter.notebookeditor.canrestartNotebookkernel';
     export const CanInterruptNotebookKernel = 'jupyter.notebookeditor.canInterruptNotebookKernel';
     export const IsPythonNotebook = 'jupyter.ispythonnotebook';
+    export const IsVSCodeNotebookActive = 'jupyter.isvscodenotebookactive';
 }
 
 export namespace RegExpValues {


### PR DESCRIPTION
For #4761 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
