### PR TITLE
Don't overwrite top level vs code save and undo commands

### DIFF
--- a/news/2 Fixes/4527.md
+++ b/news/2 Fixes/4527.md
@@ -1,0 +1,1 @@
+Don't overwrite the top level VS Code Save and Undo command keybindings.

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
                 "linux": "Z",
                 "key": "Z",
                 "when": "notebookEditorFocused && !inputFocus && notebookViewType == jupyter-notebook && config.jupyter.enableKeyboardShortcuts",
-                "command": "undo"
+                "command": "jupyter.notebookeditor.keybind.undo"
             },
             {
                 "mac": "S",
@@ -155,7 +155,7 @@
                 "linux": "S",
                 "key": "S",
                 "when": "notebookEditorFocused && !inputFocus && notebookViewType == jupyter-notebook && config.jupyter.enableKeyboardShortcuts",
-                "command": "workbench.action.files.save"
+                "command": "jupyter.notebookeditor.keybind.save"
             },
             {
                 "mac": "C",
@@ -575,6 +575,18 @@
                 "command": "jupyter.notebookeditor.redocells",
                 "title": "%jupyter.command.jupyter.redocells.title%",
                 "category": "Notebook"
+            },
+            {
+                "command": "jupyter.notebookeditor.keybind.undo",
+                "title": "%jupyter.command.jupyter.notebookeditor.keybind.undo.title%",
+                "category": "Notebook",
+                "enablement": "notebookEditorFocused && !inputFocus && notebookViewType == jupyter-notebook && config.jupyter.enableKeyboardShortcuts"
+            },
+            {
+                "command": "jupyter.notebookeditor.keybind.save",
+                "title": "%jupyter.command.jupyter.notebookeditor.keybind.save.title%",
+                "category": "Notebook",
+                "enablement": "notebookEditorFocused && !inputFocus && notebookViewType == jupyter-notebook && config.jupyter.enableKeyboardShortcuts"
             },
             {
                 "command": "jupyter.removeallcells",
@@ -1164,6 +1176,18 @@
                     "title": "%jupyter.command.jupyter.collapseallcells.title%",
                     "category": "Notebook",
                     "when": "notebookEditorFocused"
+                },
+                {
+                    "command": "jupyter.notebookeditor.keybind.undo",
+                    "title": "%jupyter.command.jupyter.notebookeditor.keybind.undo.title%",
+                    "category": "Notebook",
+                    "when": "false"
+                },
+                {
+                    "command": "jupyter.notebookeditor.keybind.save",
+                    "title": "%jupyter.command.jupyter.notebookeditor.keybind.save.title%",
+                    "category": "Notebook",
+                    "when": "false"
                 },
                 {
                     "command": "jupyter.expandallcells",

--- a/package.nls.json
+++ b/package.nls.json
@@ -92,6 +92,8 @@
     "jupyter.command.jupyter.removeallcells.title": "Delete All Interactive Cells",
     "jupyter.command.jupyter.notebookeditor.removeallcells.title": "Delete All Notebook Editor Cells",
     "jupyter.command.jupyter.notebookeditor.addcellbelow.title": "Add Empty Cell to Notebook File",
+    "jupyter.command.jupyter.notebookeditor.keybind.undo.title": "Undo",
+    "jupyter.command.jupyter.notebookeditor.keybind.save.title": "Save",
     "jupyter.command.jupyter.interruptkernel.title": "Interrupt Jupyter Kernel",
     "jupyter.command.jupyter.restartkernel.title": "Restart Jupyter Kernel",
     "jupyter.command.jupyter.expandallcells.title": "Expand All Interactive Cells",

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -88,6 +88,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     ['vscode.open']: [Uri];
     ['workbench.action.files.saveAs']: [Uri];
     ['workbench.action.files.save']: [Uri];
+    ['undo']: [];
     [DSCommands.ExportFileAndOutputAsNotebook]: [Uri];
     [DSCommands.RunAllCells]: [Uri];
     [DSCommands.RunCell]: [Uri, number, number, number, number];
@@ -151,4 +152,6 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [DSCommands.ClearSavedJupyterUris]: [];
     [DSCommands.SelectJupyterURI]: [undefined, 'toolbar' | 'nativeNotebookStatusBar' | undefined];
     [DSCommands.SelectNativeJupyterUriFromToolBar]: [];
+    [DSCommands.NotebookEditorKeybindSave]: [];
+    [DSCommands.NotebookEditorKeybindUndo]: [];
 }

--- a/src/client/datascience/commands/notebookCommands.ts
+++ b/src/client/datascience/commands/notebookCommands.ts
@@ -33,7 +33,9 @@ export class NotebookCommands implements IDisposable {
             this.commandManager.registerCommand(Commands.SwitchJupyterKernel, this.switchKernel, this),
             this.commandManager.registerCommand(Commands.SetJupyterKernel, this.setKernel, this),
             this.commandManager.registerCommand(Commands.NotebookEditorCollapseAllCells, this.collapseAll, this),
-            this.commandManager.registerCommand(Commands.NotebookEditorExpandAllCells, this.expandAll, this)
+            this.commandManager.registerCommand(Commands.NotebookEditorExpandAllCells, this.expandAll, this),
+            this.commandManager.registerCommand(Commands.NotebookEditorKeybindSave, this.keybindSave, this),
+            this.commandManager.registerCommand(Commands.NotebookEditorKeybindUndo, this.keybindUndo, this)
         );
     }
     public dispose() {
@@ -50,6 +52,16 @@ export class NotebookCommands implements IDisposable {
         if (this.notebookEditorProvider.activeEditor) {
             this.notebookEditorProvider.activeEditor.expandAllCells();
         }
+    }
+
+    private keybindSave() {
+        if (this.notebookEditorProvider.activeEditor) {
+            void this.commandManager.executeCommand('workbench.action.files.save', this.notebookEditorProvider.activeEditor.file);
+        }
+    }
+
+    private keybindUndo() {
+        void this.commandManager.executeCommand('undo');
     }
 
     private async switchKernel(options: ISwitchKernelOptions | undefined) {

--- a/src/client/datascience/commands/notebookCommands.ts
+++ b/src/client/datascience/commands/notebookCommands.ts
@@ -56,7 +56,10 @@ export class NotebookCommands implements IDisposable {
 
     private keybindSave() {
         if (this.notebookEditorProvider.activeEditor) {
-            void this.commandManager.executeCommand('workbench.action.files.save', this.notebookEditorProvider.activeEditor.file);
+            void this.commandManager.executeCommand(
+                'workbench.action.files.save',
+                this.notebookEditorProvider.activeEditor.file
+            );
         }
     }
 

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -134,6 +134,8 @@ export namespace Commands {
     export const ShowDataViewer = 'jupyter.showDataViewer';
     export const ClearSavedJupyterUris = 'jupyter.clearSavedJupyterUris';
     export const OpenVariableView = 'jupyter.openVariableView';
+    export const NotebookEditorKeybindSave = 'jupyter.notebookeditor.keybind.save';
+    export const NotebookEditorKeybindUndo = 'jupyter.notebookeditor.keybind.undo';
 }
 
 export namespace CodeLensCommands {


### PR DESCRIPTION
For #4527 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
