### PR TITLE
Unwrap boolean promise when checking if `nbconvert` is installed

### DIFF
--- a/src/client/datascience/jupyter/interpreter/nbconvertInterpreterDependencyChecker.ts
+++ b/src/client/datascience/jupyter/interpreter/nbconvertInterpreterDependencyChecker.ts
@@ -26,11 +26,11 @@ export class NbConvertInterpreterDependencyChecker implements INbConvertInterpre
         if (this.nbconvertInstalledInInterpreter.has(interpreter.path)) {
             return true;
         }
-        const installed = this.installer.isInstalled(Product.nbconvert, interpreter).then((result) => result === true);
-        if (installed) {
+        const isInstalled: boolean = !!(await this.installer.isInstalled(Product.nbconvert, interpreter));
+        if (isInstalled === true) {
             this.nbconvertInstalledInInterpreter.add(interpreter.path);
         }
-        return installed;
+        return isInstalled;
     }
 
     // Get the specific version of nbconvert installed in the given interpreter


### PR DESCRIPTION
Ran into this when looking at https://github.com/microsoft/vscode-jupyter/issues/5726. In `const installed = this.installer.isInstalled(Product.nbconvert, interpreter).then((result) => result === true);`, `installed` is of type `Promise<boolean>`, so I think this means that this method always caches any interpreter that's passed in as a valid interpreter for export.