### PR TITLE
reneable daily insiders releases

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -70,11 +70,11 @@ jobs:
           echo "vsix_name=ms-toolsai-jupyter-insiders.vsix" >> $GITHUB_ENV
           echo "test_matrix_os=[\"ubuntu-latest\", \"windows-latest\"]" >> $GITHUB_ENV
 
-    #   - name: insiders channel
-    #     # Scheduled builds will publish Insider builds.
-    #     if: github.event_name == 'schedule' && github.ref == 'refs/heads/main'
-    #     run: |
-    #       echo "release_channel=insider" >> $GITHUB_ENV
+      - name: insiders channel
+        # Scheduled builds will publish Insider builds.
+        if: github.event_name == 'schedule' && github.ref == 'refs/heads/main'
+        run: |
+          echo "release_channel=insider" >> $GITHUB_ENV
 
       - name: release
         if: github.event_name == 'push' && contains(github.ref, 'refs/heads/release')

--- a/package-lock.json
+++ b/package-lock.json
@@ -284,7 +284,7 @@
                 "yargs-parser": "^13.1.2"
             },
             "engines": {
-                "vscode": "1.57.0-insider"
+                "vscode": "1.58.0-insider"
             },
             "optionalDependencies": {
                 "canvas": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "theme": "light"
     },
     "engines": {
-        "vscode": "1.57.0-insider"
+        "vscode": "1.58.0-insider"
     },
     "keywords": [
         "jupyter",


### PR DESCRIPTION
and update engine to 1.58.0-insider

For #6195

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
