### PR TITLE
Move isUri check higher

### DIFF
--- a/src/client/datascience/commands/commandRegistry.ts
+++ b/src/client/datascience/commands/commandRegistry.ts
@@ -306,7 +306,7 @@ export class CommandRegistry implements IDisposable {
         if (activeCodeWatcher) {
             return activeCodeWatcher.runSelectionOrLine(
                 this.documentManager.activeTextEditor,
-                // If this is a URI, the runSelectionOrLine is not expected that, so act like nothing was sent.
+                // If this is a URI, the runSelectionOrLine is not expecting a URI, so act like nothing was sent.
                 isUri(textOrUri) ? undefined : textOrUri
             );
         } else {

--- a/src/client/datascience/commands/commandRegistry.ts
+++ b/src/client/datascience/commands/commandRegistry.ts
@@ -14,7 +14,7 @@ import { IFileSystem } from '../../common/platform/types';
 
 import { IConfigurationService, IDisposable, IOutputChannel } from '../../common/types';
 import { DataScience } from '../../common/utils/localize';
-import { noop } from '../../common/utils/misc';
+import { isUri, noop } from '../../common/utils/misc';
 import { LogLevel } from '../../logging/levels';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
@@ -81,9 +81,9 @@ export class CommandRegistry implements IDisposable {
         this.registerCommand(Commands.RunCell, this.runCell);
         this.registerCommand(Commands.RunCurrentCell, this.runCurrentCell);
         this.registerCommand(Commands.RunCurrentCellAdvance, this.runCurrentCellAndAdvance);
-        this.registerCommand(Commands.ExecSelectionInInteractiveWindow, (text: string | undefined) =>
-            this.runSelectionOrLine(text)
-        );
+        this.registerCommand(Commands.ExecSelectionInInteractiveWindow, (textOrUri: string | undefined | Uri) => {
+            void this.runSelectionOrLine(textOrUri);
+        });
         this.registerCommand(Commands.RunAllCellsAbove, this.runAllCellsAbove);
         this.registerCommand(Commands.RunCellAndAllBelow, this.runCellAndAllBelow);
         this.registerCommand(Commands.InsertCellBelowPosition, this.insertCellBelowPosition);
@@ -301,10 +301,14 @@ export class CommandRegistry implements IDisposable {
         }
     }
 
-    private async runSelectionOrLine(text: string | undefined): Promise<void> {
+    private async runSelectionOrLine(textOrUri: string | undefined | Uri): Promise<void> {
         const activeCodeWatcher = this.getCurrentCodeWatcher();
         if (activeCodeWatcher) {
-            return activeCodeWatcher.runSelectionOrLine(this.documentManager.activeTextEditor, text);
+            return activeCodeWatcher.runSelectionOrLine(
+                this.documentManager.activeTextEditor,
+                // If this is a URI, the runSelectionOrLine is not expected that, so act like nothing was sent.
+                isUri(textOrUri) ? undefined : textOrUri
+            );
         } else {
             return;
         }

--- a/src/client/datascience/editor-integration/codewatcher.ts
+++ b/src/client/datascience/editor-integration/codewatcher.ts
@@ -22,7 +22,6 @@ import { IFileSystem } from '../../common/platform/types';
 
 import { IConfigurationService, IDisposable, IJupyterSettings, Resource } from '../../common/types';
 import * as localize from '../../common/utils/localize';
-import { isUri } from '../../common/utils/misc';
 import { StopWatch } from '../../common/utils/stopWatch';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { ICodeExecutionHelper } from '../../terminals/types';
@@ -248,10 +247,10 @@ export class CodeWatcher implements ICodeWatcher {
     }
 
     @captureTelemetry(Telemetry.RunSelectionOrLine)
-    public async runSelectionOrLine(activeEditor: TextEditor | undefined, text?: string | Uri) {
+    public async runSelectionOrLine(activeEditor: TextEditor | undefined, text?: string) {
         if (this.document && activeEditor && this.fs.arePathsSame(activeEditor.document.uri, this.document.uri)) {
             let codeToExecute: string | undefined;
-            if (text === undefined || isUri(text)) {
+            if (text === undefined) {
                 // Get just the text of the selection or the current line if none
                 codeToExecute = await this.executionHelper.getSelectedTextToExecute(activeEditor);
             } else {


### PR DESCRIPTION
Slightly different design. Only the command system has the issue where it passes the first argument as the active editor.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
