### PR TITLE
Fix display of non-numeric DataFrame index columns

### DIFF
--- a/news/2 Fixes/5253.md
+++ b/news/2 Fixes/5253.md
@@ -1,0 +1,1 @@
+Fix data viewer display of non-numeric index columns in DataFrames.

--- a/pythonFiles/vscode_datascience_helpers/dataframes/vscodeDataFrame.py
+++ b/pythonFiles/vscode_datascience_helpers/dataframes/vscodeDataFrame.py
@@ -170,6 +170,17 @@ def _VSCODE_getDataFrameInfo(df):
 
     columnTypes = _VSCODE_builtins.list(df.dtypes)
 
+    # Compute the index column. It may have been renamed
+    try:
+        indexColumn = df.index.name if df.index.name else "index"
+    except AttributeError:
+        indexColumn = "index"
+
+    # Make sure the index column exists
+    if indexColumn not in columnNames:
+        columnNames.insert(0, indexColumn)
+        columnTypes.insert(0, "int64")
+
     # Then loop and generate our output json
     columns = []
     for n in _VSCODE_builtins.range(0, _VSCODE_builtins.len(columnNames)):
@@ -184,6 +195,7 @@ def _VSCODE_getDataFrameInfo(df):
     # Save this in our target
     target = {}
     target["columns"] = columns
+    target["indexColumn"] = indexColumn
     target["rowCount"] = rowCount
 
     # return our json object as a string

--- a/pythonFiles/vscode_datascience_helpers/getJupyterVariableDataFrameInfo.py
+++ b/pythonFiles/vscode_datascience_helpers/getJupyterVariableDataFrameInfo.py
@@ -78,7 +78,13 @@ else:
         _VSCODE_columnNames = list(_VSCODE_df)
 
     # Compute the index column. It may have been renamed
-    _VSCODE_indexColumn = _VSCODE_df.index.name if _VSCODE_df.index.name else "index"
+    try:
+        _VSCODE_indexColumn = (
+            _VSCODE_df.index.name if _VSCODE_df.index.name else "index"
+        )
+    except AttributeError:
+        _VSCODE_indexColumn = "index"
+
     _VSCODE_columnTypes = _VSCODE_builtins.list(_VSCODE_df.dtypes)
     del _VSCODE_df
 

--- a/src/datascience-ui/data-explorer/mainPanel.tsx
+++ b/src/datascience-ui/data-explorer/mainPanel.tsx
@@ -37,6 +37,7 @@ import { initializeIcons } from '@fluentui/react';
 initializeIcons(); // Register all FluentUI icons being used to prevent developer console errors
 
 const SliceableTypes: Set<string> = new Set<string>(['ndarray', 'Tensor', 'EagerTensor']);
+const RowNumberColumnName = 'No.';
 
 // Our css has to come after in order to override body styles
 export interface IMainPanelProps {
@@ -257,7 +258,7 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
             <ReactSlickGrid
                 ref={this.grid}
                 columns={this.state.gridColumns}
-                idProperty={this.state.indexColumn}
+                idProperty={RowNumberColumnName}
                 rowsAdded={this.gridAddEvent}
                 resetGridEvent={this.resetGridEvent}
                 columnsUpdated={this.gridColumnUpdateEvent}
@@ -368,7 +369,7 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
             gridRows: newActual
         });
 
-        // Tell our grid about the new ros
+        // Tell our grid about the new rows
         this.updateRows(normalized);
 
         // Get the next chunk
