### PR TITLE
remove All option from opt in/out of experiments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1353,8 +1353,7 @@
                     "default": [],
                     "items": {
                         "enum": [
-                            "CustomEditor",
-                            "All"
+                            "CustomEditor"
                         ]
                     },
                     "description": "List of experiment to opt into. If empty, user is assigned the default experiment groups. See https://github.com/microsoft/vscode-jupyter/wiki/Experiments for more details.",
@@ -1366,8 +1365,7 @@
                     "items": {
                         "enum": [
                             "NativeNotebookEditor",
-                            "CustomEditor",
-                            "All"
+                            "CustomEditor"
                         ]
                     },
                     "description": "List of experiment to opt out of. If empty, user is assigned the default experiment groups. See https://github.com/microsoft/vscode-jupyter/wiki/Experiments for more details.",

--- a/src/client/common/experiments/service.ts
+++ b/src/client/common/experiments/service.ts
@@ -43,7 +43,7 @@ export class ExperimentService implements IExperimentService {
     private logged?: boolean;
 
     private get enabled() {
-        return this._optOutFrom.includes('All') || this.settings.experiments.enabled;
+        return this.settings.experiments.enabled;
     }
     constructor(
         @inject(IConfigurationService) readonly configurationService: IConfigurationService,
@@ -141,7 +141,7 @@ export class ExperimentService implements IExperimentService {
     }
 
     public async getExperimentValue<T extends boolean | number | string>(experiment: string): Promise<T | undefined> {
-        if (!this.experimentationService || this._optOutFrom.includes('All') || this._optOutFrom.includes(experiment)) {
+        if (!this.experimentationService || this._optOutFrom.includes(experiment)) {
             return;
         }
 
@@ -170,7 +170,7 @@ export class ExperimentService implements IExperimentService {
 
         // Currently the service doesn't support opting in and out of experiments,
         // so we need to perform these checks and send the corresponding telemetry manually.
-        if (this._optOutFrom.includes('All') || this._optOutFrom.includes(experiment)) {
+        if (this._optOutFrom.includes(experiment)) {
             return 'optOut';
         }
 
@@ -179,7 +179,7 @@ export class ExperimentService implements IExperimentService {
             return this._optInto.includes(`__${experiment}__`) ? 'optIn' : undefined;
         }
 
-        if (this._optInto.includes('All') || this._optInto.includes(experiment)) {
+        if (this._optInto.includes(experiment)) {
             return 'optIn';
         }
 

--- a/src/test/common/experiments/service.unit.test.ts
+++ b/src/test/common/experiments/service.unit.test.ts
@@ -242,28 +242,6 @@ suite('Experimentation service', () => {
             sinon.assert.notCalled(isCachedFlightEnabledStub);
         });
 
-        test('If the opt-in setting contains "All", inExperiment should return true', async () => {
-            configureSettings(true, ['All'], []);
-
-            const experimentService = new ExperimentService(
-                instance(configurationService),
-                instance(appEnvironment),
-                globalMemento,
-                outputChannel,
-                extensionService,
-                instance(workspace)
-            );
-            const result = await experimentService.inExperiment(experiment);
-
-            assert.isTrue(result);
-            assert.equal(telemetryEvents.length, 1);
-            assert.deepEqual(telemetryEvents[0], {
-                eventName: EventName.JUPYTER_EXPERIMENTS_OPT_IN_OUT,
-                properties: { expNameOptedInto: experiment }
-            });
-            sinon.assert.calledOnce(isCachedFlightEnabledStub);
-        });
-
         test('If the opt-in setting contains the experiment name, inExperiment should return true', async () => {
             configureSettings(true, [experiment], []);
 
@@ -284,28 +262,6 @@ suite('Experimentation service', () => {
                 properties: { expNameOptedInto: experiment }
             });
             sinon.assert.calledOnce(isCachedFlightEnabledStub);
-        });
-
-        test('If the opt-out setting contains "All", inExperiment should return false', async () => {
-            configureSettings(true, [], ['All']);
-
-            const experimentService = new ExperimentService(
-                instance(configurationService),
-                instance(appEnvironment),
-                globalMemento,
-                outputChannel,
-                extensionService,
-                instance(workspace)
-            );
-            const result = await experimentService.inExperiment(experiment);
-
-            assert.isFalse(result);
-            assert.equal(telemetryEvents.length, 1);
-            assert.deepEqual(telemetryEvents[0], {
-                eventName: EventName.JUPYTER_EXPERIMENTS_OPT_IN_OUT,
-                properties: { expNameOptedOutOf: experiment }
-            });
-            sinon.assert.notCalled(isCachedFlightEnabledStub);
         });
 
         test('If the opt-out setting contains the experiment name, inExperiment should return false', async () => {
@@ -364,23 +320,6 @@ suite('Experimentation service', () => {
 
         test('If the experiment setting is disabled, getExperimentValue should return undefined', async () => {
             configureSettings(false, [], []);
-
-            const experimentService = new ExperimentService(
-                instance(configurationService),
-                instance(appEnvironment),
-                globalMemento,
-                outputChannel,
-                extensionService,
-                instance(workspace)
-            );
-            const result = await experimentService.getExperimentValue(experiment);
-
-            assert.isUndefined(result);
-            sinon.assert.notCalled(getTreatmentVariableAsyncStub);
-        });
-
-        test('If the opt-out setting contains "All", getExperimentValue should return undefined', async () => {
-            configureSettings(true, [], ['All']);
 
             const experimentService = new ExperimentService(
                 instance(configurationService),


### PR DESCRIPTION
-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
