### PR TITLE
Ensure data viewer sort indicator is always visible even if column name is long

### DIFF
--- a/src/datascience-ui/data-explorer/mainPanel.tsx
+++ b/src/datascience-ui/data-explorer/mainPanel.tsx
@@ -185,23 +185,25 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
         if (this.state.originalVariableShape) {
             breadcrumbText += ' (' + this.state.originalVariableShape?.join(', ') + ')';
         }
-        return (
-            <div className="breadcrumb-container control-container">
-                <div className="breadcrumb">
-                    <div className="icon-python breadcrumb-file-icon" />
-                    <span>{this.state.fileName}</span>
-                    {this.state.fileName ? (
-                        <Image
-                            baseTheme={this.props.baseTheme}
-                            class="image-button-image"
-                            codicon="chevron-right"
-                            image={ImageName.Cancel}
-                        />
-                    ) : undefined}
-                    <span>{breadcrumbText}</span>
+        if (breadcrumbText) {
+            return (
+                <div className="breadcrumb-container control-container">
+                    <div className="breadcrumb">
+                        <div className="icon-python breadcrumb-file-icon" />
+                        <span>{this.state.fileName}</span>
+                        {this.state.fileName ? (
+                            <Image
+                                baseTheme={this.props.baseTheme}
+                                class="image-button-image"
+                                codicon="chevron-right"
+                                image={ImageName.Cancel}
+                            />
+                        ) : undefined}
+                        <span>{breadcrumbText}</span>
+                    </div>
                 </div>
-            </div>
-        );
+            );
+        }
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/datascience-ui/data-explorer/reactSlickGrid.css
+++ b/src/datascience-ui/data-explorer/reactSlickGrid.css
@@ -67,6 +67,14 @@
 .slick-header-column.ui-state-default,
 .slick-group-header-column.ui-state-default {
     border-right-color: var(--vscode-editor-inactiveSelectionBackground);
+    display: flex;
+}
+
+.slick-column-name {
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .slick-sort-indicator {
@@ -74,6 +82,8 @@
     width: 0px;
     margin-right: 12px;
     margin-top: 1px;
+    flex: 0 0 auto;
+    cursor: pointer;
 }
 
 .react-grid-header-cell:hover {
@@ -137,4 +147,8 @@ input.editor-text {
 
 .codicon-button {
     cursor: pointer;
+}
+
+.header-cell-button {
+    position: absolute;
 }

--- a/src/datascience-ui/data-explorer/reactSlickGrid.tsx
+++ b/src/datascience-ui/data-explorer/reactSlickGrid.tsx
@@ -477,7 +477,7 @@ export class ReactSlickGrid extends React.Component<ISlickGridProps, ISlickGridS
                     c.header = {
                         buttons: [
                             {
-                                cssClass: 'codicon codicon-filter codicon-button',
+                                cssClass: 'codicon codicon-filter codicon-button header-cell-button',
                                 handler: this.clickFilterButton,
                                 tooltip: this.state.showingFilters
                                     ? getLocString('DataScience.dataViewerHideFilters', 'Hide filters')


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/30305945/109582381-e59d7100-7ab2-11eb-83b4-258503aaaf62.png)


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
