### PR TITLE
update package.json to new notebook value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1776,7 +1776,7 @@
                 ]
             }
         ],
-        "notebookProvider": [
+        "notebooks": [
             {
                 "viewType": "jupyter-notebook",
                 "displayName": "Jupyter Notebook (preview)",


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/93265#issuecomment-838017630

> Please note the following BREAKING change: we have renamed the package.json contribution point from notebookProvider to notebooks. For a short while we will support both variants, see #121819 for more details

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
