### PR TITLE
Variable Explorer is always sorted by something (no more 3 clicks)

### DIFF
--- a/build/ci/postInstall.js
+++ b/build/ci/postInstall.js
@@ -87,14 +87,10 @@ function createJupyterKernelWithoutSerialization() {
 function makeVariableExplorerAlwaysSorted() {
     const fileNames = ['react-data-grid.js', 'react-data-grid.min.js'];
     const alwaysSortedCode = 'case g.NONE:e=r?g.DESC:g.ASC;break;case g.ASC:e=g.DESC;break;case g.DESC:e=g.ASC';
-    const originalCode = 'case g.NONE:e=r?g.DESC:g.ASC;break;case g.ASC:e=r?g.NONE:g.DESC;break;case g.DESC:e=r?g.ASC:g.NONE';
+    const originalCode =
+        'case g.NONE:e=r?g.DESC:g.ASC;break;case g.ASC:e=r?g.NONE:g.DESC;break;case g.DESC:e=r?g.ASC:g.NONE';
     for (const fileName of fileNames) {
-        var relativePath = path.join(
-            'node_modules',
-            'react-data-grid',
-            'dist',
-            fileName
-        );
+        var relativePath = path.join('node_modules', 'react-data-grid', 'dist', fileName);
         var filePath = path.join(constants.ExtensionRootDir, relativePath);
         if (!fs.existsSync(filePath)) {
             throw new Error("react-data-grid dist file not found '" + filePath + "' (pvsc post install script)");
@@ -121,7 +117,7 @@ function makeVariableExplorerAlwaysSorted() {
 }
 
 (async () => {
-    makeVariableExplorerAlwaysSorted()
+    makeVariableExplorerAlwaysSorted();
     fixJupyterLabDTSFiles();
     createJupyterKernelWithoutSerialization();
     await downloadRendererExtension();

--- a/src/datascience-ui/interactive-common/variableExplorer.tsx
+++ b/src/datascience-ui/interactive-common/variableExplorer.tsx
@@ -303,6 +303,8 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
                     emptyRowsView={VariableExplorerEmptyRowsView}
                     rowRenderer={VariableExplorerRowRenderer}
                     onGridSort={this.sortRows}
+                    sortColumn="name"
+                    sortDirection="ASC"
                 />
             </div>
         );

--- a/src/test/datascience/variableexplorer.functional.test.tsx
+++ b/src/test/datascience/variableexplorer.functional.test.tsx
@@ -803,12 +803,6 @@ a = 1,2,3,4,5,6,7,8,9`;
                 (viewPort.props as any).onGridSort('name', 'DESC');
                 await completeDesc;
                 verifyVariables(wrapper, targetVariablesDescending);
-
-                // Sort by default order
-                const completeNone = mount.waitForMessage(InteractiveWindowMessages.VariablesComplete);
-                (viewPort.props as any).onGridSort('', 'NONE');
-                await completeNone;
-                verifyVariables(wrapper, targetVariablesAscending);
             },
             () => {
                 return Promise.resolve(ioc);
@@ -829,59 +823,6 @@ a = 1,2,3,4,5,6,7,8,9`;
 
                 // Wait for two variable completes so we get the visible list (should be about 16 items when finished)
                 await addCodeImpartial(wrapper, basicCode, true);
-
-                const targetVariablesDefault: IJupyterVariable[] = [
-                    {
-                        name: 'A',
-                        value: '[1, 2, 3]',
-                        supportsDataExplorer: true,
-                        type: 'list',
-                        size: 54,
-                        shape: '',
-                        count: 3,
-                        truncated: false
-                    },
-                    {
-                        name: 'B',
-                        value: undefined,
-                        supportsDataExplorer: false,
-                        type: 'set',
-                        size: 54,
-                        shape: '',
-                        count: 1,
-                        truncated: false
-                    },
-                    {
-                        name: 'C',
-                        value: "{'c': 1}",
-                        supportsDataExplorer: true,
-                        type: 'dict',
-                        size: 54,
-                        shape: '',
-                        count: 1,
-                        truncated: false
-                    },
-                    {
-                        name: 'a',
-                        value: '(1, 2, 3, 4, 5, 6, 7, 8, 9)',
-                        supportsDataExplorer: false,
-                        type: 'tuple',
-                        size: 54,
-                        shape: '9',
-                        count: 0,
-                        truncated: false
-                    },
-                    {
-                        name: 'z',
-                        value: '(1+1j)',
-                        supportsDataExplorer: false,
-                        type: 'complex',
-                        size: 54,
-                        shape: '',
-                        count: 0,
-                        truncated: false
-                    }
-                ];
 
                 const targetVariablesTypeAscending: IJupyterVariable[] = [
                     {
@@ -1004,12 +945,6 @@ a = 1,2,3,4,5,6,7,8,9`;
                 (viewPort.props as any).onGridSort('type', 'DESC');
                 await completeDesc;
                 verifyVariables(wrapper, targetVariablesTypeDescending);
-
-                // Sort by default order
-                const completeNone = mount.waitForMessage(InteractiveWindowMessages.VariablesComplete);
-                (viewPort.props as any).onGridSort('', 'NONE');
-                await completeNone;
-                verifyVariables(wrapper, targetVariablesDefault);
             },
             () => {
                 return Promise.resolve(ioc);


### PR DESCRIPTION
For #6079
Since variables are always retrieved sorted from the kernel, we mind as well make variable explorer always sorted. So now it goes from ASC -> DESC -> ASC instead of ASC -> DESC -> NONE (which would actually be sorted by "name" and "ASC")

Had to do it with post-install because react-data-grid has a lot of changes made and if we upgrade to a version that has this feature, we would need to change a bunch of stuff to accommodate 
![vT43YMZ8fV](https://user-images.githubusercontent.com/33995460/120877482-96605400-c56b-11eb-8b88-e69a99279d55.gif)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
