### PR TITLE
More safety when reading `notebook.cellToolbarLocation` keys

### DIFF
--- a/src/client/datascience/notebook/integration.ts
+++ b/src/client/datascience/notebook/integration.ts
@@ -113,10 +113,9 @@ export class NotebookIntegration implements IExtensionSingleActivationService {
         // already changed it on their own.
         // Make sure we don't overwrite the user's existing customization for this setting
         const settings = this.workspace.getConfiguration('notebook', undefined);
-        const toolbarSettings = settings.get('cellToolbarLocation') as {
-            [key: string]: 'left' | 'right' | 'hidden';
-        };
-        const userCustomizedSetting = JupyterNotebookView in toolbarSettings;
+        const toolbarSettings =
+            settings.get<{ [viewType: string]: 'left' | 'right' | 'hidden' }>('cellToolbarLocation') ?? {};
+        const userCustomizedSetting = Object.keys(toolbarSettings).includes(JupyterNotebookView);
         if (userCustomizedSetting) {
             // Regardless of what the user set this to, we should honor it
             return;


### PR DESCRIPTION
After updating to 1.57.0-insider on my Mac I saw Jupyter extension v2021.6.841665333 fail to activate. Unfortunately I don't have the stacktrace, but the error was about the use of the `in` operator on this line:

https://github.com/microsoft/vscode-jupyter/blob/988de20f64f651332bea06abc49e0feef76a8c1d/src/client/datascience/notebook/integration.ts#L119

`workspace.getConfiguration` returns settings objects which are apparently "proxies" instead of simple object literals (I don't actually know when, how, or why):
 
![image](https://user-images.githubusercontent.com/30305945/118343925-86130700-b4e0-11eb-98b3-5174017e1b4d.png)

When I was dealing with the `workbench.editorAssociations` setting update I found that it's illegal to do something like `delete proxySetting[mykey]`--that will throw an exception. I'm now worried that the `in` operator isn't allowed for proxy objects as well, so I want to change the way that we're checking if the 'jupyter-notebook' viewType is configured when migrating the cell toolbar setting, just in case this is an actual problem.