### PR TITLE
Only prompt to switch to perFile mode when submitting code to interactive window from a different owning file

### DIFF
--- a/news/2 Fixes/5471.md
+++ b/news/2 Fixes/5471.md
@@ -1,0 +1,1 @@
+Only ask user to switch to `"perFile"` mode if `"jupyter.interactiveWindowMode": "multiple"` and they have submitted code from two different source files.

--- a/src/client/datascience/interactive-window/interactiveWindowProvider.ts
+++ b/src/client/datascience/interactive-window/interactiveWindowProvider.ts
@@ -239,31 +239,30 @@ export class InteractiveWindowProvider implements IInteractiveWindowProvider, IA
             result === 'multiple' &&
             resource &&
             !this.globalMemento.get(AskedForPerFileSettingKey) &&
-            this._windows.length === 1
+            this._windows.length === 1 &&
+            // Only prompt if the submitting file is different
+            this._windows[0].owner?.fsPath !== resource.fsPath
         ) {
             // See if the first window was tied to a file or not.
-            const firstWindow = this._windows.find((w) => w.owner);
-            if (firstWindow) {
-                this.globalMemento.update(AskedForPerFileSettingKey, true).then(noop, noop);
-                const questions = [
-                    localize.DataScience.interactiveWindowModeBannerSwitchYes(),
-                    localize.DataScience.interactiveWindowModeBannerSwitchNo()
-                ];
-                // Ask user if they'd like to switch to per file or not.
-                const response = await this.appShell.showInformationMessage(
-                    localize.DataScience.interactiveWindowModeBannerTitle(),
-                    ...questions
+            this.globalMemento.update(AskedForPerFileSettingKey, true).then(noop, noop);
+            const questions = [
+                localize.DataScience.interactiveWindowModeBannerSwitchYes(),
+                localize.DataScience.interactiveWindowModeBannerSwitchNo()
+            ];
+            // Ask user if they'd like to switch to per file or not.
+            const response = await this.appShell.showInformationMessage(
+                localize.DataScience.interactiveWindowModeBannerTitle(),
+                ...questions
+            );
+            if (response === questions[0]) {
+                result = 'perFile';
+                this._windows[0].changeMode(result);
+                await this.configService.updateSetting(
+                    'interactiveWindowMode',
+                    result,
+                    resource,
+                    ConfigurationTarget.Global
                 );
-                if (response === questions[0]) {
-                    result = 'perFile';
-                    firstWindow.changeMode(result);
-                    await this.configService.updateSetting(
-                        'interactiveWindowMode',
-                        result,
-                        resource,
-                        ConfigurationTarget.Global
-                    );
-                }
             }
         }
         return result;

--- a/src/client/datascience/interactive-window/nativeInteractiveWindowProvider.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindowProvider.ts
@@ -188,31 +188,30 @@ export class NativeInteractiveWindowProvider implements IInteractiveWindowProvid
             result === 'multiple' &&
             resource &&
             !this.globalMemento.get(AskedForPerFileSettingKey) &&
-            this._windows.length === 1
+            this._windows.length === 1 &&
+            // Only prompt if the submitting file is different
+            this._windows[0].owner?.fsPath !== resource.fsPath
         ) {
             // See if the first window was tied to a file or not.
-            const firstWindow = this._windows.find((w) => w.owner);
-            if (firstWindow) {
-                this.globalMemento.update(AskedForPerFileSettingKey, true).then(noop, noop);
-                const questions = [
-                    localize.DataScience.interactiveWindowModeBannerSwitchYes(),
-                    localize.DataScience.interactiveWindowModeBannerSwitchNo()
-                ];
-                // Ask user if they'd like to switch to per file or not.
-                const response = await this.appShell.showInformationMessage(
-                    localize.DataScience.interactiveWindowModeBannerTitle(),
-                    ...questions
+            this.globalMemento.update(AskedForPerFileSettingKey, true).then(noop, noop);
+            const questions = [
+                localize.DataScience.interactiveWindowModeBannerSwitchYes(),
+                localize.DataScience.interactiveWindowModeBannerSwitchNo()
+            ];
+            // Ask user if they'd like to switch to per file or not.
+            const response = await this.appShell.showInformationMessage(
+                localize.DataScience.interactiveWindowModeBannerTitle(),
+                ...questions
+            );
+            if (response === questions[0]) {
+                result = 'perFile';
+                this._windows[0].changeMode(result);
+                await this.configService.updateSetting(
+                    'interactiveWindowMode',
+                    result,
+                    resource,
+                    ConfigurationTarget.Global
                 );
-                if (response === questions[0]) {
-                    result = 'perFile';
-                    firstWindow.changeMode(result);
-                    await this.configService.updateSetting(
-                        'interactiveWindowMode',
-                        result,
-                        resource,
-                        ConfigurationTarget.Global
-                    );
-                }
             }
         }
         return result;


### PR DESCRIPTION
For https://github.com/microsoft/vscode-jupyter/issues/5471

@greazer ran into this earlier today while dogfooding the new native interactive window. The problem predates native interactive window work; while unscheduled and not a regression, it was straightforward to fix.