### PR TITLE
Bump `underscore` to 1.12.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
                 "tmp": "^0.0.29",
                 "typescript-char": "^0.0.0",
                 "uint64be": "^1.0.1",
+                "underscore": "^1.12.1",
                 "unicode": "^10.0.0",
                 "untildify": "^3.0.2",
                 "uuid": "^3.3.2",
@@ -281,7 +282,7 @@
                 "yargs-parser": "^13.1.2"
             },
             "engines": {
-                "vscode": "1.56.0-insider"
+                "vscode": "1.56.0"
             },
             "optionalDependencies": {
                 "canvas": "^2.7.0",
@@ -6834,6 +6835,12 @@
                 "underscore": "1.8.3"
             }
         },
+        "node_modules/azure-devops-node-api/node_modules/underscore": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+            "dev": true
+        },
         "node_modules/azure-storage": {
             "version": "2.10.3",
             "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.3.tgz",
@@ -6874,6 +6881,12 @@
             "version": "0.10.31",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
             "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+            "dev": true
+        },
+        "node_modules/azure-storage/node_modules/underscore": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
             "dev": true
         },
         "node_modules/azure-storage/node_modules/xml2js": {
@@ -14851,30 +14864,34 @@
         },
         "node_modules/fsevents/node_modules/abbrev": {
             "version": "1.1.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/ansi-regex": {
             "version": "2.1.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/fsevents/node_modules/aproba": {
             "version": "1.2.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/are-we-there-yet": {
             "version": "1.1.5",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -14882,15 +14899,17 @@
         },
         "node_modules/fsevents/node_modules/balanced-match": {
             "version": "1.0.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/brace-expansion": {
             "version": "1.1.11",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -14898,66 +14917,75 @@
         },
         "node_modules/fsevents/node_modules/chownr": {
             "version": "1.1.4",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/code-point-at": {
             "version": "1.1.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/fsevents/node_modules/concat-map": {
             "version": "0.0.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/console-control-strings": {
             "version": "1.1.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/core-util-is": {
             "version": "1.0.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/debug": {
             "version": "3.2.6",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
         },
         "node_modules/fsevents/node_modules/deep-extend": {
             "version": "0.6.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=4.0.0"
             }
         },
         "node_modules/fsevents/node_modules/delegates": {
             "version": "1.0.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/detect-libc": {
             "version": "1.0.3",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
+            "optional": true,
             "bin": {
                 "detect-libc": "bin/detect-libc.js"
             },
@@ -14967,24 +14995,27 @@
         },
         "node_modules/fsevents/node_modules/fs-minipass": {
             "version": "1.2.7",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "minipass": "^2.6.0"
             }
         },
         "node_modules/fsevents/node_modules/fs.realpath": {
             "version": "1.0.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/gauge": {
             "version": "2.7.4",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -14998,9 +15029,10 @@
         },
         "node_modules/fsevents/node_modules/glob": {
             "version": "7.1.6",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -15018,15 +15050,17 @@
         },
         "node_modules/fsevents/node_modules/has-unicode": {
             "version": "2.0.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/iconv-lite": {
             "version": "0.4.24",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3"
             },
@@ -15036,18 +15070,20 @@
         },
         "node_modules/fsevents/node_modules/ignore-walk": {
             "version": "3.0.3",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "minimatch": "^3.0.4"
             }
         },
         "node_modules/fsevents/node_modules/inflight": {
             "version": "1.0.6",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -15055,24 +15091,27 @@
         },
         "node_modules/fsevents/node_modules/inherits": {
             "version": "2.0.4",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/ini": {
             "version": "1.3.5",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "engines": {
                 "node": "*"
             }
         },
         "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
             "version": "1.0.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "number-is-nan": "^1.0.0"
             },
@@ -15082,15 +15121,17 @@
         },
         "node_modules/fsevents/node_modules/isarray": {
             "version": "1.0.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/minimatch": {
             "version": "3.0.4",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -15100,15 +15141,17 @@
         },
         "node_modules/fsevents/node_modules/minimist": {
             "version": "1.2.5",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/minipass": {
             "version": "2.9.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -15116,9 +15159,10 @@
         },
         "node_modules/fsevents/node_modules/minizlib": {
             "version": "1.3.3",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "minipass": "^2.9.0"
             }
@@ -15126,9 +15170,10 @@
         "node_modules/fsevents/node_modules/mkdirp": {
             "version": "0.5.3",
             "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "minimist": "^1.2.5"
             },
@@ -15138,15 +15183,17 @@
         },
         "node_modules/fsevents/node_modules/ms": {
             "version": "2.1.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/needle": {
             "version": "2.3.3",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "debug": "^3.2.6",
                 "iconv-lite": "^0.4.4",
@@ -15161,9 +15208,10 @@
         },
         "node_modules/fsevents/node_modules/node-pre-gyp": {
             "version": "0.14.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "BSD-3-Clause",
+            "optional": true,
             "dependencies": {
                 "detect-libc": "^1.0.2",
                 "mkdirp": "^0.5.1",
@@ -15182,9 +15230,10 @@
         },
         "node_modules/fsevents/node_modules/nopt": {
             "version": "4.0.3",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "abbrev": "1",
                 "osenv": "^0.1.4"
@@ -15195,24 +15244,27 @@
         },
         "node_modules/fsevents/node_modules/npm-bundled": {
             "version": "1.1.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "npm-normalize-package-bin": "^1.0.1"
             }
         },
         "node_modules/fsevents/node_modules/npm-normalize-package-bin": {
             "version": "1.0.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/npm-packlist": {
             "version": "1.4.8",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "ignore-walk": "^3.0.1",
                 "npm-bundled": "^1.0.1",
@@ -15221,9 +15273,10 @@
         },
         "node_modules/fsevents/node_modules/npmlog": {
             "version": "4.1.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -15233,54 +15286,60 @@
         },
         "node_modules/fsevents/node_modules/number-is-nan": {
             "version": "1.0.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/fsevents/node_modules/object-assign": {
             "version": "4.1.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/fsevents/node_modules/once": {
             "version": "1.4.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "wrappy": "1"
             }
         },
         "node_modules/fsevents/node_modules/os-homedir": {
             "version": "1.0.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/fsevents/node_modules/os-tmpdir": {
             "version": "1.0.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/fsevents/node_modules/osenv": {
             "version": "0.1.5",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "os-homedir": "^1.0.0",
                 "os-tmpdir": "^1.0.0"
@@ -15288,24 +15347,27 @@
         },
         "node_modules/fsevents/node_modules/path-is-absolute": {
             "version": "1.0.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/fsevents/node_modules/process-nextick-args": {
             "version": "2.0.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/rc": {
             "version": "1.2.8",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+            "optional": true,
             "dependencies": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -15318,9 +15380,10 @@
         },
         "node_modules/fsevents/node_modules/readable-stream": {
             "version": "2.3.7",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -15333,9 +15396,10 @@
         },
         "node_modules/fsevents/node_modules/rimraf": {
             "version": "2.7.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -15345,57 +15409,65 @@
         },
         "node_modules/fsevents/node_modules/safe-buffer": {
             "version": "5.1.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/safer-buffer": {
             "version": "2.1.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/sax": {
             "version": "1.2.4",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/semver": {
             "version": "5.7.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "bin": {
                 "semver": "bin/semver"
             }
         },
         "node_modules/fsevents/node_modules/set-blocking": {
             "version": "2.0.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/signal-exit": {
             "version": "3.0.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/string_decoder": {
             "version": "1.1.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
         },
         "node_modules/fsevents/node_modules/string-width": {
             "version": "1.0.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -15407,9 +15479,10 @@
         },
         "node_modules/fsevents/node_modules/strip-ansi": {
             "version": "3.0.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "dependencies": {
                 "ansi-regex": "^2.0.0"
             },
@@ -15419,18 +15492,20 @@
         },
         "node_modules/fsevents/node_modules/strip-json-comments": {
             "version": "2.0.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/fsevents/node_modules/tar": {
             "version": "4.4.13",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "chownr": "^1.1.1",
                 "fs-minipass": "^1.2.5",
@@ -15446,30 +15521,34 @@
         },
         "node_modules/fsevents/node_modules/util-deprecate": {
             "version": "1.0.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/wide-align": {
             "version": "1.1.3",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "optional": true,
             "dependencies": {
                 "string-width": "^1.0.2 || 2"
             }
         },
         "node_modules/fsevents/node_modules/wrappy": {
             "version": "1.0.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/fsevents/node_modules/yallist": {
             "version": "3.1.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
-            "license": "ISC"
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/function-bind": {
             "version": "1.1.1",
@@ -24979,10 +25058,7 @@
         "node_modules/refractor/node_modules/prismjs": {
             "version": "1.23.0",
             "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
-            "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
-            "requires": {
-                "clipboard": "^2.0.0"
-            }
+            "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA=="
         },
         "node_modules/regenerate": {
             "version": "1.4.0",
@@ -29244,6 +29320,12 @@
                 "underscore": "1.8.3"
             }
         },
+        "node_modules/typed-rest-client/node_modules/underscore": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+            "dev": true
+        },
         "node_modules/typed-styles": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
@@ -29385,9 +29467,9 @@
             }
         },
         "node_modules/underscore": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+            "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
         },
         "node_modules/undertaker": {
             "version": "1.2.1",
@@ -37853,6 +37935,14 @@
                 "tunnel": "0.0.4",
                 "typed-rest-client": "1.2.0",
                 "underscore": "1.8.3"
+            },
+            "dependencies": {
+                "underscore": {
+                    "version": "1.8.3",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+                    "dev": true
+                }
             }
         },
         "azure-storage": {
@@ -37892,6 +37982,12 @@
                     "version": "0.10.31",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                },
+                "underscore": {
+                    "version": "1.8.3",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
                     "dev": true
                 },
                 "xml2js": {
@@ -44660,22 +44756,26 @@
                 "abbrev": {
                     "version": "1.1.1",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.5",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "delegates": "^1.0.0",
                         "readable-stream": "^2.0.6"
@@ -44684,12 +44784,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -44698,32 +44800,38 @@
                 "chownr": {
                     "version": "1.1.4",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "debug": {
                     "version": "3.2.6",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "ms": "^2.1.1"
                     }
@@ -44731,22 +44839,26 @@
                 "deep-extend": {
                     "version": "0.6.0",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "delegates": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "detect-libc": {
                     "version": "1.0.3",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "fs-minipass": {
                     "version": "1.2.7",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "minipass": "^2.6.0"
                     }
@@ -44754,12 +44866,14 @@
                 "fs.realpath": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "gauge": {
                     "version": "2.7.4",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "aproba": "^1.0.3",
                         "console-control-strings": "^1.0.0",
@@ -44774,7 +44888,8 @@
                 "glob": {
                     "version": "7.1.6",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
                         "inflight": "^1.0.4",
@@ -44787,12 +44902,14 @@
                 "has-unicode": {
                     "version": "2.0.1",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "iconv-lite": {
                     "version": "0.4.24",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "safer-buffer": ">= 2.1.2 < 3"
                     }
@@ -44800,7 +44917,8 @@
                 "ignore-walk": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimatch": "^3.0.4"
                     }
@@ -44808,7 +44926,8 @@
                 "inflight": {
                     "version": "1.0.6",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "once": "^1.3.0",
                         "wrappy": "1"
@@ -44817,17 +44936,20 @@
                 "inherits": {
                     "version": "2.0.4",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -44835,12 +44957,14 @@
                 "isarray": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -44848,12 +44972,14 @@
                 "minimist": {
                     "version": "1.2.5",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.9.0",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -44862,7 +44988,8 @@
                 "minizlib": {
                     "version": "1.3.3",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "minipass": "^2.9.0"
                     }
@@ -44870,7 +44997,8 @@
                 "mkdirp": {
                     "version": "0.5.3",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "^1.2.5"
                     }
@@ -44878,12 +45006,14 @@
                 "ms": {
                     "version": "2.1.2",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "needle": {
                     "version": "2.3.3",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "debug": "^3.2.6",
                         "iconv-lite": "^0.4.4",
@@ -44893,7 +45023,8 @@
                 "node-pre-gyp": {
                     "version": "0.14.0",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "detect-libc": "^1.0.2",
                         "mkdirp": "^0.5.1",
@@ -44910,7 +45041,8 @@
                 "nopt": {
                     "version": "4.0.3",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "abbrev": "1",
                         "osenv": "^0.1.4"
@@ -44919,7 +45051,8 @@
                 "npm-bundled": {
                     "version": "1.1.1",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "npm-normalize-package-bin": "^1.0.1"
                     }
@@ -44927,12 +45060,14 @@
                 "npm-normalize-package-bin": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "npm-packlist": {
                     "version": "1.4.8",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "ignore-walk": "^3.0.1",
                         "npm-bundled": "^1.0.1",
@@ -44942,7 +45077,8 @@
                 "npmlog": {
                     "version": "4.1.2",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "are-we-there-yet": "~1.1.2",
                         "console-control-strings": "~1.1.0",
@@ -44953,17 +45089,20 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -44971,17 +45110,20 @@
                 "os-homedir": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "osenv": {
                     "version": "0.1.5",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "os-homedir": "^1.0.0",
                         "os-tmpdir": "^1.0.0"
@@ -44990,17 +45132,20 @@
                 "path-is-absolute": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "process-nextick-args": {
                     "version": "2.0.1",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "rc": {
                     "version": "1.2.8",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "deep-extend": "^0.6.0",
                         "ini": "~1.3.0",
@@ -45011,7 +45156,8 @@
                 "readable-stream": {
                     "version": "2.3.7",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -45025,7 +45171,8 @@
                 "rimraf": {
                     "version": "2.7.1",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "glob": "^7.1.3"
                     }
@@ -45033,37 +45180,44 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "sax": {
                     "version": "1.2.4",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "semver": {
                     "version": "5.7.1",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "string_decoder": {
                     "version": "1.1.1",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
@@ -45071,7 +45225,8 @@
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -45081,7 +45236,8 @@
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -45089,12 +45245,14 @@
                 "strip-json-comments": {
                     "version": "2.0.1",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "tar": {
                     "version": "4.4.13",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "chownr": "^1.1.1",
                         "fs-minipass": "^1.2.5",
@@ -45108,12 +45266,14 @@
                 "util-deprecate": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "wide-align": {
                     "version": "1.1.3",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "string-width": "^1.0.2 || 2"
                     }
@@ -45121,12 +45281,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.1.1",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -53258,10 +53420,7 @@
                 "prismjs": {
                     "version": "1.23.0",
                     "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
-                    "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
-                    "requires": {
-                        "clipboard": "^2.0.0"
-                    }
+                    "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA=="
                 }
             }
         },
@@ -56938,6 +57097,14 @@
             "requires": {
                 "tunnel": "0.0.4",
                 "underscore": "1.8.3"
+            },
+            "dependencies": {
+                "underscore": {
+                    "version": "1.8.3",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+                    "dev": true
+                }
             }
         },
         "typed-styles": {
@@ -57057,9 +57224,9 @@
             "dev": true
         },
         "underscore": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+            "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
         },
         "undertaker": {
             "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -1972,6 +1972,7 @@
         "tmp": "^0.0.29",
         "typescript-char": "^0.0.0",
         "uint64be": "^1.0.1",
+        "underscore": "^1.12.1",
         "unicode": "^10.0.0",
         "untildify": "^3.0.2",
         "uuid": "^3.3.2",


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2021-23358