### PR TITLE
Pass active interpreter's controller id to VS Code when creating native interactive windows

### DIFF
--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -98,7 +98,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     ['workbench.action.files.save']: [Uri];
     ['notebook.selectKernel']: [{ id: string; extension: string }] | [];
     ['undo']: [];
-    ['interactive.open']: [ViewColumn | undefined, Uri | undefined];
+    ['interactive.open']: [ViewColumn | undefined, Uri | undefined, string | undefined];
     ['interactive.execute']: [string];
     [DSCommands.NotebookEditorInterruptKernel]: [Uri];
     [DSCommands.ExportFileAndOutputAsNotebook]: [Uri];

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -591,11 +591,14 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
         // Ensure we have a controller to execute code against
         // and a NotebookDocument to add the NotebookCell to
         const notebookDocument = this.notebookDocument;
+        if (!this.notebookController) {
+            await this.commandManager.executeCommand('notebook.selectKernel');
+        }
         await this.initialControllerSelected.promise;
         await this.kernelLoadPromise;
 
         // ensure editor is opened/focused
-        await this.commandManager.executeCommand('interactive.open', undefined, notebookDocument.uri);
+        await this.commandManager.executeCommand('interactive.open', undefined, notebookDocument.uri, this.notebookController!.id);
 
         // Strip #%% and store it in the cell metadata so we can reconstruct the cell structure when exporting to Python files
         const settings = this.configuration.getSettings();

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -589,8 +589,6 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
 
     private async addNotebookCell(code: string): Promise<NotebookCell> {
         // Ensure we have a controller to execute code against
-        // and a NotebookDocument to add the NotebookCell to
-        const notebookDocument = this.notebookDocument;
         if (!this.notebookController) {
             await this.commandManager.executeCommand('notebook.selectKernel');
         }
@@ -601,7 +599,7 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
         await this.commandManager.executeCommand(
             'interactive.open',
             undefined,
-            notebookDocument.uri,
+            this.notebookDocument.uri,
             this.notebookController!.id
         );
 
@@ -624,14 +622,14 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
         );
         notebookCellData.metadata = { interactiveWindowCellMarker };
         edit.replaceNotebookCells(
-            notebookDocument.uri,
-            new NotebookRange(notebookDocument.cellCount, notebookDocument.cellCount),
+            this.notebookDocument.uri,
+            new NotebookRange(this.notebookDocument.cellCount, this.notebookDocument.cellCount),
             [
                 notebookCellData // TODO generalize to arbitrary languages and cell types
             ]
         );
         await workspace.applyEdit(edit);
-        return notebookDocument.cellAt(notebookDocument.cellCount - 1);
+        return this.notebookDocument.cellAt(this.notebookDocument.cellCount - 1);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-empty,@typescript-eslint/no-empty-function

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -598,7 +598,12 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
         await this.kernelLoadPromise;
 
         // ensure editor is opened/focused
-        await this.commandManager.executeCommand('interactive.open', undefined, notebookDocument.uri, this.notebookController!.id);
+        await this.commandManager.executeCommand(
+            'interactive.open',
+            undefined,
+            notebookDocument.uri,
+            this.notebookController!.id
+        );
 
         // Strip #%% and store it in the cell metadata so we can reconstruct the cell structure when exporting to Python files
         const settings = this.configuration.getSettings();

--- a/src/client/datascience/notebook/notebookControllerManager.ts
+++ b/src/client/datascience/notebook/notebookControllerManager.ts
@@ -30,7 +30,6 @@ import { InterpreterPackages } from '../telemetry/interpreterPackages';
 import { sendTelemetryEvent } from '../../telemetry';
 import { NotebookCellLanguageService } from './cellLanguageService';
 import { sendKernelListTelemetry } from '../telemetry/kernelTelemetry';
-import { testOnlyMethod } from '../../common/utils/decorators';
 import { IS_CI_SERVER } from '../../../test/ciConstants';
 import { noop } from '../../common/utils/misc';
 import { IPythonExtensionChecker } from '../../api/types';
@@ -97,7 +96,6 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
     }
 
     // Function to expose currently registered controllers to test code only
-    @testOnlyMethod()
     public registeredNotebookControllers(): VSCodeNotebookController[] {
         return Array.from(this.registeredControllers.values());
     }
@@ -136,10 +134,10 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
     /**
      * Turn all our kernelConnections that we know about into registered NotebookControllers
      */
-    private async loadNotebookControllersImpl(listLocalNonPytonKernels: boolean): Promise<void> {
+    private async loadNotebookControllersImpl(listLocalNonPythonKernels: boolean): Promise<void> {
         const cancelToken = new CancellationTokenSource();
         this.wasPythonInstalledWhenFetchingControllers = this.extensionChecker.isPythonExtensionInstalled;
-        const connections = await this.getKernelConnectionMetadata(listLocalNonPytonKernels, cancelToken.token);
+        const connections = await this.getKernelConnectionMetadata(listLocalNonPythonKernels, cancelToken.token);
 
         // Now create the actual controllers from our connections
         this.createNotebookControllers(connections);
@@ -322,15 +320,15 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
     }
 
     private async getKernelConnectionMetadata(
-        listLocalNonPytonKernels: boolean,
+        listLocalNonPythonKernels: boolean,
         token: CancellationToken
     ): Promise<KernelConnectionMetadata[]> {
         if (this.isLocalLaunch) {
-            return listLocalNonPytonKernels
+            return listLocalNonPythonKernels
                 ? this.localKernelFinder.listNonPythonKernels(token)
                 : this.localKernelFinder.listKernels(undefined, token);
         } else {
-            if (listLocalNonPytonKernels) {
+            if (listLocalNonPythonKernels) {
                 return [];
             }
             const connection = await this.notebookProvider.connect({


### PR DESCRIPTION
# Background
I had a lengthy discussion with @greazer and later @rebornix today regarding honoring the user's active Python interpreter selection when starting the interactive window. Previously @DonJayamanne and I discussed requiring users to use the kernel picker UI to select a kernel, as opposed to forcing a selection automatically, because even though we are setting the preferred affinity for the controller, that only causes it to show up at the top of the kernel picker list rather than autoselecting it for the NotebookDocument. 

Interactive window usage is driven entirely by a script file tied to an active Python interpreter (in future, active Julia/R environment). From the user's standpoint, they have explicitly told us which Python environment to use via their active interpreter selection, and we would be disregarding that preference by requiring them to use the kernel picker UI.

# Description of changes
This change allows us to preserve the current UX for Python users working in interactive #%% files with the interactive window. Peng and I have added support in VS Code (https://github.com/microsoft/vscode/commit/1750b2b231b47dfc2373c7ef2ee55a1a93e0c230) and the Jupyter extension (this PR) to pass the controller ID to VS Code when creating interactive windows. If this ID is not undefined, i.e. the Python extension is installed, there is an active Python interpreter selected, and a controller has been registered for the interpreter, then VS Code will use this controller for the interactive window that it creates when handling `interactive.open`. If this ID is undefined, VS Code will then look for its own cached controller association for the interactive window's embedded notebook editor and use that instead. 

In future, particularly when we are looking at supporting a #%%-file driven scripting experience for arbitrary languages in the interactive window, we may wish to discuss first-class VS Code support for an extension-level 'active execution environment', in order to eliminate the disconnect between language extension-contributed active environments and the kernel associated with a given notebook. Alternatively, the Jupyter extension can query other language extensions which also contribute controllers to VS Code for their active environments, in order to ensure that the active environment is honored when starting an interactive window. However, this is out of scope for the initial preview of the interactive window.