### PR TITLE
Use constants for storing default nb formats

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -801,7 +801,6 @@ module.exports = {
         'src/client/datascience/themeFinder.ts',
         'src/client/datascience/multiplexingDebugService.ts',
         'src/client/datascience/interactive-window/identity.ts',
-        'src/client/datascience/interactive-window/interactiveWindow.ts',
         'src/client/datascience/datascience.ts',
         'src/client/datascience/liveshare/liveshare.ts',
         'src/client/datascience/liveshare/serviceProxy.ts',

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -711,3 +711,6 @@ export namespace LiveShareCommands {
 export const VSCodeNotebookProvider = 'VSCodeNotebookProvider';
 export const OurNotebookProvider = 'OurNotebookProvider';
 export const DataScienceStartupTime = Symbol('DataScienceStartupTime');
+
+// Default for notebook version (major & minor) used when creating notebooks.
+export const defaultNotebookFormat = { major: 4, minor: 2 };

--- a/src/client/datascience/interactive-window/interactiveWindow.ts
+++ b/src/client/datascience/interactive-window/interactiveWindow.ts
@@ -27,6 +27,7 @@ import {
 } from '../../common/types';
 import { createDeferred, Deferred } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
+import { noop } from '../../common/utils/misc';
 import { EXTENSION_ROOT_DIR } from '../../constants';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { Commands, defaultNotebookFormat, EditorContexts, Identifiers, Telemetry } from '../constants';
@@ -411,18 +412,18 @@ export class InteractiveWindow extends InteractiveBase implements IInteractiveWi
         // extension contexts
         if (this.commandManager && this.commandManager.executeCommand) {
             const interactiveContext = new ContextKey(EditorContexts.HaveInteractive, this.commandManager);
-            interactiveContext.set(!this.isDisposed).catch();
+            interactiveContext.set(!this.isDisposed).catch(noop);
             const interactiveCellsContext = new ContextKey(EditorContexts.HaveInteractiveCells, this.commandManager);
             const redoableContext = new ContextKey(EditorContexts.HaveRedoableCells, this.commandManager);
             const hasCellSelectedContext = new ContextKey(EditorContexts.HaveCellSelected, this.commandManager);
             if (info) {
-                interactiveCellsContext.set(info.cellCount > 0).catch();
-                redoableContext.set(info.redoCount > 0).catch();
-                hasCellSelectedContext.set(info.selectedCell ? true : false).catch();
+                interactiveCellsContext.set(info.cellCount > 0).catch(noop);
+                redoableContext.set(info.redoCount > 0).catch(noop);
+                hasCellSelectedContext.set(info.selectedCell ? true : false).catch(noop);
             } else {
-                interactiveCellsContext.set(false).catch();
-                redoableContext.set(false).catch();
-                hasCellSelectedContext.set(false).catch();
+                interactiveCellsContext.set(false).catch(noop);
+                redoableContext.set(false).catch(noop);
+                hasCellSelectedContext.set(false).catch(noop);
             }
         }
     }
@@ -557,7 +558,7 @@ export class InteractiveWindow extends InteractiveBase implements IInteractiveWi
             this.owningResource,
             defaultFileName,
             this.notebook?.getMatchingInterpreter()
-        );
+        ).then(noop, noop);
     }
 
     private handleModelChange(update: NotebookModelChange) {

--- a/src/client/datascience/interactive-window/interactiveWindow.ts
+++ b/src/client/datascience/interactive-window/interactiveWindow.ts
@@ -29,7 +29,7 @@ import { createDeferred, Deferred } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
 import { EXTENSION_ROOT_DIR } from '../../constants';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
-import { Commands, EditorContexts, Identifiers, Telemetry } from '../constants';
+import { Commands, defaultNotebookFormat, EditorContexts, Identifiers, Telemetry } from '../constants';
 import { IDataViewerFactory } from '../data-viewing/types';
 import { ExportFormat, IExportDialog } from '../export/types';
 import { InteractiveBase } from '../interactive-common/interactiveBase';
@@ -533,7 +533,7 @@ export class InteractiveWindow extends InteractiveBase implements IInteractiveWi
         }
 
         // Pull out the metadata from our active notebook
