### PR TITLE
Use the right interpreter and kernel with notebooks

### DIFF
--- a/src/client/datascience/jupyter/kernels/helpers.ts
+++ b/src/client/datascience/jupyter/kernels/helpers.ts
@@ -382,6 +382,18 @@ export function findPreferredKernel(
                     score += 100;
                 }
 
+                // If the user has kernelspec in metadata & this is a kernelspec we generated & names match, then use that kernelspec.
+                // Reason we are only interested kernelspecs we generate is because user can have kernelspecs named `python`.
+                // Such kernelspecs are ambiguous (we have no idea what `python` kernel means, its not necessarily tied to a specific interpreter).
+                if (
+                    notebookMetadata?.kernelspec?.name &&
+                    isKernelRegisteredByUs(spec) &&
+                    notebookMetadata.kernelspec.name === spec.name
+                ) {
+                    // This is a perfect match.
+                    score += 100;
+                }
+
                 // See if the path matches.
                 if (
                     spec &&

--- a/src/client/datascience/kernel-launcher/localKernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/localKernelFinder.ts
@@ -204,9 +204,7 @@ export class LocalKernelFinder implements ILocalKernelFinder {
 
                     // If interpreters were found, remove them from the interpreter list we'll eventually
                     // return as interpreter only items
-                    filteredInterpreters = filteredInterpreters.filter(
-                        (i) => matchingInterpreter === i || this.fs.areLocalPathsSame(matchingInterpreter.path, i.path)
-                    );
+                    filteredInterpreters = filteredInterpreters.filter((i) => matchingInterpreter === i);
 
                     // Return our metadata that uses an interpreter to start
                     return result;

--- a/src/client/datascience/kernel-launcher/localKernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/localKernelFinder.ts
@@ -193,18 +193,20 @@ export class LocalKernelFinder implements ILocalKernelFinder {
             kernelSpecs.map(async (k) => {
                 // Find the interpreter that matches. If we find one, we want to use
                 // this to start the kernel.
-                const matchingInterpreters = this.findMatchingInterpreters(k, interpreters);
-                if (matchingInterpreters && matchingInterpreters.length) {
+                const matchingInterpreter = this.findMatchingInterpreter(k, interpreters);
+                if (matchingInterpreter) {
                     const result: PythonKernelConnectionMetadata = {
                         kind: 'startUsingPythonInterpreter',
                         kernelSpec: k,
-                        interpreter: matchingInterpreters[0],
-                        id: getKernelId(k, matchingInterpreters[0])
+                        interpreter: matchingInterpreter,
+                        id: getKernelId(k, matchingInterpreter)
                     };
 
                     // If interpreters were found, remove them from the interpreter list we'll eventually
                     // return as interpreter only items
-                    filteredInterpreters = filteredInterpreters.filter((i) => !matchingInterpreters.includes(i));
+                    filteredInterpreters = filteredInterpreters.filter(
+                        (i) => matchingInterpreter === i || this.fs.areLocalPathsSame(matchingInterpreter.path, i.path)
+                    );
 
                     // Return our metadata that uses an interpreter to start
                     return result;
@@ -276,62 +278,63 @@ export class LocalKernelFinder implements ILocalKernelFinder {
         });
     }
 
-    private findMatchingInterpreters(
+    private findMatchingInterpreter(
         kernelSpec: IJupyterKernelSpec,
         interpreters: PythonEnvironment[]
-    ): PythonEnvironment[] | undefined {
-        return interpreters.filter((i) => {
-            // If we know for a fact that the kernel spec is a Non-Python kernel, then return nothing.
-            if (kernelSpec.language && kernelSpec.language !== PYTHON_LANGUAGE) {
-                traceInfoIf(
-                    !!process.env.VSC_JUPYTER_LOG_KERNEL_OUTPUT,
-                    `Kernel ${kernelSpec.name} is not python based so does not have an interpreter.`
-                );
-                return false;
-            }
-
-            // 1. Check if current interpreter has the same path
+    ): PythonEnvironment | undefined {
+        // If we know for a fact that the kernel spec is a Non-Python kernel, then return nothing.
+        if (kernelSpec.language && kernelSpec.language !== PYTHON_LANGUAGE) {
+            return;
+        }
+        // 1. Check if current interpreter has the same path
+        const exactMatch = interpreters.find((i) => {
             if (
                 kernelSpec.metadata?.interpreter?.path &&
                 this.fs.areLocalPathsSame(kernelSpec.metadata?.interpreter?.path, i.path)
             ) {
-                traceInfoIf(
-                    !!process.env.VSC_JUPYTER_LOG_KERNEL_OUTPUT,
-                    `Kernel ${kernelSpec.name} matches ${i.displayName} based on metadata path.`
-                );
+                traceInfo(`Kernel ${kernelSpec.name} matches ${i.displayName} based on metadata path.`);
                 return true;
             }
-            if (kernelSpec.interpreterPath && this.fs.areLocalPathsSame(kernelSpec.interpreterPath, i.path)) {
-                traceInfoIf(
-                    !!process.env.VSC_JUPYTER_LOG_KERNEL_OUTPUT,
-                    `Kernel ${kernelSpec.name} matches ${i.displayName} based on interpreter path.`
-                );
-                return true;
-            }
-
-            // 2. Check if we have a fully qualified path in `argv`
-            const pathInArgv =
-                kernelSpec && Array.isArray(kernelSpec.argv) && kernelSpec.argv.length > 0
-                    ? kernelSpec.argv[0]
-                    : undefined;
+            return false;
+        });
+        if (exactMatch) {
+            return exactMatch;
+        }
+        // 2. Check if we have a fully qualified path in `argv`
+        const pathInArgv =
+            kernelSpec && Array.isArray(kernelSpec.argv) && kernelSpec.argv.length > 0 ? kernelSpec.argv[0] : undefined;
+        const exactMatchBasedOnArgv = interpreters.find((i) => {
             if (
                 pathInArgv &&
                 path.basename(pathInArgv) !== pathInArgv &&
                 this.fs.areLocalPathsSame(pathInArgv, i.path)
             ) {
-                traceInfoIf(
-                    !!process.env.VSC_JUPYTER_LOG_KERNEL_OUTPUT,
-                    `Kernel ${kernelSpec.name} matches ${i.displayName} based on path in argv.`
-                );
+                traceInfo(`Kernel ${kernelSpec.name} matches ${i.displayName} based on path in argv.`);
                 return true;
             }
+            return false;
+        });
+        if (exactMatchBasedOnArgv) {
+            return exactMatchBasedOnArgv;
+        }
+        // 2. Check if `interpreterPath` is defined in kernel metadata.
+        if (kernelSpec.interpreterPath) {
+            const matchBasedOnInterpreterPath = interpreters.find((i) => {
+                if (kernelSpec.interpreterPath && this.fs.areLocalPathsSame(kernelSpec.interpreterPath, i.path)) {
+                    traceInfo(`Kernel ${kernelSpec.name} matches ${i.displayName} based on interpreter path.`);
+                    return true;
+                }
+                return false;
+            });
+            if (matchBasedOnInterpreterPath) {
+                return matchBasedOnInterpreterPath;
+            }
+        }
 
+        return interpreters.find((i) => {
             // 3. Check display name
             if (kernelSpec.display_name === i.displayName) {
-                traceInfoIf(
-                    !!process.env.VSC_JUPYTER_LOG_KERNEL_OUTPUT,
-                    `Kernel ${kernelSpec.name} matches ${i.displayName} based on display name.`
-                );
+                traceInfo(`Kernel ${kernelSpec.name} matches ${i.displayName} based on display name.`);
                 return true;
             }
 

--- a/src/client/datascience/kernel-launcher/localKernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/localKernelFinder.ts
@@ -284,6 +284,10 @@ export class LocalKernelFinder implements ILocalKernelFinder {
     ): PythonEnvironment | undefined {
         // If we know for a fact that the kernel spec is a Non-Python kernel, then return nothing.
         if (kernelSpec.language && kernelSpec.language !== PYTHON_LANGUAGE) {
+            traceInfoIf(
+                !!process.env.VSC_JUPYTER_LOG_KERNEL_OUTPUT,
+                `Kernel ${kernelSpec.name} is not python based so does not have an interpreter.`
+            );
             return;
         }
         // 1. Check if current interpreter has the same path

--- a/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
@@ -38,6 +38,45 @@ import { Uri } from 'vscode';
         let fs: IFileSystem;
         let extensionChecker: IPythonExtensionChecker;
         const defaultPython3Name = 'python3';
+        const pyEnvInterpreter: PythonEnvironment = {
+            displayName: 'Python 3 Environment for PyEnv',
+            path: '/users/username/pyenv/envs/temp/python',
+            sysPrefix: 'python',
+            version: {
+                major: 3,
+                minor: 8,
+                raw: '3.8',
+                build: ['0'],
+                patch: 0,
+                prerelease: ['0']
+            }
+        };
+        const pyEnvInterpreter2: PythonEnvironment = {
+            displayName: 'Python 3 Environment for PyEnv',
+            path: '/users/username/pyenv/envs/temp2/python',
+            sysPrefix: 'python',
+            version: {
+                major: 3,
+                minor: 8,
+                raw: '3.8',
+                build: ['0'],
+                patch: 0,
+                prerelease: ['0']
+            }
+        };
+        const pyEnvInterpreter3: PythonEnvironment = {
+            displayName: 'Python 3 on Disk',
+            path: '/users/username/pyenv/envs/temp3/python',
+            sysPrefix: 'python',
+            version: {
+                major: 3,
+                minor: 8,
+                raw: '3.8',
+                build: ['0'],
+                patch: 0,
+                prerelease: ['0']
+            }
+        };
         const python3Interpreter: PythonEnvironment = {
             displayName: 'Python 3 Environment',
             path: '/usr/bin/python3',
@@ -70,6 +109,23 @@ import { Uri } from 'vscode';
             path: '/usr/bin/conda/python3',
             sysPrefix: 'conda',
             envType: EnvironmentType.Conda
+        };
+        const pyEnvPython3spec: Kernel.ISpecModel = {
+            display_name: 'Python 3 on Disk',
+            name: 'python38664bitpyenv87d47e496650464eac2bd1421064a987',
+            argv: ['/users/username/pyenv/envs/temp/python'],
+            language: 'python',
+            resources: {},
+            metadata: {
+                interpreter: pyEnvInterpreter
+            }
+        };
+        const pyEnvUsingNewNamesPython3spec: Kernel.ISpecModel = {
+            display_name: 'Python 3 on Disk',
+            name: 'pythonjvsc74a57bd0857c2ac1a2d121b2884435ca7334db9e850ee37c2dd417fb5029a40e4d8390b5',
+            argv: ['/users/username/pyenv/envs/temp2/python'],
+            language: 'python',
+            resources: {}
         };
         const python3spec: Kernel.ISpecModel = {
             display_name: 'Python 3 on Disk',
@@ -124,6 +180,7 @@ import { Uri } from 'vscode';
             getRealPathStub.returnsArg(0);
             interpreterService = mock(InterpreterService);
             when(interpreterService.getInterpreters(anything())).thenResolve([]);
+            when(interpreterService.getInterpreterDetails(anything())).thenResolve();
             platformService = mock(PlatformService);
             when(platformService.isWindows).thenReturn(isWindows);
             when(platformService.isLinux).thenReturn(!isWindows);
@@ -149,9 +206,21 @@ import { Uri } from 'vscode';
                 if (c.startsWith('conda')) {
                     return Promise.resolve(['interpreter.json']);
                 }
-                return Promise.resolve(['python3.json', 'python3dupe.json', 'julia.json', 'python2.json']);
+                return Promise.resolve([
+                    // 'python.json',
+                    'python3.json',
+                    'python3dupe.json',
+                    'julia.json',
+                    'python2.json'
+                ]);
             });
             when(fs.readLocalFile(anything())).thenCall((f) => {
+                if (f.endsWith('python.json')) {
+                    return Promise.resolve(JSON.stringify(pyEnvPython3spec));
+                }
+                if (f.endsWith('pythonPyEnvNew.json')) {
+                    return Promise.resolve(JSON.stringify(pyEnvUsingNewNamesPython3spec));
+                }
                 if (f.endsWith('python3.json')) {
                     return Promise.resolve(JSON.stringify(python3spec));
                 }
@@ -230,6 +299,7 @@ import { Uri } from 'vscode';
                 python3Interpreter,
                 condaEnvironment,
                 python2Interpreter,
+                pyEnvInterpreter,
                 condaEnvironmentBase
             ]);
             when(extensionChecker.isPythonExtensionInstalled).thenReturn(true);
@@ -426,6 +496,90 @@ import { Uri } from 'vscode';
                 orig_nbformat: 4
             });
             assert.equal(kernel?.kernelSpec?.language, 'python', 'No python kernel found matching notebook metadata');
+        });
+        test('Can match (exactly) based on notebook metadata (metadata contains kernelspec name that we generated)', async () => {
+            when(fs.searchLocal(anything(), anything(), true)).thenCall((_p, c, _d) => {
+                if (c.startsWith('python')) {
+                    return Promise.resolve(['interpreter.json']);
+                }
+                if (c.startsWith('conda')) {
+                    return Promise.resolve(['interpreter.json']);
+                }
+                return Promise.resolve([
+                    'python.json',
+                    'pythonPyEnvNew.json',
+                    'python3.json',
+                    'python3dupe.json',
+                    'julia.json',
+                    'python2.json'
+                ]);
+            });
+            when(interpreterService.getActiveInterpreter(anything())).thenResolve(activeInterpreter);
+            when(interpreterService.getInterpreters(anything())).thenResolve([
+                python3Interpreter,
+                condaEnvironment,
+                python2Interpreter,
+                pyEnvInterpreter, // Previously this would not get picked.
+                condaEnvironmentBase
+            ]);
+            when(extensionChecker.isPythonExtensionInstalled).thenReturn(true);
+
+            // Generic python 3
+            const kernel = await kernelFinder.findKernel(Uri.file('test.ipynb'), {
+                kernelspec: {
+                    display_name: pyEnvPython3spec.display_name,
+                    // Use a kernelspec name that we generate.
+                    name: pyEnvPython3spec.name
+                },
+                language_info: { name: PYTHON_LANGUAGE },
+                orig_nbformat: 4
+            });
+            assert.equal(kernel?.kernelSpec?.language, 'python', 'No kernel found matching default notebook metadata');
+            assert.equal(kernel?.kind, 'startUsingPythonInterpreter', 'Should start using Python');
+            assert.deepEqual(kernel?.interpreter, pyEnvInterpreter, 'Should start using PyEnv');
+        });
+        test('Can match (exactly) based on notebook metadata (metadata contains kernelspec name that we generated using the new algorightm)', async () => {
+            when(fs.searchLocal(anything(), anything(), true)).thenCall((_p, c, _d) => {
+                if (c.startsWith('python')) {
+                    return Promise.resolve(['interpreter.json']);
+                }
+                if (c.startsWith('conda')) {
+                    return Promise.resolve(['interpreter.json']);
+                }
+                return Promise.resolve([
+                    'python.json',
+                    'pythonPyEnvNew.json',
+                    'python3.json',
+                    'python3dupe.json',
+                    'julia.json',
+                    'python2.json'
+                ]);
+            });
+            when(interpreterService.getActiveInterpreter(anything())).thenResolve(activeInterpreter);
+            when(interpreterService.getInterpreters(anything())).thenResolve([
+                python3Interpreter,
+                condaEnvironment,
+                python2Interpreter,
+                pyEnvInterpreter,
+                pyEnvInterpreter3, // Previously this would get picked due to the order.
+                pyEnvInterpreter2,
+                condaEnvironmentBase
+            ]);
+            when(extensionChecker.isPythonExtensionInstalled).thenReturn(true);
+
+            // Generic python 3
+            const kernel = await kernelFinder.findKernel(Uri.file('test.ipynb'), {
+                kernelspec: {
+                    display_name: pyEnvUsingNewNamesPython3spec.display_name,
+                    // Use a kernelspec name that we generate.
+                    name: pyEnvUsingNewNamesPython3spec.name
+                },
+                language_info: { name: PYTHON_LANGUAGE },
+                orig_nbformat: 4
+            });
+            assert.equal(kernel?.kernelSpec?.language, 'python', 'No kernel found matching default notebook metadata');
+            assert.equal(kernel?.kind, 'startUsingPythonInterpreter', 'Should start using Python');
+            assert.deepEqual(kernel?.interpreter, pyEnvInterpreter2, 'Should start using PyEnv');
         });
     });
 });


### PR DESCRIPTION
For #5489 

This has two fixes
* Ensure we select the right interpreter associated with a kernelspec
* Ensure we pick the right kernelspec based on notebook metadata