### PR TITLE
Bump prismjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24973,14 +24973,14 @@
             "dependencies": {
                 "hastscript": "^5.0.0",
                 "parse-entities": "^1.1.2",
-                "prismjs": "~1.17.0"
+                "prismjs": "1.23.0"
             }
         },
         "node_modules/refractor/node_modules/prismjs": {
-            "version": "1.17.1",
-            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-            "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
-            "optionalDependencies": {
+            "version": "1.23.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
+            "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
+            "requires": {
                 "clipboard": "^2.0.0"
             }
         },
@@ -53252,13 +53252,13 @@
             "requires": {
                 "hastscript": "^5.0.0",
                 "parse-entities": "^1.1.2",
-                "prismjs": "~1.17.0"
+                "prismjs": "1.23.0"
             },
             "dependencies": {
                 "prismjs": {
-                    "version": "1.17.1",
-                    "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-                    "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+                    "version": "1.23.0",
+                    "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
+                    "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
                     "requires": {
                         "clipboard": "^2.0.0"
                     }


### PR DESCRIPTION
This just hacks the package-lock.json to use prismjs@1.23.0 until the upstream dependency is fixed. This is temporary and really only necessary in the release branch. Writing a postInstall script doesn't suffice to ensure that the package-lock.json is preserved, because other npm tasks run and modify the package-lock after the postInstall script runs on an npm install. 

This also needs to be ported to release