### PR TITLE
Use interpreter info stored in kernelspec.json

### DIFF
--- a/news/2 Fixes/5495.md
+++ b/news/2 Fixes/5495.md
@@ -1,0 +1,1 @@
+Use interpreter information stored in kernelspec.json file when starting kernels.

--- a/src/client/datascience/kernel-launcher/localKernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/localKernelFinder.ts
@@ -224,7 +224,6 @@ export class LocalKernelFinder implements ILocalKernelFinder {
                                 return interpreter;
                             });
                     }
-                    // No interpreter found. If python, use the active interpreter anyway
                     const result: KernelSpecConnectionMetadata = {
                         kind: 'startUsingKernelSpec',
                         kernelSpec: k,

--- a/src/client/datascience/kernel-launcher/localKernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/localKernelFinder.ts
@@ -211,6 +211,14 @@ export class LocalKernelFinder implements ILocalKernelFinder {
                 } else {
                     let interpreter = k.language === PYTHON_LANGUAGE ? activeInterpreter : undefined;
                     // If the interpreter information is stored in kernelspec.json then use that to determine the interpreter.
+                    // This can happen under the following circumstances:
+                    // 1. Open workspace folder XYZ, and create a virtual environment named venvA
+                    // 2. Now assume we don't have raw kernels, and a kernel gets registered for venvA in kernelspecs folder.
+                    // 3. The kernel spec will contain metadata pointing to venvA.
+                    // 4. Now open a different folder (e.g. a sub directory of XYZ or a completely different folder).
+                    // 5. Now venvA will not be listed as an interpreter as Python will not discover this.
+                    // 6. However the kernel we registered against venvA will be in global kernels folder
+                    // In such an instance the interpreter information is stored in the kernelspec.json file.
                     if (
                         k.language === PYTHON_LANGUAGE &&
                         this.extensionChecker.isPythonExtensionInstalled &&


### PR DESCRIPTION
For #5495

Not sure if we need this in the point release, but this is a regression.
