### PR TITLE
Ctrl+Enter should put cell into command mode after executing

### DIFF
--- a/news/2 Fixes/6198.md
+++ b/news/2 Fixes/6198.md
@@ -1,0 +1,1 @@
+In preview native notebooks interface, contribute `ctrl+enter` keybinding which puts the current cell into control mode instead of leaving it in edit mode after running.

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
             {
                 "key": "ctrl+enter",
                 "when": "editorTextFocus && inputFocus && notebookEditorFocused && notebookType == jupyter-notebook && config.jupyter.enableKeyboardShortcuts",
-                "command": "notebook.cell.execute"
+                "command": "jupyter.notebookeditor.keybind.executeCell"
             },
             {
                 "key": "ctrl+enter",

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -53,6 +53,7 @@ interface ICommandNameWithoutArgumentTypeMapping {
     [DSCommands.ResetLoggingLevel]: [];
     [DSCommands.OpenVariableView]: [];
     [DSCommands.NotebookEditorToggleOutput]: [];
+    [DSCommands.NotebookEditorKeybindExecuteCell]: [];
     [DSCommands.NotebookEditorKeybindRenderMarkdownAndSelectBelow]: [];
     ['notebook.cell.quitEdit']: [];
     ['notebook.cell.executeAndSelectBelow']: [];

--- a/src/client/datascience/commands/notebookCommands.ts
+++ b/src/client/datascience/commands/notebookCommands.ts
@@ -39,6 +39,7 @@ export class NotebookCommands implements IDisposable {
             this.commandManager.registerCommand(Commands.NotebookEditorKeybindSave, this.keybindSave, this),
             this.commandManager.registerCommand(Commands.NotebookEditorKeybindUndo, this.keybindUndo, this),
             this.commandManager.registerCommand(Commands.NotebookEditorToggleOutput, this.toggleOutput, this),
+            this.commandManager.registerCommand(Commands.NotebookEditorKeybindExecuteCell, this.executeCell, this),
             this.commandManager.registerCommand(
                 Commands.NotebookEditorKeybindRenderMarkdownAndSelectBelow,
                 this.renderMarkdownAndSelectBelow,
@@ -54,6 +55,12 @@ export class NotebookCommands implements IDisposable {
         if (this.notebookEditorProvider.activeEditor?.toggleOutput) {
             this.notebookEditorProvider.activeEditor.toggleOutput();
         }
+    }
+
+    private executeCell() {
+        void this.commandManager
+            .executeCommand('notebook.cell.execute')
+            .then(() => this.commandManager.executeCommand('notebook.cell.quitEdit'));
     }
 
     private renderMarkdownAndSelectBelow() {

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -163,6 +163,7 @@ export namespace Commands {
     export const NotebookEditorKeybindUndo = 'jupyter.notebookeditor.keybind.undo';
     export const NotebookEditorKeybindRenderMarkdownAndSelectBelow =
         'jupyter.notebookeditor.keybind.renderMarkdownAndSelectBelow';
+    export const NotebookEditorKeybindExecuteCell = 'jupyter.notebookeditor.keybind.executeCell';
     export const NotebookEditorToggleOutput = 'jupyter.notebookeditor.keybind.toggleOutput';
 }
 


### PR DESCRIPTION
For #6198

Following up on https://github.com/microsoft/vscode-jupyter/commit/cb5ae1c28259166b00b915c687e68ae247bbcf0f I didn't notice that `ctrl+enter` for code cells doesn't behave the way users expect as well. Since I was working on resolving open keybindings issues I figured I'd go back and clean this particular problem up (should have been covered in https://github.com/microsoft/vscode-jupyter/issues/4438).

The VS Code-contributed `ctrl+enter` keybinding for `notebook.cell.execute` will run the current cell but leave the cell in edit mode. This PR adds our own command which also takes the cell out of edit mode after running it, in order to match classic Jupyter behavior.