### PR TITLE
Fix missing interpreter check

### DIFF
--- a/src/client/datascience/kernel-launcher/localKernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/localKernelFinder.ts
@@ -236,7 +236,7 @@ export class LocalKernelFinder implements ILocalKernelFinder {
                         kind: 'startUsingKernelSpec',
                         kernelSpec: k,
                         interpreter,
-                        id: getKernelId(k, activeInterpreter)
+                        id: getKernelId(k, interpreter)
                     };
                     return result;
                 }


### PR DESCRIPTION
Missed a spot when checking for an interpreter in a different folder