### PR TITLE
Bump @nteract/presentational-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "@jupyterlab/services": "^4.2.0",
                 "@loadable/component": "^5.12.0",
                 "@nteract/messaging": "^7.0.0",
+                "@nteract/presentational-components": "^3.4.10",
                 "@nteract/transform-dataresource": "^4.3.5",
                 "@nteract/transform-geojson": "^3.2.3",
                 "@nteract/transform-model-debug": "^3.2.3",
@@ -3156,16 +3157,20 @@
             "integrity": "sha512-1Km5MtjyUL9POZjU6LMzH/npFUYIC6vewH0Gd2Ua1FON3qN1KCRoJ8em5Gkp+K57QJRpMET1F4z4N9d3U9HOqA=="
         },
         "node_modules/@nteract/presentational-components": {
-            "version": "3.4.9",
-            "resolved": "https://registry.npmjs.org/@nteract/presentational-components/-/presentational-components-3.4.9.tgz",
-            "integrity": "sha512-fcCYOdBRFyuj9vvXnrr2L2ynqouHnexUxpzt5VGTs4Mf/72r93vksarBStw2BD19utCVci7Fb5z6tNkFgveAZA==",
+            "version": "3.4.10",
+            "resolved": "https://registry.npmjs.org/@nteract/presentational-components/-/presentational-components-3.4.10.tgz",
+            "integrity": "sha512-oT5bT/bc6fhSIzUwxBu8qUlNNouOntis3KBPceXXEtJtleuiolj3Tmih0ZO3qYx3Z5J9PB4dUs0sR1aFRlYXkQ==",
             "dependencies": {
                 "@blueprintjs/core": "^3.7.0",
                 "@blueprintjs/select": "^3.2.0",
                 "classnames": "^2.2.6",
                 "re-resizable": "^6.5.0",
-                "react-syntax-highlighter": "^12.0.0",
+                "react-syntax-highlighter": "^13.0.0",
                 "react-toggle": "^4.1.1"
+            },
+            "peerDependencies": {
+                "react": "^16.3.2",
+                "styled-components": ">= 5.0.1"
             }
         },
         "node_modules/@nteract/styled-blueprintjsx": {
@@ -4187,6 +4192,14 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/hast": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.1.tgz",
+            "integrity": "sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==",
+            "dependencies": {
+                "@types/unist": "*"
+            }
+        },
         "node_modules/@types/hoist-non-react-statics": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -4626,6 +4639,11 @@
             "version": "1.9.4",
             "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.9.4.tgz",
             "integrity": "sha512-CjHWEMECc2/UxOZh0kpiz3lEyX2Px3rQS9HzD20lxMvx571ivOBQKeLnqEjxUY0BMgp6WJWo/pQLRBwMW5v4WQ=="
