### PR TITLE
update context when notebook closes

### DIFF
--- a/src/client/datascience/commands/activeEditorContext.ts
+++ b/src/client/datascience/commands/activeEditorContext.ts
@@ -113,6 +113,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
             this.onDidChangeActiveTextEditor(this.docManager.activeTextEditor);
         }
         this.vscNotebook.onDidChangeNotebookEditorSelection(this.updateNativeNotebookContext, this, this.disposables);
+        this.vscNotebook.onDidCloseNotebookDocument(this.updateNativeNotebookContext, this, this.disposables);
 
         this.usingWebViewNotebook.set(!this.inNativeNotebookExperiment).ignoreErrors();
     }


### PR DESCRIPTION
Something messed this up, but technically its still not a regression.

When you closed the last notebook, the variable view stayed in place. This event makes it go away as it should.