### PR TITLE
Add quotations to arguments with blank spaces when executing kernel processes

### DIFF
--- a/news/2 Fixes/4647.md
+++ b/news/2 Fixes/4647.md
@@ -1,0 +1,1 @@
+Add quotations to arguments with blank spaces when executing kernel processes.

--- a/src/client/datascience/kernel-launcher/kernelProcess.ts
+++ b/src/client/datascience/kernel-launcher/kernelProcess.ts
@@ -344,7 +344,9 @@ export class KernelProcess implements IKernelProcess {
                 this.kernelEnvVarsService.getEnvironmentVariables(this.resource, this.launchKernelSpec)
             ]);
 
-            // Add quotations to arguments if they have a blank space in them
+            // Add quotations to arguments if they have a blank space in them.
+            // This will mainly quote paths so that they can run, other arguments shouldn't be quoted or it may cause errors.
+            // The first argument is sliced because it is the executable command.
             const args = this.launchKernelSpec.argv.slice(1).map((a) => {
                 if (a.includes(' ')) {
                     return `"${a}"`;

--- a/src/client/datascience/kernel-launcher/kernelProcess.ts
+++ b/src/client/datascience/kernel-launcher/kernelProcess.ts
@@ -343,7 +343,15 @@ export class KernelProcess implements IKernelProcess {
                 this.processExecutionFactory.create(this.resource),
                 this.kernelEnvVarsService.getEnvironmentVariables(this.resource, this.launchKernelSpec)
             ]);
-            exeObs = executionService.execObservable(executable, this.launchKernelSpec.argv.slice(1), {
+
+            // Add quotations to arguments if they have a blank space in them
+            const args = this.launchKernelSpec.argv.slice(1).map((a) => {
+                if (a.includes(' ')) {
+                    return `"${a}"`;
+                }
+                return a;
+            });
+            exeObs = executionService.execObservable(executable, args, {
                 env,
                 cwd: workingDirectory
             });


### PR DESCRIPTION
For #4647

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
