### PR TITLE
Ignore errors when getting activated env variables

### DIFF
--- a/news/2 Fixes/5093.md
+++ b/news/2 Fixes/5093.md
@@ -1,0 +1,1 @@
+Ignore errors when getting the environment variables for a Python environment.

--- a/src/client/api/pythonApi.ts
+++ b/src/client/api/pythonApi.ts
@@ -266,7 +266,7 @@ export class EnvironmentActivationService implements IEnvironmentActivationServi
     ): Promise<NodeJS.ProcessEnv | undefined> {
         return this.apiProvider
             .getApi()
-            .then((api) => api.getActivatedEnvironmentVariables(resource, interpreter, true));
+            .then((api) => api.getActivatedEnvironmentVariables(resource, interpreter, false));
     }
 }
 


### PR DESCRIPTION
For #5093 (originally reported in #4947)
