### PR TITLE
Fix export to python script not appearing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -883,7 +883,6 @@ module.exports = {
         'src/client/datascience/editor-integration/codelensprovider.ts',
         'src/client/datascience/editor-integration/cellhashprovider.ts',
         'src/client/datascience/commands/commandLineSelector.ts',
-        'src/client/datascience/commands/exportCommands.ts',
         'src/client/datascience/cellFactory.ts',
         'src/client/datascience/notebook/notebookEditorCompatibilitySupport.ts',
         'src/client/datascience/notebook/constants.ts',

--- a/news/2 Fixes/5403.md
+++ b/news/2 Fixes/5403.md
@@ -1,0 +1,1 @@
+Fix for 'Export as Python Script' option not appearing.

--- a/src/client/datascience/commands/exportCommands.ts
+++ b/src/client/datascience/commands/exportCommands.ts
@@ -3,7 +3,6 @@
 
 'use strict';
 
-import { nbformat } from '@jupyterlab/coreutils';
 import { inject, injectable } from 'inversify';
 import { QuickPickItem, QuickPickOptions, Uri } from 'vscode';
 import { getLocString } from '../../../datascience-ui/react-common/locReactSide';
@@ -17,7 +16,6 @@ import { sendTelemetryEvent } from '../../telemetry';
 import { Commands, Telemetry } from '../constants';
 import { ExportManager } from '../export/exportManager';
 import { ExportFormat, IExportManager } from '../export/types';
-import { isPythonNotebook } from '../notebook/helpers/helpers';
 import { INotebookEditorProvider } from '../types';
 
 interface IExportQuickPickItem extends QuickPickItem {
@@ -125,9 +123,8 @@ export class ExportCommands implements IDisposable {
         interpreter?: PythonEnvironment
     ): IExportQuickPickItem[] {
         const items: IExportQuickPickItem[] = [];
-        const notebook = JSON.parse(contents) as nbformat.INotebookContent;
 
-        if (notebook.metadata && isPythonNotebook(notebook.metadata)) {
+        if (interpreter) {
             items.push({
                 label: DataScience.exportPythonQuickPickLabel(),
                 picked: true,

--- a/src/client/datascience/commands/exportCommands.ts
+++ b/src/client/datascience/commands/exportCommands.ts
@@ -3,6 +3,7 @@
 
 'use strict';
 
+import { nbformat } from '@jupyterlab/coreutils';
 import { inject, injectable } from 'inversify';
 import { QuickPickItem, QuickPickOptions, Uri } from 'vscode';
 import { getLocString } from '../../../datascience-ui/react-common/locReactSide';
@@ -16,6 +17,7 @@ import { sendTelemetryEvent } from '../../telemetry';
 import { Commands, Telemetry } from '../constants';
 import { ExportManager } from '../export/exportManager';
 import { ExportFormat, IExportManager } from '../export/types';
+import { isPythonNotebook } from '../notebook/helpers/helpers';
 import { INotebookEditorProvider } from '../types';
 
 interface IExportQuickPickItem extends QuickPickItem {
@@ -123,8 +125,9 @@ export class ExportCommands implements IDisposable {
         interpreter?: PythonEnvironment
     ): IExportQuickPickItem[] {
         const items: IExportQuickPickItem[] = [];
+        const notebook = JSON.parse(contents) as nbformat.INotebookContent;
 
-        if (interpreter) {
+        if (interpreter || (notebook.metadata && isPythonNotebook(notebook.metadata))) {
             items.push({
                 label: DataScience.exportPythonQuickPickLabel(),
                 picked: true,
@@ -132,7 +135,12 @@ export class ExportCommands implements IDisposable {
                     sendTelemetryEvent(Telemetry.ClickedExportNotebookAsQuickPick, undefined, {
                         format: ExportFormat.python
                     });
-                    this.commandManager.executeCommand(Commands.ExportAsPythonScript, contents, source, interpreter);
+                    void this.commandManager.executeCommand(
+                        Commands.ExportAsPythonScript,
+                        contents,
+                        source,
+                        interpreter
+                    );
                 }
             });
         }
@@ -146,7 +154,7 @@ export class ExportCommands implements IDisposable {
                         sendTelemetryEvent(Telemetry.ClickedExportNotebookAsQuickPick, undefined, {
                             format: ExportFormat.html
                         });
-                        this.commandManager.executeCommand(
+                        void this.commandManager.executeCommand(
                             Commands.ExportToHTML,
                             contents,
                             source,
@@ -162,7 +170,7 @@ export class ExportCommands implements IDisposable {
                         sendTelemetryEvent(Telemetry.ClickedExportNotebookAsQuickPick, undefined, {
                             format: ExportFormat.pdf
                         });
-                        this.commandManager.executeCommand(
+                        void this.commandManager.executeCommand(
                             Commands.ExportToPDF,
                             contents,
                             source,

--- a/src/client/datascience/notebook/helpers/helpers.ts
+++ b/src/client/datascience/notebook/helpers/helpers.ts
@@ -109,6 +109,11 @@ export function isPythonNotebook(metadata?: nbformat.INotebookMetadata) {
     if (metadata?.language_info?.name && metadata.language_info.name !== PYTHON_LANGUAGE) {
         return false;
     }
+
+    if (kernelSpec?.name.includes(PYTHON_LANGUAGE)) {
+        return true;
+    }
+
     // Valid notebooks will have a language information in the metadata.
     return kernelSpec?.language === PYTHON_LANGUAGE;
 }


### PR DESCRIPTION
Assume a notebook is a python notebook if the kernelspec name includes 'python'

For #5403
(and still works with #4965)

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
