### PR TITLE
Hide server status bar item for 3rd party kernels

### DIFF
--- a/news/1 Enhancements/5156.md
+++ b/news/1 Enhancements/5156.md
@@ -1,0 +1,1 @@
+Hide the Jupyter Server status bar item when a third party extension kernel is used.

--- a/src/client/datascience/notebook/remoteSwitcher.ts
+++ b/src/client/datascience/notebook/remoteSwitcher.ts
@@ -48,7 +48,11 @@ export class RemoteSwitcher implements IExtensionSingleActivationService {
         await this.serverSelector.selectJupyterURI(true, 'nativeNotebookToolbar');
     }
     private async updateStatusBar() {
-        if (!this.notebook.activeNotebookEditor || !isJupyterNotebook(this.notebook.activeNotebookEditor.document) || !isJupyterKernel(this.notebook.activeNotebookEditor.kernel)) {
+        if (
+            !this.notebook.activeNotebookEditor ||
+            !isJupyterNotebook(this.notebook.activeNotebookEditor.document) ||
+            !isJupyterKernel(this.notebook.activeNotebookEditor.kernel)
+        ) {
             this.statusBarItem.hide();
             return;
         }

--- a/src/client/datascience/notebook/remoteSwitcher.ts
+++ b/src/client/datascience/notebook/remoteSwitcher.ts
@@ -11,7 +11,7 @@ import { noop } from '../../common/utils/misc';
 import { Commands, Settings } from '../constants';
 import { JupyterServerSelector } from '../jupyter/serverSelector';
 import { IJupyterServerUriStorage } from '../types';
-import { isJupyterNotebook } from './helpers/helpers';
+import { isJupyterKernel, isJupyterNotebook } from './helpers/helpers';
 
 @injectable()
 export class RemoteSwitcher implements IExtensionSingleActivationService {
@@ -40,6 +40,7 @@ export class RemoteSwitcher implements IExtensionSingleActivationService {
         this.notebook.onDidChangeActiveNotebookEditor(this.updateStatusBar.bind(this), this.disposables);
         this.documentManager.onDidChangeActiveTextEditor(this.updateStatusBar.bind(this), this.disposables);
         this.serverUriStorage.onDidChangeUri(this.updateStatusBar.bind(this), this.disposables);
+        this.notebook.onDidChangeActiveNotebookKernel(this.updateStatusBar.bind(this), this.disposables);
         this.disposables.push(this.statusBarItem);
         this.updateStatusBar().catch(noop);
     }
@@ -47,7 +48,7 @@ export class RemoteSwitcher implements IExtensionSingleActivationService {
         await this.serverSelector.selectJupyterURI(true, 'nativeNotebookToolbar');
     }
     private async updateStatusBar() {
-        if (!this.notebook.activeNotebookEditor || !isJupyterNotebook(this.notebook.activeNotebookEditor.document)) {
+        if (!this.notebook.activeNotebookEditor || !isJupyterNotebook(this.notebook.activeNotebookEditor.document) || !isJupyterKernel(this.notebook.activeNotebookEditor.kernel)) {
             this.statusBarItem.hide();
             return;
         }


### PR DESCRIPTION
For #5156 

Tested with .NET Interactive kernels as I believe the VS Code Julia extension's kernel support is still under development. (The error messages in the GIF below are because I have a messed up .NET SDK install locally)

![thirdpartykernels](https://user-images.githubusercontent.com/30305945/113617098-d4dc9f80-960a-11eb-9709-32ef4b65ce31.gif)


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] ~Appropriate comments and documentation strings in the code.~
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.!
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
