### PR TITLE
Adds ability for users to disable candy cursh

### DIFF
--- a/news/1 Enhancements/5387.md
+++ b/news/1 Enhancements/5387.md
@@ -1,0 +1,2 @@
+Adds config option `"jupyter.disableCandyCursh": true` so that users can disable menu contributions.
+ 

--- a/package.json
+++ b/package.json
@@ -735,52 +735,52 @@
         "menus": {
             "editor/context": [
                 {
-                    "when": "editorFocus && editorLangId == python && jupyter.hascodecells && !notebookEditorFocused",
+                    "when": "editorFocus && editorLangId == python && jupyter.hascodecells && !notebookEditorFocused && !config.jupyter.disableCandyCursh",
                     "command": "jupyter.runallcells",
                     "group": "Jupyter2"
                 },
                 {
-                    "when": "editorFocus && editorLangId == python && jupyter.hascodecells && !notebookEditorFocused",
+                    "when": "editorFocus && editorLangId == python && jupyter.hascodecells && !notebookEditorFocused && !config.jupyter.disableCandyCursh",
                     "command": "jupyter.runcurrentcell",
                     "group": "Jupyter2"
                 },
                 {
-                    "when": "editorFocus && editorLangId == python && jupyter.hascodecells && !notebookEditorFocused",
+                    "when": "editorFocus && editorLangId == python && jupyter.hascodecells && !notebookEditorFocused && !config.jupyter.disableCandyCursh",
                     "command": "jupyter.runcurrentcelladvance",
                     "group": "Jupyter2"
                 },
                 {
                     "command": "jupyter.runFileInteractive",
                     "group": "Jupyter2",
-                    "when": "editorFocus && editorLangId == python && !notebookEditorFocused"
+                    "when": "editorFocus && editorLangId == python && !notebookEditorFocused && !config.jupyter.disableCandyCursh"
                 },
                 {
                     "command": "jupyter.runfromline",
                     "group": "Jupyter2",
-                    "when": "editorFocus && editorLangId == python && !notebookEditorFocused"
+                    "when": "editorFocus && editorLangId == python && !notebookEditorFocused && !config.jupyter.disableCandyCursh"
                 },
                 {
                     "command": "jupyter.runtoline",
                     "group": "Jupyter2",
-                    "when": "editorFocus && editorLangId == python && !notebookEditorFocused"
+                    "when": "editorFocus && editorLangId == python && !notebookEditorFocused && !config.jupyter.disableCandyCursh"
                 },
                 {
                     "command": "jupyter.execSelectionInteractive",
                     "group": "Jupyter2",
-                    "when": "editorFocus && editorLangId == python && !notebookEditorFocused"
+                    "when": "editorFocus && editorLangId == python && !notebookEditorFocused && !config.jupyter.disableCandyCursh"
                 },
                 {
-                    "when": "editorFocus && editorLangId == python && resourceLangId == jupyter && !notebookEditorFocused",
+                    "when": "editorFocus && editorLangId == python && resourceLangId == jupyter && !notebookEditorFocused && !config.jupyter.disableCandyCursh",
                     "command": "jupyter.importnotebook",
                     "group": "Jupyter3@1"
                 },
                 {
-                    "when": "editorFocus && editorLangId == python && jupyter.hascodecells && !notebookEditorFocused",
+                    "when": "editorFocus && editorLangId == python && jupyter.hascodecells && !notebookEditorFocused && !config.jupyter.disableCandyCursh",
                     "command": "jupyter.exportfileasnotebook",
                     "group": "Jupyter3@2"
                 },
                 {
-                    "when": "editorFocus && editorLangId == python && jupyter.hascodecells && !notebookEditorFocused",
+                    "when": "editorFocus && editorLangId == python && jupyter.hascodecells && !notebookEditorFocused && !config.jupyter.disableCandyCursh",
                     "command": "jupyter.exportfileandoutputasnotebook",
                     "group": "Jupyter3@3"
                 }
@@ -839,22 +839,22 @@
             ],
             "explorer/context": [
                 {
-                    "when": "resourceLangId == python && !notebookEditorFocused",
+                    "when": "resourceLangId == python && !notebookEditorFocused && !config.jupyter.disableCandyCursh",
                     "command": "jupyter.runFileInteractive",
                     "group": "Jupyter2"
                 },
                 {
-                    "when": "resourceLangId == jupyter",
+                    "when": "resourceLangId == jupyter && !config.jupyter.disableCandyCursh",
                     "command": "jupyter.opennotebook",
                     "group": "Jupyter"
                 },
                 {
-                    "when": "resourceLangId == jupyter && jupyter.vscode.channel == 'insiders' && jupyter.opennotebookInPreviewEditor.enabled",
+                    "when": "resourceLangId == jupyter && jupyter.vscode.channel == 'insiders' && jupyter.opennotebookInPreviewEditor.enabled && !config.jupyter.disableCandyCursh",
                     "command": "jupyter.opennotebookInPreviewEditor",
                     "group": "Jupyter"
                 },
                 {
-                    "when": "resourceLangId == jupyter",
+                    "when": "resourceLangId == jupyter && !config.jupyter.disableCandyCursh",
                     "command": "jupyter.importnotebookfile",
                     "group": "Jupyter"
                 }
@@ -1732,6 +1732,11 @@
                     "default": false,
                     "markdownDescription": "Enabling this setting will automatically trust any opened notebook and therefore display markdown and render code cells. You will no longer be prompted to trust individual notebooks and harmful code could automatically run. \n\n[Learn more.](https://aka.ms/trusted-notebooks)",
                     "scope": "machine"
+                },
+                "jupyter.disableCandyCursh": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Setting to true will disable menus"
                 }
             }
         },


### PR DESCRIPTION
For #5387, and sorta #5056


Which was closed and locked without proper consideration. 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging~.
-   [x] ~Has telemetry for enhancements~.
-   [x] ~Unit tests & system/integration tests are added/updated~.
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate~.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
