### PR TITLE
Support listing non-python kernels early

### DIFF
--- a/src/client/datascience/kernel-launcher/localKnownPathKernelSpecFinder.ts
+++ b/src/client/datascience/kernel-launcher/localKnownPathKernelSpecFinder.ts
@@ -12,6 +12,7 @@ import { IJupyterKernelSpec } from '../types';
 import { LocalKernelSpecFinderBase } from './localKernelSpecFinderBase';
 import { JupyterPaths } from './jupyterPaths';
 import { PYTHON_LANGUAGE } from '../../common/constants';
+import { IPythonExtensionChecker } from '../../api/types';
 
 /**
  * This class searches for kernels on the file system in well known paths documented by Jupyter.
@@ -23,9 +24,10 @@ export class LocalKnownPathKernelSpecFinder extends LocalKernelSpecFinderBase {
     constructor(
         @inject(IFileSystem) fs: IFileSystem,
         @inject(IWorkspaceService) workspaceService: IWorkspaceService,
-        @inject(JupyterPaths) private readonly jupyterPaths: JupyterPaths
+        @inject(JupyterPaths) private readonly jupyterPaths: JupyterPaths,
+        @inject(IPythonExtensionChecker) extensionChecker: IPythonExtensionChecker
     ) {
-        super(fs, workspaceService);
+        super(fs, workspaceService, extensionChecker);
     }
     /**
      * @param {boolean} includePythonKernels Include/exclude Python kernels in the result.
@@ -34,7 +36,7 @@ export class LocalKnownPathKernelSpecFinder extends LocalKernelSpecFinderBase {
         includePythonKernels: boolean,
         cancelToken?: CancellationToken
     ): Promise<(KernelSpecConnectionMetadata | PythonKernelConnectionMetadata)[]> {
-        return this.listKernelsWithCache(includePythonKernels ? 'IncludePython' : 'ExcludePython', async () => {
+        return this.listKernelsWithCache(includePythonKernels ? 'IncludePython' : 'ExcludePython', false, async () => {
             // First find the on disk kernel specs and interpreters
             const kernelSpecs = await this.findKernelSpecs(cancelToken);
 

--- a/src/client/datascience/kernel-launcher/localPythonAndRelatedNonPythonKernelSpecFinder.ts
+++ b/src/client/datascience/kernel-launcher/localPythonAndRelatedNonPythonKernelSpecFinder.ts
@@ -64,12 +64,13 @@ export class LocalPythonAndRelatedNonPythonKernelSpecFinder extends LocalKernelS
         // If we don't have Python extension installed or don't discover any Python interpreters
         // then list all of the global python kernel specs.
         if (interpreters.length === 0 || !this.extensionChecker.isPythonExtensionInstalled) {
-            return this.listGlobalPythonKernelSpecs(cancelToken);
+            return this.listGlobalPythonKernelSpecs(false, cancelToken);
         } else {
             return this.listPythonAndRelatedNonPythonKernelSpecs(resource, interpreters, cancelToken);
         }
     }
     private async listGlobalPythonKernelSpecs(
+        includeKernelsRegisteredByUs: boolean,
         cancelToken?: CancellationToken
     ): Promise<(KernelSpecConnectionMetadata | PythonKernelConnectionMetadata)[]> {
         const kernelSpecs = await this.kernelSpecsFromKnownLocations.listKernelSpecs(true, cancelToken);
@@ -79,7 +80,7 @@ export class LocalPythonAndRelatedNonPythonKernelSpecFinder extends LocalKernelS
                 // If there are any kernels that we regsitered (then don't return them).
                 // Those were registered by us to start kernels from Jupyter extension (not stuff that user created).
                 // We should only return global kernels the user created themselves, others will appear when searching for interprters.
-                .filter((item) => !isKernelRegisteredByUs(item.kernelSpec))
+                .filter((item) => (includeKernelsRegisteredByUs ? true : !isKernelRegisteredByUs(item.kernelSpec)))
         );
     }
     /**
@@ -103,7 +104,7 @@ export class LocalPythonAndRelatedNonPythonKernelSpecFinder extends LocalKernelS
             this.findKernelSpecsInInterpreters(interpreters, cancelToken),
             rootSpecPathPromise,
             activeInterpreterPromise,
-            this.listGlobalPythonKernelSpecs(cancelToken)
+            this.listGlobalPythonKernelSpecs(true, cancelToken)
         ]);
 
         const globalPythonKernelSpecsRegisteredByUs = globalKernelSpecs.filter((item) =>

--- a/src/client/datascience/notebook/notebookControllerManager.ts
+++ b/src/client/datascience/notebook/notebookControllerManager.ts
@@ -12,8 +12,7 @@ import {
     IDisposableRegistry,
     IExtensionContext,
     IExtensions,
-    IPathUtils,
-    Resource
+    IPathUtils
 } from '../../common/types';
 import { StopWatch } from '../../common/utils/stopWatch';
 import { Telemetry } from '../constants';

--- a/src/client/datascience/notebook/notebookControllerManager.ts
+++ b/src/client/datascience/notebook/notebookControllerManager.ts
@@ -51,7 +51,6 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
     // Listing of the controllers that we have registered
     private registeredControllers = new Map<string, VSCodeNotebookController>();
 
-    private cancelToken: CancellationTokenSource | undefined;
     private readonly isLocalLaunch: boolean;
     private wasPythonInstalledWhenFetchingControllers?: boolean;
     constructor(

--- a/src/client/datascience/notebook/notebookControllerManager.ts
+++ b/src/client/datascience/notebook/notebookControllerManager.ts
@@ -17,11 +17,7 @@ import {
 } from '../../common/types';
 import { StopWatch } from '../../common/utils/stopWatch';
 import { Telemetry } from '../constants';
-import {
-    areKernelConnectionsEqual,
-    getDisplayNameOrNameOfKernelConnection,
-    isLocalLaunch
-} from '../jupyter/kernels/helpers';
+import { getDisplayNameOrNameOfKernelConnection, isLocalLaunch } from '../jupyter/kernels/helpers';
 import { IKernelProvider, KernelConnectionMetadata } from '../jupyter/kernels/types';
 import { ILocalKernelFinder, IRemoteKernelFinder } from '../kernel-launcher/types';
 import { PreferredRemoteKernelIdProvider } from '../notebookStorage/preferredRemoteKernelIdProvider';
@@ -37,6 +33,8 @@ import { NotebookCellLanguageService } from './cellLanguageService';
 import { sendKernelListTelemetry } from '../telemetry/kernelTelemetry';
 import { testOnlyMethod } from '../../common/utils/decorators';
 import { IS_CI_SERVER } from '../../../test/ciConstants';
+import { noop } from '../../common/utils/misc';
+import { IPythonExtensionChecker } from '../../api/types';
 /**
  * This class tracks notebook documents that are open and the provides NotebookControllers for
  * each of them
@@ -52,10 +50,11 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
     private controllersPromise?: Promise<void>;
 
     // Listing of the controllers that we have registered
-    private registeredControllers: VSCodeNotebookController[] = [];
+    private registeredControllers = new Map<string, VSCodeNotebookController>();
 
     private cancelToken: CancellationTokenSource | undefined;
     private readonly isLocalLaunch: boolean;
+    private wasPythonInstalledWhenFetchingControllers?: boolean;
     constructor(
         @inject(IVSCodeNotebook) private readonly notebook: IVSCodeNotebook,
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
@@ -73,7 +72,8 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
         @inject(NotebookIPyWidgetCoordinator) private readonly widgetCoordinator: NotebookIPyWidgetCoordinator,
         @inject(InterpreterPackages) private readonly interpreterPackages: InterpreterPackages,
         @inject(NotebookCellLanguageService) private readonly languageService: NotebookCellLanguageService,
-        @inject(IWorkspaceService) private readonly workspace: IWorkspaceService
+        @inject(IWorkspaceService) private readonly workspace: IWorkspaceService,
+        @inject(IPythonExtensionChecker) private readonly extensionChecker: IPythonExtensionChecker
     ) {
         this._onNotebookControllerSelected = new EventEmitter<{
             notebook: NotebookDocument;
@@ -98,64 +98,61 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
     // Function to expose currently registered controllers to test code only
     @testOnlyMethod()
     public registeredNotebookControllers(): VSCodeNotebookController[] {
-        return this.registeredControllers;
+        return Array.from(this.registeredControllers.values());
     }
 
     // Find all the notebook controllers that we have registered
     public async loadNotebookControllers(): Promise<void> {
         if (!this.controllersPromise) {
-            this.controllersPromise = this.loadNotebookControllersImpl()
-                .then((controllers) => {
-                    // Just assign here as this is our initial set of controllers
-                    // anything that adds or updates should make sure the initial load has happened first
-                    this.registeredControllers = controllers;
-                })
+            const stopWatch = new StopWatch();
+
+            this.controllersPromise = Promise.all([
+                this.loadNotebookControllersImpl(true),
+                this.loadNotebookControllersImpl(false)
+            ])
+                .then(() => noop())
                 .catch((error) => {
                     traceError('Error loading notebook controllers', error);
                     throw error;
+                })
+                .finally(() => {
+                    // Send telemetry related to fetching the kernel connections
+                    sendKernelListTelemetry(
+                        Uri.file('test.ipynb'), // Give a dummy ipynb value, we need this as its used in telemetry to determine the resource.
+                        Array.from(this.registeredControllers.values()).map((item) => item.connection),
+                        stopWatch
+                    );
+
+                    traceInfoIf(
+                        !!process.env.VSC_JUPYTER_LOG_KERNEL_OUTPUT,
+                        `Providing notebook controllers with length ${this.registeredControllers.size}.`
+                    );
                 });
         }
         return this.controllersPromise;
     }
 
-    // Turn all our kernelConnections that we know about into registered NotebookControllers
-    private async loadNotebookControllersImpl(): Promise<VSCodeNotebookController[]> {
-        const stopWatch = new StopWatch();
+    /**
+     * Turn all our kernelConnections that we know about into registered NotebookControllers
+     */
+    private async loadNotebookControllersImpl(listLocalNonPytonKernels: boolean): Promise<void> {
+        const cancelToken = new CancellationTokenSource();
+        this.wasPythonInstalledWhenFetchingControllers = this.extensionChecker.isPythonExtensionInstalled;
+        const connections = await this.getKernelConnectionMetadata(listLocalNonPytonKernels, cancelToken.token);
 
-        try {
-            this.cancelToken = new CancellationTokenSource();
-
-            const connections = await this.getKernelConnectionMetadata(this.cancelToken.token);
-
-            if (this.cancelToken.token.isCancellationRequested) {
-                // Bail out on making the controllers if we are cancelling
-                traceInfo('Cancelled loading notebook controllers');
-                return [];
-            }
-
-            // Now create the actual controllers from our connections
-            const controllers = this.createNotebookControllers(connections);
-
-            // Send telemetry related to fetching the kernel connections
-            sendKernelListTelemetry(
-                Uri.file('test.ipynb'), // Give a dummy ipynb value, we need this as its used in telemetry to determine the resource.
-                controllers.map((item) => item.connection),
-                stopWatch
-            );
-
-            traceInfoIf(
-                !!process.env.VSC_JUPYTER_LOG_KERNEL_OUTPUT,
-                `Providing notebook controllers with length ${controllers.length}.`
-            );
-
-            return controllers;
-        } finally {
-            this.cancelToken = undefined;
-        }
+        // Now create the actual controllers from our connections
+        this.createNotebookControllers(connections);
     }
 
