### PR TITLE
Ensure our contributed notebook keybindings respect `jupyter.enableKeyboardShortcuts` setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,22 +174,22 @@
             },
             {
                 "key": "ctrl+enter",
-                "when": "editorTextFocus && inputFocus && notebookEditorFocused && notebookType == jupyter-notebook && config.jupyter.enableKeyboardShortcuts",
+                "when": "editorTextFocus && inputFocus && notebookEditorFocused && notebookType == jupyter-notebook && config.jupyter.enableKeyboardShortcuts || notebookCellListFocused && notebookCellType == 'code' && notebookType == jupyter-notebook && config.jupyter.enableKeyboardShortcuts",
                 "command": "jupyter.notebookeditor.keybind.executeCell"
             },
             {
                 "key": "ctrl+enter",
-                "when": "inputFocus && notebookEditorFocused && !editorHasMultipleSelections && !editorHasSelection && !editorHoverVisible && notebookCellType == 'markup'",
+                "when": "inputFocus && notebookEditorFocused && !editorHasMultipleSelections && !editorHasSelection && !editorHoverVisible && notebookCellType == 'markup' && config.jupyter.enableKeyboardShortcuts",
                 "command": "notebook.cell.quitEdit"
             },
             {
                 "key": "shift+enter",
-                "when": "editorTextFocus && inputFocus && notebookEditorFocused && notebookType == jupyter-notebook && config.jupyter.enableKeyboardShortcuts || notebookCellListFocused && notebookCellType == 'markup' || notebookCellListFocused && notebookCellType == 'code' && notebookCellExecutionState == 'failed' || notebookCellExecutionState == 'idle' || notebookCellExecutionState == 'succeeded' && notebookKernelCount > 0",
+                "when": "editorTextFocus && inputFocus && notebookEditorFocused && notebookType == jupyter-notebook && config.jupyter.enableKeyboardShortcuts || notebookCellListFocused && notebookCellType == 'code' && notebookType == jupyter-notebook && config.jupyter.enableKeyboardShortcuts",
                 "command": "notebook.cell.executeAndSelectBelow"
             },
             {
                 "key": "shift+enter",
-                "when": "inputFocus && notebookEditorFocused && !editorHasMultipleSelections && !editorHasSelection && !editorHoverVisible && notebookCellType == 'markup'",
+                "when": "inputFocus && notebookEditorFocused && !editorHasMultipleSelections && !editorHasSelection && !editorHoverVisible && notebookCellType == 'markup' && config.jupyter.enableKeyboardShortcuts",
                 "command": "jupyter.notebookeditor.keybind.renderMarkdownAndSelectBelow"
             },
             {


### PR DESCRIPTION
This also fixes the issue we found where ctrl+enter inserts a new cell below the current cell when in command mode. This was caused by a built-in keybinding:

![image](https://user-images.githubusercontent.com/30305945/122100679-46ce2380-cdc8-11eb-8d0c-c22e7d1377d3.png)

Solution is to ensure our contributed ctrl+enter keybinding (for executing the current cell without advancing and leaving the cell in command mode) is active when the notebook cell list has focus, not just when a cell is in edit mode.

While looking at this I also found that the when clauses used for VS Code's ctrl+enter and shift+enter keybindings check the cell execution state and active kernel count. This didn't seem at all necessary to me so I removed those checks from the when clauses. Looking for feedback on whether that's a reasonable approach.

This also needs to be ported to main, but I'm creating this directly into the release branch first so as not to hold up the point release.