### PR TITLE
Show run above/below buttons if `notebook.consolidatedRunButton` is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,6 @@
    ([#5954](https://github.com/Microsoft/vscode-jupyter/issues/5954))
 1. Tweak variable view fit and finish to match VS Code.
    ([#5955](https://github.com/Microsoft/vscode-jupyter/issues/5955))
-1. Replace 'Run cells above' and 'Run cell and below' commands and cell toolbar buttons with VS Code's built-in 'Execute Above Cells' and 'Execute Cell And Below' commands and unified run button.
-   ([#6025](https://github.com/microsoft/vscode-jupyter/issues/6025))
 
 ### Fixes
 

--- a/package.json
+++ b/package.json
@@ -300,6 +300,20 @@
                 "enablement": "notebookType == jupyter-notebook && isWorkspaceTrusted"
             },
             {
+                "command": "jupyter.notebookeditor.runallcellsabove",
+                "title": "%DataScience.runAbove%",
+                "category": "Notebook",
+                "icon": "$(run-above)",
+                "enablement": "notebookType == jupyter-notebook && isWorkspaceTrusted"
+            },
+            {
+                "command": "jupyter.notebookeditor.runcellandallbelow",
+                "title": "%DataScience.runBelow%",
+                "category": "Notebook",
+                "icon": "$(run-below)",
+                "enablement": "notebookType == jupyter-notebook && isWorkspaceTrusted"
+            },
+            {
                 "command": "jupyter.export",
                 "title": "%DataScience.notebookExportAs%",
                 "category": "Jupyter",
@@ -844,6 +858,20 @@
                     "when": "notebookType == 'jupyter-notebook' && isWorkspaceTrusted"
                 }
             ],
+            "notebook/cell/title": [
+                {
+                    "command": "jupyter.notebookeditor.runallcellsabove",
+                    "title": "%DataScience.runAbove%",
+                    "group": "inline/cell@0",
+                    "when": "notebookType == 'jupyter-notebook' && isWorkspaceTrusted"
+                },
+                {
+                    "command": "jupyter.notebookeditor.runcellandallbelow",
+                    "title": "%DataScience.runBelow%",
+                    "group": "inline/cell@0",
+                    "when": "notebookType == 'jupyter-notebook' && isWorkspaceTrusted"
+                }
+            ],
             "notebook/toolbar": [
                 {
                     "command": "jupyter.notebookeditor.restartkernel",
@@ -893,6 +921,16 @@
                     "command": "jupyter.notebookeditor.keybind.toggleOutput",
                     "title": "%DataScience.toggleCellOutput%",
                     "when": "notebookType == jupyter-notebook"
+                },
+                {
+                    "command": "jupyter.notebookeditor.runallcellsabove",
+                    "title": "%DataScience.runAbove%",
+                    "when": "notebookEditorFocused && notebookType == 'jupyter-notebook' && isWorkspaceTrusted"
+                },
+                {
+                    "command": "jupyter.notebookeditor.runcellandallbelow",
+                    "title": "%DataScience.runBelow%",
+                    "when": "notebookEditorFocused && notebookType == 'jupyter-notebook' && isWorkspaceTrusted"
                 },
                 {
                     "command": "jupyter.exportAsPythonScript",

--- a/package.json
+++ b/package.json
@@ -863,13 +863,13 @@
                     "command": "jupyter.notebookeditor.runallcellsabove",
                     "title": "%DataScience.runAbove%",
                     "group": "inline/cell@0",
-                    "when": "notebookType == 'jupyter-notebook' && isWorkspaceTrusted"
+                    "when": "notebookType == 'jupyter-notebook' && isWorkspaceTrusted && config.notebook.consolidatedRunButton"
                 },
                 {
                     "command": "jupyter.notebookeditor.runcellandallbelow",
                     "title": "%DataScience.runBelow%",
-                    "group": "inline/cell@0",
-                    "when": "notebookType == 'jupyter-notebook' && isWorkspaceTrusted"
+                    "group": "inline/cell@1",
+                    "when": "notebookType == 'jupyter-notebook' && isWorkspaceTrusted && config.notebook.consolidatedRunButton"
                 }
             ],
             "notebook/toolbar": [
@@ -925,12 +925,12 @@
                 {
                     "command": "jupyter.notebookeditor.runallcellsabove",
                     "title": "%DataScience.runAbove%",
-                    "when": "notebookEditorFocused && notebookType == 'jupyter-notebook' && isWorkspaceTrusted"
+                    "when": "notebookEditorFocused && notebookType == 'jupyter-notebook' && isWorkspaceTrusted && config.notebook.consolidatedRunButton"
                 },
                 {
                     "command": "jupyter.notebookeditor.runcellandallbelow",
                     "title": "%DataScience.runBelow%",
-                    "when": "notebookEditorFocused && notebookType == 'jupyter-notebook' && isWorkspaceTrusted"
+                    "when": "notebookEditorFocused && notebookType == 'jupyter-notebook' && isWorkspaceTrusted && config.notebook.consolidatedRunButton"
                 },
                 {
                     "command": "jupyter.exportAsPythonScript",

--- a/package.nls.json
+++ b/package.nls.json
@@ -384,6 +384,8 @@
     "DataScience.insertAbove": "Insert cell above",
     "DataScience.addCell": "Add cell",
     "DataScience.runAll": "Run all cells",
+    "DataScience.runAbove": "Run cells above",
+    "DataScience.runBelow": "Run cell and below",
     "DataScience.toggleCellOutput": "Toggle Cell Output",
     "DataScience.convertingToPythonFile": "Converting ipynb to python file",
     "DataScience.untitledNotebookMessage": "Your changes will be lost if you don't save them.",

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import { CancellationToken, Position, TextDocument, Uri } from 'vscode';
+import { CancellationToken, NotebookCell, Position, TextDocument, Uri } from 'vscode';
 import { Commands as DSCommands } from '../../datascience/constants';
 import { IShowDataViewerFromVariablePanel } from '../../datascience/interactive-common/interactiveWindowTypes';
 import { KernelConnectionMetadata } from '../../datascience/jupyter/kernels/types';
@@ -93,6 +93,8 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [DSCommands.RunCell]: [Uri, number, number, number, number];
     [DSCommands.RunAllCellsAbove]: [Uri, number, number];
     [DSCommands.RunCellAndAllBelow]: [Uri, number, number];
+    [DSCommands.NativeNotebookRunAllCellsAbove]: [NotebookCell];
+    [DSCommands.NativeNotebookRunCellAndAllBelow]: [NotebookCell];
     [DSCommands.RunAllCellsAbovePalette]: [];
     [DSCommands.RunCellAndAllBelowPalette]: [];
     [DSCommands.DebugCurrentCellPalette]: [];

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -78,6 +78,8 @@ export namespace Commands {
     export const RunAllCells = 'jupyter.runallcells';
     export const RunAllCellsAbove = 'jupyter.runallcellsabove';
     export const RunCellAndAllBelow = 'jupyter.runcellandallbelow';
+    export const NativeNotebookRunAllCellsAbove = 'jupyter.notebookeditor.runallcellsabove';
+    export const NativeNotebookRunCellAndAllBelow = 'jupyter.notebookeditor.runcellandallbelow';
     export const SetJupyterKernel = 'jupyter.setKernel';
     export const SwitchJupyterKernel = 'jupyter.switchKernel';
     export const RunAllCellsAbovePalette = 'jupyter.runallcellsabove.palette';

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -437,6 +437,13 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         throw Error('Not implemented Exception');
     }
 
+    public runAbove(): void {
+        throw Error('Not implemented Exception');
+    }
+    public runCellAndBelow(): void {
+        throw Error('Not implemented Exception');
+    }
+
     protected addSysInfo(reason: SysInfoReason): Promise<void> {
         // We need to send a message when restarting
         if (reason === SysInfoReason.Restart || reason === SysInfoReason.New) {

--- a/src/client/datascience/interactive-ipynb/nativeEditorCommandListener.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorCommandListener.ts
@@ -5,9 +5,9 @@ import '../../common/extensions';
 
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import { Uri } from 'vscode';
+import { NotebookCell, Uri } from 'vscode';
 
-import { ICommandManager } from '../../common/application/types';
+import { ICommandManager, IVSCodeNotebook } from '../../common/application/types';
 import { traceError, traceInfo } from '../../common/logger';
 import { IDisposableRegistry } from '../../common/types';
 import { captureTelemetry } from '../../telemetry';
@@ -20,6 +20,7 @@ export class NativeEditorCommandListener implements IDataScienceCommandListener 
     constructor(
         @inject(IDisposableRegistry) private disposableRegistry: IDisposableRegistry,
         @inject(INotebookEditorProvider) private provider: INotebookEditorProvider,
+        @inject(IVSCodeNotebook) private readonly notebook: IVSCodeNotebook,
         @inject(IDataScienceErrorHandler) private dataScienceErrorHandler: IDataScienceErrorHandler
     ) {}
 
@@ -53,6 +54,14 @@ export class NativeEditorCommandListener implements IDataScienceCommandListener 
         );
         this.disposableRegistry.push(
             commandManager.registerCommand(Commands.NotebookEditorAddCellBelow, () => this.addCellBelow())
+        );
+        this.disposableRegistry.push(
+            commandManager.registerCommand(Commands.NativeNotebookRunAllCellsAbove, (cell) => this.runAbove(cell))
+        );
+        this.disposableRegistry.push(
+            commandManager.registerCommand(Commands.NativeNotebookRunCellAndAllBelow, (cell) =>
+                this.runCellAndBelow(cell)
+            )
         );
     }
 
@@ -136,6 +145,30 @@ export class NativeEditorCommandListener implements IDataScienceCommandListener 
             } catch (e) {
                 await this.dataScienceErrorHandler.handleError(e);
             }
+        }
+    }
+
+    private runAbove(cell: NotebookCell | undefined): void {
+        const activeEditor = this.provider.activeEditor;
+        cell = cell || this.getActiveCell(); // When called from command palette, we don't have a cell as the first argument.
+        if (activeEditor && cell) {
+            activeEditor.runAbove(cell);
+        }
+    }
+    private getActiveCell() {
+        const document = this.notebook.activeNotebookEditor?.document;
+        const selection = this.notebook.activeNotebookEditor?.selections;
+        if (!selection || !document) {
+            return;
+        }
+        const cells = document.getCells(selection[0]);
+        return cells.length ? cells[0] : undefined;
+    }
+    private runCellAndBelow(cell: NotebookCell | undefined): void {
+        const activeEditor = this.provider.activeEditor;
+        cell = cell || this.getActiveCell(); // When called from command palette, we don't have a cell as the first argument.
+        if (activeEditor && cell) {
+            activeEditor.runCellAndBelow(cell);
         }
     }
 }

--- a/src/client/datascience/notebook/notebookEditor.ts
+++ b/src/client/datascience/notebook/notebookEditor.ts
@@ -7,6 +7,7 @@ import {
     ConfigurationTarget,
     Event,
     EventEmitter,
+    NotebookCell,
     NotebookCellKind,
     NotebookRange,
     NotebookDocument,
@@ -288,6 +289,24 @@ export class NotebookEditor implements INotebookEditor {
         this._closed.fire(this);
     }
 
+    public runAbove(cell: NotebookCell | undefined): void {
+        if (cell && cell.index > 0) {
+            void this.commandManager.executeCommand(
+                'notebook.cell.execute',
+                { start: 0, end: cell.index },
+                cell.notebook.uri
+            );
+        }
+    }
+    public runCellAndBelow(cell: NotebookCell | undefined): void {
+        if (cell && cell.index >= 0) {
+            void this.commandManager.executeCommand(
+                'notebook.cell.execute',
+                { start: cell.index, end: cell.notebook.cellCount },
+                cell.notebook.uri
+            );
+        }
+    }
     private onClosedDocument(e?: NotebookDocument) {
         if (this.document === e) {
             this._closed.fire(this);

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -620,6 +620,8 @@ export interface INotebookEditor extends Disposable, IInteractiveBase {
     interruptKernel(): Promise<void>;
     restartKernel(): Promise<void>;
     syncAllCells(): Promise<void>;
+    runAbove(cell: NotebookCell | undefined): void;
+    runCellAndBelow(cell: NotebookCell | undefined): void;
 }
 
 export const INotebookExtensibility = Symbol('INotebookExtensibility');

--- a/src/test/datascience/notebook/notebookEditor.vscode.test.ts
+++ b/src/test/datascience/notebook/notebookEditor.vscode.test.ts
@@ -4,10 +4,12 @@
 'use strict';
 
 import { assert } from 'chai';
+import { NotebookCellExecutionState } from 'vscode';
 import { ICommandManager, IVSCodeNotebook } from '../../../client/common/application/types';
 import { traceInfo } from '../../../client/common/logger';
 import { IDisposable } from '../../../client/common/types';
 import { Commands } from '../../../client/datascience/constants';
+import { hasErrorOutput, NotebookCellStateTracker } from '../../../client/datascience/notebook/helpers/helpers';
 import { IExtensionTestApi, waitForCondition } from '../../common';
 import { closeActiveWindows, initialize } from '../../initialize';
 import {
@@ -83,5 +85,61 @@ suite('Notebook Editor tests', function () {
             10000,
             'Outputs were not collapsed'
         );
+    });
+
+    test('Run cells above', async function () {
+        return this.skip();
+        // add some cells
+        await insertCodeCell('print("0")', { index: 0 });
+        await insertCodeCell('print("1")', { index: 1 });
+        await insertCodeCell('print("2")', { index: 2 });
+
+        // select second cell
+        await selectCell(vscodeNotebook.activeNotebookEditor?.document!, 1, 1);
+
+        // run command
+        await commandManager.executeCommand(
+            Commands.NativeNotebookRunAllCellsAbove,
+            vscodeNotebook.activeNotebookEditor?.document.cellAt(1)!
+        );
+
+        const firstCell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        await waitForExecutionCompletedSuccessfully(firstCell);
+        const thirdCell = vscodeNotebook.activeNotebookEditor?.document.getCells()![2]!;
+
+        // The first cell should have a runState of Success
+        assert.strictEqual(NotebookCellStateTracker.getCellState(firstCell), NotebookCellExecutionState.Idle);
+        assert.isFalse(hasErrorOutput(firstCell.outputs));
+
+        // The third cell should have an undefined runState
+        assert.strictEqual(NotebookCellStateTracker.getCellState(thirdCell), undefined);
+    });
+
+    test('Run cells below', async function () {
+        return this.skip();
+        // add some cells
+        await insertCodeCell('print("0")', { index: 0 });
+        await insertCodeCell('print("1")', { index: 1 });
+        await insertCodeCell('print("2")', { index: 2 });
+
+        // select second cell
+        await selectCell(vscodeNotebook.activeNotebookEditor?.document!, 1, 1);
+
+        // run command
+        await commandManager.executeCommand(
+            Commands.NativeNotebookRunCellAndAllBelow,
+            vscodeNotebook.activeNotebookEditor?.document.cellAt(1)!
+        );
+
+        const firstCell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const thirdCell = vscodeNotebook.activeNotebookEditor?.document.getCells()![2]!;
+        await waitForExecutionCompletedSuccessfully(thirdCell);
+
+        // The first cell should have an undefined runState
+        assert.strictEqual(NotebookCellStateTracker.getCellState(firstCell), undefined);
+
+        // The third cell should have a runState of Success
+        assert.strictEqual(NotebookCellStateTracker.getCellState(thirdCell), NotebookCellExecutionState.Idle);
+        assert.isFalse(hasErrorOutput(thirdCell.outputs));
     });
 });


### PR DESCRIPTION
VS Code isn't shipping notebook profiles this release. We removed these buttons on the premise that VS Code's implementation of run above/below would appear in the cell toolbar when `notebook.consolidatedRunButton` is set to false (which is the case for the Jupyter profile but not for the default profile). We need to make sure users continue to have these buttons (otherwise we're removing functionality that they previously had access to).

Solution here is to keep our run above/below contributions to the cell toolbar but show them only when the consolidated run button is enabled (since in that case VS Code's buttons won't show in the toolbar and there won't be duplicates).

Alternative is to migrate the `notebook.consolidatedRunButton` setting ourselves, but I believe @roblourens would prefer we didn't configure this setting globally for Jupyter users because the setting applies for all notebooks and the notebook layout story is supposed to take other notebooks into consideration.

There is a limitation to this PR: while the buttons will continue to appear regardless of the setting value, they are bound to different underlying commands, which could be confusing for users.