### PR TITLE
Cell execution requests should block on trust prompt in untrusted notebooks

### DIFF
--- a/news/2 Fixes/5436.md
+++ b/news/2 Fixes/5436.md
@@ -1,0 +1,1 @@
+When native notebook is untrusted, do not allow cell execution and prompt to trust.

--- a/src/client/datascience/interactive-ipynb/trustCommandHandler.ts
+++ b/src/client/datascience/interactive-ipynb/trustCommandHandler.ts
@@ -9,7 +9,7 @@ import { IExtensionSingleActivationService } from '../../activation/types';
 import { IApplicationShell, ICommandManager } from '../../common/application/types';
 import { ContextKey } from '../../common/contextKey';
 import '../../common/extensions';
-import { traceInfo } from '../../common/logger';
+import { traceError, traceInfo } from '../../common/logger';
 import { IDisposableRegistry } from '../../common/types';
 import { swallowExceptions } from '../../common/utils/decorators';
 import { DataScience } from '../../common/utils/localize';
@@ -65,10 +65,14 @@ export class TrustCommandHandler implements IExtensionSingleActivationService {
                 sendTelemetryEvent(Telemetry.TrustAllNotebooks);
                 break;
             case DataScience.trustNotebook():
-                if (model instanceof VSCodeNotebookModel) {
-                    await this.trustNativeNotebook(model);
-                } else {
-                    await this.trustNotebook(model);
+                try {
+                    if (model instanceof VSCodeNotebookModel) {
+                        await this.trustNativeNotebook(model);
+                    } else {
+                        await this.trustNotebook(model);
+                    }
+                } catch (e) {
+                    traceError('Error while trusting notebook', e);
                 }
                 break;
             case DataScience.doNotTrustNotebook():

--- a/src/client/datascience/interactive-ipynb/trustCommandHandler.ts
+++ b/src/client/datascience/interactive-ipynb/trustCommandHandler.ts
@@ -40,15 +40,15 @@ export class TrustCommandHandler implements IExtensionSingleActivationService {
         this.disposables.push(this.commandManager.registerCommand(Commands.NotebookTrusted, () => noop(), this));
     }
     @swallowExceptions('Trusting notebook')
-    private async onTrustNotebook(uri?: Uri) {
+    private async onTrustNotebook(uri?: Uri): Promise<boolean> {
         uri = uri ?? this.editorProvider.activeEditor?.file;
         if (!uri) {
-            return;
+            return true;
         }
 
         const model = await this.storageProvider.getOrCreateModel({ file: uri });
         if (model.isTrusted) {
-            return;
+            return true;
         }
         traceInfo('Display prompt to trust notebook');
         const selection = await this.applicationShell.showErrorMessage(
@@ -77,6 +77,7 @@ export class TrustCommandHandler implements IExtensionSingleActivationService {
             default:
                 break;
         }
+        return selection === DataScience.trustNotebook();
     }
     private async trustNotebook(model: INotebookModel) {
         // Update model trust

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -703,7 +703,7 @@ export async function runAllCellsInActiveNotebook() {
         throw new Error('No notebook or kernel');
     }
     const document = vscodeNotebook.activeNotebookEditor.document;
-    void vscodeNotebook.activeNotebookEditor.kernel.executeCellsRequest(document, [
+    await vscodeNotebook.activeNotebookEditor.kernel.executeCellsRequest(document, [
         new NotebookCellRange(0, document.cellCount)
     ]);
 }

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -703,7 +703,7 @@ export async function runAllCellsInActiveNotebook() {
         throw new Error('No notebook or kernel');
     }
     const document = vscodeNotebook.activeNotebookEditor.document;
-    await vscodeNotebook.activeNotebookEditor.kernel.executeCellsRequest(document, [
+    void vscodeNotebook.activeNotebookEditor.kernel.executeCellsRequest(document, [
         new NotebookCellRange(0, document.cellCount)
     ]);
 }

--- a/src/test/datascience/notebook/notebookTrust.vscode.test.ts
+++ b/src/test/datascience/notebook/notebookTrust.vscode.test.ts
@@ -7,8 +7,8 @@ import { assert } from 'chai';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import { NotebookCellKind, commands, Uri } from 'vscode';
-import { IVSCodeNotebook } from '../../../client/common/application/types';
+import { NotebookCellKind, commands, Uri, NotebookDocument } from 'vscode';
+import { IApplicationShell, IVSCodeNotebook } from '../../../client/common/application/types';
 import { PYTHON_LANGUAGE } from '../../../client/common/constants';
 import { traceInfo } from '../../../client/common/logger';
 import { IConfigurationService, IDisposable, IJupyterSettings, ReadWrite } from '../../../client/common/types';
@@ -29,6 +29,7 @@ import {
     deleteCell,
     hijackPrompt,
     insertCodeCell,
+    runAllCellsInActiveNotebook,
     saveActiveNotebook,
     waitForKernelToGetAutoSelected
 } from './helper';
@@ -58,7 +59,7 @@ suite('DataScience - VSCode Notebook - (Trust) (slow)', function () {
     let storageProvider: INotebookStorageProvider;
     let vscodeNotebook: IVSCodeNotebook;
     let trustService: ITrustService;
-    this.timeout(15_000);
+    this.timeout(30_000);
     suiteSetup(async function () {
         api = await initialize();
         if (!(await canRunNotebookTests())) {
@@ -95,6 +96,14 @@ suite('DataScience - VSCode Notebook - (Trust) (slow)', function () {
         });
         return true;
     }
+
+    function numberOfExecutedCells(document: NotebookDocument) {
+        const cells = document.getCells();
+        return cells.filter((cell) => {
+            return cell.latestExecutionSummary?.duration !== undefined;
+        }).length;
+    }
+
     [true, false].forEach((withOutput) => {
         suite(`Test notebook ${withOutput ? 'with' : 'without'} output`, () => {
             let ipynbFile: Uri;
@@ -321,6 +330,67 @@ suite('DataScience - VSCode Notebook - (Trust) (slow)', function () {
                 // Confirm the notebook is now trusted.
                 assert.isTrue(model.isTrusted);
                 await waitForCondition(async () => assertDocumentTrust(true, withOutput), 10_000, 'Not trusted');
+            });
+            test('Running cells in an untrusted notebook', async () => {
+                const sandbox = sinon.createSandbox();
+
+                // Open an untrusted notebook and ignore the first prompt
+                const ignorePrompt = await hijackPrompt(
+                    'showErrorMessage',
+                    { exactMatch: DataScience.launchNotebookTrustPrompt() },
+                    { dismissPrompt: true },
+                    disposables
+                );
+                await openNotebook(api.serviceContainer, ipynbFile.fsPath, { isNotTrusted: true });
+                await waitForCondition(() => ignorePrompt.displayed, 10_000, 'Prompt to trust not displayed');
+                const document = vscodeNotebook.activeNotebookEditor?.document;
+                assert.ok(document !== undefined, 'No active notebook document');
+                ignorePrompt.clickButton();
+                ignorePrompt.dispose(); // Remove stub
+
+                // Set up trust prompt stub to select 'No'
+                const applicationShell = api.serviceManager.get<IApplicationShell>(IApplicationShell);
+                const doNotTrustPrompt = sandbox
+                    .stub(applicationShell, 'showErrorMessage')
+                    .withArgs(
+                        DataScience.launchNotebookTrustPrompt(),
+                        DataScience.trustNotebook() as any,
+                        DataScience.doNotTrustNotebook() as any,
+                        DataScience.trustAllNotebooks() as any
+                    )
+                    .resolves(DataScience.doNotTrustNotebook() as any);
+                // Try to run a cell
+                await runAllCellsInActiveNotebook();
+                // Verify trust prompt comes up
+                assert.ok(doNotTrustPrompt.calledOnce, 'Trust prompt was not shown');
+                // No cells should have been executed
+                assert.ok(numberOfExecutedCells(document!) === 0, 'Cells were executed for untrusted notebook');
+                sandbox.restore();
+
+                // Set up trust prompt stub to select 'Trust notebook'
+                const trustPrompt = sandbox
+                    .stub(applicationShell, 'showErrorMessage')
+                    .withArgs(
+                        DataScience.launchNotebookTrustPrompt(),
+                        DataScience.trustNotebook() as any,
+                        DataScience.doNotTrustNotebook() as any,
+                        DataScience.trustAllNotebooks() as any
+                    )
+                    .resolves(DataScience.trustNotebook() as any);
+                const trustSetEvent = createEventHandler(trustService, 'onDidSetNotebookTrust', disposables);
+                // Try to run a cell
+                await runAllCellsInActiveNotebook();
+                // Verify trust prompt comes up
+                assert.ok(trustPrompt.calledOnce, 'Trust prompt was not shown');
+                await trustSetEvent.assertFiredAtLeast(1, 10_000);
+                sandbox.restore();
+
+                // Confirm the notebook is now trusted.
+                const model = storageProvider.get(ipynbFile)!;
+                assert.isTrue(model.isTrusted);
+                await waitForCondition(async () => assertDocumentTrust(true, withOutput), 10_000, 'Not trusted');
+                // Verify cells executed
+                assert.ok(numberOfExecutedCells(document!) > 0, 'Cells not executed for trusted document');
             });
         });
     });

--- a/src/test/datascience/notebook/notebookTrust.vscode.test.ts
+++ b/src/test/datascience/notebook/notebookTrust.vscode.test.ts
@@ -389,6 +389,8 @@ suite('DataScience - VSCode Notebook - (Trust) (slow)', function () {
                 const model = storageProvider.get(ipynbFile)!;
                 assert.isTrue(model.isTrusted);
                 await waitForCondition(async () => assertDocumentTrust(true, withOutput), 10_000, 'Not trusted');
+                // Try to run a cell
+                await runAllCellsInActiveNotebook();
                 // Verify cells executed
                 assert.ok(numberOfExecutedCells(document!) > 0, 'Cells not executed for trusted document');
             });


### PR DESCRIPTION
For #5436

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
