### PR TITLE
Restore the 'Select a Kernel' command on the interactive window.

### DIFF
--- a/news/2 Fixes/4479.md
+++ b/news/2 Fixes/4479.md
@@ -1,0 +1,1 @@
+Restore the 'Select a Kernel' command on the interactive window.

--- a/package.json
+++ b/package.json
@@ -680,7 +680,7 @@
                 "command": "jupyter.switchKernel",
                 "title": "%DataScience.selectKernel%",
                 "category": "Jupyter",
-                "enablement": "jupyter.isnativeactive"
+                "enablement": "jupyter.isinteractiveactive"
             },
             {
                 "command": "jupyter.latestExtension",
@@ -1231,7 +1231,7 @@
                     "command": "jupyter.switchKernel",
                     "title": "%DataScience.selectKernel%",
                     "category": "Jupyter",
-                    "when": "jupyter.isnativeactive && !notebookEditorFocused"
+                    "when": "jupyter.isinteractiveactive"
                 },
                 {
                     "command": "jupyter.latestExtension",

--- a/package.json
+++ b/package.json
@@ -680,7 +680,7 @@
                 "command": "jupyter.switchKernel",
                 "title": "%DataScience.selectKernel%",
                 "category": "Jupyter",
-                "enablement": "jupyter.isinteractiveactive"
+                "enablement": "jupyter.isinteractiveactive || (jupyter.isnativeactive && jupyter.usingwebviewnotebook)"
             },
             {
                 "command": "jupyter.latestExtension",
@@ -1231,7 +1231,7 @@
                     "command": "jupyter.switchKernel",
                     "title": "%DataScience.selectKernel%",
                     "category": "Jupyter",
-                    "when": "jupyter.isinteractiveactive"
+                    "when": "jupyter.isinteractiveactive || (jupyter.isnativeactive && jupyter.usingwebviewnotebook)"
                 },
                 {
                     "command": "jupyter.latestExtension",

--- a/package.json
+++ b/package.json
@@ -680,7 +680,7 @@
                 "command": "jupyter.switchKernel",
                 "title": "%DataScience.selectKernel%",
                 "category": "Jupyter",
-                "enablement": "jupyter.isinteractiveactive || (jupyter.isnativeactive && jupyter.usingwebviewnotebook)"
+                "enablement": "jupyter.isinteractiveactive || jupyter.isnativeactive && jupyter.usingwebviewnotebook"
             },
             {
                 "command": "jupyter.latestExtension",
@@ -1231,7 +1231,7 @@
                     "command": "jupyter.switchKernel",
                     "title": "%DataScience.selectKernel%",
                     "category": "Jupyter",
-                    "when": "jupyter.isinteractiveactive || (jupyter.isnativeactive && jupyter.usingwebviewnotebook)"
+                    "when": "jupyter.isinteractiveactive || jupyter.isnativeactive && jupyter.usingwebviewnotebook"
                 },
                 {
                     "command": "jupyter.latestExtension",

--- a/src/client/datascience/commands/activeEditorContext.ts
+++ b/src/client/datascience/commands/activeEditorContext.ts
@@ -4,15 +4,14 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { TextEditor, env } from 'vscode';
+import { TextEditor } from 'vscode';
 import { ServerStatus } from '../../../datascience-ui/interactive-common/mainState';
 import { IExtensionSingleActivationService } from '../../activation/types';
 import { ICommandManager, IDocumentManager, IVSCodeNotebook } from '../../common/application/types';
 import { PYTHON_LANGUAGE, UseVSCodeNotebookEditorApi } from '../../common/constants';
 import { ContextKey } from '../../common/contextKey';
-import { Experiments } from '../../common/experiments/groups';
 import { traceError } from '../../common/logger';
-import { IDisposable, IDisposableRegistry, IExperimentService } from '../../common/types';
+import { IDisposable, IDisposableRegistry } from '../../common/types';
 import { isNotebookCell } from '../../common/utils/misc';
 import { EditorContexts } from '../constants';
 import { isPythonNotebook } from '../notebook/helpers/helpers';
@@ -53,8 +52,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
         @inject(UseVSCodeNotebookEditorApi) private readonly inNativeNotebookExperiment: boolean,
         @inject(INotebookProvider) private readonly notebookProvider: INotebookProvider,
         @inject(IVSCodeNotebook) private readonly vscNotebook: IVSCodeNotebook,
-        @inject(ITrustService) private readonly trustService: ITrustService,
-        @inject(IExperimentService) private readonly experimentService: IExperimentService
+        @inject(ITrustService) private readonly trustService: ITrustService
     ) {
         disposables.push(this);
         this.nativeContext = new ContextKey(EditorContexts.IsNativeActive, this.commandManager);
@@ -114,10 +112,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
         }
         this.vscNotebook.onDidChangeNotebookEditorSelection(this.updateNativeNotebookContext, this, this.disposables);
 
-        const usingWebview =
-            !env.appName.includes('Insider') &&
-            !(await this.experimentService.inExperiment(Experiments.NativeNotebook));
-        this.usingWebViewNotebook.set(usingWebview).ignoreErrors();
+        this.usingWebViewNotebook.set(!this.inNativeNotebookExperiment).ignoreErrors();
     }
 
     private updateNativeNotebookCellContext() {

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -158,6 +158,7 @@ export namespace EditorContexts {
     export const HaveNativeRedoableCells = 'jupyter.havenativeredoablecells';
     export const HaveNative = 'jupyter.havenative';
     export const IsNativeActive = 'jupyter.isnativeactive';
+    export const UsingWebviewNotebook = 'jupyter.usingwebviewnotebook';
     export const IsInteractiveOrNativeActive = 'jupyter.isinteractiveornativeactive';
     export const canRunCellsAboveInNativeNotebook = 'jupyter.notebookeditor.canRunCellsAboveInNativeNotebook';
     export const IsPythonOrNativeActive = 'jupyter.ispythonornativeactive';


### PR DESCRIPTION
For #4479

For notebooks, there's the command 'Select Notebook Kernel', and for Interactive window there's 'Select a Kernel'

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
