### PR TITLE
Add string argument to jupyter.execSelectionInteractive for extensibility

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -902,7 +902,6 @@ module.exports = {
         'src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts',
         'src/client/datascience/interactive-ipynb/autoSaveService.ts',
         'src/client/datascience/editor-integration/codeLensFactory.ts',
-        'src/client/datascience/editor-integration/codewatcher.ts',
         'src/client/datascience/editor-integration/decorator.ts',
         'src/client/datascience/editor-integration/codelensprovider.ts',
         'src/client/datascience/editor-integration/cellhashprovider.ts',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -253,7 +253,6 @@ module.exports = {
         'src/test/datascience/editor-integration/helpers.ts',
         'src/test/datascience/editor-integration/cellhashprovider.unit.test.ts',
         'src/test/datascience/editor-integration/codelensprovider.unit.test.ts',
-        'src/test/datascience/editor-integration/codewatcher.unit.test.ts',
         'src/test/datascience/jupyterPasswordConnect.unit.test.ts',
         'src/test/datascience/testHelpers.tsx',
         'src/test/datascience/mockLanguageClient.ts',

--- a/news/1 Enhancements/1689.md
+++ b/news/1 Enhancements/1689.md
@@ -1,0 +1,2 @@
+Be able to provide string argument to jupyter.execSelectionInteractive for extensibility.
+(thanks [Andrew Craig](https://github.com/andycraig/))

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -32,7 +32,6 @@ interface ICommandNameWithoutArgumentTypeMapping {
     ['jupyterViewVariables.focus']: [];
     [DSCommands.RunCurrentCell]: [];
     [DSCommands.RunCurrentCellAdvance]: [];
-    [DSCommands.ExecSelectionInInteractiveWindow]: [];
     [DSCommands.CreateNewInteractive]: [];
     [DSCommands.UndoCells]: [];
     [DSCommands.RedoCells]: [];
@@ -102,6 +101,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [DSCommands.OpenNotebook]: [undefined | Uri, undefined | string, undefined | CommandSource];
     [DSCommands.OpenNotebookInPreviewEditor]: [undefined | Uri];
     [DSCommands.ExportFileAsNotebook]: [undefined | Uri, undefined | CommandSource];
+    [DSCommands.ExecSelectionInInteractiveWindow]: [string | undefined];
     [DSCommands.RunFileInInteractiveWindows]: [Uri];
     [DSCommands.DebugFileInInteractiveWindows]: [Uri];
     [DSCommands.DebugCell]: [Uri, number, number, number, number];

--- a/src/client/datascience/commands/commandRegistry.ts
+++ b/src/client/datascience/commands/commandRegistry.ts
@@ -81,7 +81,9 @@ export class CommandRegistry implements IDisposable {
         this.registerCommand(Commands.RunCell, this.runCell);
         this.registerCommand(Commands.RunCurrentCell, this.runCurrentCell);
         this.registerCommand(Commands.RunCurrentCellAdvance, this.runCurrentCellAndAdvance);
-        this.registerCommand(Commands.ExecSelectionInInteractiveWindow, (text: string | undefined) => this.runSelectionOrLine(text));
+        this.registerCommand(Commands.ExecSelectionInInteractiveWindow, (text: string | undefined) =>
+            this.runSelectionOrLine(text)
+        );
         this.registerCommand(Commands.RunAllCellsAbove, this.runAllCellsAbove);
         this.registerCommand(Commands.RunCellAndAllBelow, this.runCellAndAllBelow);
         this.registerCommand(Commands.InsertCellBelowPosition, this.insertCellBelowPosition);

--- a/src/client/datascience/commands/commandRegistry.ts
+++ b/src/client/datascience/commands/commandRegistry.ts
@@ -81,7 +81,7 @@ export class CommandRegistry implements IDisposable {
         this.registerCommand(Commands.RunCell, this.runCell);
         this.registerCommand(Commands.RunCurrentCell, this.runCurrentCell);
         this.registerCommand(Commands.RunCurrentCellAdvance, this.runCurrentCellAndAdvance);
-        this.registerCommand(Commands.ExecSelectionInInteractiveWindow, this.runSelectionOrLine);
+        this.registerCommand(Commands.ExecSelectionInInteractiveWindow, (text: string | null = null) => this.runSelectionOrLine(text));
         this.registerCommand(Commands.RunAllCellsAbove, this.runAllCellsAbove);
         this.registerCommand(Commands.RunCellAndAllBelow, this.runCellAndAllBelow);
         this.registerCommand(Commands.InsertCellBelowPosition, this.insertCellBelowPosition);
@@ -299,10 +299,10 @@ export class CommandRegistry implements IDisposable {
         }
     }
 
-    private async runSelectionOrLine(): Promise<void> {
+    private async runSelectionOrLine(text: string | null): Promise<void> {
         const activeCodeWatcher = this.getCurrentCodeWatcher();
         if (activeCodeWatcher) {
-            return activeCodeWatcher.runSelectionOrLine(this.documentManager.activeTextEditor);
+            return activeCodeWatcher.runSelectionOrLine(this.documentManager.activeTextEditor, text);
         } else {
             return;
         }

--- a/src/client/datascience/commands/commandRegistry.ts
+++ b/src/client/datascience/commands/commandRegistry.ts
@@ -81,7 +81,7 @@ export class CommandRegistry implements IDisposable {
         this.registerCommand(Commands.RunCell, this.runCell);
         this.registerCommand(Commands.RunCurrentCell, this.runCurrentCell);
         this.registerCommand(Commands.RunCurrentCellAdvance, this.runCurrentCellAndAdvance);
-        this.registerCommand(Commands.ExecSelectionInInteractiveWindow, (text: string | null = null) => this.runSelectionOrLine(text));
+        this.registerCommand(Commands.ExecSelectionInInteractiveWindow, (text: string | undefined = undefined) => this.runSelectionOrLine(text));
         this.registerCommand(Commands.RunAllCellsAbove, this.runAllCellsAbove);
         this.registerCommand(Commands.RunCellAndAllBelow, this.runCellAndAllBelow);
         this.registerCommand(Commands.InsertCellBelowPosition, this.insertCellBelowPosition);
@@ -299,7 +299,7 @@ export class CommandRegistry implements IDisposable {
         }
     }
 
-    private async runSelectionOrLine(text: string | null): Promise<void> {
+    private async runSelectionOrLine(text: string | undefined): Promise<void> {
         const activeCodeWatcher = this.getCurrentCodeWatcher();
         if (activeCodeWatcher) {
             return activeCodeWatcher.runSelectionOrLine(this.documentManager.activeTextEditor, text);

--- a/src/client/datascience/commands/commandRegistry.ts
+++ b/src/client/datascience/commands/commandRegistry.ts
@@ -81,7 +81,7 @@ export class CommandRegistry implements IDisposable {
         this.registerCommand(Commands.RunCell, this.runCell);
         this.registerCommand(Commands.RunCurrentCell, this.runCurrentCell);
         this.registerCommand(Commands.RunCurrentCellAdvance, this.runCurrentCellAndAdvance);
-        this.registerCommand(Commands.ExecSelectionInInteractiveWindow, (text: string | undefined = undefined) => this.runSelectionOrLine(text));
+        this.registerCommand(Commands.ExecSelectionInInteractiveWindow, (text: string | undefined) => this.runSelectionOrLine(text));
         this.registerCommand(Commands.RunAllCellsAbove, this.runAllCellsAbove);
         this.registerCommand(Commands.RunCellAndAllBelow, this.runCellAndAllBelow);
         this.registerCommand(Commands.InsertCellBelowPosition, this.insertCellBelowPosition);

--- a/src/client/datascience/editor-integration/codewatcher.ts
+++ b/src/client/datascience/editor-integration/codewatcher.ts
@@ -247,7 +247,7 @@ export class CodeWatcher implements ICodeWatcher {
     }
 
     @captureTelemetry(Telemetry.RunSelectionOrLine)
-    public async runSelectionOrLine(activeEditor: TextEditor | undefined, text: string | undefined = undefined) {
+    public async runSelectionOrLine(activeEditor: TextEditor | undefined, text?: string) {
         if (this.document && activeEditor && this.fs.arePathsSame(activeEditor.document.uri, this.document.uri)) {
             let codeToExecute: string | undefined;
             if (text === undefined) {

--- a/src/client/datascience/editor-integration/codewatcher.ts
+++ b/src/client/datascience/editor-integration/codewatcher.ts
@@ -247,10 +247,10 @@ export class CodeWatcher implements ICodeWatcher {
     }
 
     @captureTelemetry(Telemetry.RunSelectionOrLine)
-    public async runSelectionOrLine(activeEditor: TextEditor | undefined, text: string | null = null) {
+    public async runSelectionOrLine(activeEditor: TextEditor | undefined, text: string | undefined = undefined) {
         if (this.document && activeEditor && this.fs.arePathsSame(activeEditor.document.uri, this.document.uri)) {
             let codeToExecute: string | undefined;
-            if (text === null) {
+            if (text === undefined) {
                 // Get just the text of the selection or the current line if none
                 codeToExecute = await this.executionHelper.getSelectedTextToExecute(activeEditor);
             } else {

--- a/src/client/datascience/editor-integration/codewatcher.ts
+++ b/src/client/datascience/editor-integration/codewatcher.ts
@@ -358,7 +358,7 @@ export class CodeWatcher implements ICodeWatcher {
         const cellDelineator = this.getDefaultCellMarker(editor.document.uri);
 
         if (editor) {
-            editor.edit((editBuilder) => {
+            void editor.edit((editBuilder) => {
                 let lastCell = true;
 
                 for (let i = editor.selection.end.line + 1; i < editor.document.lineCount; i += 1) {
@@ -449,7 +449,7 @@ export class CodeWatcher implements ICodeWatcher {
             new Position(startLineNumber, startCharacterNumber),
             new Position(endLineNumber, endCharacterNumber)
         );
-        editor.edit((editBuilder) => {
+        void editor.edit((editBuilder) => {
             editBuilder.replace(cellExtendedRange, '');
             this.codeLensUpdatedEvent.fire();
         });
@@ -745,7 +745,7 @@ export class CodeWatcher implements ICodeWatcher {
                 ? `${cellMarker} [markdown]${definitionExtra}` // code -> markdown
                 : `${cellMarker}${definitionExtra}`; // markdown -> code
 
-        editor.edit(async (editBuilder) => {
+        void editor.edit(async (editBuilder) => {
             editBuilder.replace(definitionLine.range, newDefinitionText);
             cell.cell_type = toCellType;
             if (cell.range.start.line < cell.range.end.line) {
@@ -758,9 +758,9 @@ export class CodeWatcher implements ICodeWatcher {
                 // ensure all lines in markdown cell have a comment.
                 // these are not included in the test because it's unclear
                 // how TypeMoq works with them.
-                commands.executeCommand('editor.action.removeCommentLine');
+                void commands.executeCommand('editor.action.removeCommentLine');
                 if (toCellType === 'markdown') {
-                    commands.executeCommand('editor.action.addCommentLine');
+                    void commands.executeCommand('editor.action.addCommentLine');
                 }
             }
         });
@@ -945,7 +945,7 @@ export class CodeWatcher implements ICodeWatcher {
         const cellStartPosition = new Position(line, 0);
         const newCursorPosition = new Position(line + 1, 0);
 
-        editor.edit((editBuilder) => {
+        void editor.edit((editBuilder) => {
             editBuilder.insert(cellStartPosition, newCell);
             this.codeLensUpdatedEvent.fire();
         });

--- a/src/client/datascience/editor-integration/codewatcher.ts
+++ b/src/client/datascience/editor-integration/codewatcher.ts
@@ -247,10 +247,15 @@ export class CodeWatcher implements ICodeWatcher {
     }
 
     @captureTelemetry(Telemetry.RunSelectionOrLine)
-    public async runSelectionOrLine(activeEditor: TextEditor | undefined) {
+    public async runSelectionOrLine(activeEditor: TextEditor | undefined, text: string | null = null) {
         if (this.document && activeEditor && this.fs.arePathsSame(activeEditor.document.uri, this.document.uri)) {
-            // Get just the text of the selection or the current line if none
-            const codeToExecute = await this.executionHelper.getSelectedTextToExecute(activeEditor);
+            let codeToExecute: string | undefined;
+            if (text === null) {
+                // Get just the text of the selection or the current line if none
+                codeToExecute = await this.executionHelper.getSelectedTextToExecute(activeEditor);
+            } else {
+                codeToExecute = text;
+            }
             if (!codeToExecute) {
                 return;
             }

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -697,7 +697,7 @@ export interface ICodeWatcher {
     debugCell(range: Range): Promise<void>;
     runCurrentCell(): Promise<void>;
     runCurrentCellAndAdvance(): Promise<void>;
-    runSelectionOrLine(activeEditor: TextEditor | undefined): Promise<void>;
+    runSelectionOrLine(activeEditor: TextEditor | undefined, text: string | null): Promise<void>;
     runToLine(targetLine: number): Promise<void>;
     runFromLine(targetLine: number): Promise<void>;
     runAllCellsAbove(stopLine: number, stopCharacter: number): Promise<void>;

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -697,7 +697,7 @@ export interface ICodeWatcher {
     debugCell(range: Range): Promise<void>;
     runCurrentCell(): Promise<void>;
     runCurrentCellAndAdvance(): Promise<void>;
-    runSelectionOrLine(activeEditor: TextEditor | undefined, text: string | null): Promise<void>;
+    runSelectionOrLine(activeEditor: TextEditor | undefined, text: string | undefined): Promise<void>;
     runToLine(targetLine: number): Promise<void>;
     runFromLine(targetLine: number): Promise<void>;
     runAllCellsAbove(stopLine: number, stopCharacter: number): Promise<void>;

--- a/src/test/datascience/editor-integration/codewatcher.unit.test.ts
+++ b/src/test/datascience/editor-integration/codewatcher.unit.test.ts
@@ -817,7 +817,7 @@ testing2`;
                 )
             )
             .returns(() => Promise.resolve('testing2'));
-        helper.setup((h) => h.normalizeLines(TypeMoq.It.isAny())).returns(() => Promise.resolve('testing2'));
+        helper.setup((h) => h.normalizeLines(TypeMoq.It.isAny())).returns((x: string) => Promise.resolve(x));
 
         // Set up our expected calls to add code
         activeInteractiveWindow


### PR DESCRIPTION
For #1689

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~

Not sure about logging/telemetry/test plan items above.

This PR adds a string argument to `jupyter.execSelectionInteractive` for extensibility. This allows users to send custom text to the Interactive Window using keybindings, and (more importantly) allows other extensions to send custom text to the Interactive Window. Existing <kbd>Shift+Enter</kbd> behaviour of `jupyter.execSelectionInteractive` is unchanged.

**Demo**

I've added a unit test but this demo might make it clearer how this feature is intended to be used.

Add this to `keybindings.json`:

```json
    {
        "key": "alt+shift+a",
        "command":"jupyter.execSelectionInteractive",
        "args": "print('sent to Interactive Window by command')"
    }
```

Create a file `temp.py` with the following text:

```py
print('sent using Shift+Enter')
```

Enable setting `Jupyter: Send Selection to Interactive Window` (necessary for checking <kbd>Shift+Enter</kbd> behaviour)

Create an Interactive Window using command `Jupyter: Create Interactive Window`

Use <kbd>Alt+Shift+a</kbd>, observe that `print('sent to Interactive Window by command')` is sent to Interactive Window (new feature)

Use <kbd>Shift+Enter</kbd>, observe that `print('sent using Shift+Enter')` is sent to Interactive Window (preserving existing behaviour)