### PR TITLE
Change cell lang to one thats supported by kernel

### DIFF
--- a/news/2 Fixes/5924.md
+++ b/news/2 Fixes/5924.md
@@ -1,0 +1,1 @@
+Change language of cell to reflect langauges supported by the selected Kernel.

--- a/package.json
+++ b/package.json
@@ -1769,6 +1769,9 @@
                 ]
             },
             {
+                "id": "raw"
+            },
+            {
                 "id": "julia",
                 "aliases": [
                     "Julia",

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -31,7 +31,7 @@ export const LanguagesSupportedByPythonkernel = [
     'ruby', // %%ruby
     'sql', // %%sql
     'perl', // %%perl
-    'plaintext' // raw cells (no formatting)
+    'raw' // raw cells (no formatting)
 ];
 
 // List of 'language' names that we know about. All should be lower case as that's how we compare.

--- a/src/client/datascience/jupyter/kernels/cellExecution.ts
+++ b/src/client/datascience/jupyter/kernels/cellExecution.ts
@@ -380,10 +380,7 @@ export class CellExecution {
     }
     private canExecuteCell() {
         // Raw cells cannot be executed.
-        if (
-            isPythonKernelConnection(this.kernelConnection) &&
-            (this.cell.document.languageId === 'raw' || this.cell.document.languageId === 'plaintext')
-        ) {
+        if (isPythonKernelConnection(this.kernelConnection) && this.cell.document.languageId === 'raw') {
             return false;
         }
 

--- a/src/client/datascience/notebook/helpers/helpers.ts
+++ b/src/client/datascience/notebook/helpers/helpers.ts
@@ -256,7 +256,7 @@ export function createJupyterCellFromVSCNotebookCell(
     let cell: nbformat.IRawCell | nbformat.IMarkdownCell | nbformat.ICodeCell;
     if (vscCell.kind === NotebookCellKind.Markup) {
         cell = createMarkdownCellFromNotebookCell(vscCell);
-    } else if (vscCell.document.languageId === 'raw' || vscCell.document.languageId === 'plaintext') {
+    } else if (vscCell.document.languageId === 'raw') {
         cell = createRawCellFromNotebookCell(vscCell);
     } else {
         cell = createCodeCellFromNotebookCell(vscCell);

--- a/src/client/datascience/notebook/noPythonKernelsNotebookController.ts
+++ b/src/client/datascience/notebook/noPythonKernelsNotebookController.ts
@@ -9,7 +9,7 @@ import { IDisposable, IDisposableRegistry } from '../../common/types';
 import { Common, DataScience } from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
 import { sendTelemetryEvent } from '../../telemetry';
-import { PythonExtension, Telemetry } from '../constants';
+import { LanguagesSupportedByPythonkernel, PythonExtension, Telemetry } from '../constants';
 import { JupyterNotebookView } from './constants';
 import { getNotebookMetadata, isPythonNotebook } from './helpers/helpers';
 
@@ -33,6 +33,7 @@ export class NoPythonKernelsNotebookController implements Disposable {
         this.disposables.push(this.controller);
         this.controller.description = '';
         this.controller.detail = 'python3';
+        this.controller.supportedLanguages = LanguagesSupportedByPythonkernel;
     }
 
     public dispose() {

--- a/src/client/datascience/notebook/notebookControllerManager.ts
+++ b/src/client/datascience/notebook/notebookControllerManager.ts
@@ -32,7 +32,12 @@ import { PreferredRemoteKernelIdProvider } from '../notebookStorage/preferredRem
 import { sendNotebookControllerCreateTelemetry } from '../telemetry/kernelTelemetry';
 import { sendKernelTelemetryEvent, trackKernelResourceInformation } from '../telemetry/telemetry';
 import { IDataScienceErrorHandler, INotebookProvider } from '../types';
-import { getNotebookMetadata, isJupyterNotebook, trackKernelInNotebookMetadata } from './helpers/helpers';
+import {
+    getNotebookMetadata,
+    isJupyterNotebook,
+    isPythonNotebook,
+    trackKernelInNotebookMetadata
+} from './helpers/helpers';
 import { VSCodeNotebookController } from './vscodeNotebookController';
 import { INotebookControllerManager } from './types';
 import { JupyterNotebookView } from './constants';
@@ -190,6 +195,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
                     traceInfo('Find preferred kernel cancelled');
                     return;
                 }
+                await this.createOrDeletePlaceholderPythonKernel();
 
                 // If we found a preferred kernel, set the association on the NotebookController
                 if (preferredConnection) {
@@ -201,7 +207,16 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
                     this.setPreferredController(document, preferredConnection).catch(traceError);
                 } else {
                     const controllers = await this.controllersPromise?.catch(() => []);
-                    if (controllers?.length === 0 && !canOtherExtensionsRunCellsInNotebook(document)) {
+                    if (
+                        this.isLocalLaunch &&
+                        isPythonNotebook(getNotebookMetadata(document)) &&
+                        !controllers?.some((item) => isPythonKernelConnection(item.connection))
+                    ) {
+                        // Ensure the dummy Python kernel is selected as preferred.
+                        this.createNoPythonKernelNotebookController()
+                            .updateNotebookAffinity(document, NotebookControllerAffinity.Preferred)
+                            .catch(traceError);
+                    } else if (controllers?.length === 0 && !canOtherExtensionsRunCellsInNotebook(document)) {
                         // Add a dummy controller to indicate this notebook is not supported.
                         this.getNoKernelNotebookController()
                             .updateNotebookAffinity(document, NotebookControllerAffinity.Preferred)
@@ -235,10 +250,25 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
             this.handleOnNotebookControllerSelected({ notebook: document, controller: targetController }).catch(
                 traceError
             );
-        } else if (this.isLocalLaunch && !controllers.some((item) => isPythonKernelConnection(item.connection))) {
+        }
+    }
+
+    private async createOrDeletePlaceholderPythonKernel() {
+        if (!this.isLocalLaunch) {
+            return;
+        }
+        // Wait for our controllers to be loaded before we try to set a preferred on
+        // can happen if a document is opened quick and we have not yet loaded our controllers
+        const controllers = await this.getNotebookControllers();
+        if (!controllers.some((item) => isPythonKernelConnection(item.connection))) {
+            // Ensure we always have a `Python` kernel.
             // If we're dealing with local launch and user doesn't have a Python kernel (controller in the list)
             // then add a dummy one where we'll prompt the user to either install Python extension or Python itself.
             this.createNoPythonKernelNotebookController();
+        } else if (this.noPythonKernelNotebookController) {
+            // If subsequently user installs the python extension.
+            this.noPythonKernelNotebookController.dispose();
+            this.noPythonKernelNotebookController = undefined;
         }
     }
 

--- a/src/client/datascience/notebook/notebookControllerManager.ts
+++ b/src/client/datascience/notebook/notebookControllerManager.ts
@@ -44,6 +44,7 @@ import { canOtherExtensionsRunCellsInNotebook } from '../extensionRecommendation
 import { NoKernelsNotebookController } from './noKernelsNotebookController';
 import { NoPythonKernelsNotebookController } from './noPythonKernelsNotebookController';
 import { IPythonExtensionChecker } from '../../api/types';
+import { NotebookCellLanguageService } from './cellLanguageService';
 /**
  * This class tracks notebook documents that are open and the provides NotebookControllers for
  * each of them
@@ -85,7 +86,8 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
         @inject(InterpreterPackages) private readonly interpreterPackages: InterpreterPackages,
         @inject(IDataScienceErrorHandler) private readonly errorHandler: IDataScienceErrorHandler,
         @inject(IPythonExtensionChecker) private readonly pythonExtensionChecker: IPythonExtensionChecker,
-        @inject(IApplicationShell) private readonly appShell: IApplicationShell
+        @inject(IApplicationShell) private readonly appShell: IApplicationShell,
+        @inject(NotebookCellLanguageService) private readonly languageService: NotebookCellLanguageService
     ) {
         this._onNotebookControllerSelected = new EventEmitter<{
             notebook: NotebookDocument;
@@ -342,7 +344,8 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
                 this.context,
                 this,
                 this.pathUtils,
-                this.disposables
+                this.disposables,
+                this.languageService
             );
 
             // Hook up to if this NotebookController is selected or de-selected

--- a/src/client/datascience/notebook/notebookEditor.ts
+++ b/src/client/datascience/notebook/notebookEditor.ts
@@ -35,7 +35,7 @@ import {
     InterruptResult,
     IStatusProvider
 } from '../types';
-import { NotebookCellLanguageService } from './defaultCellLanguageService';
+import { NotebookCellLanguageService } from './cellLanguageService';
 import { chainWithPendingUpdates } from './helpers/notebookUpdater';
 
 export class NotebookEditor implements INotebookEditor {

--- a/src/client/datascience/notebook/notebookEditorProvider.ts
+++ b/src/client/datascience/notebook/notebookEditorProvider.ts
@@ -20,7 +20,7 @@ import { INotebookStorageProvider } from '../notebookStorage/notebookStorageProv
 import { VSCodeNotebookModel } from '../notebookStorage/vscNotebookModel';
 import { INotebookEditor, INotebookEditorProvider, INotebookProvider, IStatusProvider } from '../types';
 import { JupyterNotebookView } from './constants';
-import { NotebookCellLanguageService } from './defaultCellLanguageService';
+import { NotebookCellLanguageService } from './cellLanguageService';
 import { isJupyterNotebook } from './helpers/helpers';
 import { NotebookEditor } from './notebookEditor';
 

--- a/src/client/datascience/notebook/serviceRegistry.ts
+++ b/src/client/datascience/notebook/serviceRegistry.ts
@@ -12,7 +12,7 @@ import { IKernelProvider } from '../jupyter/kernels/types';
 import { NotebookContentProvider } from './contentProvider';
 import { CreationOptionService } from './creation/creationOptionsService';
 import { NotebookCreator } from './creation/notebookCreator';
-import { NotebookCellLanguageService } from './defaultCellLanguageService';
+import { NotebookCellLanguageService } from './cellLanguageService';
 import { EmptyNotebookCellLanguageService } from './emptyNotebookCellLanguageService';
 import { NotebookIntegration } from './integration';
 import { NotebookCompletionProvider } from './intellisense/completionProvider';

--- a/src/client/datascience/notebookStorage/factory.ts
+++ b/src/client/datascience/notebookStorage/factory.ts
@@ -7,7 +7,7 @@ import { Memento, Uri } from 'vscode';
 import { IVSCodeNotebook } from '../../common/application/types';
 import { UseVSCodeNotebookEditorApi } from '../../common/constants';
 import { ICryptoUtils } from '../../common/types';
-import { NotebookCellLanguageService } from '../notebook/defaultCellLanguageService';
+import { NotebookCellLanguageService } from '../notebook/cellLanguageService';
 import { ICell, INotebookModel } from '../types';
 import { NativeEditorNotebookModel } from './notebookModel';
 import { INotebookModelFactory } from './types';

--- a/src/client/datascience/notebookStorage/vscNotebookModel.ts
+++ b/src/client/datascience/notebookStorage/vscNotebookModel.ts
@@ -4,6 +4,7 @@
 import type { nbformat } from '@jupyterlab/coreutils';
 import { Memento, NotebookDocument, Uri } from 'vscode';
 import { IVSCodeNotebook } from '../../common/application/types';
+import { PYTHON_LANGUAGE } from '../../common/constants';
 import { ICryptoUtils } from '../../common/types';
 import { NotebookModelChange } from '../interactive-common/interactiveWindowTypes';
 import {
@@ -88,7 +89,7 @@ export class VSCodeNotebookModel extends BaseNotebookModel {
             this.notebookContentWithoutCells,
             this.file,
             this.notebookJson.cells || [],
-            this.preferredLanguage || 'plaintext',
+            this.preferredLanguage || PYTHON_LANGUAGE,
             this.originalJson
         );
     }

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -190,7 +190,7 @@ import {
     IKernelLauncher,
     IRemoteKernelFinder
 } from '../../client/datascience/kernel-launcher/types';
-import { NotebookCellLanguageService } from '../../client/datascience/notebook/defaultCellLanguageService';
+import { NotebookCellLanguageService } from '../../client/datascience/notebook/cellLanguageService';
 import { NotebookCreationTracker } from '../../client/datascience/notebookAndInteractiveTracker';
 import { NotebookExtensibility } from '../../client/datascience/notebookExtensibility';
 import { NotebookModelFactory } from '../../client/datascience/notebookStorage/factory';

--- a/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
@@ -35,7 +35,7 @@ import {
 } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { TrustService } from '../../../client/datascience/interactive-ipynb/trustService';
 import { JupyterExecutionFactory } from '../../../client/datascience/jupyter/jupyterExecutionFactory';
-import { NotebookCellLanguageService } from '../../../client/datascience/notebook/defaultCellLanguageService';
+import { NotebookCellLanguageService } from '../../../client/datascience/notebook/cellLanguageService';
 import { NotebookModelFactory } from '../../../client/datascience/notebookStorage/factory';
 import { NativeEditorStorage } from '../../../client/datascience/notebookStorage/nativeEditorStorage';
 import { NativeEditorNotebookModel } from '../../../client/datascience/notebookStorage/notebookModel';

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -48,7 +48,7 @@ import {
     hasErrorOutput,
     NotebookCellStateTracker
 } from '../../../client/datascience/notebook/helpers/helpers';
-import { LastSavedNotebookCellLanguage } from '../../../client/datascience/notebook/defaultCellLanguageService';
+import { LastSavedNotebookCellLanguage } from '../../../client/datascience/notebook/cellLanguageService';
 import { chainWithPendingUpdates } from '../../../client/datascience/notebook/helpers/notebookUpdater';
 import { NotebookEditor } from '../../../client/datascience/notebook/notebookEditor';
 import {

--- a/src/test/datascience/notebook/nonPythonKernels.vscode.test.ts
+++ b/src/test/datascience/notebook/nonPythonKernels.vscode.test.ts
@@ -12,7 +12,7 @@ import { IVSCodeNotebook } from '../../../client/common/application/types';
 import { traceInfo } from '../../../client/common/logger';
 import { IDisposable } from '../../../client/common/types';
 import { VSCodeNotebookProvider } from '../../../client/datascience/constants';
-import { NotebookCellLanguageService } from '../../../client/datascience/notebook/defaultCellLanguageService';
+import { NotebookCellLanguageService } from '../../../client/datascience/notebook/cellLanguageService';
 import { INotebookEditorProvider } from '../../../client/datascience/types';
 import { IExtensionTestApi, waitForCondition } from '../../common';
 import { EXTENSION_ROOT_DIR_FOR_TESTS, IS_REMOTE_NATIVE_TEST, IS_NON_RAW_NATIVE_TEST } from '../../constants';


### PR DESCRIPTION
For #5924

**Scenario 1:**
*  Assume user opens a notebook and language is C++ or .NET Interactive, they start writing python code.
*  Next users hits the run button, next user will be promtped to select a kernel.
*  User now selects a Python kernel.
*  Nothing happens, that's right nothing happens.
*  This is because C++ is not a lanaugage supported by the python kernel.
*  Hence VS Code will not send the execution call to the extension.
* 
*  Solution, go through the cells and change the languges to something that's supported.

**Scenario 2:**
*  User has .NET extension installed.
*  User opens a Python notebook and runs a cell with a .NET kernel (accidentally or deliberately).
*  User gets errors in output & realizes mistake & changes the kernel.
*  Now user runs a cell & nothing happens again.
