### PR TITLE
Remove usages of NotebookEditor and clean resoruces

### DIFF
--- a/src/client/datascience/jupyter/kernels/cellExecution.ts
+++ b/src/client/datascience/jupyter/kernels/cellExecution.ts
@@ -10,7 +10,7 @@ import { ExtensionMode, NotebookCell, NotebookCellRunState, workspace } from 'vs
 import { concatMultilineString, formatStreamText } from '../../../../datascience-ui/common';
 import { IApplicationShell } from '../../../common/application/types';
 import { disposeAllDisposables } from '../../../common/helpers';
-import { traceError, traceErrorIf, traceInfoIf, traceWarning } from '../../../common/logger';
+import { traceError, traceErrorIf, traceInfo, traceInfoIf, traceWarning } from '../../../common/logger';
 import { RefBool } from '../../../common/refBool';
 import { IDisposable, IDisposableRegistry, IExtensionContext } from '../../../common/types';
 import { createDeferred, Deferred } from '../../../common/utils/async';
@@ -142,6 +142,11 @@ export class CellExecution {
                 // No point keeping it alive, just chewing resources.
                 if (e === this.cell.document) {
                     this.request?.dispose(); // NOSONAR
+                }
+                if (this.started && !this._completed) {
+                    this.completedDueToCancellation().catch((ex) =>
+                        traceInfo('Failures when cancelling due to cell removal', ex)
+                    );
                 }
             },
             this,

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -95,7 +95,8 @@ export class Kernel implements IKernel {
             vscNotebook,
             kernelConnectionMetadata,
             context,
-            interruptTimeout
+            interruptTimeout,
+            disposables
         );
     }
     private perceivedJupyterStartupTelemetryCaptured?: boolean;

--- a/src/client/datascience/notebook/helpers/helpers.ts
+++ b/src/client/datascience/notebook/helpers/helpers.ts
@@ -10,13 +10,12 @@ import {
     NotebookCell,
     NotebookCellData,
     NotebookCellMetadata,
-    NotebookCellRunState,
     NotebookData,
     NotebookDocument,
-    NotebookEditor,
     NotebookKernel as VSCNotebookKernel,
     NotebookCellKind,
-    NotebookDocumentMetadata
+    NotebookDocumentMetadata,
+    NotebookCellRunState
 } from 'vscode';
 import { concatMultilineString, splitMultilineString } from '../../../../datascience-ui/common';
 import { IVSCodeNotebook } from '../../../common/application/types';
@@ -258,7 +257,7 @@ function createCodeCellFromNotebookCell(cell: NotebookCell): nbformat.ICodeCell 
         cell_type: 'code',
         execution_count: cell.metadata.executionOrder ?? null,
         source: splitMultilineString(code),
-        outputs: createIOutputFromCellOutputs(cell.outputs),
+        outputs: cell.outputs.map(translateCellDisplayOutput),
         metadata: cellMetadata?.metadata || {} // This cannot be empty.
     };
 }
@@ -362,22 +361,18 @@ function sortOutputItemsBasedOnDisplayOrder(outputItems: NotebookCellOutputItem[
     });
 }
 
