### PR TITLE
Clean up the API we expose

### DIFF
--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -10,7 +10,6 @@ import { traceError } from './common/logger';
 import { VSCodeNotebookProvider } from './datascience/constants';
 import { IDataViewerDataProvider, IDataViewerFactory } from './datascience/data-viewing/types';
 import { NotebookCellRunState } from './datascience/jupyter/kernels/types';
-import { CreationOptionService } from './datascience/notebook/creation/creationOptionsService';
 import { KernelStateEventArgs } from './datascience/notebookExtensibility';
 import {
     IJupyterUriProvider,
@@ -59,19 +58,6 @@ export interface IExtensionApi {
     registerRemoteServerProvider(serverProvider: IJupyterUriProvider): void;
     registerPythonApi(pythonApi: PythonApi): void;
     /**
-     * When called by other extensions we will display these extensions in a dropdown list when creating a new notebook.
-     */
-    registerNewNotebookContent(options: {
-        /**
-         * Use this language as the language of cells for new notebooks created (when user picks this extension).
-         */
-        defaultCellLanguage: string;
-        /**
-         * Value in the quickpick (if not provided, will use the displayName of the extension).
-         */
-        label: string;
-    }): Promise<void>;
-    /**
      * Creates a blank notebook and defaults the empty cell to the language provided.
      */
     createBlankNotebook(options: { defaultCellLanguage: string }): Promise<void>;
@@ -110,11 +96,6 @@ export function buildApi(
         },
         onKernelStateChange: notebookExtensibility.onKernelStateChange.bind(notebookExtensibility),
         registerCellToolbarButton: webviewExtensibility.registerCellToolbarButton.bind(webviewExtensibility),
-        registerNewNotebookContent(options: { defaultCellLanguage: string; label?: string }) {
-            return serviceContainer
-                .get<CreationOptionService>(CreationOptionService)
-                .registerNewNotebookContent(options);
-        },
         createBlankNotebook: async (options: { defaultCellLanguage: string }): Promise<void> => {
             const service = serviceContainer.get<INotebookEditorProvider>(VSCodeNotebookProvider);
             await service.createNew(options);

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -74,7 +74,6 @@ export async function activate(context: IExtensionContext): Promise<IExtensionAp
             onKernelStateChange: () => ({ dispose: noop }),
             ready: Promise.resolve(),
             registerCellToolbarButton: () => ({ dispose: noop }),
-            registerNewNotebookContent: () => Promise.resolve(),
             registerPythonApi: noop,
             registerRemoteServerProvider: noop,
             showDataViewer: () => Promise.resolve()

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -667,7 +667,6 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
 
         this.serviceManager.addSingletonInstance<NotebookCreator>(NotebookCreator, instance(mock(NotebookCreator)));
         const creationService = mock<CreationOptionService>();
-        when(creationService.registerNewNotebookContent(anything())).thenResolve();
         when(creationService.registrations).thenReturn([]);
         this.serviceManager.addSingletonInstance<CreationOptionService>(
             CreationOptionService,

--- a/src/test/datascience/extensionapi/exampleextension/ms-ai-tools-test/package.json
+++ b/src/test/datascience/extensionapi/exampleextension/ms-ai-tools-test/package.json
@@ -34,6 +34,12 @@
 				"title": "Create new blank Julia notebook",
 				"category": "Notebook"
 			}
+		],
+        "jupyter.kernels": [
+			{
+				"title": "Julia",
+				"defaultLanguage": "julia"
+			}
 		]
 	},
 	"scripts": {

--- a/src/test/datascience/extensionapi/exampleextension/ms-ai-tools-test/src/extension.ts
+++ b/src/test/datascience/extensionapi/exampleextension/ms-ai-tools-test/src/extension.ts
@@ -13,7 +13,6 @@ export async function activate(_context: vscode.ExtensionContext) {
             await jupyter.exports.ready;
         }
         jupyter.exports.registerRemoteServerProvider(new RemoteServerPickerExample());
-        jupyter.exports.registerNewNotebookContent({ defaultCellLanguage: 'julia' });
         vscode.commands.registerCommand(
             'ms-toolsai-test.createBlankNotebook',
             () => void jupyter.exports.createBlankNotebook({ defaultCellLanguage: 'julia' })

--- a/src/test/datascience/notebook/creation/notebookCreation.vscode.test.ts
+++ b/src/test/datascience/notebook/creation/notebookCreation.vscode.test.ts
@@ -54,7 +54,7 @@ suite('DataScience - VSCode Notebook - (Creation Integration)', function () {
         );
     }
     test('With 3rd party integration, display quick pick when selecting create blank notebook command', async function () {
-        await creationOptions.registerNewNotebookContent({ defaultCellLanguage: 'julia' });
+        await creationOptions.registerNewNotebookContent('julia');
         assert.equal(creationOptions.registrations.length, 1);
         assert.isUndefined(vscodeNotebook.activeNotebookEditor);
 


### PR DESCRIPTION
Part of the work done to expose `jupyter.kernels` contributions.
This will remove the API we added, its no longer necessary & it doesn't work properly.
Also changed casing of text from `defaultlangauge` to `defaultLanguage`, both .NET team & I made a mistake here. Besides in JS its camel casing hence this should be fixed.