+        },
+        "node_modules/@types/unist": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+            "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
         },
         "node_modules/@types/untildify": {
             "version": "3.0.0",
@@ -8743,7 +8761,11 @@
         "node_modules/comma-separated-tokens": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
-            "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
+            "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
         },
         "node_modules/commander": {
             "version": "2.20.0",
@@ -13780,6 +13802,10 @@
             "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
             "dependencies": {
                 "format": "^0.2.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/fbjs": {
@@ -16538,17 +16564,26 @@
         "node_modules/hast-util-parse-selector": {
             "version": "2.2.5",
             "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
-            "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ=="
+            "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
         },
         "node_modules/hastscript": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
-            "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
+            "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
             "dependencies": {
+                "@types/hast": "^2.0.0",
                 "comma-separated-tokens": "^1.0.0",
                 "hast-util-parse-selector": "^2.0.0",
                 "property-information": "^5.0.0",
                 "space-separated-tokens": "^1.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/he": {
@@ -16561,9 +16596,9 @@
             }
         },
         "node_modules/highlight.js": {
-            "version": "9.15.10",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
-            "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==",
+            "version": "10.7.2",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.2.tgz",
+            "integrity": "sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg==",
             "engines": {
                 "node": "*"
             }
@@ -19351,12 +19386,16 @@
             }
         },
         "node_modules/lowlight": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.12.1.tgz",
-            "integrity": "sha512-OqaVxMGIESnawn+TU/QMV5BJLbUghUfjDWPAtFqDYDmDtr4FnB+op8xM+pR7nKlauHNUHXGt0VgWatFB8voS5w==",
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+            "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
             "dependencies": {
-                "fault": "^1.0.2",
-                "highlight.js": "~9.15.0"
+                "fault": "^1.0.0",
+                "highlight.js": "~10.7.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/lru-cache": {
@@ -24071,6 +24110,10 @@
             "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
             "dependencies": {
                 "xtend": "^4.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/proxy-addr": {
@@ -24727,15 +24770,18 @@
             }
         },
         "node_modules/react-syntax-highlighter": {
-            "version": "12.2.1",
-            "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-12.2.1.tgz",
-            "integrity": "sha512-CTsp0ZWijwKRYFg9xhkWD4DSpQqE4vb2NKVMdPAkomnILSmsNBHE0n5GuI5zB+PU3ySVvXvdt9jo+ViD9XibCA==",
+            "version": "13.5.3",
+            "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-13.5.3.tgz",
+            "integrity": "sha512-crPaF+QGPeHNIblxxCdf2Lg936NAHKhNhuMzRL3F9ct6aYXL3NcZtCL0Rms9+qVo6Y1EQLdXGypBNSbPL/r+qg==",
             "dependencies": {
                 "@babel/runtime": "^7.3.1",
-                "highlight.js": "~9.15.1",
-                "lowlight": "1.12.1",
-                "prismjs": "^1.8.4",
-                "refractor": "^2.4.1"
+                "highlight.js": "^10.1.1",
+                "lowlight": "^1.14.0",
+                "prismjs": "^1.21.0",
+                "refractor": "^3.1.0"
+            },
+            "peerDependencies": {
+                "react": ">= 0.14.0"
             }
         },
         "node_modules/react-table": {
@@ -25046,19 +25092,35 @@
             "dev": true
         },
         "node_modules/refractor": {
-            "version": "2.10.1",
-            "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
-            "integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.3.1.tgz",
+            "integrity": "sha512-vaN6R56kLMuBszHSWlwTpcZ8KTMG6aUCok4GrxYDT20UIOXxOc5o6oDc8tNTzSlH3m2sI+Eu9Jo2kVdDcUTWYw==",
             "dependencies": {
-                "hastscript": "^5.0.0",
-                "parse-entities": "^1.1.2",
-                "prismjs": "1.23.0"
+                "hastscript": "^6.0.0",
+                "parse-entities": "^2.0.0",
+                "prismjs": "~1.23.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/refractor/node_modules/prismjs": {
-            "version": "1.23.0",
-            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
-            "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA=="
+        "node_modules/refractor/node_modules/parse-entities": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+            "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+            "dependencies": {
+                "character-entities": "^1.0.0",
+                "character-entities-legacy": "^1.0.0",
+                "character-reference-invalid": "^1.0.0",
+                "is-alphanumerical": "^1.0.0",
+                "is-decimal": "^1.0.0",
+                "is-hexadecimal": "^1.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
         },
         "node_modules/regenerate": {
             "version": "1.4.0",
@@ -26731,7 +26793,11 @@
         "node_modules/space-separated-tokens": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
-            "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
+            "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
         },
         "node_modules/sparkles": {
             "version": "1.0.1",
@@ -34616,15 +34682,15 @@
             "integrity": "sha512-1Km5MtjyUL9POZjU6LMzH/npFUYIC6vewH0Gd2Ua1FON3qN1KCRoJ8em5Gkp+K57QJRpMET1F4z4N9d3U9HOqA=="
         },
         "@nteract/presentational-components": {
-            "version": "3.4.9",
-            "resolved": "https://registry.npmjs.org/@nteract/presentational-components/-/presentational-components-3.4.9.tgz",
-            "integrity": "sha512-fcCYOdBRFyuj9vvXnrr2L2ynqouHnexUxpzt5VGTs4Mf/72r93vksarBStw2BD19utCVci7Fb5z6tNkFgveAZA==",
+            "version": "3.4.10",
+            "resolved": "https://registry.npmjs.org/@nteract/presentational-components/-/presentational-components-3.4.10.tgz",
+            "integrity": "sha512-oT5bT/bc6fhSIzUwxBu8qUlNNouOntis3KBPceXXEtJtleuiolj3Tmih0ZO3qYx3Z5J9PB4dUs0sR1aFRlYXkQ==",
             "requires": {
                 "@blueprintjs/core": "^3.7.0",
                 "@blueprintjs/select": "^3.2.0",
                 "classnames": "^2.2.6",
                 "re-resizable": "^6.5.0",
-                "react-syntax-highlighter": "^12.0.0",
+                "react-syntax-highlighter": "^13.0.0",
                 "react-toggle": "^4.1.1"
             }
         },
@@ -35642,6 +35708,14 @@
                 "@types/node": "*"
             }
         },
+        "@types/hast": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.1.tgz",
+            "integrity": "sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==",
+            "requires": {
+                "@types/unist": "*"
+            }
+        },
         "@types/hoist-non-react-statics": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -36079,6 +36153,11 @@
             "version": "1.9.4",
             "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.9.4.tgz",
             "integrity": "sha512-CjHWEMECc2/UxOZh0kpiz3lEyX2Px3rQS9HzD20lxMvx571ivOBQKeLnqEjxUY0BMgp6WJWo/pQLRBwMW5v4WQ=="
+        },
+        "@types/unist": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+            "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
         },
         "@types/untildify": {
             "version": "3.0.0",
@@ -46126,10 +46205,11 @@
             "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ=="
         },
         "hastscript": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
-            "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
+            "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
             "requires": {
+                "@types/hast": "^2.0.0",
                 "comma-separated-tokens": "^1.0.0",
                 "hast-util-parse-selector": "^2.0.0",
                 "property-information": "^5.0.0",
@@ -46143,9 +46223,9 @@
             "dev": true
         },
         "highlight.js": {
-            "version": "9.15.10",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
-            "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw=="
+            "version": "10.7.2",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.2.tgz",
+            "integrity": "sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg=="
         },
         "hmac-drbg": {
             "version": "1.0.1",
@@ -48480,12 +48560,12 @@
             "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
         },
         "lowlight": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.12.1.tgz",
-            "integrity": "sha512-OqaVxMGIESnawn+TU/QMV5BJLbUghUfjDWPAtFqDYDmDtr4FnB+op8xM+pR7nKlauHNUHXGt0VgWatFB8voS5w==",
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+            "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
             "requires": {
-                "fault": "^1.0.2",
-                "highlight.js": "~9.15.0"
+                "fault": "^1.0.0",
+                "highlight.js": "~10.7.0"
             }
         },
         "lru-cache": {
@@ -53113,15 +53193,15 @@
             }
         },
         "react-syntax-highlighter": {
-            "version": "12.2.1",
-            "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-12.2.1.tgz",
-            "integrity": "sha512-CTsp0ZWijwKRYFg9xhkWD4DSpQqE4vb2NKVMdPAkomnILSmsNBHE0n5GuI5zB+PU3ySVvXvdt9jo+ViD9XibCA==",
+            "version": "13.5.3",
+            "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-13.5.3.tgz",
+            "integrity": "sha512-crPaF+QGPeHNIblxxCdf2Lg936NAHKhNhuMzRL3F9ct6aYXL3NcZtCL0Rms9+qVo6Y1EQLdXGypBNSbPL/r+qg==",
             "requires": {
                 "@babel/runtime": "^7.3.1",
-                "highlight.js": "~9.15.1",
-                "lowlight": "1.12.1",
-                "prismjs": "^1.8.4",
-                "refractor": "^2.4.1"
+                "highlight.js": "^10.1.1",
+                "lowlight": "^1.14.0",
+                "prismjs": "^1.21.0",
+                "refractor": "^3.1.0"
             }
         },
         "react-table": {
@@ -53408,19 +53488,27 @@
             "dev": true
         },
         "refractor": {
-            "version": "2.10.1",
-            "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
-            "integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.3.1.tgz",
+            "integrity": "sha512-vaN6R56kLMuBszHSWlwTpcZ8KTMG6aUCok4GrxYDT20UIOXxOc5o6oDc8tNTzSlH3m2sI+Eu9Jo2kVdDcUTWYw==",
             "requires": {
-                "hastscript": "^5.0.0",
-                "parse-entities": "^1.1.2",
-                "prismjs": "1.23.0"
+                "hastscript": "^6.0.0",
+                "parse-entities": "^2.0.0",
+                "prismjs": "~1.23.0"
             },
             "dependencies": {
-                "prismjs": {
-                    "version": "1.23.0",
-                    "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
-                    "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA=="
+                "parse-entities": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+                    "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+                    "requires": {
+                        "character-entities": "^1.0.0",
+                        "character-entities-legacy": "^1.0.0",
+                        "character-reference-invalid": "^1.0.0",
+                        "is-alphanumerical": "^1.0.0",
+                        "is-decimal": "^1.0.0",
+                        "is-hexadecimal": "^1.0.0"
+                    }
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -1905,6 +1905,7 @@
         "@jupyterlab/services": "^4.2.0",
         "@loadable/component": "^5.12.0",
         "@nteract/messaging": "^7.0.0",
+        "@nteract/presentational-components": "^3.4.10",
         "@nteract/transform-dataresource": "^4.3.5",
         "@nteract/transform-geojson": "^3.2.3",
         "@nteract/transform-model-debug": "^3.2.3",


### PR DESCRIPTION
For https://github.com/microsoft/vscode-jupyter/issues/5701

This removes the need to add a CI check for our hacked package-lock. The latest version of presentational-components no longer depends on an insecure version of react-syntax-highlighter.