### PR TITLE
format readme consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 A [Visual Studio Code](https://code.visualstudio.com/) [extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) that provides basic notebook support for [language kernels](https://github.com/jupyter/jupyter/wiki/Jupyter-kernels) that are supported in [Jupyter Notebooks](https://jupyter.org/) today. Many language kernels will work with no modification. To enable advanced features, modifications may be needed in the VS Code language extensions.
 
-
 ## Working with Python
 
 Whether you are on VS Code Stable or VS Code Insiders, if you would like to work with Python just make sure you're using the latest version of the [Python Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) to enjoy the joint partnership of the Python and Juypter Extensions.
@@ -23,37 +22,35 @@ The Jupyter Extension supports other languages in addition to Python such as Jul
 
 -   **Step 4.** Open or create a notebook file and start coding!
 
-- **Special Note:**  The Jupyter Extension in VS Code Insiders will include our Native Notebooks experience by default. Because we are running in VS Code Insiders and this build is updated every day, there may be times when our extension may fail to work at all. We do attempt to ensure that this doesn't happen frequently. If it does, we strive to provide an updated extension build by the next business day. However, if you'd like to opt out of the native experience while working in VS Code Insiders:
-    - Open the command palette (Windows: Ctrl + Shift + P, iOS: Command + Shift + P) and select "Preferences: Open Settings (JSON)"
-    - Add the following code to your JSON settings:
-     `"jupyter.experiments.optOutFrom": ["NativeNotebookEditor"],`
+-   **Special Note:** The Jupyter Extension in VS Code Insiders will include our Native Notebooks experience by default. Because we are running in VS Code Insiders and this build is updated every day, there may be times when our extension may fail to work at all. We do attempt to ensure that this doesn't happen frequently. If it does, we strive to provide an updated extension build by the next business day. However, if you'd like to opt out of the native experience while working in VS Code Insiders:
+    -   Open the command palette (Windows: Ctrl + Shift + P, iOS: Command + Shift + P) and select "Preferences: Open Settings (JSON)"
+    -   Add the following code to your JSON settings:
+        `"jupyter.experiments.optOutFrom": ["NativeNotebookEditor"],`
 
 ## Notebooks Quick Start
 
-- To create a new notebook open the command palette (Windows: Ctrl + Shift + P, iOS: Command + Shift + P) and select the command `"Jupyter: Create New Blank Notebook"`
+-   To create a new notebook open the command palette (Windows: Ctrl + Shift + P, iOS: Command + Shift + P) and select the command `"Jupyter: Create New Blank Notebook"`
 
-     <img src=https://raw.githubusercontent.com/microsoft/vscode-jupyter/main/images/Jupyter%20README/CreateNewNotebook.png>
+         <img src=https://raw.githubusercontent.com/microsoft/vscode-jupyter/main/images/Jupyter%20README/CreateNewNotebook.png>
 
-- Select your kernel by clicking on the kernel picker in the bottom right of the status bar or by invoking the `"Notebook: Select Notebook Kernel"` command.
+-   Select your kernel by clicking on the kernel picker in the bottom right of the status bar or by invoking the `"Notebook: Select Notebook Kernel"` command.
 
-     <img src=https://raw.githubusercontent.com/microsoft/vscode-jupyter/main/images/Jupyter%20README/KernelPicker.gif?>
+         <img src=https://raw.githubusercontent.com/microsoft/vscode-jupyter/main/images/Jupyter%20README/KernelPicker.gif?>
 
-- Change the cell language by clicking the language picker or by invoking the `"Notebook: Change Cell Language"` command.
+-   Change the cell language by clicking the language picker or by invoking the `"Notebook: Change Cell Language"` command.
 
-     <img src=https://raw.githubusercontent.com/microsoft/vscode-jupyter/main/images/Jupyter%20README/LanguagePicker.gif?>
-
-
+         <img src=https://raw.githubusercontent.com/microsoft/vscode-jupyter/main/images/Jupyter%20README/LanguagePicker.gif?>
 
 ## Useful commands
 
 Open the Command Palette (Command+Shift+P on macOS and Ctrl+Shift+P on Windows/Linux) and type in one of the following commands:
 
-| Command                               | Description                                                                                                                                                    |
-| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Jupyter: Create New Blank Notebook`| Create a new blank Jupyter Notebook   |
-| `Notebook: Select Notebook Kernel`        | Select or switch kernels within your notebook|
-| `Notebook: Change Cell Language`        | Change the language of the cell currently in focus |
-| `Jupyter: Export to HTML Jupyter: Export to PDF` | Create a presentation-friendly version of your notebook in HTML or PDF
+| Command                                          | Description                                                            |
+| ------------------------------------------------ | ---------------------------------------------------------------------- |
+| `Jupyter: Create New Blank Notebook`             | Create a new blank Jupyter Notebook                                    |
+| `Notebook: Select Notebook Kernel`               | Select or switch kernels within your notebook                          |
+| `Notebook: Change Cell Language`                 | Change the language of the cell currently in focus                     |
+| `Jupyter: Export to HTML Jupyter: Export to PDF` | Create a presentation-friendly version of your notebook in HTML or PDF |
 
 To see all available Jupyter Notebook commands, open the Command Palette and type `Jupyter` or `Notebook`.
 
@@ -62,10 +59,10 @@ To see all available Jupyter Notebook commands, open the Command Palette and typ
 Learn more about the rich features of the Jupyter extension:
 
 -   [IntelliSense](https://code.visualstudio.com/docs/python/editing#_autocomplete-and-intellisense): Edit your code with auto-completion, code navigation, syntax checking and more!
-     - *May be limited due to kernelspec of choice*
+
+    -   _May be limited due to kernelspec of choice_
 
 -   [Jupyter Notebooks](https://code.visualstudio.com/docs/python/jupyter-support): Create and edit Jupyter Notebooks, add and run code/markdown cells, render plots, create presentation-friendly versions of your notebook by exporting to HTML or PDF and more!
-
 
 ## Supported locales
 
@@ -75,9 +72,10 @@ The extension is available in multiple languages: `de`, `en`, `es`, `fa`, `fr`, 
 
 -   If you have a question about how to accomplish something with the extension, please [ask on Stack Overflow](https://stackoverflow.com/questions/tagged/visual-studio-code+jupyter). Our [wiki](https://github.com/microsoft/vscode-jupyter/wiki) is also updated periodically with useful information.
 -   Any and all feedback is appreciated and welcome! If you come across a problem with the extension, please [file an issue](https://github.com/microsoft/vscode-jupyter).
-      - If someone has already [filed an issue](https://github.com/Microsoft/vscode-jupyter) that encompasses your feedback, please leave a 👍/👎 reaction on the issue.
 
-- Contributions are always welcome! Please see our [contributing guide](https://github.com/Microsoft/vscode-jupyter/blob/main/CONTRIBUTING.md) for more details.
+    -   If someone has already [filed an issue](https://github.com/Microsoft/vscode-jupyter) that encompasses your feedback, please leave a 👍/👎 reaction on the issue.
+
+-   Contributions are always welcome! Please see our [contributing guide](https://github.com/Microsoft/vscode-jupyter/blob/main/CONTRIBUTING.md) for more details.
 
 -   If you're interested in the development of the extension, you can read about our [development process](https://github.com/microsoft/vscode-jupyter/blob/main/CONTRIBUTING.md#development-process)
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ The Jupyter Extension supports other languages in addition to Python such as Jul
 
 -   To create a new notebook open the command palette (Windows: Ctrl + Shift + P, iOS: Command + Shift + P) and select the command `"Jupyter: Create New Blank Notebook"`
 
-         <img src=https://raw.githubusercontent.com/microsoft/vscode-jupyter/main/images/Jupyter%20README/CreateNewNotebook.png>
+    <img src=https://raw.githubusercontent.com/microsoft/vscode-jupyter/main/images/Jupyter%20README/CreateNewNotebook.png>
 
 -   Select your kernel by clicking on the kernel picker in the bottom right of the status bar or by invoking the `"Notebook: Select Notebook Kernel"` command.
 
-         <img src=https://raw.githubusercontent.com/microsoft/vscode-jupyter/main/images/Jupyter%20README/KernelPicker.gif?>
+    <img src=https://raw.githubusercontent.com/microsoft/vscode-jupyter/main/images/Jupyter%20README/KernelPicker.gif?>
 
 -   Change the cell language by clicking the language picker or by invoking the `"Notebook: Change Cell Language"` command.
 
-         <img src=https://raw.githubusercontent.com/microsoft/vscode-jupyter/main/images/Jupyter%20README/LanguagePicker.gif?>
+    <img src=https://raw.githubusercontent.com/microsoft/vscode-jupyter/main/images/Jupyter%20README/LanguagePicker.gif?>
 
 ## Useful commands
 
@@ -81,13 +81,7 @@ The extension is available in multiple languages: `de`, `en`, `es`, `fa`, `fr`, 
 
 ## Data and telemetry
 
-The Microsoft Jupyter Extension for Visual Studio Code collects usage
-data and sends it to Microsoft to help improve our products and
-services. Read our
-[privacy statement](https://privacy.microsoft.com/privacystatement) to
-learn more. This extension respects the `telemetry.enableTelemetry`
-setting which you can learn more about at
-https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting.
+The Microsoft Jupyter Extension for Visual Studio Code collects usage data and sends it to Microsoft to help improve our products and services. Read our [privacy statement](https://privacy.microsoft.com/privacystatement) to learn more. This extension respects the `telemetry.enableTelemetry` setting which you can learn more about at https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting.
 
 ## Trademarks
 

--- a/news/2 Fixes/6648.md
+++ b/news/2 Fixes/6648.md
@@ -1,1 +1,1 @@
-Format the readme to render correclty on the VS Code extensions side bar. Thanks [jyooru](https://github.com/jyooru)!
+Format the readme to render correctly on the VS Code extensions side bar. Thanks [jyooru](https://github.com/jyooru)!

--- a/news/2 Fixes/6648.md
+++ b/news/2 Fixes/6648.md
@@ -1,0 +1,1 @@
+Format the readme to render correclty on the VS Code extensions side bar. Thanks [jyooru](https://github.com/jyooru)!


### PR DESCRIPTION
Does not close an issue. Fixes dot point being styled as code:

![Screenshot from 2021-06-15 23-38-24](https://user-images.githubusercontent.com/63786778/122064677-aa8e3600-ce34-11eb-8a7f-d49a0ba7990e.png)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
    Does this apply to me?
-   [x] ~~Appropriate comments and documentation strings in the code.~~
-   [x] ~~Has sufficient logging.~~
-   [x] ~~Has telemetry for enhancements.~~
-   [x] ~~Unit tests & system/integration tests are added/updated.~~
-   [x] ~~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~~
-   [x] ~~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~~
