### PR TITLE
Delete extension context secrets if we get an error when getting them.

### DIFF
--- a/news/2 Fixes/5419.md
+++ b/news/2 Fixes/5419.md
@@ -1,0 +1,2 @@
+Delete extension context secrets if we get an error when getting them.
+Small fixes on error handling.

--- a/src/client/common/application/encryptedStorage.ts
+++ b/src/client/common/application/encryptedStorage.ts
@@ -34,8 +34,14 @@ export class EncryptedStorage implements IEncryptedStorage {
         if (IS_REMOTE_NATIVE_TEST && this.extensionContext.extensionMode !== ExtensionMode.Production) {
             return this.testingState.get(`${service}#${key}`);
         }
-        // eslint-disable-next-line
-        const val = await this.extensionContext.secrets.get(`${service}.${key}`);
-        return val;
+        try {
+            // eslint-disable-next-line
+            const val = await this.extensionContext.secrets.get(`${service}.${key}`);
+            return val;
+        } catch (e) {
+            // If we get an error trying to get a secret, it might be corrupted. So we delete it.
+            await this.extensionContext.secrets.delete(`${service}.${key}`);
+            return;
+        }
     }
 }

--- a/src/client/common/errors/errorUtils.ts
+++ b/src/client/common/errors/errorUtils.ts
@@ -41,7 +41,9 @@ export function getLastFrameFromPythonTraceback(
     }
     //             File "/Users/donjayamanne/miniconda3/envs/env3/lib/python3.7/site-packages/appnope/_nope.py", line 38, in C
 
-    const lastFrame = traceback
+    // This parameter might be either a string or a string array
+    const fixedTraceback: string = Array.isArray(traceback) ? traceback[0] : traceback;
+    const lastFrame = fixedTraceback
         .split('\n')
         .map((item) => item.trim().toLowerCase())
         .filter((item) => item.length)

--- a/src/client/common/errors/errors.ts
+++ b/src/client/common/errors/errors.ts
@@ -12,8 +12,12 @@ const taggers = [
 ];
 export function getErrorTags(stdErrOrStackTrace: string) {
     const tags: string[] = [];
-    stdErrOrStackTrace = stdErrOrStackTrace.toLowerCase();
-    taggers.forEach((tagger) => tagger(stdErrOrStackTrace, tags));
+
+    // This parameter might be either a string or a string array
+    let stdErrOrStackTraceLowered = Array.isArray(stdErrOrStackTrace)
+        ? stdErrOrStackTrace[0].toLowerCase()
+        : stdErrOrStackTrace.toLowerCase();
+    taggers.forEach((tagger) => tagger(stdErrOrStackTraceLowered, tags));
 
     return Array.from(new Set(tags)).join(',');
 }


### PR DESCRIPTION
And small fixes on error handling.

For #5419

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
