### PR TITLE
Fix problems found while debugging synapse connections

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -909,7 +909,6 @@ module.exports = {
         'src/client/datascience/jupyter/interpreter/jupyterInterpreterOldCacheStateStore.ts',
         'src/client/datascience/jupyter/interpreter/jupyterInterpreterSelector.ts',
         'src/client/datascience/jupyter/interpreter/jupyterInterpreterService.ts',
-        'src/client/datascience/jupyter/jupyterRequest.ts',
         'src/client/datascience/jupyter/commandLineSelector.ts',
         'src/client/datascience/jupyter/jupyterDebugger.ts',
         'src/client/datascience/jupyter/liveshare/roleBasedFactory.ts',

--- a/src/client/datascience/jupyter/jupyterRequest.ts
+++ b/src/client/datascience/jupyter/jupyterRequest.ts
@@ -15,7 +15,7 @@ export function createAuthorizingRequest(getAuthHeader: () => any) {
             const authorizationHeader = getAuthHeader();
             const keys = Object.keys(authorizationHeader);
             keys.forEach((k) => origHeaders.append(k, authorizationHeader[k].toString()));
-            origHeaders.append('Content-Type', 'application/json');
+            origHeaders.set('Content-Type', 'application/json');
 
             // Rewrite the 'append' method for the headers to disallow 'authorization' after this point
             const origAppend = origHeaders.append.bind(origHeaders);

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -244,11 +244,12 @@ export class JupyterSession extends BaseJupyterSession {
         }
 
         // Create our session options using this temporary notebook and our connection info
-        const options: Session.IOptions = {
-            path: backingFile?.path || '.',
-            kernelName: getNameOfKernelConnection(kernelConnection) || '',
+        const options: Session.IOptions = { 
+            path: backingFile?.path || `${uuid()}.ipynb`, // Name has to be unique
+            kernelName: getNameOfKernelConnection(kernelConnection) || '', // TODO: This can't be empty. See https://github.com/microsoft/vscode-jupyter/issues/5290
             name: uuid(), // This is crucial to distinguish this session from any other.
-            serverSettings: serverSettings
+            serverSettings: serverSettings,
+            type: 'notebook'
         };
 
         traceInfo(`Starting a new session for kernel id = ${kernelConnection?.id}, name = ${options.kernelName}`);

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -244,7 +244,7 @@ export class JupyterSession extends BaseJupyterSession {
         }
 
         // Create our session options using this temporary notebook and our connection info
-        const options: Session.IOptions = { 
+        const options: Session.IOptions = {
             path: backingFile?.path || `${uuid()}.ipynb`, // Name has to be unique
             kernelName: getNameOfKernelConnection(kernelConnection) || '', // TODO: This can't be empty. See https://github.com/microsoft/vscode-jupyter/issues/5290
             name: uuid(), // This is crucial to distinguish this session from any other.


### PR DESCRIPTION
While debugging the connection to synapse last night there were some settings we had that Synapse wasn't allowing. Jupyter seems to be more flexible in this regard, but this tightening doesn't hurt (I tested with Azure ML and it still works).

