### PR TITLE
Fix some problems running kernels with 'jupyter' or no raw kernel

### DIFF
--- a/news/2 Fixes/6409.md
+++ b/news/2 Fixes/6409.md
@@ -1,0 +1,1 @@
+Fix problem where the active interpreter is not being used for the interactive window when not running with raw kernel.

--- a/src/client/datascience/jupyter/liveshare/serverCache.ts
+++ b/src/client/datascience/jupyter/liveshare/serverCache.ts
@@ -135,6 +135,7 @@ export class ServerCache implements IAsyncDisposable {
                     ? options.workingDir
                     : await calculateWorkingDirectory(this.configService, this.workspace, this.fs),
             metadata: options?.metadata,
+            kernelConnection: options?.kernelConnection,
             allowUI: options?.allowUI ? options.allowUI : () => false
         };
     }

--- a/src/client/datascience/kernel-launcher/localKernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/localKernelFinder.ts
@@ -63,7 +63,7 @@ export class LocalKernelFinder implements ILocalKernelFinder {
             const isPythonNbOrInteractiveWindow = isPythonNotebook(notebookMetadata) || resourceType === 'interactive';
             // Always include the interpreter in the search if we can
             const preferredInterpreter =
-                resource && isPythonNbOrInteractiveWindow && this.extensionChecker.isPythonExtensionInstalled
+                isPythonNbOrInteractiveWindow && this.extensionChecker.isPythonExtensionInstalled
                     ? await this.interpreterService.getActiveInterpreter(resource)
                     : undefined;
 


### PR DESCRIPTION
For #6409 

Bunch of issues found
- Active interpreter not used in kernel finder if no resource
- Kernel connection metadata not propagated to server options when starting jupyter
- Active interpreter changed event is not firing because no 'activation' event for python