-export function createIOutputFromCellOutputs(cellOutputs: readonly NotebookCellOutput[]): nbformat.IOutput[] {
-    return cellOutputs.map(translateCellDisplayOutput);
-}
-
-export async function clearCellForExecution(editor: NotebookEditor, cell: NotebookCell) {
-    await chainWithPendingUpdates(editor.document, (edit) => {
+export async function clearCellForExecution(cell: NotebookCell) {
+    await chainWithPendingUpdates(cell.notebook, (edit) => {
         const metadata = cell.metadata.with({
             statusMessage: undefined,
             executionOrder: null,
             lastRunDuration: null,
             runStartTime: null
         });
-        edit.replaceNotebookCellMetadata(editor.document.uri, cell.index, metadata);
-        edit.replaceNotebookCellOutput(editor.document.uri, cell.index, []);
+        edit.replaceNotebookCellMetadata(cell.notebook.uri, cell.index, metadata);
+        edit.replaceNotebookCellOutput(cell.notebook.uri, cell.index, []);
     });
-    await updateCellExecutionTimes(editor, cell);
+    await updateCellExecutionTimes(cell);
 }
 
 export function traceCellMessage(cell: NotebookCell, message: string) {
@@ -391,7 +386,6 @@ export function traceCellMessage(cell: NotebookCell, message: string) {
  * Stored as ISO for portability.
  */
 export async function updateCellExecutionTimes(
-    editor: NotebookEditor,
     cell: NotebookCell,
     times?: { startTime?: number; lastRunDuration?: number }
 ) {
@@ -399,10 +393,10 @@ export async function updateCellExecutionTimes(
         return;
     }
     const lastRunDuration = times.lastRunDuration ?? cell.metadata.lastRunDuration;
-    await chainWithPendingUpdates(editor.document, (edit) => {
+    await chainWithPendingUpdates(cell.notebook, (edit) => {
         traceCellMessage(cell, 'Update run duration');
         const metadata = cell.metadata.with({ lastRunDuration });
-        edit.replaceNotebookCellMetadata(editor.document.uri, cell.index, metadata);
+        edit.replaceNotebookCellMetadata(cell.notebook.uri, cell.index, metadata);
     });
 }
 
@@ -628,7 +622,7 @@ export function translateCellErrorOutput(output: NotebookCellOutput): nbformat.I
     };
 }
 
-function translateCellDisplayOutput(output: NotebookCellOutput): JupyterOutput {
+export function translateCellDisplayOutput(output: NotebookCellOutput): JupyterOutput {
     const customMetadata = output.metadata as CellOutputMetadata | undefined;
     let result: JupyterOutput;
     // Possible some other extension added some output (do best effort to translate & save in ipynb).

--- a/src/client/datascience/notebook/kernelWithMetadata.ts
+++ b/src/client/datascience/notebook/kernelWithMetadata.ts
@@ -41,7 +41,7 @@ export class VSCodeNotebookKernelMetadata implements VSCNotebookKernel {
         private readonly commandManager: ICommandManager
     ) {}
     public executeCell(doc: NotebookDocument, cell: NotebookCell) {
-        traceInfo(`Execute Cell ${cell.index} ${cell.document.uri.toString()} in kernelWithMetadata.ts`);
+        traceInfo(`Execute Cell ${cell.index} ${cell.notebook.uri.toString()} in kernelWithMetadata.ts`);
         const kernel = this.kernelProvider.getOrCreate(cell.notebook.uri, { metadata: this.selection });
         if (kernel) {
             this.updateKernelInfoInNotebookWhenAvailable(kernel, doc);

--- a/src/test/datascience/notebook/interrupRestart.vscode.test.ts
+++ b/src/test/datascience/notebook/interrupRestart.vscode.test.ts
@@ -14,6 +14,7 @@ import { DataScience } from '../../../client/common/utils/localize';
 import { noop } from '../../../client/common/utils/misc';
 import { Commands } from '../../../client/datascience/constants';
 import { IKernelProvider } from '../../../client/datascience/jupyter/kernels/types';
+import { traceCellMessage } from '../../../client/datascience/notebook/helpers/helpers';
 import { INotebookEditorProvider } from '../../../client/datascience/types';
 import { createEventHandler, getOSType, IExtensionTestApi, OSType, waitForCondition } from '../../common';
 import { IS_REMOTE_NATIVE_TEST } from '../../constants';
@@ -173,7 +174,7 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
 
         await waitForCondition(
             async () => {
-                traceInfo(`Step 8 Cell Status = ${cell.metadata.runState}`);
+                traceCellMessage(cell, 'Step 8 Cell Status');
                 return assertVSCCellIsNotRunning(cell);
             },
             15_000,


### PR DESCRIPTION
1. Ensure we support scenarios where cell is deleted while its being executed. We don't handle it well,

2.The NotebookEditor is not required anymore, we used this in the past as this was used to perform all Edit operations.
Then VSCode added Workspace Edits  and we stopped using Notebook Editor.
Basically cleaning up code we dont need, the goal is to not rely on Notbeook Editor if we don't need it (its an unnecessary dependency in the code base).

Also allows VS Code to make changes to Notebook editor without breaking us when they change proposed API.