### PR TITLE
Remove deprecated event onDidChangeCellLanguage

### DIFF
--- a/src/client/common/application/notebook.ts
+++ b/src/client/common/application/notebook.ts
@@ -112,9 +112,6 @@ export class VSCodeNotebook implements IVSCodeNotebook {
         this.addedEventHandlers = true;
         this.disposables.push(
             ...[
-                notebook.onDidChangeCellLanguage((e) =>
-                    this._onDidChangeNotebookDocument.fire({ ...e, type: 'changeCellLanguage' })
-                ),
                 notebook.onDidChangeCellMetadata((e) =>
                     this._onDidChangeNotebookDocument.fire({ ...e, type: 'changeCellMetadata' })
                 ),

--- a/src/client/common/application/types.ts
+++ b/src/client/common/application/types.ts
@@ -1547,7 +1547,6 @@ export interface IClipboard {
 export type NotebookCellsChangeEvent = { type: 'changeCells' } & VSCNotebookCellsChangeEvent;
 export type NotebookCellOutputsChangeEvent = { type: 'changeCellOutputs' } & VSCNotebookCellOutputsChangeEvent;
 export type NotebookCellMetadataChangeEvent = { type: 'changeCellMetadata' } & VSCNotebookCellMetadataChangeEvent;
-export type NotebookCellLanguageChangeEvent = { type: 'changeCellLanguage' } & VSCNotebookCellLanguageChangeEvent;
 export type NotebookDocumentMetadataChangeEvent = {
     type: 'changeNotebookMetadata';
 } & VSCNotebookDocumentMetadataChangeEvent;
@@ -1555,8 +1554,7 @@ export type NotebookCellChangedEvent =
     | NotebookCellsChangeEvent
     | NotebookCellOutputsChangeEvent
     | NotebookCellMetadataChangeEvent
-    | NotebookDocumentMetadataChangeEvent
-    | NotebookCellLanguageChangeEvent;
+    | NotebookDocumentMetadataChangeEvent;
 export const IVSCodeNotebook = Symbol('IVSCodeNotebook');
 export interface IVSCodeNotebook {
     readonly onDidChangeActiveNotebookKernel: Event<{

--- a/types/vscode-proposed/index.d.ts
+++ b/types/vscode-proposed/index.d.ts
@@ -438,10 +438,6 @@ export namespace notebook {
     export const onDidChangeNotebookDocumentMetadata: Event<NotebookDocumentMetadataChangeEvent>;
     export const onDidChangeNotebookCells: Event<NotebookCellsChangeEvent>;
     export const onDidChangeCellOutputs: Event<NotebookCellOutputsChangeEvent>;
-
-    // todo@API we send document close and open events when the language of a document changes and
-    // I believe we should stick that for cells as well
-    export const onDidChangeCellLanguage: Event<NotebookCellLanguageChangeEvent>;
     export const onDidChangeCellMetadata: Event<NotebookCellMetadataChangeEvent>;
 }
 

--- a/types/vscode.proposed.d.ts
+++ b/types/vscode.proposed.d.ts
@@ -315,15 +315,6 @@ declare module 'vscode' {
         readonly cells: NotebookCell[];
     }
 
-    export interface NotebookCellLanguageChangeEvent {
-        /**
-         * The affected document.
-         */
-        readonly document: NotebookDocument;
-        readonly cell: NotebookCell;
-        readonly language: string;
-    }
-
     export interface NotebookCellMetadataChangeEvent {
         readonly document: NotebookDocument;
         readonly cell: NotebookCell;
@@ -423,10 +414,6 @@ declare module 'vscode' {
         export const onDidChangeNotebookDocumentMetadata: Event<NotebookDocumentMetadataChangeEvent>;
         export const onDidChangeNotebookCells: Event<NotebookCellsChangeEvent>;
         export const onDidChangeCellOutputs: Event<NotebookCellOutputsChangeEvent>;
-
-        // todo@API we send document close and open events when the language of a document changes and
-        // I believe we should stick that for cells as well
-        export const onDidChangeCellLanguage: Event<NotebookCellLanguageChangeEvent>;
         export const onDidChangeCellMetadata: Event<NotebookCellMetadataChangeEvent>;
     }
 

--- a/typings/vscode-proposed/index.d.ts
+++ b/typings/vscode-proposed/index.d.ts
@@ -438,10 +438,6 @@ export namespace notebook {
     export const onDidChangeNotebookDocumentMetadata: Event<NotebookDocumentMetadataChangeEvent>;
     export const onDidChangeNotebookCells: Event<NotebookCellsChangeEvent>;
     export const onDidChangeCellOutputs: Event<NotebookCellOutputsChangeEvent>;
-
-    // todo@API we send document close and open events when the language of a document changes and
-    // I believe we should stick that for cells as well
-    export const onDidChangeCellLanguage: Event<NotebookCellLanguageChangeEvent>;
     export const onDidChangeCellMetadata: Event<NotebookCellMetadataChangeEvent>;
 }
 


### PR DESCRIPTION
This was never used and the event has been deprecated in VS Code.