### PR TITLE
Avoid calling `reveal` if a webview is already active or visible

### DIFF
--- a/src/client/common/application/webviewPanels/webviewPanel.ts
+++ b/src/client/common/application/webviewPanels/webviewPanel.ts
@@ -29,8 +29,18 @@ export class WebviewPanel extends Webview implements IWebviewPanel {
 
     public async show(preserveFocus: boolean) {
         await this.loadPromise;
-        if (this.panel) {
-            this.panel.reveal(this.panel.viewColumn, preserveFocus);
+        if (!this.panel) {
+            return;
+        }
+
+        if (preserveFocus) {
+            if (!this.panel.visible) {
+                this.panel.reveal(this.panel.viewColumn, preserveFocus);
+            }
+        } else {
+            if (!this.panel.active) {
+                this.panel.reveal(this.panel.viewColumn, preserveFocus);
+            }
         }
     }
 


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/118764

This prevents a duplicate editor from being opened when `show` is called on a webview that is part of a diff view 

I gave this a quick test but don't know all potential custom editor base notebook scenarios so it will need more testing from the folks that work on this extension