### PR TITLE
Clear cached interpreter on active interpreter change

### DIFF
--- a/news/2 Fixes/5470.md
+++ b/news/2 Fixes/5470.md
@@ -1,0 +1,1 @@
+Invalidate cached interpreters when Python extension active interpreter changes.

--- a/src/client/api/pythonApi.ts
+++ b/src/client/api/pythonApi.ts
@@ -382,7 +382,10 @@ export class InterpreterService implements IInterpreterService {
             .then((api) => {
                 if (!this.eventHandlerAdded) {
                     this.eventHandlerAdded = true;
-                    api.onDidChangeInterpreter(() => this.didChangeInterpreter.fire(), this, this.disposables);
+                    api.onDidChangeInterpreter(() => { 
+                        this.didChangeInterpreter.fire();
+                        this.workspaceCachedActiveInterpreter.clear();
+                    }, this, this.disposables);
                 }
             })
             .catch(noop);

--- a/src/client/api/pythonApi.ts
+++ b/src/client/api/pythonApi.ts
@@ -382,10 +382,14 @@ export class InterpreterService implements IInterpreterService {
             .then((api) => {
                 if (!this.eventHandlerAdded) {
                     this.eventHandlerAdded = true;
-                    api.onDidChangeInterpreter(() => { 
-                        this.didChangeInterpreter.fire();
-                        this.workspaceCachedActiveInterpreter.clear();
-                    }, this, this.disposables);
+                    api.onDidChangeInterpreter(
+                        () => {
+                            this.didChangeInterpreter.fire();
+                            this.workspaceCachedActiveInterpreter.clear();
+                        },
+                        this,
+                        this.disposables
+                    );
                 }
             })
             .catch(noop);


### PR DESCRIPTION
For https://github.com/microsoft/vscode-jupyter/issues/5470

This needs to be ported to the April point release.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