@@ -384,13 +385,13 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
     }
 
     private generateColumns(variable: IDataFrameInfo): Slick.Column<Slick.SlickData>[] {
-        // Generate an index column
-        const indexColumn = {
-            key: this.state.indexColumn,
-            type: ColumnType.Number
-        };
         if (variable.columns) {
-            const columns = [indexColumn].concat(variable.columns);
+            // Generate a column for row numbers
+            const rowNumberColumn = {
+                key: RowNumberColumnName,
+                type: ColumnType.Number
+            };
+            const columns = [rowNumberColumn].concat(variable.columns);
             return columns.map((c: { key: string; type: ColumnType }, i: number) => {
                 return {
                     type: c.type,
@@ -416,7 +417,7 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
             if (!r) {
                 r = {};
             }
-            r[this.state.indexColumn] = this.state.fetchedRowCount + idx;
+            r[RowNumberColumnName] = this.state.fetchedRowCount + idx;
             for (let [key, value] of Object.entries(r)) {
                 switch (value) {
                     case 'nan':

--- a/src/datascience-ui/data-explorer/mainPanel.tsx
+++ b/src/datascience-ui/data-explorer/mainPanel.tsx
@@ -392,20 +392,27 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
                 type: ColumnType.Number
             };
             const columns = [rowNumberColumn].concat(variable.columns);
-            return columns.reduce((accum: Slick.Column<Slick.SlickData>[], c: { key: string; type: ColumnType }, i: number) => {
-                // Only show index column for pandas DataFrame and Series
-                if ((variable?.type === 'DataFrame' || variable?.type === 'Series' || c.key !== this.state.indexColumn)) {
-                    accum.push({
-                        type: c.type,
-                        field: c.key.toString(),
-                        id: `${i}`,
-                        name: c.key.toString(),
-                        sortable: true,
-                        formatter: cellFormatterFunc
-                    } as Slick.Column<Slick.SlickData>);
-                }
-                return accum;
-            }, []);
+            return columns.reduce(
+                (accum: Slick.Column<Slick.SlickData>[], c: { key: string; type: ColumnType }, i: number) => {
+                    // Only show index column for pandas DataFrame and Series
+                    if (
+                        variable?.type === 'DataFrame' ||
+                        variable?.type === 'Series' ||
+                        c.key !== this.state.indexColumn
+                    ) {
+                        accum.push({
+                            type: c.type,
+                            field: c.key.toString(),
+                            id: `${i}`,
+                            name: c.key.toString(),
+                            sortable: true,
+                            formatter: cellFormatterFunc
+                        } as Slick.Column<Slick.SlickData>);
+                    }
+                    return accum;
+                },
+                []
+            );
         }
         return [];
     }

--- a/src/datascience-ui/data-explorer/mainPanel.tsx
+++ b/src/datascience-ui/data-explorer/mainPanel.tsx
@@ -392,16 +392,20 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
                 type: ColumnType.Number
             };
             const columns = [rowNumberColumn].concat(variable.columns);
-            return columns.map((c: { key: string; type: ColumnType }, i: number) => {
-                return {
-                    type: c.type,
-                    field: c.key.toString(),
-                    id: `${i}`,
-                    name: c.key.toString(),
-                    sortable: true,
-                    formatter: cellFormatterFunc
-                };
-            });
+            return columns.reduce((accum: Slick.Column<Slick.SlickData>[], c: { key: string; type: ColumnType }, i: number) => {
+                // Only show index column for pandas DataFrame and Series
+                if ((variable?.type === 'DataFrame' || variable?.type === 'Series' || c.key !== this.state.indexColumn)) {
+                    accum.push({
+                        type: c.type,
+                        field: c.key.toString(),
+                        id: `${i}`,
+                        name: c.key.toString(),
+                        sortable: true,
+                        formatter: cellFormatterFunc
+                    } as Slick.Column<Slick.SlickData>);
+                }
+                return accum;
+            }, []);
         }
         return [];
     }

--- a/src/datascience-ui/data-explorer/mainPanel.tsx
+++ b/src/datascience-ui/data-explorer/mainPanel.tsx
@@ -32,12 +32,13 @@ import '../react-common/codicon/codicon.css';
 import '../react-common/seti/seti.less';
 import { SliceControl } from './sliceControl';
 import { debounce } from 'lodash';
+import * as uuid from 'uuid/v4';
 
 import { initializeIcons } from '@fluentui/react';
 initializeIcons(); // Register all FluentUI icons being used to prevent developer console errors
 
 const SliceableTypes: Set<string> = new Set<string>(['ndarray', 'Tensor', 'EagerTensor']);
-const RowNumberColumnName = 'No.';
+const RowNumberColumnName = uuid(); // Unique key for our column containing row numbers
 
 // Our css has to come after in order to override body styles
 export interface IMainPanelProps {

--- a/src/datascience-ui/data-explorer/reactSlickGrid.tsx
+++ b/src/datascience-ui/data-explorer/reactSlickGrid.tsx
@@ -520,7 +520,6 @@ export class ReactSlickGrid extends React.Component<ISlickGridProps, ISlickGridS
         this.dataView.setItems([]);
         const styledColumns = this.styleColumns(data.columns);
         this.setColumns(styledColumns);
-        this.autoResizeColumns();
     };
 
     private updateColumns = (_e: Slick.EventData, newColumns: Slick.Column<Slick.SlickData>[]) => {
@@ -535,6 +534,7 @@ export class ReactSlickGrid extends React.Component<ISlickGridProps, ISlickGridS
         // The solution is to force the header row to become visible just before sending our slice request.
         this.state.grid?.setHeaderRowVisibility(true);
         this.state.grid?.setColumns(newColumns);
+        this.autoResizeColumns();
     };
 
     private addedRows = (_e: Slick.EventData, data: ISlickGridAdd) => {

--- a/src/datascience-ui/data-explorer/reactSlickGrid.tsx
+++ b/src/datascience-ui/data-explorer/reactSlickGrid.tsx
@@ -473,7 +473,7 @@ export class ReactSlickGrid extends React.Component<ISlickGridProps, ISlickGridS
             const placeholder = '99999999999';
             const maxFieldWidth = measureText(placeholder, fontString);
             columns.forEach((c) => {
-                if (c.id !== '0') {
+                if (c.field !== this.props.idProperty) {
                     c.width = maxFieldWidth;
                 } else {
                     c.width = maxFieldWidth / 2;
@@ -573,7 +573,7 @@ export class ReactSlickGrid extends React.Component<ISlickGridProps, ISlickGridS
     }
 
     private renderFilterCell = (_e: Slick.EventData, args: Slick.OnHeaderRowCellRenderedEventArgs<Slick.SlickData>) => {
-        if (args.column.id === '0') {
+        if (args.column.field === this.props.idProperty) {
             const tooltipText = getLocString('DataScience.clearFilters', 'Clear all filters');
             ReactDOM.render(
                 <div

--- a/src/test/datascience/dataviewer.functional.test.tsx
+++ b/src/test/datascience/dataviewer.functional.test.tsx
@@ -284,7 +284,17 @@ suite('DataScience DataViewer tests', () => {
         assert.ok(dv, 'DataViewer not created');
         await gotAllRows;
 
-        verifyRows(wrapper.wrapper, [0, 0, 1, 1, 2, 2, 3, 3]);
+        verifyRows(wrapper.wrapper, [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3]);
+    });
+
+    runMountedTest('Transposed Data Frame', async (wrapper) => {
+        await injectCode('import pandas as pd\r\ndata = [["tom", 10], ["nick", 15], ["juli", 14]]\r\ndf = pd.DataFrame(data, columns=["Name", "Age"])\r\ndf = df.transpose()');
+        const gotAllRows = getCompletedPromise(wrapper);
+        const dv = await createJupyterVariableDataViewer('df', 'DataFrame');
+        assert.ok(dv, 'DataViewer not created');
+        await gotAllRows;
+
+        verifyRows(wrapper.wrapper, [0, "Name", "tom", "nick", "juli", 1, "Age", "10", "15", "14"]);
     });
 
     runMountedTest('List', async (wrapper) => {
@@ -304,7 +314,7 @@ suite('DataScience DataViewer tests', () => {
         assert.ok(dv, 'DataViewer not created');
         await gotAllRows;
 
-        verifyRows(wrapper.wrapper, [0, 0, 1, 1, 2, 2, 3, 3]);
+        verifyRows(wrapper.wrapper, [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3]);
     });
 
     runMountedTest('np.array', async (wrapper) => {

--- a/src/test/datascience/dataviewer.functional.test.tsx
+++ b/src/test/datascience/dataviewer.functional.test.tsx
@@ -288,13 +288,15 @@ suite('DataScience DataViewer tests', () => {
     });
 
     runMountedTest('Transposed Data Frame', async (wrapper) => {
-        await injectCode('import pandas as pd\r\ndata = [["tom", 10], ["nick", 15], ["juli", 14]]\r\ndf = pd.DataFrame(data, columns=["Name", "Age"])\r\ndf = df.transpose()');
+        await injectCode(
+            'import pandas as pd\r\ndata = [["tom", 10], ["nick", 15], ["juli", 14]]\r\ndf = pd.DataFrame(data, columns=["Name", "Age"])\r\ndf = df.transpose()'
+        );
         const gotAllRows = getCompletedPromise(wrapper);
         const dv = await createJupyterVariableDataViewer('df', 'DataFrame');
         assert.ok(dv, 'DataViewer not created');
         await gotAllRows;
 
-        verifyRows(wrapper.wrapper, [0, "Name", "tom", "nick", "juli", 1, "Age", "10", "15", "14"]);
+        verifyRows(wrapper.wrapper, [0, 'Name', 'tom', 'nick', 'juli', 1, 'Age', '10', '15', '14']);
     });
 
     runMountedTest('List', async (wrapper) => {


### PR DESCRIPTION
For #5253 

The change here is to show the index column in addition to the row number column only for pandas DataFrames and Series objects, because index columns are meaningful for DFs and Series but for ndarrays, lists, dicts and tensors the index column is generated by us as part of the DataFrame conversion code and is hence not meaningful to the user.

DataFrame:
![image](https://user-images.githubusercontent.com/30305945/112345077-f7250380-8c81-11eb-80a6-3045a5d1879b.png)

Same data as an ndarray (note that there isn't actually an index column being generated on the ndarray itself):
![image](https://user-images.githubusercontent.com/30305945/112345339-2e93b000-8c82-11eb-9c7a-979694641ba6.png)


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