-        const metadata: nbformat.INotebookMetadata = { orig_nbformat: 3 };
+        const metadata: nbformat.INotebookMetadata = { orig_nbformat: defaultNotebookFormat.major };
         if (this.notebook) {
             updateNotebookMetadata(metadata, this.notebook?.getKernelConnection());
         }

--- a/src/client/datascience/interactive-window/interactiveWindow.ts
+++ b/src/client/datascience/interactive-window/interactiveWindow.ts
@@ -552,13 +552,15 @@ export class InteractiveWindow extends InteractiveBase implements IInteractiveWi
         }
 
         // Then run the export command with these contents
-        this.commandManager.executeCommand(
-            Commands.Export,
-            contents,
-            this.owningResource,
-            defaultFileName,
-            this.notebook?.getMatchingInterpreter()
-        ).then(noop, noop);
+        this.commandManager
+            .executeCommand(
+                Commands.Export,
+                contents,
+                this.owningResource,
+                defaultFileName,
+                this.notebook?.getMatchingInterpreter()
+            )
+            .then(noop, noop);
     }
 
     private handleModelChange(update: NotebookModelChange) {

--- a/src/client/datascience/jupyter/jupyterExporter.ts
+++ b/src/client/datascience/jupyter/jupyterExporter.ts
@@ -18,7 +18,7 @@ import * as localize from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
 import { CellMatcher } from '../cellMatcher';
 import { pruneCell } from '../common';
-import { CodeSnippets, Identifiers } from '../constants';
+import { CodeSnippets, defaultNotebookFormat, Identifiers } from '../constants';
 import {
     CellState,
     ICell,
@@ -104,7 +104,7 @@ export class JupyterExporter implements INotebookExporter {
                 pygments_lexer: `ipython${pythonNumber}`,
                 version: pythonNumber
             },
-            orig_nbformat: 2,
+            orig_nbformat: defaultNotebookFormat.major,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             kernelspec: kernelSpec as any
         };
@@ -115,8 +115,8 @@ export class JupyterExporter implements INotebookExporter {
         // Combine this into a JSON object
         return {
             cells: this.pruneCells(cells, matcher),
-            nbformat: 4,
-            nbformat_minor: 2,
+            nbformat: defaultNotebookFormat.major,
+            nbformat_minor: defaultNotebookFormat.minor,
             metadata: metadata
         };
     }

--- a/src/client/datascience/notebook/helpers/helpers.ts
+++ b/src/client/datascience/notebook/helpers/helpers.ts
@@ -25,7 +25,7 @@ import '../../../common/extensions';
 import { traceError, traceInfo, traceInfoIf, traceWarning } from '../../../common/logger';
 import { isUntitledFile } from '../../../common/utils/misc';
 import { sendTelemetryEvent } from '../../../telemetry';
-import { Telemetry } from '../../constants';
+import { originalNbFormat, Telemetry } from '../../constants';
 import { KernelConnectionMetadata, NotebookCellRunState } from '../../jupyter/kernels/types';
 import { updateNotebookMetadata } from '../../notebookStorage/baseModel';
 import { CellState, IJupyterKernelSpec } from '../../types';
@@ -73,7 +73,7 @@ export function getNotebookMetadata(document: NotebookDocument): nbformat.INoteb
     // If language isn't specified in the metadata, at least specify that
     if (!notebookContent?.metadata?.language_info?.name) {
         const content = notebookContent || {};
-        const metadata = content.metadata || { orig_nbformat: 3, language_info: {} };
+        const metadata = content.metadata || { orig_nbformat: originalNbFormat, language_info: {} };
         const language_info = { ...metadata.language_info };
         // Fix nyc compiler not working.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/client/datascience/notebook/helpers/helpers.ts
+++ b/src/client/datascience/notebook/helpers/helpers.ts
@@ -25,7 +25,7 @@ import '../../../common/extensions';
 import { traceError, traceInfo, traceInfoIf, traceWarning } from '../../../common/logger';
 import { isUntitledFile } from '../../../common/utils/misc';
 import { sendTelemetryEvent } from '../../../telemetry';
-import { originalNbFormat, Telemetry } from '../../constants';
+import { defaultNotebookFormat, Telemetry } from '../../constants';
 import { KernelConnectionMetadata, NotebookCellRunState } from '../../jupyter/kernels/types';
 import { updateNotebookMetadata } from '../../notebookStorage/baseModel';
 import { CellState, IJupyterKernelSpec } from '../../types';
@@ -73,7 +73,7 @@ export function getNotebookMetadata(document: NotebookDocument): nbformat.INoteb
     // If language isn't specified in the metadata, at least specify that
     if (!notebookContent?.metadata?.language_info?.name) {
         const content = notebookContent || {};
-        const metadata = content.metadata || { orig_nbformat: originalNbFormat, language_info: {} };
+        const metadata = content.metadata || { orig_nbformat: defaultNotebookFormat.major, language_info: {} };
         const language_info = { ...metadata.language_info };
         // Fix nyc compiler not working.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/client/datascience/notebookStorage/baseModel.ts
+++ b/src/client/datascience/notebookStorage/baseModel.ts
@@ -11,6 +11,7 @@ import { ICryptoUtils } from '../../common/types';
 import { isUntitledFile, noop } from '../../common/utils/misc';
 import { getInterpreterHash } from '../../pythonEnvironments/info/interpreter';
 import { pruneCell } from '../common';
+import { defaultNotebookFormat, originalNbFormat } from '../constants';
 import { NotebookModelChange } from '../interactive-common/interactiveWindowTypes';
 import {
     getInterpreterFromKernelConnectionMetadata,
@@ -155,14 +156,14 @@ export function getDefaultNotebookContent(pythonNumber: number = 3): Partial<nbf
             pygments_lexer: `ipython${pythonNumber}`,
             version: pythonNumber
         },
-        orig_nbformat: 2
+        orig_nbformat: defaultNotebookFormat.major
     };
 
     // Default notebook data.
     return {
         metadata: metadata,
-        nbformat: 4,
-        nbformat_minor: 2
+        nbformat: defaultNotebookFormat.major,
+        nbformat_minor: defaultNotebookFormat.minor
     };
 }
 /**
@@ -181,7 +182,7 @@ export function getDefaultNotebookContentForNativeNotebooks(language: string = '
                     name: language,
                     nbconvert_exporter: 'python'
                 },
-                orig_nbformat: 2
+                orig_nbformat: defaultNotebookFormat.major
             };
             break;
         default:
@@ -189,14 +190,14 @@ export function getDefaultNotebookContentForNativeNotebooks(language: string = '
                 language_info: {
                     name: language
                 },
-                orig_nbformat: 2
+                orig_nbformat: defaultNotebookFormat.major
             };
     }
 
     return {
         metadata,
-        nbformat: 4,
-        nbformat_minor: 2
+        nbformat: defaultNotebookFormat.major,
+        nbformat_minor: defaultNotebookFormat.minor
     };
 }
 export abstract class BaseNotebookModel implements INotebookModel {

--- a/src/client/datascience/notebookStorage/baseModel.ts
+++ b/src/client/datascience/notebookStorage/baseModel.ts
@@ -11,7 +11,7 @@ import { ICryptoUtils } from '../../common/types';
 import { isUntitledFile, noop } from '../../common/utils/misc';
 import { getInterpreterHash } from '../../pythonEnvironments/info/interpreter';
 import { pruneCell } from '../common';
-import { defaultNotebookFormat, originalNbFormat } from '../constants';
+import { defaultNotebookFormat } from '../constants';
 import { NotebookModelChange } from '../interactive-common/interactiveWindowTypes';
 import {
     getInterpreterFromKernelConnectionMetadata,


### PR DESCRIPTION
I've managed to get a notebook document that cannot be opened in jupyter.
Found that we're hardcoding the version numbers, moved into a single constant.

`orig_nbformat` is updated by jupyter when converting from one version into another.
Since we're creating notebooks, they're always version `4` & not `3`.

This doesn't fix how i ended up with a document that cannot be opened, but cleans it up.
I have a notebook with major & minor as `2`. Not sure how.