### PR TITLE
Upload build early without waiting for tests on release

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -885,7 +885,7 @@ jobs:
     runs-on: ubuntu-latest
     # This should happen in the release and insiders branch
     if: github.repository == 'microsoft/vscode-jupyter' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release'))
-    needs: [build-vsix, pick_environment, lint, ts_tests, vscodeTests, smoke-tests]
+    needs: [build-vsix]
     env:
       BLOB_CONTAINER_NAME: extension-builds-jupyter
 


### PR DESCRIPTION
This is safe at least in this branch, we check the tests & we manually test.