### PR TITLE
Slice validation error message tweaks for data viewer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -394,7 +394,6 @@ module.exports = {
         'src/datascience-ui/react-common/flyout.tsx',
         'src/datascience-ui/react-common/logger.ts',
         'src/datascience-ui/react-common/svgList.tsx',
-        'src/datascience-ui/react-common/locReactSide.ts',
         'src/datascience-ui/react-common/button.tsx',
         'src/datascience-ui/react-common/themeDetector.ts',
         'src/datascience-ui/react-common/event.ts',

--- a/package.nls.json
+++ b/package.nls.json
@@ -480,5 +480,7 @@
     "DataScience.sliceSummaryTitle": "SLICING",
     "DataScience.dataViewerShowFilters": "Show filters",
     "DataScience.dataViewerHideFilters": "Hide filters",
-    "DataScience.sliceData": "Slice Data"
+    "DataScience.sliceData": "Slice Data",
+    "DataScience.sliceIndexError": "Index {0} out of range for axis {1} with {2} elements",
+    "DataScience.sliceMismatchedAxesError": "Expected {0} axes, got {1} in slice expression"
 }

--- a/src/datascience-ui/data-explorer/helpers.ts
+++ b/src/datascience-ui/data-explorer/helpers.ts
@@ -1,4 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
+
+import { format, getLocString } from '../react-common/locReactSide';
+
 // Licensed under the MIT License.
 export const sliceRegEx = /^\s*((?<StartRange>-?\d+:)|(?<StopRange>-?:\d+)|(?:(?<Start>-?\d+)(?::(?<Stop>-?\d+))?(?::(?<Step>-?\d+))?))\s*$/;
 
@@ -54,9 +57,17 @@ export function validateSliceExpression(sliceExpression: string, shape: number[]
 
         if (hasOutOfRangeIndex) {
             const { shapeIndex, value } = hasOutOfRangeIndex;
-            return `IndexError at axis ${shapeIndex}, index ${value}`;
+            const localized = getLocString(
+                'DataScience.sliceIndexError',
+                'Index {0} out of range for axis {1} with {2} elements'
+            );
+            return format(localized, value.toString(), shapeIndex.toString(), shape[shapeIndex].toString());
         } else if (parsedExpression && parsedExpression.length !== shape.length) {
-            return 'Invalid slice expression';
+            const localized = getLocString(
+                'DataScience.sliceMismatchedAxesError',
+                'Expected {0} axes, got {1} in slice expression'
+            );
+            return format(localized, shape.length.toString(), parsedExpression.length.toString());
         }
     }
     return '';

--- a/src/datascience-ui/data-explorer/reactSlickGrid.css
+++ b/src/datascience-ui/data-explorer/reactSlickGrid.css
@@ -14,17 +14,6 @@
     bottom: 5px;
 }
 
-.react-grid-filter-button {
-    background: var(--vscode-button-background);
-    color: var(--vscode-button-foreground);
-    padding: 10px 15px;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-    margin: 8px 4px;
-    margin-right: 18px;
-}
-
 .react-grid-header-cell {
     padding: 0px 4px;
     background-color: var(--vscode-menu-background);
@@ -45,8 +34,8 @@
 }
 
 .react-grid-cell.active {
-    background-color: var(--vscode-list-focusBackground);
-    color: var(--vscode-button-foreground);
+    background-color: var(--vscode-list-activeSelectionBackground);
+    color: var(--vscode-list-activeSelectionForeground);
 }
 
 /* Some overrides necessary to get the colors we want */

--- a/src/datascience-ui/data-explorer/sliceControl.css
+++ b/src/datascience-ui/data-explorer/sliceControl.css
@@ -87,6 +87,7 @@ details[open] > summary::before {
     font-family: var(--vscode-font-family);
     font-weight: var(--vscode-font-weight);
     font-size: var(--vscode-font-size);
+    max-width: fit-content;
 }
 
 .slice-enablement-checkbox {
@@ -152,4 +153,5 @@ details[open] > summary::before {
     font-size: var(--vscode-font-size);
     padding: 5px 3px;
     align-items: center;
+    max-width: fit-content;
 }

--- a/src/datascience-ui/react-common/locReactSide.ts
+++ b/src/datascience-ui/react-common/locReactSide.ts
@@ -18,3 +18,7 @@ export function getLocString(key: string, defValue: string): string {
 export function storeLocStrings(collection: Record<string, string>) {
     loadedCollection = collection;
 }
+
+export function format(locString: string, ...args: string[]) {
+    return locString.replace(/{(\d+)}/g, (match, number) => (args[number] === undefined ? match : args[number]));
+}


### PR DESCRIPTION
Got feedback that the messages should be more specific. Also localizing them and ensuring that long message text wraps around. FWIW we also considered a tooltip as an alternative way to display long text, but I'm not submitting that after discussing with Jill because VS Code doesn't have a pattern of showing error messages in tooltips.

![image](https://user-images.githubusercontent.com/30305945/109696153-93576100-7b41-11eb-97bd-4b94067e70d5.png)


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
