### PR TITLE
Pass default kernelspec name in KernelConnection when starting remote Jupyter server

### DIFF
--- a/news/2 Fixes/5290.md
+++ b/news/2 Fixes/5290.md
@@ -1,0 +1,1 @@
+Pass remote Jupyter server's default kernelspec name in remote kernel connection.

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -243,10 +243,15 @@ export class JupyterSession extends BaseJupyterSession {
             await this.kernelService.ensureKernelIsUsable(kernelConnection, cancelToken, disableUI);
         }
 
+        // If kernelName is empty this can cause problems for servers that don't
+        // understand that empty kernel name means the default kernel.
+        // See https://github.com/microsoft/vscode-jupyter/issues/5290
+        const kernelName = getNameOfKernelConnection(kernelConnection) ?? this.sessionManager?.specs?.default ?? '';
+
         // Create our session options using this temporary notebook and our connection info
         const options: Session.IOptions = {
             path: backingFile?.path || `${uuid()}.ipynb`, // Name has to be unique
-            kernelName: getNameOfKernelConnection(kernelConnection) || '', // TODO: This can't be empty. See https://github.com/microsoft/vscode-jupyter/issues/5290
+            kernelName,
             name: uuid(), // This is crucial to distinguish this session from any other.
             serverSettings: serverSettings,
             type: 'notebook'


### PR DESCRIPTION
For #5290

This is a bit of an optimistic fix as I don't have remote Synapse setup so can't validate. I have validated this doesn't cause problems for remote Jupyter connections on Azure ML at least. /cc @zesluo for feedback and awareness.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
