### PR TITLE
Allow users to opt into preview native interactive window experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -1453,6 +1453,12 @@
                     "description": "Enables/disables A/B tests.",
                     "scope": "machine"
                 },
+                "jupyter.enableNativeInteractiveWindow": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enables the preview native interactive window experience. Set to false to opt back into the webview interactive window experience.",
+                    "scope": "machine"
+                },
                 "jupyter.logging.level": {
                     "type": "string",
                     "default": "debug",

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -293,8 +293,8 @@ export function registerTypes(serviceManager: IServiceManager, inNotebookApiExpe
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, MigrateJupyterInterpreterStateService);
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, VariableViewActivationService);
     serviceManager.addSingleton<IInteractiveWindowListener>(IInteractiveWindowListener, DataScienceSurveyBannerLogger);
-    const interactiveConfiguration = workspace.getConfiguration('interactive.experiments');
-    if (interactiveConfiguration.get<boolean | undefined>('enable') === true) {
+    const jupyterConfiguration = workspace.getConfiguration('jupyter');
+    if (jupyterConfiguration.get<boolean>('experiments.enabled') === true && jupyterConfiguration.get<boolean>('enableNativeInteractiveWindow') === true) {
         serviceManager.addSingleton<IInteractiveWindowProvider>(IInteractiveWindowProvider, NativeInteractiveWindowProvider);
         serviceManager.addSingleton<IDataScienceCommandListener>(IDataScienceCommandListener, NativeInteractiveWindowCommandListener);
     } else {


### PR DESCRIPTION
Per discussion with @rebornix and @claudiaregio, we would like to roll out the new interactive window experience for Jupyter VS Code Insiders users as soon as possible to get early feedback. One blocker right now is that IntelliSense will only be available for users who are opted into the Python Daily insiders channel. We are planning to flip the default value of the setting introduced in this PR to `true` for Python Daily insiders users as soon as our IntelliSense PR lands in vscode-python main.