### PR TITLE
Activate Jupyter extension on interactive window open

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
         "onCommand:jupyter.openVariableView",
         "onCommand:jupyter.selectNativeJupyterUriFromToolBar",
         "onNotebook:jupyter-notebook",
+        "onNotebook:interactive",
         "onCustomEditor:jupyter.notebook.ipynb"
     ],
     "main": "./out/client/extension",


### PR DESCRIPTION
This impacts whether the Jupyter extension activates on VS Code reload with an existing interactive window restored from backup.