### PR TITLE
Stop wrapping new errors if we threw the original error

### DIFF
--- a/news/2 Fixes/5089.md
+++ b/news/2 Fixes/5089.md
@@ -1,0 +1,1 @@
+Stop wrapping new errors if we threw the original error.

--- a/src/client/common/errors/types.ts
+++ b/src/client/common/errors/types.ts
@@ -22,6 +22,15 @@ export class WrappedError extends BaseError {
             this.stack = `${new Error('').stack}${EOL}${EOL}${originalException.stack}`;
         }
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public from(err: any) {
+        if (err instanceof BaseError) {
+            throw err;
+        } else {
+            throw this;
+        }
+    }
 }
 
 export function getErrorCategory(error?: Error): ErrorCategory {

--- a/src/client/common/errors/types.ts
+++ b/src/client/common/errors/types.ts
@@ -24,11 +24,11 @@ export class WrappedError extends BaseError {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public from(err: any) {
+    public static from(message: string, err: any) {
         if (err instanceof BaseError) {
-            throw err;
+            return err;
         } else {
-            throw this;
+            return new WrappedError(message, err);
         }
     }
 }

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -279,20 +279,20 @@ export class JupyterExecutionBase implements IJupyterExecution {
                                 sendTelemetryEvent(Telemetry.ConnectRemoteSelfCertFailedJupyter);
                                 throw new JupyterSelfCertsError(connection.baseUrl);
                             } else {
-                                throw new WrappedError(
+                                throw WrappedError.from(
                                     localize.DataScience.jupyterNotebookRemoteConnectFailed().format(
                                         connection.baseUrl,
                                         err
                                     ),
                                     err
-                                ).from(err);
+                                );
                             }
                         } else {
                             sendTelemetryEvent(Telemetry.ConnectFailedJupyter, undefined, undefined, err, true);
-                            throw new WrappedError(
+                            throw WrappedError.from(
                                 localize.DataScience.jupyterNotebookConnectFailed().format(connection.baseUrl, err),
                                 err
-                            ).from(err);
+                            );
                         }
                     } else {
                         kernelSpecCancelSource.cancel();

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -285,14 +285,14 @@ export class JupyterExecutionBase implements IJupyterExecution {
                                         err
                                     ),
                                     err
-                                );
+                                ).from(err);
                             }
                         } else {
                             sendTelemetryEvent(Telemetry.ConnectFailedJupyter, undefined, undefined, err, true);
                             throw new WrappedError(
                                 localize.DataScience.jupyterNotebookConnectFailed().format(connection.baseUrl, err),
                                 err
-                            );
+                            ).from(err);
                         }
                     } else {
                         kernelSpecCancelSource.cancel();

--- a/src/client/datascience/jupyter/notebookStarter.ts
+++ b/src/client/datascience/jupyter/notebookStarter.ts
@@ -157,7 +157,7 @@ export class NotebookStarter implements Disposable {
             if (exitCode !== 0) {
                 throw new Error(localize.DataScience.jupyterServerCrashed().format(exitCode?.toString()));
             } else {
-                throw new WrappedError(localize.DataScience.jupyterNotebookFailure().format(err), err);
+                throw new WrappedError(localize.DataScience.jupyterNotebookFailure().format(err), err).from(err);
             }
         } finally {
             starter?.dispose();

--- a/src/client/datascience/jupyter/notebookStarter.ts
+++ b/src/client/datascience/jupyter/notebookStarter.ts
@@ -157,7 +157,7 @@ export class NotebookStarter implements Disposable {
             if (exitCode !== 0) {
                 throw new Error(localize.DataScience.jupyterServerCrashed().format(exitCode?.toString()));
             } else {
-                throw new WrappedError(localize.DataScience.jupyterNotebookFailure().format(err), err).from(err);
+                throw WrappedError.from(localize.DataScience.jupyterNotebookFailure().format(err), err);
             }
         } finally {
             starter?.dispose();


### PR DESCRIPTION
For #5089

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
