### PR TITLE
Fix command palette for interactive commands

### DIFF
--- a/news/2 Fixes/4833.md
+++ b/news/2 Fixes/4833.md
@@ -1,0 +1,1 @@
+Fix interactive cell commands not showing up when switching between a python file and a notebook.

--- a/src/client/datascience/commands/activeEditorContext.ts
+++ b/src/client/datascience/commands/activeEditorContext.ts
@@ -12,6 +12,7 @@ import { PYTHON_LANGUAGE, UseVSCodeNotebookEditorApi } from '../../common/consta
 import { ContextKey } from '../../common/contextKey';
 import { traceError } from '../../common/logger';
 import { IDisposable, IDisposableRegistry } from '../../common/types';
+import { isNotebookCell } from '../../common/utils/misc';
 import { EditorContexts } from '../constants';
 import { isPythonNotebook } from '../notebook/helpers/helpers';
 import {
@@ -191,7 +192,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
         this.updateContextOfActiveNotebookKernel(activeEditor);
     }
     private onDidChangeActiveTextEditor(e?: TextEditor) {
-        this.isPythonFileActive = e?.document.languageId === PYTHON_LANGUAGE;
+        this.isPythonFileActive = e?.document.languageId === PYTHON_LANGUAGE && !isNotebookCell(e.document.uri);
         this.updateNativeNotebookCellContext();
         this.updateMergedContexts();
     }

--- a/src/client/datascience/commands/activeEditorContext.ts
+++ b/src/client/datascience/commands/activeEditorContext.ts
@@ -114,9 +114,10 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
         if (!this.inNativeNotebookExperiment) {
             return;
         }
-        this.hasNativeNotebookCells
-            .set((this.notebookEditorProvider.activeEditor?.model?.cellCount || 0) > 0)
-            .ignoreErrors();
+
+        // Separate for debugging.
+        const hasNativeCells = (this.vscNotebook.activeNotebookEditor?.document.cells.length || 0) > 0;
+        this.hasNativeNotebookCells.set(hasNativeCells).ignoreErrors();
     }
     private onDidChangeActiveInteractiveWindow(e?: IInteractiveWindow) {
         this.interactiveContext.set(!!e).ignoreErrors();
@@ -134,9 +135,10 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
         }
         this.isNotebookTrusted.set(e?.model?.isTrusted === true).ignoreErrors();
         this.isPythonNotebook.set(isPythonNotebook(e?.model?.metadata)).ignoreErrors();
-        this.updateMergedContexts();
         this.updateContextOfActiveNotebookKernel(e);
         this.updateNativeNotebookContext();
+        this.updateNativeNotebookCellContext();
+        this.updateMergedContexts();
     }
     private updateNativeNotebookContext() {
         if (!this.vscNotebook.activeNotebookEditor) {
@@ -189,8 +191,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
         this.updateContextOfActiveNotebookKernel(activeEditor);
     }
     private onDidChangeActiveTextEditor(e?: TextEditor) {
-        this.isPythonFileActive =
-            e?.document.languageId === PYTHON_LANGUAGE && !this.notebookEditorProvider.activeEditor;
+        this.isPythonFileActive = e?.document.languageId === PYTHON_LANGUAGE;
         this.updateNativeNotebookCellContext();
         this.updateMergedContexts();
     }

--- a/src/client/datascience/notebook/notebookEditorProvider.ts
+++ b/src/client/datascience/notebook/notebookEditorProvider.ts
@@ -44,7 +44,7 @@ export class NotebookEditorProvider implements INotebookEditorProvider {
         return this._onDidOpenNotebookEditor.event;
     }
     public get activeEditor(): INotebookEditor | undefined {
-        // Ask VS code for which one is active. Don't use webview tracking
+        // Ask VS code for which one is active. Don't use webview tracking as it seems to be inaccurate
         return (
             this.vscodeNotebook.activeNotebookEditor &&
             this.editors.find(

--- a/src/client/datascience/notebook/notebookEditorProvider.ts
+++ b/src/client/datascience/notebook/notebookEditorProvider.ts
@@ -44,7 +44,13 @@ export class NotebookEditorProvider implements INotebookEditorProvider {
         return this._onDidOpenNotebookEditor.event;
     }
     public get activeEditor(): INotebookEditor | undefined {
-        return this.editors.find((e) => e.visible && e.active);
+        // Ask VS code for which one is active. Don't use webview tracking
+        return (
+            this.vscodeNotebook.activeNotebookEditor &&
+            this.editors.find(
+                (e) => e.file.toString() === this.vscodeNotebook.activeNotebookEditor?.document.uri.toString()
+            )
+        );
     }
     public get editors(): INotebookEditor[] {
         return [...this.openedEditors];


### PR DESCRIPTION
For #4833 

Root cause is that notebookEditor.activeEditor does not actually update when changing to a python file.

This ripples into a couple of spots though. I don't think we should port this to the release branch.

