### PR TITLE
Resize grid height on slice panel toggle

### DIFF
--- a/news/2 Fixes/5309.md
+++ b/news/2 Fixes/5309.md
@@ -1,0 +1,1 @@
+Ensure data viewer grid is resized when slice panel is toggled so that horizontal scrollbar remains visible.

--- a/src/datascience-ui/data-explorer/mainPanel.tsx
+++ b/src/datascience-ui/data-explorer/mainPanel.tsx
@@ -71,6 +71,7 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
     private sentDone = false;
     private postOffice: PostOffice = new PostOffice();
     private resetGridEvent: Slick.Event<ISlickGridSlice> = new Slick.Event<ISlickGridSlice>();
+    private resizeGridEvent: Slick.Event<void> = new Slick.Event<void>();
     private gridAddEvent: Slick.Event<ISlickGridAdd> = new Slick.Event<ISlickGridAdd>();
     private gridColumnUpdateEvent: Slick.Event<Slick.Column<Slick.SlickData>[]> = new Slick.Event<
         Slick.Column<Slick.SlickData>[]
@@ -180,6 +181,7 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
                     originalVariableShape={this.state.originalVariableShape}
                     handleSliceRequest={this.handleSliceRequest}
                     onCheckboxToggled={this.handleCheckboxToggle}
+                    onPanelToggled={() => this.resizeGridEvent.notify()}
                 />
             );
         }
@@ -262,6 +264,7 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
                 idProperty={RowNumberColumnName}
                 rowsAdded={this.gridAddEvent}
                 resetGridEvent={this.resetGridEvent}
+                resizeGridEvent={this.resizeGridEvent}
                 columnsUpdated={this.gridColumnUpdateEvent}
                 filterRowsTooltip={filterRowsTooltip}
                 forceHeight={this.props.testMode ? 200 : undefined}

--- a/src/datascience-ui/data-explorer/reactSlickGrid.tsx
+++ b/src/datascience-ui/data-explorer/reactSlickGrid.tsx
@@ -62,6 +62,7 @@ export interface ISlickGridProps {
     columns: Slick.Column<ISlickRow>[];
     rowsAdded: Slick.Event<ISlickGridAdd>;
     resetGridEvent: Slick.Event<ISlickGridSlice>;
+    resizeGridEvent: Slick.Event<void>;
     columnsUpdated: Slick.Event<Slick.Column<Slick.SlickData>[]>;
     filterRowsTooltip: string;
     forceHeight?: number;
@@ -171,6 +172,7 @@ export class ReactSlickGrid extends React.Component<ISlickGridProps, ISlickGridS
         this.measureRef = React.createRef<HTMLDivElement>();
         this.props.rowsAdded.subscribe(this.addedRows);
         this.props.resetGridEvent.subscribe(this.resetGrid);
+        this.props.resizeGridEvent.subscribe(this.windowResized);
         this.props.columnsUpdated.subscribe(this.updateColumns);
     }
 

--- a/src/datascience-ui/data-explorer/sliceControl.tsx
+++ b/src/datascience-ui/data-explorer/sliceControl.tsx
@@ -32,6 +32,7 @@ interface ISliceControlProps {
     loadingData: boolean;
     originalVariableShape: number[];
     sliceExpression: string | undefined;
+    onPanelToggled(): void;
     onCheckboxToggled(newState: boolean): void;
     handleSliceRequest(slice: IGetSliceRequest): void;
 }
@@ -65,7 +66,7 @@ export class SliceControl extends React.Component<ISliceControlProps, ISliceCont
                     className="slicing-control"
                     {...(this.props.originalVariableShape.length > 2 ? { open: true } : {})}
                 >
-                    <summary className="slice-summary">
+                    <summary className="slice-summary" onClick={() => this.props.onPanelToggled()}>
                         <span className="slice-summary-detail">
                             {getLocString('DataScience.sliceSummaryTitle', 'SLICING')}
                         </span>


### PR DESCRIPTION
For #5309

If the slice panel is initally collapsed and then is expanded by the user, the bottom ~4 rows are cut off because the SlickGrid grid height is manually calculated and set, and the grid isn't aware that neighboring elements have increased in height. The solution here is to tell the grid to resize itself.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
