### PR TITLE
Fix duplicate kernel generation

### DIFF
--- a/news/2 Fixes/4720.md
+++ b/news/2 Fixes/4720.md
@@ -1,0 +1,1 @@
+Fixes problem with duplicate jupyter kernels being generated.

--- a/src/client/datascience/kernel-launcher/kernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/kernelFinder.ts
@@ -98,16 +98,14 @@ export class KernelFinder implements IKernelFinder {
     // Search all our local file system locations for installed kernel specs and return them
     @captureTelemetry(Telemetry.KernelListingPerf)
     public async listKernelSpecs(resource: Resource): Promise<IJupyterKernelSpec[]> {
-        if (!resource) {
-            // We need a resource to search for related kernel specs
-            return [];
-        }
-
         // Get an id for the workspace folder, if we don't have one, use the fsPath of the resource
-        const workspaceFolderId = this.workspaceService.getWorkspaceFolderIdentifier(resource, resource.fsPath);
+        const workspaceFolderId = this.workspaceService.getWorkspaceFolderIdentifier(
+            resource,
+            resource?.fsPath || this.workspaceService.rootPath
+        );
 
         // If we have not already searched for this resource, then generate the search
-        if (!this.workspaceToKernels.has(workspaceFolderId)) {
+        if (workspaceFolderId && !this.workspaceToKernels.has(workspaceFolderId)) {
             this.workspaceToKernels.set(workspaceFolderId, this.findResourceKernelSpecs(resource));
         }
 
@@ -119,7 +117,7 @@ export class KernelFinder implements IKernelFinder {
             .then((items) =>
                 traceInfoIf(
                     !!process.env.VSC_JUPYTER_LOG_KERNEL_OUTPUT,
-                    `Kernel specs for ${resource.toString()} are \n ${JSON.stringify(items)}`
+                    `Kernel specs for ${resource?.toString() || 'undefined'} are \n ${JSON.stringify(items)}`
                 )
             )
             .catch(noop);

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -1272,6 +1272,9 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         when(workspaceService.workspaceFolders).thenReturn(this.workspaceFolders);
         when(workspaceService.rootPath).thenReturn(testWorkspaceFolder);
         when(workspaceService.getWorkspaceFolder(anything())).thenCall(this.getWorkspaceFolder.bind(this));
+        when(workspaceService.getWorkspaceFolderIdentifier(anything(), anything())).thenCall(
+            this.getWorkspaceFolderIdentifier.bind(this)
+        );
         this.addWorkspaceFolder(testWorkspaceFolder);
         return workspaceService;
     }
@@ -1281,6 +1284,15 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
             return this.workspaceFolders.find((w) => w.ownedResources.has(uri.toString()));
         }
         return undefined;
+    }
+    private getWorkspaceFolderIdentifier(uri: Resource, defaultValue: string | undefined): string | undefined {
+        if (uri) {
+            const folder = this.workspaceFolders.find((w) => w.ownedResources.has(uri.toString()));
+            if (folder) {
+                return folder.uri.fsPath;
+            }
+        }
+        return defaultValue;
     }
 
     private getResourceKey(resource: Resource): string {


### PR DESCRIPTION
For #4720

KernelFinder changes broke this. The kernelFinder required a resource to work. In some cases when starting jupyter (or the interactive window) we don't always have a resource. 

Made it use the default root path if no resource found.

