### PR TITLE
Bump VS Code engine to 1.57-insiders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -283,7 +283,7 @@
                 "yargs-parser": "^13.1.2"
             },
             "engines": {
-                "vscode": "1.56.0-insider"
+                "vscode": "1.57.0-insider"
             },
             "optionalDependencies": {
                 "canvas": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "theme": "light"
     },
     "engines": {
-        "vscode": "1.56.0-insider"
+        "vscode": "1.57.0-insider"
     },
     "keywords": [
         "jupyter",


### PR DESCRIPTION
Ensure no further insiders builds are published for VS Code 1.56 