-    private onDidChangeExtensions() {
-        // KERNELPUSH: On extension load we might fetch different kernels, need to invalidate here and regen
+    private async onDidChangeExtensions() {
+        if (!this.isLocalLaunch || !this.controllersPromise) {
+            return;
+        }
+        // If we just installed the Pytohn extnsion and we fetched the controllers, then fetch it again.
+        if (!this.wasPythonInstalledWhenFetchingControllers && this.extensionChecker.isPythonExtensionInstalled) {
+            this.controllersPromise = undefined;
+            await this.loadNotebookControllers();
+        }
     }
 
     // When a document is opened we need to look for a perferred kernel for it
@@ -224,8 +221,8 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
             // Wait for our controllers to be loaded before we try to set a preferred on
             // can happen if a document is opened quick and we have not yet loaded our controllers
             await loadControllersPromise;
-            const targetController = this.registeredControllers.find((value) =>
-                areKernelConnectionsEqual(preferredConnection, value.connection)
+            const targetController = Array.from(this.registeredControllers.values()).find(
+                (value) => preferredConnection?.id === value.connection.id
             );
 
             if (targetController) {
@@ -244,7 +241,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
         }
     }
 
-    private createNotebookControllers(kernelConnections: KernelConnectionMetadata[]): VSCodeNotebookController[] {
+    private createNotebookControllers(kernelConnections: KernelConnectionMetadata[]) {
         // First sort our items by label
         const connectionsWithLabel = kernelConnections.map((value) => {
             return { connection: value, label: getDisplayNameOrNameOfKernelConnection(value) };
@@ -259,58 +256,49 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
             }
         });
 
-        // Map KernelConnectionMetadata => NotebookController
-        const allControllers: VSCodeNotebookController[] = [];
         connectionsWithLabel.forEach((value) => {
-            const controllers = this.createNotebookController(value.connection, value.label);
-            if (controllers) {
-                allControllers.push(...controllers);
-            }
+            this.createNotebookController(value.connection, value.label);
         });
-
-        return allControllers;
     }
-    private createNotebookController(
-        kernelConnection: KernelConnectionMetadata,
-        label: string
-    ): VSCodeNotebookController[] | undefined {
+    private createNotebookController(kernelConnection: KernelConnectionMetadata, label: string) {
         try {
             // Create notebook selector
-            return [
+            [
                 [kernelConnection.id, JupyterNotebookView],
                 [`${kernelConnection.id} (Interactive)`, InteractiveWindowView]
-            ].map(([id, viewType]) => {
-                const controller = new VSCodeNotebookController(
-                    kernelConnection,
-                    id,
-                    viewType,
-                    label,
-                    this.notebook,
-                    this.commandManager,
-                    this.kernelProvider,
-                    this.preferredRemoteKernelIdProvider,
-                    this.context,
-                    this.pathUtils,
-                    this.disposables,
-                    this.languageService,
-                    this.workspace,
-                    this.isLocalLaunch ? 'local' : 'remote',
-                    this.interpreterPackages,
-                    this.configuration,
-                    this.widgetCoordinator
-                );
-                // Hook up to if this NotebookController is selected or de-selected
-                controller.onNotebookControllerSelected(
-                    this.handleOnNotebookControllerSelected,
-                    this,
-                    this.disposables
-                );
+            ]
+                .filter(([id]) => !this.registeredControllers.has(id))
+                .forEach(([id, viewType]) => {
+                    const controller = new VSCodeNotebookController(
+                        kernelConnection,
+                        id,
+                        viewType,
+                        label,
+                        this.notebook,
+                        this.commandManager,
+                        this.kernelProvider,
+                        this.preferredRemoteKernelIdProvider,
+                        this.context,
+                        this.pathUtils,
+                        this.disposables,
+                        this.languageService,
+                        this.workspace,
+                        this.isLocalLaunch ? 'local' : 'remote',
+                        this.interpreterPackages,
+                        this.configuration,
+                        this.widgetCoordinator
+                    );
+                    // Hook up to if this NotebookController is selected or de-selected
+                    controller.onNotebookControllerSelected(
+                        this.handleOnNotebookControllerSelected,
+                        this,
+                        this.disposables
+                    );
 
-                // We are disposing as documents are closed, but do this as well
-                this.disposables.push(controller);
-
-                return controller;
-            });
+                    // We are disposing as documents are closed, but do this as well
+                    this.disposables.push(controller);
+                    this.registeredControllers.set(controller.id, controller);
+                });
         } catch (ex) {
             // We know that this fails when we have xeus kernels installed (untill that's resolved thats one instance when we can have duplicates).
             sendTelemetryEvent(
@@ -332,26 +320,27 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
         this._onNotebookControllerSelected.fire(event);
     }
 
-    private async getKernelConnectionMetadata(token: CancellationToken): Promise<KernelConnectionMetadata[]> {
-        let kernels: KernelConnectionMetadata[] = [];
-
-        // Instead of a specific resource, we can just search on undefined for the workspace
-        const resource: Resource = undefined;
-
+    private async getKernelConnectionMetadata(
+        listLocalNonPytonKernels: boolean,
+        token: CancellationToken
+    ): Promise<KernelConnectionMetadata[]> {
         if (this.isLocalLaunch) {
-            kernels = await this.localKernelFinder.listKernels(resource, token);
+            return listLocalNonPytonKernels
+                ? this.localKernelFinder.listNonPythonKernels(token)
+                : this.localKernelFinder.listKernels(undefined, token);
         } else {
+            if (listLocalNonPytonKernels) {
+                return [];
+            }
             const connection = await this.notebookProvider.connect({
                 getOnly: false,
-                resource: resource,
+                resource: undefined,
                 disableUI: false,
                 localOnly: false
             });
 
-            kernels = await this.remoteKernelFinder.listKernels(resource, connection, token);
+            return this.remoteKernelFinder.listKernels(undefined, connection, token);
         }
-
-        return kernels;
     }
 
     // Update any new or removed kernel connections, LiveKernelModels might be added or removed
@@ -361,7 +350,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
         await this.loadNotebookControllers();
 
         // We've connected and done the intial fetch, so this is speedy
-        const connections = await this.getKernelConnectionMetadata(cancelToken);
+        const connections = await this.getKernelConnectionMetadata(false, cancelToken);
 
         if (cancelToken.isCancellationRequested) {
             // Bail out on making the controllers if we are cancelling
@@ -371,15 +360,13 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
 
         // Look for any connections that are not registered already as controllers
         const missingConnections = connections.filter((connection) => {
-            return !this.registeredControllers.some((controller) => {
-                return controller.id === connection.id;
-            });
+            return !this.registeredControllers.has(connection.id);
         });
 
         // Look for any controllers that we have disposed
-        const disposedControllers = this.registeredControllers.filter((controller) => {
+        const disposedControllers = Array.from(this.registeredControllers.values()).filter((controller) => {
             return !connections.some((connection) => {
-                return connection.id === controller.id;
+                return connection.id === controller.connection.id;
             });
         });
 
@@ -390,18 +377,13 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
             });
 
             connectionsWithLabel.forEach((value) => {
-                const controllers = this.createNotebookController(value.connection, value.label);
-                if (controllers) {
-                    this.registeredControllers.push(...controllers);
-                }
+                this.createNotebookController(value.connection, value.label);
             });
         }
 
         // If we have any out of date connections, dispose of them
         disposedControllers.forEach((controller) => {
-            this.registeredControllers = this.registeredControllers.filter((regController) => {
-                return regController.id !== controller.id;
-            });
+            this.registeredControllers.delete(controller.id);
             traceInfoIf(IS_CI_SERVER, `Disposing controller ${controller.id}`);
             controller.dispose();
         });

--- a/src/client/datascience/notebook/notebookControllerManager.ts
+++ b/src/client/datascience/notebook/notebookControllerManager.ts
@@ -84,6 +84,9 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
     get onNotebookControllerSelected() {
         return this._onNotebookControllerSelected.event;
     }
+    public getSelectedNotebookController(notebook: NotebookDocument) {
+        return Array.from(this.registeredControllers.values()).find((item) => item.isAssociatedWithDocument(notebook));
+    }
 
     public activate() {
         // Sign up for document either opening or closing

--- a/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
@@ -35,7 +35,7 @@ import { JupyterPaths } from '../../../client/datascience/kernel-launcher/jupyte
 import { LocalPythonAndRelatedNonPythonKernelSpecFinder } from '../../../client/datascience/kernel-launcher/localPythonAndRelatedNonPythonKernelSpecFinder';
 import { getInterpreterHash } from '../../../client/pythonEnvironments/info/interpreter';
 
-[false].forEach((isWindows) => {
+[false, true].forEach((isWindows) => {
     suite(`Local Kernel Finder ${isWindows ? 'Windows' : 'Unix'}`, () => {
         let kernelFinder: ILocalKernelFinder;
         let interpreterService: IInterpreterService;

--- a/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
@@ -256,7 +256,8 @@ import { LocalPythonAndRelatedNonPythonKernelSpecFinder } from '../../../client/
             const nonPythonKernelSpecFinder = new LocalKnownPathKernelSpecFinder(
                 instance(fs),
                 instance(workspaceService),
-                jupyterPaths
+                jupyterPaths,
+                instance(extensionChecker)
             );
             kernelFinder = new LocalKernelFinder(
                 instance(interpreterService),

--- a/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
@@ -33,8 +33,9 @@ import { IExtensions } from '../../../client/common/types';
 import { LocalKnownPathKernelSpecFinder } from '../../../client/datascience/kernel-launcher/localKnownPathKernelSpecFinder';
 import { JupyterPaths } from '../../../client/datascience/kernel-launcher/jupyterPaths';
 import { LocalPythonAndRelatedNonPythonKernelSpecFinder } from '../../../client/datascience/kernel-launcher/localPythonAndRelatedNonPythonKernelSpecFinder';
+import { getInterpreterHash } from '../../../client/pythonEnvironments/info/interpreter';
 
-[false, true].forEach((isWindows) => {
+[false].forEach((isWindows) => {
     suite(`Local Kernel Finder ${isWindows ? 'Windows' : 'Unix'}`, () => {
         let kernelFinder: ILocalKernelFinder;
         let interpreterService: IInterpreterService;
@@ -294,11 +295,7 @@ import { LocalPythonAndRelatedNonPythonKernelSpecFinder } from '../../../client/
             when(extensionChecker.isPythonExtensionInstalled).thenReturn(false);
             const kernels = await kernelFinder.listKernels(undefined);
 
-            assert.isAtLeast(kernels.length, 3, 'Not enough kernels returned');
-            assert.ok(
-                kernels.find((k) => getDisplayNameOrNameOfKernelConnection(k) === 'Python 3 on Disk'),
-                'Python 3 kernel not found'
-            );
+            assert.isAtLeast(kernels.length, 2, 'Not enough kernels returned');
             assert.ok(
                 kernels.find((k) => getDisplayNameOrNameOfKernelConnection(k) === 'Python 2 on Disk'),
                 'Python 2 kernel not found'
@@ -659,25 +656,25 @@ import { LocalPythonAndRelatedNonPythonKernelSpecFinder } from '../../../client/
                     assert.equal(kernel?.kind, 'startUsingPythonInterpreter', 'Should start using Python');
                     assert.deepEqual(kernel?.interpreter, pyEnvInterpreter, 'Should start using PyEnv');
 
-                    // // Find based on interpreter hash in metadata
-                    // kernel = await kernelFinder.findKernel(Uri.file('test.ipynb'), {
-                    //     kernelspec: {
-                    //         display_name: 'Something',
-                    //         name: 'python3'
-                    //     },
-                    //     interpreter: {
-                    //         hash: getInterpreterHash({ path: condaEnvironmentBase.path })
-                    //     },
-                    //     language_info: { name: PYTHON_LANGUAGE },
-                    //     orig_nbformat: 4
-                    // });
-                    // assert.equal(
-                    //     kernel?.kernelSpec?.language,
-                    //     'python',
-                    //     'No kernel found matching default notebook metadata'
-                    // );
-                    // assert.equal(kernel?.kind, 'startUsingPythonInterpreter', 'Should start using Python');
-                    // assert.deepEqual(kernel?.interpreter, condaEnvironmentBase, 'Should start using PyEnv');
+                    // Find based on interpreter hash in metadata
+                    kernel = await kernelFinder.findKernel(Uri.file('test.ipynb'), {
+                        kernelspec: {
+                            display_name: 'Something',
+                            name: 'python3'
+                        },
+                        interpreter: {
+                            hash: getInterpreterHash({ path: condaEnvironmentBase.path })
+                        },
+                        language_info: { name: PYTHON_LANGUAGE },
+                        orig_nbformat: 4
+                    });
+                    assert.equal(
+                        kernel?.kernelSpec?.language,
+                        'python',
+                        'No kernel found matching default notebook metadata'
+                    );
+                    assert.equal(kernel?.kind, 'startUsingPythonInterpreter', 'Should start using Python');
+                    assert.deepEqual(kernel?.interpreter, condaEnvironmentBase, 'Should start using PyEnv');
                 });
                 test('Can match (exactly) based on notebook metadata (metadata contains kernelspec name that we generated using the new algorightm)', async () => {
                     when(fs.searchLocal(anything(), anything(), true)).thenCall((_p, c, _d) => {


### PR DESCRIPTION
* List non-pyton kernels early
* Non-Python & Python kernels are loaded separately (asynchronously)
	* As we get new kernels they are registered
	* The assumption is non-python kernels will be fetched very quickly
* At the same time, if users install Pytohn extension after opening a notebook, the changes now detect this and re-discover the kernels
	* Was easy as i could use the same infrastructure


![recording (1)](https://user-images.githubusercontent.com/1948812/123178839-e7fa5100-d43c-11eb-917c-17361faeea1b.gif)
