### PR TITLE
Fix .NET interactive to always use native

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,7 +84,6 @@ module.exports = {
         'src/test/common/misc.test.ts',
         'src/test/common/socketStream.test.ts',
         'src/test/common/configSettings.test.ts',
-        'src/test/common/experiments/service.unit.test.ts',
         'src/test/common/experiments/manager.unit.test.ts',
         'src/test/common/experiments/telemetry.unit.test.ts',
         'src/test/common/platform/filesystem.unit.test.ts',

--- a/news/2 Fixes/4771.md
+++ b/news/2 Fixes/4771.md
@@ -1,0 +1,1 @@
+If .NET interactive is installed, make sure to use the new notebook editor.

--- a/src/client/common/experiments/service.ts
+++ b/src/client/common/experiments/service.ts
@@ -14,6 +14,7 @@ import {
     GLOBAL_MEMENTO,
     IConfigurationService,
     IExperimentService,
+    IExtensions,
     IJupyterSettings,
     IMemento,
     IOutputChannel
@@ -45,7 +46,8 @@ export class ExperimentService implements IExperimentService {
         @inject(IConfigurationService) readonly configurationService: IConfigurationService,
         @inject(IApplicationEnvironment) private readonly appEnvironment: IApplicationEnvironment,
         @inject(IMemento) @named(GLOBAL_MEMENTO) private readonly globalState: Memento,
-        @inject(IOutputChannel) @named(STANDARD_OUTPUT_CHANNEL) private readonly output: IOutputChannel
+        @inject(IOutputChannel) @named(STANDARD_OUTPUT_CHANNEL) private readonly output: IOutputChannel,
+        @inject(IExtensions) private readonly extensions: IExtensions
     ) {
         this.settings = configurationService.getSettings(undefined);
 
@@ -93,6 +95,15 @@ export class ExperimentService implements IExperimentService {
             this.getOptInOptOutStatus(ExperimentGroups.NativeNotebook) === 'optIn'
         ) {
             return false;
+        }
+
+        // If user has .NET interactive installed, we HAVE to be in the native experiment. See this issue:
+        // https://github.com/microsoft/vscode-jupyter/issues/4771
+        if (
+            experiment === ExperimentGroups.NativeNotebook &&
+            this.extensions.getExtension('ms-dotnettools.dotnet-interactive-vscode')
+        ) {
+            return true;
         }
 
         // Currently the service doesn't support opting in and out of experiments,

--- a/src/test/common/experiments/service.unit.test.ts
+++ b/src/test/common/experiments/service.unit.test.ts
@@ -11,11 +11,12 @@ import { ApplicationEnvironment } from '../../../client/common/application/appli
 import { Channel, IApplicationEnvironment } from '../../../client/common/application/types';
 import { ConfigurationService } from '../../../client/common/configuration/service';
 import { ExperimentService } from '../../../client/common/experiments/service';
-import { IConfigurationService } from '../../../client/common/types';
+import { IConfigurationService, IExtensions } from '../../../client/common/types';
 import { Experiments } from '../../../client/common/utils/localize';
 import * as Telemetry from '../../../client/telemetry';
 import { EventName } from '../../../client/telemetry/constants';
 import { JVSC_EXTENSION_ID_FOR_TESTS } from '../../constants';
+import { MockExtensions } from '../../datascience/mockExtensions';
 import { MockOutputChannel } from '../../mockClasses';
 import { MockMemento } from '../../mocks/mementos';
 
@@ -26,12 +27,14 @@ suite('Experimentation service', () => {
     let appEnvironment: IApplicationEnvironment;
     let globalMemento: MockMemento;
     let outputChannel: MockOutputChannel;
+    let extensionService: IExtensions;
 
     setup(() => {
         configurationService = mock(ConfigurationService);
         appEnvironment = mock(ApplicationEnvironment);
         globalMemento = new MockMemento();
         outputChannel = new MockOutputChannel('');
+        extensionService = new MockExtensions();
     });
 
     teardown(() => {
@@ -68,7 +71,8 @@ suite('Experimentation service', () => {
                 instance(configurationService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel
+                outputChannel,
+                extensionService
             );
 
             sinon.assert.calledWithExactly(
@@ -92,7 +96,8 @@ suite('Experimentation service', () => {
                 instance(configurationService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel
+                outputChannel,
+                extensionService
             );
 
             sinon.assert.calledWithExactly(
@@ -115,7 +120,8 @@ suite('Experimentation service', () => {
                 instance(configurationService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel
+                outputChannel,
+                extensionService
             );
 
             assert.deepEqual(experimentService._optInto, ['Foo - experiment']);
@@ -130,7 +136,8 @@ suite('Experimentation service', () => {
                 instance(configurationService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel
+                outputChannel,
+                extensionService
             );
 
             assert.deepEqual(experimentService._optOutFrom, ['Foo - experiment']);
@@ -149,7 +156,8 @@ suite('Experimentation service', () => {
                 instance(configurationService),
                 instance(appEnvironment),
                 instance(globalMemento),
-                outputChannel
+                outputChannel,
+                extensionService
             );
             const output = `${Experiments.inGroup().format('pythonExperiment')}\n`;
 
@@ -192,7 +200,8 @@ suite('Experimentation service', () => {
                 instance(configurationService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel
+                outputChannel,
+                extensionService
             );
             const result = await experimentService.inExperiment(experiment);
 
@@ -208,7 +217,8 @@ suite('Experimentation service', () => {
                 instance(configurationService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel
+                outputChannel,
+                extensionService
             );
             const result = await experimentService.inExperiment(experiment);
 
@@ -224,7 +234,8 @@ suite('Experimentation service', () => {
                 instance(configurationService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel
+                outputChannel,
+                extensionService
             );
             const result = await experimentService.inExperiment(experiment);
 
@@ -244,7 +255,8 @@ suite('Experimentation service', () => {
                 instance(configurationService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel
+                outputChannel,
+                extensionService
             );
             const result = await experimentService.inExperiment(experiment);
 
@@ -264,7 +276,8 @@ suite('Experimentation service', () => {
                 instance(configurationService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel
+                outputChannel,
+                extensionService
             );
             const result = await experimentService.inExperiment(experiment);
 
@@ -284,7 +297,8 @@ suite('Experimentation service', () => {
                 instance(configurationService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel
+                outputChannel,
+                extensionService
             );
             const result = await experimentService.inExperiment(experiment);
 
@@ -319,7 +333,8 @@ suite('Experimentation service', () => {
                 instance(configurationService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel
+                outputChannel,
+                extensionService
             );
             const result = await experimentService.getExperimentValue(experiment);
 
@@ -334,7 +349,8 @@ suite('Experimentation service', () => {
                 instance(configurationService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel
+                outputChannel,
+                extensionService
             );
             const result = await experimentService.getExperimentValue(experiment);
 
@@ -349,7 +365,8 @@ suite('Experimentation service', () => {
                 instance(configurationService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel
+                outputChannel,
+                extensionService
             );
             const result = await experimentService.getExperimentValue(experiment);
 
@@ -364,7 +381,8 @@ suite('Experimentation service', () => {
                 instance(configurationService),
                 instance(appEnvironment),
                 globalMemento,
-                outputChannel
+                outputChannel,
+                extensionService
             );
             const result = await experimentService.getExperimentValue(experiment);
 


### PR DESCRIPTION
For #4771 

This is to make sure that the new .NET interactive extension can open notebooks and run their kernel. In this situation, the old webview cannot run .NET (as there's no jupyter kernel installed)

