### PR TITLE
Fix interactive window debug cell, codelens tracking, go to cell, expand/collapse all from toolbar when focus is not on notebook editor

### DIFF
--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -272,7 +272,13 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
         return result;
     }
 
-    private async submitCodeImpl(code: string, file: string, line: number, isDebug: boolean, notebookCell: NotebookCell) {
+    private async submitCodeImpl(
+        code: string,
+        file: string,
+        line: number,
+        isDebug: boolean,
+        notebookCell: NotebookCell
+    ) {
         const notebook = this.kernel?.notebook;
         if (!notebook) {
             return false;
@@ -297,9 +303,7 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
             const owningResource = this.owningResource;
             const id = uuid();
             const observable = this.kernel!.notebook!.executeObservable(code, file, line, id, false);
-            const temporaryExecution = this.notebookController!.controller.createNotebookCellExecution(
-                notebookCell
-            );
+            const temporaryExecution = this.notebookController!.controller.createNotebookCellExecution(notebookCell);
             temporaryExecution?.start();
 
             // Sign up for cell changes
@@ -484,7 +488,7 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
         throw new Error('Method not implemented.');
     }
 
-    public expandAllCells() {
+    public async expandAllCells() {
         const edit = new WorkspaceEdit();
         this.notebookDocument.getCells().forEach((cell, index) => {
             const metadata = {
@@ -494,16 +498,16 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
             };
             edit.replaceNotebookCellMetadata(this.notebookDocument.uri, index, metadata);
         });
-        return workspace.applyEdit(edit);
+        await workspace.applyEdit(edit);
     }
 
-    public collapseAllCells() {
+    public async collapseAllCells() {
         const edit = new WorkspaceEdit();
         this.notebookDocument.getCells().forEach((cell, index) => {
             const metadata = { ...(cell.metadata || {}), inputCollapsed: true, outputCollapsed: false };
             edit.replaceNotebookCellMetadata(this.notebookDocument.uri, index, metadata);
         });
-        return workspace.applyEdit(edit);
+        await workspace.applyEdit(edit);
     }
 
     public scrollToCell(_id: string): void {
@@ -637,7 +641,8 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
             isMarkdown ? MARKDOWN_LANGUAGE : language
         );
         notebookCellData.metadata = {
-            interactiveWindowCellMarker, interactive: {
+            interactiveWindowCellMarker,
+            interactive: {
                 file: file.fsPath,
                 line: line
             }

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -314,7 +314,7 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
                     await temporaryExecution.replaceOutput(converted);
                     const executionCount = (cells[0].data as nbformat.ICodeCell).execution_count;
                     if (executionCount) {
-                        temporaryExecution.executionOrder = parseInt(executionCount.toString(), 10)
+                        temporaryExecution.executionOrder = parseInt(executionCount.toString(), 10);
                     }
 
                     // Any errors will move our result to false (if allowed)

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -263,12 +263,7 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
         return result;
     }
 
-    private async submitCodeImpl(
-        code: string,
-        fileUri: Uri,
-        line: number,
-        isDebug: boolean
-    ) {
+    private async submitCodeImpl(code: string, fileUri: Uri, line: number, isDebug: boolean) {
         await this.updateOwners(fileUri);
         const notebookCell = await this.addNotebookCell(code, fileUri, line);
         const notebook = this.kernel?.notebook;

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -308,6 +308,10 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
                     // Then send the combined output to the UI
                     const converted = (cells[0].data as nbformat.ICodeCell).outputs.map(cellOutputToVSCCellOutput);
                     await temporaryExecution.replaceOutput(converted);
+                    const executionCount = (cells[0].data as nbformat.ICodeCell).execution_count;
+                    if (executionCount) {
+                        temporaryExecution.executionOrder = parseInt(executionCount.toString(), 10)
+                    }
 
                     // Any errors will move our result to false (if allowed)
                     if (this.configuration.getSettings(owningResource).stopOnError) {

--- a/src/client/datascience/interactive-window/nativeInteractiveWindowCommandListener.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindowCommandListener.ts
@@ -432,7 +432,7 @@ export class NativeInteractiveWindowCommandListener {
 
     private expandAllCells(uri?: Uri) {
         const interactiveWindow = uri
-            ? this.interactiveWindowProvider.windows.find((window) => window.notebookUri.toString() === uri.toString())
+            ? this.interactiveWindowProvider.windows.find((window) => window.notebookUri!.toString() === uri.toString())
             : this.interactiveWindowProvider.activeWindow;
         if (interactiveWindow) {
             interactiveWindow.expandAllCells();
@@ -441,7 +441,7 @@ export class NativeInteractiveWindowCommandListener {
 
     private collapseAllCells(uri?: Uri) {
         const interactiveWindow = uri
-            ? this.interactiveWindowProvider.windows.find((window) => window.notebookUri.toString() === uri.toString())
+            ? this.interactiveWindowProvider.windows.find((window) => window.notebookUri!.toString() === uri.toString())
             : this.interactiveWindowProvider.activeWindow;
         if (interactiveWindow) {
             interactiveWindow.collapseAllCells();
@@ -457,7 +457,7 @@ export class NativeInteractiveWindowCommandListener {
 
     private exportAs(uri?: Uri) {
         const interactiveWindow = uri
-            ? this.interactiveWindowProvider.windows.find((window) => window.notebookUri.toString() === uri.toString())
+            ? this.interactiveWindowProvider.windows.find((window) => window.notebookUri?.toString() === uri.toString())
             : this.interactiveWindowProvider.activeWindow;
         if (interactiveWindow) {
             interactiveWindow.exportAs();
@@ -466,7 +466,7 @@ export class NativeInteractiveWindowCommandListener {
 
     private export(uri?: Uri) {
         const interactiveWindow = uri
-            ? this.interactiveWindowProvider.windows.find((window) => window.notebookUri.toString() === uri.toString())
+            ? this.interactiveWindowProvider.windows.find((window) => window.notebookUri?.toString() === uri.toString())
             : this.interactiveWindowProvider.activeWindow;
         if (interactiveWindow) {
             interactiveWindow.export();

--- a/src/client/datascience/interactive-window/nativeInteractiveWindowCommandListener.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindowCommandListener.ts
@@ -63,7 +63,7 @@ export class NativeInteractiveWindowCommandListener {
         @inject(IExportManager) private exportManager: IExportManager,
         @inject(IExportDialog) private exportDialog: IExportDialog,
         @inject(IClipboard) private clipboard: IClipboard
-    ) {}
+    ) { }
 
     public register(commandManager: ICommandManager): void {
         let disposable = commandManager.registerCommand(Commands.CreateNewInteractive, () =>

--- a/src/client/datascience/interactive-window/nativeInteractiveWindowCommandListener.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindowCommandListener.ts
@@ -63,7 +63,7 @@ export class NativeInteractiveWindowCommandListener {
         @inject(IExportManager) private exportManager: IExportManager,
         @inject(IExportDialog) private exportDialog: IExportDialog,
         @inject(IClipboard) private clipboard: IClipboard
-    ) { }
+    ) {}
 
     public register(commandManager: ICommandManager): void {
         let disposable = commandManager.registerCommand(Commands.CreateNewInteractive, () =>
@@ -151,10 +151,18 @@ export class NativeInteractiveWindowCommandListener {
             )
         );
         this.disposableRegistry.push(
-            commandManager.registerCommand(Commands.ExpandAllCells, () => this.expandAllCells())
+            commandManager.registerCommand(
+                Commands.ExpandAllCells,
+                (context?: { notebookEditor: { notebookUri: Uri } }) =>
+                    this.expandAllCells(context?.notebookEditor.notebookUri)
+            )
         );
         this.disposableRegistry.push(
-            commandManager.registerCommand(Commands.CollapseAllCells, () => this.collapseAllCells())
+            commandManager.registerCommand(
+                Commands.CollapseAllCells,
+                (context?: { notebookEditor: { notebookUri: Uri } }) =>
+                    this.collapseAllCells(context?.notebookEditor.notebookUri)
+            )
         );
         this.disposableRegistry.push(
             commandManager.registerCommand(Commands.ExportOutputAsNotebook, () => this.exportCells())
@@ -422,15 +430,19 @@ export class NativeInteractiveWindowCommandListener {
         }
     }
 
-    private expandAllCells() {
-        const interactiveWindow = this.interactiveWindowProvider.activeWindow;
+    private expandAllCells(uri?: Uri) {
+        const interactiveWindow = uri
+            ? this.interactiveWindowProvider.windows.find((window) => window.notebookUri.toString() === uri.toString())
+            : this.interactiveWindowProvider.activeWindow;
         if (interactiveWindow) {
             interactiveWindow.expandAllCells();
         }
     }
 
-    private collapseAllCells() {
-        const interactiveWindow = this.interactiveWindowProvider.activeWindow;
+    private collapseAllCells(uri?: Uri) {
+        const interactiveWindow = uri
+            ? this.interactiveWindowProvider.windows.find((window) => window.notebookUri.toString() === uri.toString())
+            : this.interactiveWindowProvider.activeWindow;
         if (interactiveWindow) {
             interactiveWindow.collapseAllCells();
         }
@@ -445,7 +457,7 @@ export class NativeInteractiveWindowCommandListener {
 
     private exportAs(uri?: Uri) {
         const interactiveWindow = uri
-            ? this.interactiveWindowProvider.windows.find((window) => window.notebookUri!.toString() === uri.toString())
+            ? this.interactiveWindowProvider.windows.find((window) => window.notebookUri.toString() === uri.toString())
             : this.interactiveWindowProvider.activeWindow;
         if (interactiveWindow) {
             interactiveWindow.exportAs();
@@ -454,7 +466,7 @@ export class NativeInteractiveWindowCommandListener {
 
     private export(uri?: Uri) {
         const interactiveWindow = uri
-            ? this.interactiveWindowProvider.windows.find((window) => window.notebookUri!.toString() === uri.toString())
+            ? this.interactiveWindowProvider.windows.find((window) => window.notebookUri.toString() === uri.toString())
             : this.interactiveWindowProvider.activeWindow;
         if (interactiveWindow) {
             interactiveWindow.export();


### PR DESCRIPTION
For #6418, #6423, #6426, #6457

Debug Cell problem was because executeObservable has side effects (updating execution count) that the `notebook.cell.execute` codepath doesn't.

Go to cell problem was because notebook cell metadata wasn't populated.

Cell markers were caused by interactive window editor taking focus when it shouldn't (required fix in core).

Collapse cell problem was because clicking on a toolbar button does not set focus to the interactive window, and the command handler relied on the `activeNotebookEditor` instead of using the `interactive/toolbar` context.

Will be porting this PR to release branch.