### PR TITLE
Logging for kernel shutdown when closing Notebooks

### DIFF
--- a/src/client/common/application/notebook.ts
+++ b/src/client/common/application/notebook.ts
@@ -19,6 +19,7 @@ import {
     window
 } from 'vscode';
 import { UseVSCodeNotebookEditorApi } from '../constants';
+import { traceError } from '../logger';
 import { IDisposableRegistry } from '../types';
 import { IApplicationEnvironment, IVSCodeNotebook, NotebookCellChangedEvent } from './types';
 
@@ -70,6 +71,7 @@ export class VSCodeNotebook implements IVSCodeNotebook {
             this.onDidSaveNotebookDocument = notebook.onDidSaveNotebookDocument;
             this.onDidChangeNotebookDocument = this._onDidChangeNotebookDocument.event;
         } else {
+            traceError('Not using Notebooks');
             this.onDidChangeActiveNotebookKernel = this.createDisposableEventEmitter<{
                 document: NotebookDocument;
                 kernel: NotebookKernel | undefined;

--- a/src/client/common/application/notebook.ts
+++ b/src/client/common/application/notebook.ts
@@ -19,7 +19,6 @@ import {
     window
 } from 'vscode';
 import { UseVSCodeNotebookEditorApi } from '../constants';
-import { traceError } from '../logger';
 import { IDisposableRegistry } from '../types';
 import { IApplicationEnvironment, IVSCodeNotebook, NotebookCellChangedEvent } from './types';
 
@@ -71,7 +70,6 @@ export class VSCodeNotebook implements IVSCodeNotebook {
             this.onDidSaveNotebookDocument = notebook.onDidSaveNotebookDocument;
             this.onDidChangeNotebookDocument = this._onDidChangeNotebookDocument.event;
         } else {
-            traceError('Not using Notebooks');
             this.onDidChangeActiveNotebookKernel = this.createDisposableEventEmitter<{
                 document: NotebookDocument;
                 kernel: NotebookKernel | undefined;

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -125,6 +125,7 @@ export class Kernel implements IKernel {
         return this.kernelExecution.interrupt(document, this._notebookPromise);
     }
     public async dispose(): Promise<void> {
+        traceInfo(`Dispose kernel ${this.uri.toString()}`);
         this.restarting = undefined;
         this._notebookPromise = undefined;
         if (this.notebook) {
@@ -263,6 +264,7 @@ export class Kernel implements IKernel {
             this.hookedNotebookForEvents.add(this.notebook);
             this.notebook.kernelSocket.subscribe(this._kernelSocket);
             this.notebook.onDisposed(() => {
+                traceInfo(`Kernel got disposed as a result of notebook.onDisposed ${this.uri.toString()}`);
                 this._notebookPromise = undefined;
                 this._onDisposed.fire();
             });

--- a/src/client/datascience/notebook/kernelWithMetadata.ts
+++ b/src/client/datascience/notebook/kernelWithMetadata.ts
@@ -68,7 +68,7 @@ export class VSCodeNotebookKernelMetadata implements VSCNotebookKernel {
                 cell.kind === NotebookCellKind.Code &&
                 ranges.some((range) => range.start <= cell.index && cell.index < range.end)
         );
-
+        traceInfo(`Execute Cells request ${cells.length} ${cells.map((cell) => cell.index).join(', ')}`);
         await cells.map((cell) => this.executeCell(document, cell));
     }
 

--- a/src/client/datascience/notebook/notebookDisposeService.ts
+++ b/src/client/datascience/notebook/notebookDisposeService.ts
@@ -31,6 +31,7 @@ export class NotebookDisposeService implements IExtensionSingleActivationService
         this.vscNotebook.onDidCloseNotebookDocument(this.onDidCloseNotebookDocument, this, this.disposables);
     }
     private onDidCloseNotebookDocument(document: NotebookDocument) {
+        traceInfo(`Notebook Closed ${document.uri.toString()}`);
         const kernel = this.kernelProvider.get(document.uri);
         if (kernel) {
             traceInfo(

--- a/src/client/datascience/notebook/notebookDisposeService.ts
+++ b/src/client/datascience/notebook/notebookDisposeService.ts
@@ -8,6 +8,7 @@ import { NotebookDocument } from 'vscode';
 import { IExtensionSingleActivationService } from '../../activation/types';
 import { IVSCodeNotebook } from '../../common/application/types';
 import { UseVSCodeNotebookEditorApi } from '../../common/constants';
+import { traceInfo } from '../../common/logger';
 import { IDisposableRegistry } from '../../common/types';
 import { noop } from '../../common/utils/misc';
 import { IKernelProvider } from '../jupyter/kernels/types';
@@ -32,6 +33,10 @@ export class NotebookDisposeService implements IExtensionSingleActivationService
     private onDidCloseNotebookDocument(document: NotebookDocument) {
         const kernel = this.kernelProvider.get(document.uri);
         if (kernel) {
+            traceInfo(
+                `Kernel got disposed as a result of closing the notebook ${document.uri.toString()}`,
+                kernel.uri.toString()
+            );
             kernel.dispose().catch(noop);
         }
         this.notebookProvider.disposeAssociatedNotebook({ identity: document.uri });

--- a/src/client/datascience/notebook/notebookDisposeService.ts
+++ b/src/client/datascience/notebook/notebookDisposeService.ts
@@ -4,8 +4,7 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { NotebookDocument } from 'vscode';
-import { notebook } from '../../../../types/vscode-proposed';
+import { notebook, NotebookDocument } from 'vscode';
 import { IExtensionSingleActivationService } from '../../activation/types';
 import { IVSCodeNotebook } from '../../common/application/types';
 import { UseVSCodeNotebookEditorApi } from '../../common/constants';

--- a/src/client/datascience/notebook/notebookDisposeService.ts
+++ b/src/client/datascience/notebook/notebookDisposeService.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { notebook, NotebookDocument } from 'vscode';
+import { NotebookDocument } from 'vscode';
 import { IExtensionSingleActivationService } from '../../activation/types';
 import { IVSCodeNotebook } from '../../common/application/types';
 import { UseVSCodeNotebookEditorApi } from '../../common/constants';
@@ -28,23 +28,10 @@ export class NotebookDisposeService implements IExtensionSingleActivationService
             return;
         }
 
-        notebook.onDidCloseNotebookDocument(this.onDidCloseNotebookDocument2, this, this.disposables);
         this.vscNotebook.onDidCloseNotebookDocument(this.onDidCloseNotebookDocument, this, this.disposables);
     }
     private onDidCloseNotebookDocument(document: NotebookDocument) {
         traceInfo(`Notebook Closed ${document.uri.toString()}`);
-        const kernel = this.kernelProvider.get(document.uri);
-        if (kernel) {
-            traceInfo(
-                `Kernel got disposed as a result of closing the notebook ${document.uri.toString()}`,
-                kernel.uri.toString()
-            );
-            kernel.dispose().catch(noop);
-        }
-        this.notebookProvider.disposeAssociatedNotebook({ identity: document.uri });
-    }
-    private onDidCloseNotebookDocument2(document: NotebookDocument) {
-        traceInfo(`Notebook Closed2 ${document.uri.toString()}`);
         const kernel = this.kernelProvider.get(document.uri);
         if (kernel) {
             traceInfo(


### PR DESCRIPTION
Added logging to detect when a kernel is shutdown & when a notebook is closed.
After adding this logging, things are now magically working.
Lets leave this in here, if this crops up again we'll be able to tell whether our events get fired or not.