### PR TITLE
No prompt to install Python when open an exist nb without Kernel

### DIFF
--- a/src/client/datascience/jupyter/kernels/helpers.ts
+++ b/src/client/datascience/jupyter/kernels/helpers.ts
@@ -339,8 +339,9 @@ export function findPreferredKernel(
 
     // If still not found, look for a match based on notebook metadata and interpreter
     if (index < 0) {
+        const hasLanguageInfo = notebookMetadata?.language_info?.name ? true : false;
         const nbMetadataLanguage =
-            !notebookMetadata || isPythonNotebook(notebookMetadata)
+            !notebookMetadata || isPythonNotebook(notebookMetadata) || !hasLanguageInfo
                 ? PYTHON_LANGUAGE
                 : (
                       (notebookMetadata?.kernelspec?.language as string) || notebookMetadata?.language_info?.name

--- a/src/client/datascience/notebook/helpers/helpers.ts
+++ b/src/client/datascience/notebook/helpers/helpers.ts
@@ -107,11 +107,8 @@ export function isPythonNotebook(metadata?: nbformat.INotebookMetadata) {
     if (metadata?.language_info?.name && metadata.language_info.name !== PYTHON_LANGUAGE) {
         return false;
     }
-    if (kernelSpec?.language && kernelSpec.language !== PYTHON_LANGUAGE) {
-        return false;
-    }
-    // All other notebooks are python notebooks.
-    return true;
+    // Valid notebooks will have a language information in the metadata.
+    return kernelSpec?.language === PYTHON_LANGUAGE;
 }
 /**
  * No need to update the notebook metadata just yet.

--- a/src/client/datascience/notebookStorage/vscNotebookModel.ts
+++ b/src/client/datascience/notebookStorage/vscNotebookModel.ts
@@ -83,15 +83,12 @@ export class VSCodeNotebookModel extends BaseNotebookModel {
         return this.document ? this.document.cells.length : this.notebookJson.cells?.length ?? 0;
     }
     public getNotebookData() {
-        if (!this.preferredLanguage) {
-            throw new Error('Preferred Language not initialized');
-        }
         return notebookModelToVSCNotebookData(
             this.isTrusted,
             this.notebookContentWithoutCells,
             this.file,
             this.notebookJson.cells || [],
-            this.preferredLanguage,
+            this.preferredLanguage || 'plaintext',
             this.originalJson
         );
     }

--- a/src/client/datascience/openNotebookBanner.ts
+++ b/src/client/datascience/openNotebookBanner.ts
@@ -30,7 +30,7 @@ export class OpenNotebookBanner implements IExtensionSingleActivationService {
     private async openedNotebook(editor: INotebookEditor) {
         if (
             !this.pythonExtensionChecker.isPythonExtensionInstalled &&
-            editor.model.metadata &&
+            editor.model.metadata?.kernelspec &&
             isPythonNotebook(editor.model.metadata) &&
             !isUntitledFile(editor.file)
         ) {


### PR DESCRIPTION
For #4965
If you have a notebook with metadata that has a language of `python`, but no kernel information, we still prompt to install Python.
Not sure how users can create such notebooks, in our extension users can create such notebooks because we always default language to `python` for blank notebooks.
This ensures we don't display prompts if there is no kernel information.