### PR TITLE
Fix inverted filter condition when building kernel list

### DIFF
--- a/src/client/datascience/kernel-launcher/localKernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/localKernelFinder.ts
@@ -204,7 +204,7 @@ export class LocalKernelFinder implements ILocalKernelFinder {
 
                     // If interpreters were found, remove them from the interpreter list we'll eventually
                     // return as interpreter only items
-                    filteredInterpreters = filteredInterpreters.filter((i) => matchingInterpreter === i);
+                    filteredInterpreters = filteredInterpreters.filter((i) => matchingInterpreter !== i);
 
                     // Return our metadata that uses an interpreter to start
                     return result;


### PR DESCRIPTION
For https://github.com/microsoft/vscode-jupyter/issues/5694

Simple fix. Filter condition was inverted judging by the comment and what this line of code was prior to the change. Caused interpreters to be excluded when they should be included.
![image](https://user-images.githubusercontent.com/30305945/116627266-a4361000-a901-11eb-8870-a2092ffef5d9.png)
https://github.com/microsoft/vscode-jupyter/commit/071283e544376e237d660ea88a3099eb01c44e42#diff-9c576b18e870d241026b9d491ba69a25521cd7bf813cac9cb44d26a97af407e6R205-R207

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
