### PR TITLE
Pass notebook metadata when Starting Jupyter

### DIFF
--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -905,7 +905,8 @@ export abstract class InteractiveBase extends WebviewPanelHost<IInteractiveWindo
         // Check to see if we are already connected to our provider
         const providerConnection = await this.notebookProvider.connect({
             getOnly: true,
-            resource: this.owningResource
+            resource: this.owningResource,
+            metadata: this.notebookMetadata
         });
 
         if (providerConnection) {
@@ -934,7 +935,11 @@ export abstract class InteractiveBase extends WebviewPanelHost<IInteractiveWindo
             serverUri !== Settings.JupyterServerLocalLaunch &&
             !this.configService.getSettings(this.owningResource).disableJupyterAutoStart
         ) {
-            serverConnection = await this.notebookProvider.connect({ disableUI: true, resource: this.owningResource });
+            serverConnection = await this.notebookProvider.connect({
+                disableUI: true,
+                resource: this.owningResource,
+                metadata: this.notebookMetadata
+            });
         }
         let displayName =
             serverConnection?.displayName ||
@@ -991,7 +996,8 @@ export abstract class InteractiveBase extends WebviewPanelHost<IInteractiveWindo
             const serverConnection = await this.notebookProvider.connect({
                 getOnly: false,
                 disableUI: false,
-                resource: this.owningResource
+                resource: this.owningResource,
+                metadata: this.notebookMetadata
             });
             if (serverConnection) {
                 await this.ensureNotebook(serverConnection);

--- a/src/client/datascience/notebook/notebookEditor.ts
+++ b/src/client/datascience/notebook/notebookEditor.ts
@@ -344,7 +344,12 @@ export class NotebookEditor implements INotebookEditor {
                 if (notebook) {
                     await notebook.dispose();
                 }
-                await this.notebookProvider.connect({ getOnly: false, disableUI: false, resource: this.file });
+                await this.notebookProvider.connect({
+                    getOnly: false,
+                    disableUI: false,
+                    resource: this.file,
+                    metadata: this.model.metadata
+                });
             } else {
                 sendKernelTelemetryEvent(this.document.uri, Telemetry.NotebookRestart, stopWatch.elapsedTime, exc);
                 // Show the error message

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -249,6 +249,7 @@ export type ConnectNotebookProviderOptions = {
     localOnly?: boolean;
     token?: CancellationToken;
     resource: Resource;
+    metadata?: nbformat.INotebookMetadata;
     onConnectionMade?(): void; // Optional callback for when the first connection is made
 };
 


### PR DESCRIPTION
For #https://github.com/microsoft/vscode-jupyter/issues/4556

I believe this was introduced when I tried to minimize the use of Noteboteook metadata (in the case of Jupyter we need to pass this information around. As he kernel is determined in Jupyter Execution).

The compiler didn't pick this up because we use a spread operator to pass settings from one type to another.

E.g. 
```typescript
const options: ConnectNotebookProviderOptions = {};

// GetServerOptions has `metadata` but it is optional, 
// `metadata` property from `ConnectNotebookProviderOptions` was removed as I didn't see any usages of `metadata` (but it was being passed indirectly - see below).

const serverOptions: GetServerOptions = {...options}

```