### PR TITLE
Move logic to individual controllers

### DIFF
--- a/src/client/datascience/kernel-launcher/kernelDaemonPreWarmer.ts
+++ b/src/client/datascience/kernel-launcher/kernelDaemonPreWarmer.ts
@@ -4,17 +4,12 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { NotebookDocument, NotebookCell } from 'vscode';
+import { NotebookDocument } from 'vscode';
 import { IPythonExtensionChecker } from '../../api/types';
 import { IVSCodeNotebook } from '../../common/application/types';
-import { PYTHON_LANGUAGE } from '../../common/constants';
 import '../../common/extensions';
 import { IConfigurationService, IDisposableRegistry, Resource } from '../../common/types';
 import { swallowExceptions } from '../../common/utils/decorators';
-import { isUntitledFile } from '../../common/utils/misc';
-import { isPythonKernelConnection } from '../jupyter/kernels/helpers';
-import { getNotebookMetadata, isJupyterNotebook, isPythonNotebook } from '../notebook/helpers/helpers';
-import { INotebookControllerManager } from '../notebook/types';
 import {
     IInteractiveWindowProvider,
     INotebookCreationTracker,
@@ -36,8 +31,7 @@ export class KernelDaemonPreWarmer {
         @inject(IRawNotebookSupportedService) private readonly rawNotebookSupported: IRawNotebookSupportedService,
         @inject(IConfigurationService) private readonly configService: IConfigurationService,
         @inject(IVSCodeNotebook) private readonly vscodeNotebook: IVSCodeNotebook,
-        @inject(IPythonExtensionChecker) private readonly extensionChecker: IPythonExtensionChecker,
-        @inject(INotebookControllerManager) private readonly controllerManager: INotebookControllerManager
+        @inject(IPythonExtensionChecker) private readonly extensionChecker: IPythonExtensionChecker
     ) {}
     public async activate(_resource: Resource): Promise<void> {
         // Check to see if raw notebooks are supported
@@ -88,23 +82,23 @@ export class KernelDaemonPreWarmer {
     }
 
     // Handle opening of native documents
-    private async onDidOpenNotebookDocument(doc: NotebookDocument): Promise<void> {
-        // It could be anything, lets not make any assumptions.
-        if (isUntitledFile(doc.uri) || !isJupyterNotebook(doc)) {
-            return;
-        }
-        const kernelConnection = this.controllerManager.getSelectedNotebookController(doc)?.connection;
-        const isPythonKernel = kernelConnection ? isPythonKernelConnection(kernelConnection) : false;
-        const notebookMetadata = isPythonNotebook(getNotebookMetadata(doc));
-        if (
-            isPythonKernel ||
-            notebookMetadata ||
-            doc.getCells().some((cell: NotebookCell) => {
-                return cell.document.languageId === PYTHON_LANGUAGE;
-            })
-        ) {
-            await this.preWarmKernelDaemonPool();
-        }
+    private async onDidOpenNotebookDocument(_doc: NotebookDocument): Promise<void> {
+        // // It could be anything, lets not make any assumptions.
+        // if (isUntitledFile(doc.uri) || !isJupyterNotebook(doc)) {
+        //     return;
+        // }
+        // const kernelConnection = this.controllerManager.getSelectedNotebookController(doc)?.connection;
+        // const isPythonKernel = kernelConnection ? isPythonKernelConnection(kernelConnection) : false;
+        // const notebookMetadata = isPythonNotebook(getNotebookMetadata(doc));
+        // if (
+        //     isPythonKernel ||
+        //     notebookMetadata ||
+        //     doc.getCells().some((cell: NotebookCell) => {
+        //         return cell.document.languageId === PYTHON_LANGUAGE;
+        //     })
+        // ) {
+        //     await this.preWarmKernelDaemonPool();
+        // }
     }
 
     private shouldPreWarmDaemonPool(lastTime?: Date) {

--- a/src/client/datascience/notebook/notebookControllerManager.ts
+++ b/src/client/datascience/notebook/notebookControllerManager.ts
@@ -2,11 +2,10 @@
 // Licensed under the MIT License.
 'use strict';
 import { inject, injectable } from 'inversify';
-import { CancellationToken, ExtensionMode, NotebookControllerAffinity, Uri } from 'vscode';
+import { CancellationToken, NotebookControllerAffinity, Uri } from 'vscode';
 import { CancellationTokenSource, EventEmitter, NotebookDocument } from 'vscode';
 import { IExtensionSyncActivationService } from '../../activation/types';
 import { ICommandManager, IVSCodeNotebook, IWorkspaceService } from '../../common/application/types';
-import { JVSC_EXTENSION_ID, PYTHON_LANGUAGE } from '../../common/constants';
 import { traceError, traceInfo, traceInfoIf } from '../../common/logger';
 import {
     IConfigurationService,
@@ -17,7 +16,6 @@ import {
     Resource
 } from '../../common/types';
 import { StopWatch } from '../../common/utils/stopWatch';
-import { sendNotebookOrKernelLanguageTelemetry } from '../common';
 import { Telemetry } from '../constants';
 import {
     areKernelConnectionsEqual,
@@ -26,22 +24,18 @@ import {
 } from '../jupyter/kernels/helpers';
 import { IKernelProvider, KernelConnectionMetadata } from '../jupyter/kernels/types';
 import { ILocalKernelFinder, IRemoteKernelFinder } from '../kernel-launcher/types';
-import { INotebookStorageProvider } from '../notebookStorage/notebookStorageProvider';
 import { PreferredRemoteKernelIdProvider } from '../notebookStorage/preferredRemoteKernelIdProvider';
-import { sendKernelTelemetryEvent, trackKernelResourceInformation } from '../telemetry/telemetry';
 import { INotebookProvider } from '../types';
-import { getNotebookMetadata, isJupyterNotebook, updateNotebookDocumentMetadata } from './helpers/helpers';
+import { getNotebookMetadata } from './helpers/helpers';
 import { VSCodeNotebookController } from './vscodeNotebookController';
 import { INotebookControllerManager } from './types';
 import { InteractiveWindowView, JupyterNotebookView } from './constants';
 import { NotebookIPyWidgetCoordinator } from '../ipywidgets/notebookIPyWidgetCoordinator';
-import { IPyWidgetMessages } from '../interactive-common/interactiveWindowTypes';
 import { InterpreterPackages } from '../telemetry/interpreterPackages';
 import { sendTelemetryEvent } from '../../telemetry';
 import { NotebookCellLanguageService } from './cellLanguageService';
 import { sendKernelListTelemetry } from '../telemetry/kernelTelemetry';
 import { testOnlyMethod } from '../../common/utils/decorators';
-import { noop } from '../../common/utils/misc';
 import { IS_CI_SERVER } from '../../../test/ciConstants';
 /**
  * This class tracks notebook documents that are open and the provides NotebookControllers for
@@ -49,8 +43,6 @@ import { IS_CI_SERVER } from '../../../test/ciConstants';
  */
 @injectable()
 export class NotebookControllerManager implements INotebookControllerManager, IExtensionSyncActivationService {
-    // Keep tabs on which controller is selected relative to each notebook document
-    private controllerMapping = new WeakMap<NotebookDocument, VSCodeNotebookController | undefined>();
     private readonly _onNotebookControllerSelected: EventEmitter<{
         notebook: NotebookDocument;
         controller: VSCodeNotebookController;
@@ -77,7 +69,6 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
         @inject(PreferredRemoteKernelIdProvider)
         private readonly preferredRemoteKernelIdProvider: PreferredRemoteKernelIdProvider,
         @inject(IRemoteKernelFinder) private readonly remoteKernelFinder: IRemoteKernelFinder,
-        @inject(INotebookStorageProvider) private readonly storageProvider: INotebookStorageProvider,
         @inject(IPathUtils) private readonly pathUtils: IPathUtils,
         @inject(NotebookIPyWidgetCoordinator) private readonly widgetCoordinator: NotebookIPyWidgetCoordinator,
         @inject(InterpreterPackages) private readonly interpreterPackages: InterpreterPackages,
@@ -99,15 +90,9 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
     public activate() {
         // Sign up for document either opening or closing
         this.notebook.onDidOpenNotebookDocument(this.onDidOpenNotebookDocument, this, this.disposables);
-        this.notebook.onDidCloseNotebookDocument(this.onDidCloseNotebookDocument, this, this.disposables);
 
         // Be aware of if we need to re-look for kernels on extension change
         this.extensions.onDidChange(this.onDidChangeExtensions, this, this.disposables);
-    }
-
-    // Look up what NotebookController is currently selected for the given notebook document
-    public getSelectedNotebookController(document: NotebookDocument): VSCodeNotebookController | undefined {
-        return this.controllerMapping.get(document);
     }
 
     // Function to expose currently registered controllers to test code only
@@ -193,7 +178,6 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
 
         // Prep so that we can track the selected controller for this document
         traceInfoIf(IS_CI_SERVER, `Clear controller mapping for ${document.uri.toString()}`);
-        this.controllerMapping.delete(document);
         const loadControllersPromise = this.loadNotebookControllers();
 
         try {
@@ -260,11 +244,6 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
         }
     }
 
-    private onDidCloseNotebookDocument(document: NotebookDocument) {
-        // Remove from our current selection tracking list
-        this.controllerMapping.delete(document);
-    }
-
     private createNotebookControllers(kernelConnections: KernelConnectionMetadata[]): VSCodeNotebookController[] {
         // First sort our items by label
         const connectionsWithLabel = kernelConnections.map((value) => {
@@ -311,12 +290,14 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
                     this.kernelProvider,
                     this.preferredRemoteKernelIdProvider,
                     this.context,
-                    this,
                     this.pathUtils,
                     this.disposables,
                     this.languageService,
                     this.workspace,
-                    this.setAsActiveControllerForTests.bind(this)
+                    this.isLocalLaunch ? 'local' : 'remote',
+                    this.interpreterPackages,
+                    this.configuration,
+                    this.widgetCoordinator
                 );
                 // Hook up to if this NotebookController is selected or de-selected
                 controller.onNotebookControllerSelected(
@@ -342,54 +323,11 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
             traceError(`Failed to create notebook controller for ${kernelConnection.id}`, ex);
         }
     }
-    /**
-     * In our tests, preferred controllers are setup as the active controller.
-     *
-     * This method is called on when running tests, else in the real world,
-     * users need to select a kernel (preferred is on top of the list).
-     */
-    private async setAsActiveControllerForTests(controller: VSCodeNotebookController, notebook: NotebookDocument) {
-        // Only when running tests should we force the selection of the kernel.
-        // Else the general VS Code behavior is for the user to select a kernel (here we make it look as though use selected it).
-        if (this.context.extensionMode !== ExtensionMode.Test) {
-            return;
-        }
-        traceInfoIf(
-            IS_CI_SERVER,
-            `Command notebook.selectKernel executing for ${notebook.uri.toString()} ${controller.id}`
-        );
-        await this.commandManager.executeCommand('notebook.selectKernel', {
-            id: controller.id,
-            extension: JVSC_EXTENSION_ID
-        });
-        traceInfoIf(
-            IS_CI_SERVER,
-            `Command notebook.selectKernel exected for ${notebook.uri.toString()} ${controller.id}`
-        );
-        // Used in tests to determine when the controller has been associated with a document.
-        VSCodeNotebookController.kernelAssociatedWithDocument = true;
-
-        // Sometimes the selection doesn't work (after all this is a hack).
-        if (!this.controllerMapping.get(notebook)) {
-            await this.handleOnNotebookControllerSelected({ notebook, controller });
-        }
-    }
     // A new NotebookController has been selected, find the associated notebook document and update it
     private async handleOnNotebookControllerSelected(event: {
         notebook: NotebookDocument;
         controller: VSCodeNotebookController;
     }) {
-        if (this.controllerMapping.get(event.notebook) === event.controller) {
-            // Possible it gets called again in our tests (due to hacks for testing purposes).
-            return;
-        }
-        traceInfoIf(IS_CI_SERVER, `Notebook Controller set ${event.notebook.uri.toString()}, ${event.controller.id}`);
-        this.widgetCoordinator.setActiveController(event.notebook, event.controller);
-        this.controllerMapping.set(event.notebook, event.controller);
-
-        // Now actually handle the change
-        await this.notebookKernelChanged(event.notebook, event.controller);
-
         // Now notify out that we have updated a notebooks controller
         this._onNotebookControllerSelected.fire(event);
     }
@@ -467,91 +405,5 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
             traceInfoIf(IS_CI_SERVER, `Disposing controller ${controller.id}`);
             controller.dispose();
         });
-    }
-
-    private async notebookKernelChanged(document: NotebookDocument, controller: VSCodeNotebookController) {
-        // We're only interested in our Jupyter Notebooks.
-        if (!isJupyterNotebook(document) || document.notebookType !== InteractiveWindowView) {
-            return;
-        }
-        const selectedKernelConnectionMetadata = controller.connection;
-
-        const model = this.storageProvider.get(document.uri);
-        if (model && model.isTrusted === false) {
-            // eslint-disable-next-line
-            // TODO: https://github.com/microsoft/vscode-python/issues/13476
-            // If a model is not trusted, we cannot change the kernel (this results in changes to notebook metadata).
-            // This is because we store selected kernel in the notebook metadata.
-            traceInfoIf(!!process.env.VSC_JUPYTER_LOG_KERNEL_OUTPUT, 'Kernel not switched, model not trusted');
-            return;
-        }
-
-        const existingKernel = this.kernelProvider.get(document.uri);
-        if (
-            existingKernel &&
-            areKernelConnectionsEqual(existingKernel.kernelConnectionMetadata, selectedKernelConnectionMetadata)
-        ) {
-            traceInfo('Switch kernel did not change kernel.');
-            return;
-        }
-        switch (controller.connection.kind) {
-            case 'startUsingPythonInterpreter':
-                sendNotebookOrKernelLanguageTelemetry(Telemetry.SwitchToExistingKernel, PYTHON_LANGUAGE);
-                break;
-            case 'connectToLiveKernel':
-                sendNotebookOrKernelLanguageTelemetry(
-                    Telemetry.SwitchToExistingKernel,
-                    controller.connection.kernelModel.language
-                );
-                break;
-            case 'startUsingKernelSpec':
-                sendNotebookOrKernelLanguageTelemetry(
-                    Telemetry.SwitchToExistingKernel,
-                    controller.connection.kernelSpec.language
-                );
-                break;
-            default:
-            // We don't know as its the default kernel on Jupyter server.
-        }
-        trackKernelResourceInformation(document.uri, { kernelConnection: controller.connection });
-        sendKernelTelemetryEvent(document.uri, Telemetry.SwitchKernel);
-        // If we have an existing kernel, then we know for a fact the user is changing the kernel.
-        // Else VSC is just setting a kernel for a notebook after it has opened.
-        if (existingKernel) {
-            const telemetryEvent = this.isLocalLaunch
-                ? Telemetry.SelectLocalJupyterKernel
-                : Telemetry.SelectRemoteJupyterKernel;
-            sendKernelTelemetryEvent(document.uri, telemetryEvent);
-            this.notebook.notebookEditors
-                .filter((editor) => editor.document === document)
-                .forEach((editor) =>
-                    controller.postMessage(
-                        { message: IPyWidgetMessages.IPyWidgets_onKernelChanged, payload: undefined },
-                        editor
-                    )
-                );
-        }
-        if (selectedKernelConnectionMetadata.interpreter) {
-            this.interpreterPackages.trackPackages(selectedKernelConnectionMetadata.interpreter);
-        }
-
-        // Before we start the notebook, make sure the metadata is set to this new kernel.
-        await updateNotebookDocumentMetadata(document, selectedKernelConnectionMetadata);
-
-        // Make this the new kernel (calling this method will associate the new kernel with this Uri).
-        // Calling `getOrCreate` will ensure a kernel is created and it is mapped to the Uri provided.
-        // This will dispose any existing (older kernels) associated with this notebook.
-        // This way other parts of extension have access to this kernel immediately after event is handled.
-        // Unlike webview notebooks we cannot revert to old kernel if kernel switching fails.
-        const newKernel = this.kernelProvider.getOrCreate(document.uri, {
-            metadata: selectedKernelConnectionMetadata,
-            controller: controller.controller
-        });
-        traceInfo(`KernelProvider switched kernel to id = ${newKernel?.kernelConnectionMetadata.id}`);
-
-        // Auto start the local kernels.
-        if (newKernel && !this.configuration.getSettings(undefined).disableJupyterAutoStart && this.isLocalLaunch) {
-            await newKernel.start({ disableUI: true, document }).catch(noop);
-        }
     }
 }

--- a/src/client/datascience/notebook/types.ts
+++ b/src/client/datascience/notebook/types.ts
@@ -8,7 +8,6 @@ export const INotebookKernelResolver = Symbol('INotebookKernelResolver');
 export const INotebookControllerManager = Symbol('INotebookControllerManager');
 export interface INotebookControllerManager {
     readonly onNotebookControllerSelected: Event<{ notebook: NotebookDocument; controller: VSCodeNotebookController }>;
-    getSelectedNotebookController(document: NotebookDocument): VSCodeNotebookController | undefined;
     loadNotebookControllers(): Promise<void>;
     // Marked test only, just for tests to access registered controllers
     registeredNotebookControllers(): VSCodeNotebookController[];

--- a/src/client/datascience/notebook/vscodeNotebookController.ts
+++ b/src/client/datascience/notebook/vscodeNotebookController.ts
@@ -17,24 +17,37 @@ import {
     Uri
 } from 'vscode';
 import { ICommandManager, IVSCodeNotebook, IWorkspaceService } from '../../common/application/types';
-import { PYTHON_LANGUAGE } from '../../common/constants';
+import { isCI, JVSC_EXTENSION_ID, PYTHON_LANGUAGE } from '../../common/constants';
 import { disposeAllDisposables } from '../../common/helpers';
-import { traceInfo } from '../../common/logger';
-import { IDisposable, IDisposableRegistry, IExtensionContext, IPathUtils } from '../../common/types';
+import { traceInfo, traceInfoIf } from '../../common/logger';
+import {
+    IConfigurationService,
+    IDisposable,
+    IDisposableRegistry,
+    IExtensionContext,
+    IPathUtils
+} from '../../common/types';
+import { testOnlyMethod } from '../../common/utils/decorators';
 import { noop } from '../../common/utils/misc';
 import { ConsoleForegroundColors } from '../../logging/_global';
-import { Commands } from '../constants';
+import { sendNotebookOrKernelLanguageTelemetry } from '../common';
+import { Commands, Telemetry } from '../constants';
+import { IPyWidgetMessages } from '../interactive-common/interactiveWindowTypes';
+import { NotebookIPyWidgetCoordinator } from '../ipywidgets/notebookIPyWidgetCoordinator';
 import {
+    areKernelConnectionsEqual,
     getDescriptionOfKernelConnection,
     getDetailOfKernelConnection,
     isPythonKernelConnection
 } from '../jupyter/kernels/helpers';
 import { IKernel, IKernelProvider, KernelConnectionMetadata } from '../jupyter/kernels/types';
 import { PreferredRemoteKernelIdProvider } from '../notebookStorage/preferredRemoteKernelIdProvider';
+import { InterpreterPackages } from '../telemetry/interpreterPackages';
+import { sendKernelTelemetryEvent, trackKernelResourceInformation } from '../telemetry/telemetry';
 import { KernelSocketInformation } from '../types';
 import { NotebookCellLanguageService } from './cellLanguageService';
-import { traceCellMessage, updateNotebookDocumentMetadata } from './helpers/helpers';
-import { INotebookControllerManager } from './types';
+import { InteractiveWindowView } from './constants';
+import { isJupyterNotebook, traceCellMessage, updateNotebookDocumentMetadata } from './helpers/helpers';
 
 export class VSCodeNotebookController implements Disposable {
     private readonly _onNotebookControllerSelected: EventEmitter<{
@@ -67,6 +80,11 @@ export class VSCodeNotebookController implements Disposable {
     get onDidReceiveMessage() {
         return this.controller.onDidReceiveMessage;
     }
+    @testOnlyMethod()
+    public isAssociatedWithDocument(doc: NotebookDocument) {
+        return this.associatedDocuments.has(doc);
+    }
+    private readonly associatedDocuments = new WeakSet<NotebookDocument>();
     constructor(
         private readonly kernelConnection: KernelConnectionMetadata,
         id: string,
@@ -77,15 +95,14 @@ export class VSCodeNotebookController implements Disposable {
         private readonly kernelProvider: IKernelProvider,
         private readonly preferredRemoteKernelIdProvider: PreferredRemoteKernelIdProvider,
         private readonly context: IExtensionContext,
-        private readonly notebookControllerManager: INotebookControllerManager,
         private readonly pathUtils: IPathUtils,
         disposableRegistry: IDisposableRegistry,
         private readonly languageService: NotebookCellLanguageService,
         private readonly workspace: IWorkspaceService,
-        private readonly setAsActiveControllerForTests: (
-            controller: VSCodeNotebookController,
-            notebook: NotebookDocument
-        ) => Promise<void>
+        private readonly localOrRemoteKernel: 'local' | 'remote',
+        private readonly interpreterPackages: InterpreterPackages,
+        private readonly configuration: IConfigurationService,
+        private readonly widgetCoordinator: NotebookIPyWidgetCoordinator
     ) {
         disposableRegistry.push(this);
         this._onNotebookControllerSelected = new EventEmitter<{
@@ -136,7 +153,7 @@ export class VSCodeNotebookController implements Disposable {
         // Only when running tests should we force the selection of the kernel.
         // Else the general VS Code behavior is for the user to select a kernel (here we make it look as though use selected it).
         if (this.context.extensionMode === ExtensionMode.Test) {
-            await this.setAsActiveControllerForTests(this, notebook);
+            await this.setAsActiveControllerForTests(notebook);
         }
     }
 
@@ -159,6 +176,19 @@ export class VSCodeNotebookController implements Disposable {
         await Promise.all(cells.map((cell) => this.executeCell(targetNotebook, cell)));
     }
     private async onDidChangeSelectedNotebooks(event: { notebook: NotebookDocument; selected: boolean }) {
+        if (this.associatedDocuments.has(event.notebook) && event.selected) {
+            // Possible it gets called again in our tests (due to hacks for testing purposes).
+            return;
+        }
+        if (!event.selected) {
+            this.associatedDocuments.delete(event.notebook);
+        }
+        traceInfoIf(isCI, `Notebook Controller set ${event.notebook.uri.toString()}, ${this.id}`);
+        this.widgetCoordinator.setActiveController(event.notebook, this);
+
+        // Now actually handle the change
+        await this.notebookKernelChanged(event.notebook);
+
         // If this NotebookController was selected, fire off the event
         if (event.selected) {
             await this.updateCellLanguages(event.notebook);
@@ -265,9 +295,8 @@ export class VSCodeNotebookController implements Disposable {
                 return;
             }
 
-            const documentConnection = this.notebookControllerManager.getSelectedNotebookController(doc);
-            if (!documentConnection || documentConnection.id !== this.id) {
-                // Disregard if we've changed kernels
+            // Disregard if we've changed kernels (i.e. if this controller is no longer associated with the document)
+            if (!this.associatedDocuments.has(doc)) {
                 return;
             }
             await updateNotebookDocumentMetadata(doc, kernel.kernelConnectionMetadata, kernel.info);
@@ -285,5 +314,116 @@ export class VSCodeNotebookController implements Disposable {
         handlerDisposables.push({ dispose: () => subscriptionDisposables.unsubscribe() });
         handlerDisposables.push({ dispose: () => statusChangeDisposable.dispose() });
         handlerDisposables.push({ dispose: () => kernelDisposedDisposable?.dispose() });
+    }
+    private async notebookKernelChanged(document: NotebookDocument) {
+        // We're only interested in our Jupyter Notebooks.
+        if (!isJupyterNotebook(document) || document.notebookType !== InteractiveWindowView) {
+            return;
+        }
+        const selectedKernelConnectionMetadata = this.connection;
+
+        if (!this.workspace.isTrusted) {
+            return;
+        }
+
+        const existingKernel = this.kernelProvider.get(document.uri);
+        if (
+            existingKernel &&
+            areKernelConnectionsEqual(existingKernel.kernelConnectionMetadata, selectedKernelConnectionMetadata)
+        ) {
+            traceInfo('Switch kernel did not change kernel.');
+            return;
+        }
+        switch (this.connection.kind) {
+            case 'startUsingPythonInterpreter':
+                sendNotebookOrKernelLanguageTelemetry(Telemetry.SwitchToExistingKernel, PYTHON_LANGUAGE);
+                break;
+            case 'connectToLiveKernel':
+                sendNotebookOrKernelLanguageTelemetry(
+                    Telemetry.SwitchToExistingKernel,
+                    this.connection.kernelModel.language
+                );
+                break;
+            case 'startUsingKernelSpec':
+                sendNotebookOrKernelLanguageTelemetry(
+                    Telemetry.SwitchToExistingKernel,
+                    this.connection.kernelSpec.language
+                );
+                break;
+            default:
+            // We don't know as its the default kernel on Jupyter server.
+        }
+        trackKernelResourceInformation(document.uri, { kernelConnection: this.connection });
+        sendKernelTelemetryEvent(document.uri, Telemetry.SwitchKernel);
+        // If we have an existing kernel, then we know for a fact the user is changing the kernel.
+        // Else VSC is just setting a kernel for a notebook after it has opened.
+        if (existingKernel) {
+            const telemetryEvent =
+                this.localOrRemoteKernel === 'local'
+                    ? Telemetry.SelectLocalJupyterKernel
+                    : Telemetry.SelectRemoteJupyterKernel;
+            sendKernelTelemetryEvent(document.uri, telemetryEvent);
+            this.notebookApi.notebookEditors
+                .filter((editor) => editor.document === document)
+                .forEach((editor) =>
+                    this.postMessage(
+                        { message: IPyWidgetMessages.IPyWidgets_onKernelChanged, payload: undefined },
+                        editor
+                    )
+                );
+        }
+        if (selectedKernelConnectionMetadata.interpreter) {
+            this.interpreterPackages.trackPackages(selectedKernelConnectionMetadata.interpreter);
+        }
+
+        // Before we start the notebook, make sure the metadata is set to this new kernel.
+        await updateNotebookDocumentMetadata(document, selectedKernelConnectionMetadata);
+
+        // Make this the new kernel (calling this method will associate the new kernel with this Uri).
+        // Calling `getOrCreate` will ensure a kernel is created and it is mapped to the Uri provided.
+        // This will dispose any existing (older kernels) associated with this notebook.
+        // This way other parts of extension have access to this kernel immediately after event is handled.
+        // Unlike webview notebooks we cannot revert to old kernel if kernel switching fails.
+        const newKernel = this.kernelProvider.getOrCreate(document.uri, {
+            metadata: selectedKernelConnectionMetadata,
+            controller: this.controller
+        });
+        traceInfo(`KernelProvider switched kernel to id = ${newKernel?.kernelConnectionMetadata.id}`);
+
+        // Auto start the local kernels.
+        if (
+            newKernel &&
+            !this.configuration.getSettings(undefined).disableJupyterAutoStart &&
+            this.localOrRemoteKernel === 'local'
+        ) {
+            await newKernel.start({ disableUI: true, document }).catch(noop);
+        }
+    }
+    /**
+     * In our tests, preferred controllers are setup as the active controller.
+     *
+     * This method is called on when running tests, else in the real world,
+     * users need to select a kernel (preferred is on top of the list).
+     */
+    private async setAsActiveControllerForTests(notebook: NotebookDocument) {
+        // Only when running tests should we force the selection of the kernel.
+        // Else the general VS Code behavior is for the user to select a kernel (here we make it look as though use selected it).
+        if (this.context.extensionMode !== ExtensionMode.Test) {
+            return;
+        }
+        traceInfoIf(isCI, `Command notebook.selectKernel executing for ${notebook.uri.toString()} ${this.id}`);
+        await this.commandManager.executeCommand('notebook.selectKernel', {
+            id: this.id,
+            extension: JVSC_EXTENSION_ID
+        });
+        traceInfoIf(isCI, `Command notebook.selectKernel exected for ${notebook.uri.toString()} ${this.id}`);
+        // Used in tests to determine when the controller has been associated with a document.
+        VSCodeNotebookController.kernelAssociatedWithDocument = true;
+
+        // Sometimes the selection doesn't work (after all this is a hack).
+        if (!this.associatedDocuments.has(notebook)) {
+            this.associatedDocuments.add(notebook);
+            this._onNotebookControllerSelected.fire({ notebook, controller: this });
+        }
     }
 }

--- a/src/client/datascience/notebook/vscodeNotebookController.ts
+++ b/src/client/datascience/notebook/vscodeNotebookController.ts
@@ -182,7 +182,7 @@ export class VSCodeNotebookController implements Disposable {
             return;
         }
         // We're only interested in our Notebooks.
-        if (!isJupyterNotebook(event.notebook) || event.notebook.notebookType !== InteractiveWindowView) {
+        if (!isJupyterNotebook(event.notebook) && event.notebook.notebookType !== InteractiveWindowView) {
             return;
         }
         if (!this.workspace.isTrusted) {

--- a/src/test/datascience/kernel-launcher/kernelDaemonPoolPreWarmer.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/kernelDaemonPoolPreWarmer.unit.test.ts
@@ -8,7 +8,6 @@ import { JupyterSettings } from '../../../client/common/configSettings';
 import { IConfigurationService, IExperimentService, IWatchableJupyterSettings } from '../../../client/common/types';
 import { KernelDaemonPool } from '../../../client/datascience/kernel-launcher/kernelDaemonPool';
 import { KernelDaemonPreWarmer } from '../../../client/datascience/kernel-launcher/kernelDaemonPreWarmer';
-import { INotebookControllerManager } from '../../../client/datascience/notebook/types';
 import {
     IInteractiveWindowProvider,
     INotebookCreationTracker,
@@ -28,7 +27,6 @@ suite('DataScience - Kernel Daemon Pool PreWarmer', () => {
     let settings: IWatchableJupyterSettings;
     let vscodeNotebook: IVSCodeNotebook;
     let extensionChecker: PythonExtensionChecker;
-    let notebookController: INotebookControllerManager;
     setup(() => {
         notebookEditorProvider = mock<INotebookEditorProvider>();
         interactiveProvider = mock<IInteractiveWindowProvider>();
@@ -42,7 +40,6 @@ suite('DataScience - Kernel Daemon Pool PreWarmer', () => {
         extensionChecker = mock(PythonExtensionChecker);
         when(extensionChecker.isPythonExtensionInstalled).thenReturn(true);
         when(extensionChecker.isPythonExtensionActive).thenReturn(true);
-        notebookController = mock<INotebookControllerManager>();
 
         // Set up our config settings
         settings = mock(JupyterSettings);
@@ -58,8 +55,7 @@ suite('DataScience - Kernel Daemon Pool PreWarmer', () => {
             instance(rawNotebookSupported),
             instance(configService),
             instance(vscodeNotebook),
-            instance(extensionChecker),
-            instance(notebookController)
+            instance(extensionChecker)
         );
     });
     test('Should not pre-warm daemon pool if ds was never used', async () => {

--- a/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
@@ -35,7 +35,7 @@ import { JupyterPaths } from '../../../client/datascience/kernel-launcher/jupyte
 import { LocalPythonAndRelatedNonPythonKernelSpecFinder } from '../../../client/datascience/kernel-launcher/localPythonAndRelatedNonPythonKernelSpecFinder';
 
 [false, true].forEach((isWindows) => {
-    suite.only(`Local Kernel Finder ${isWindows ? 'Windows' : 'Unix'}`, () => {
+    suite(`Local Kernel Finder ${isWindows ? 'Windows' : 'Unix'}`, () => {
         let kernelFinder: ILocalKernelFinder;
         let interpreterService: IInterpreterService;
         let platformService: IPlatformService;

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -265,13 +265,14 @@ export async function waitForKernelToChange(criteria: { labelOrId?: string; inte
     // Send a select kernel on the active notebook editor
     void commands.executeCommand('notebook.selectKernel', { id, extension: JVSC_EXTENSION_ID });
     const isRightKernel = () => {
-        if (!vscodeNotebook.activeNotebookEditor) {
+        const doc = vscodeNotebook.activeNotebookEditor?.document;
+        if (!doc) {
             return false;
         }
 
-        const selectedController = notebookControllerManager.getSelectedNotebookController(
-            vscodeNotebook.activeNotebookEditor.document
-        );
+        const selectedController = notebookControllerManager
+            .registeredNotebookControllers()
+            .find((item) => item.isAssociatedWithDocument(doc));
         if (!selectedController) {
             return false;
         }
@@ -301,9 +302,13 @@ export async function waitForKernelToGetAutoSelected(expectedLanguage?: string, 
     let selectedController: VSCodeNotebookController;
     await waitForCondition(
         async () => {
-            const controller = notebookControllerManager.getSelectedNotebookController(
-                vscodeNotebook.activeNotebookEditor?.document!
-            );
+            const doc = vscodeNotebook.activeNotebookEditor?.document;
+            if (!doc) {
+                return false;
+            }
+            const controller = notebookControllerManager
+                .registeredNotebookControllers()
+                .find((item) => item.isAssociatedWithDocument(doc));
             if (controller) {
                 selectedController = controller;
             }


### PR DESCRIPTION
VS Code doesn't have a concept of a controller manager. I think we had this prior to kernel push.
In VS Code each controller has its own event whether its selected/de-selected.
Looking at the code we're trying to move this back to controller manager (kind of the way it was preivously) & i feel that's incorrect, 
If VS Code has events in the controllers, then I think we should handle that in the controller and do what ever we need to do there, rather than adding an abstraction & propagating the events to the manager & then doing the stuff in the manager.

Also, the manager creates the controller, but the controller calls methods on the Manager via callbacks (test method i added) & some otehr public methods to get the controller associated with a document..
I've removed that as well.

This way, the relationship is simple, mnanager creates controllers and can call methods in controllers.
But controllers cannot access methods in manager. (else its a cyclic dependency)

