### PR TITLE
Bump plotly.js to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
                 "node-stream-zip": "^1.6.0",
                 "onigasm": "^2.2.2",
                 "pdfkit": "^0.12.1",
-                "plotly.js-dist": "^1.58.4",
+                "plotly.js-dist": "^2.2.1",
                 "portfinder": "^1.0.25",
                 "re-resizable": "~6.5.5",
                 "react": "^16.5.2",
@@ -3244,6 +3244,11 @@
                 "lodash": "^4.17.4",
                 "plotly.js-dist": "^1.48.3"
             }
+        },
+        "node_modules/@nteract/transform-plotly/node_modules/plotly.js-dist": {
+            "version": "1.58.5",
+            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.58.5.tgz",
+            "integrity": "sha512-gy4cm5gYeem1eoXeryrSfftDm/CacQUE+W6xPRGiC5PnB/WHDPaex+HVeAGdKEek57ok1j2IkDw3lnXoB0Bfiw=="
         },
         "node_modules/@nteract/transform-vdom": {
             "version": "2.2.5",
@@ -22729,9 +22734,9 @@
             }
         },
         "node_modules/plotly.js-dist": {
-            "version": "1.58.4",
-            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.58.4.tgz",
-            "integrity": "sha512-oXCTRJFN8FBsHZSQPYoM3LuJQchPUrf6sOXFC0EFdvcr5lmJmLcAsW74jDy9PkRpm3PB+A+2oY1hsUMmk2eZbw=="
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-2.2.1.tgz",
+            "integrity": "sha512-xgsho2rx/XhrkqqqhycnsY0uBJa6R1YO+uEph4DgJpW8p/JLQZgBWQKtmc8Q6QXhoysQthjvTmP97H4PFTYSww=="
         },
         "node_modules/plugin-error": {
             "version": "0.1.2",
@@ -34734,6 +34739,13 @@
             "requires": {
                 "lodash": "^4.17.4",
                 "plotly.js-dist": "^1.48.3"
+            },
+            "dependencies": {
+                "plotly.js-dist": {
+                    "version": "1.58.5",
+                    "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.58.5.tgz",
+                    "integrity": "sha512-gy4cm5gYeem1eoXeryrSfftDm/CacQUE+W6xPRGiC5PnB/WHDPaex+HVeAGdKEek57ok1j2IkDw3lnXoB0Bfiw=="
+                }
             }
         },
         "@nteract/transform-vdom": {
@@ -51463,9 +51475,9 @@
             }
         },
         "plotly.js-dist": {
-            "version": "1.58.4",
-            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.58.4.tgz",
-            "integrity": "sha512-oXCTRJFN8FBsHZSQPYoM3LuJQchPUrf6sOXFC0EFdvcr5lmJmLcAsW74jDy9PkRpm3PB+A+2oY1hsUMmk2eZbw=="
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-2.2.1.tgz",
+            "integrity": "sha512-xgsho2rx/XhrkqqqhycnsY0uBJa6R1YO+uEph4DgJpW8p/JLQZgBWQKtmc8Q6QXhoysQthjvTmP97H4PFTYSww=="
         },
         "plugin-error": {
             "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "@nteract/transform-dataresource": "^4.3.5",
                 "@nteract/transform-geojson": "^3.2.3",
                 "@nteract/transform-model-debug": "^3.2.3",
-                "@nteract/transform-plotly": "^6.0.0",
+                "@nteract/transform-plotly": "^7.0.0",
                 "@nteract/transform-vega": "^7.0.0",
                 "@nteract/transforms": "^4.4.7",
                 "@octokit/rest": "^18.0.6",
@@ -3237,18 +3237,16 @@
             }
         },
         "node_modules/@nteract/transform-plotly": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@nteract/transform-plotly/-/transform-plotly-6.0.0.tgz",
-            "integrity": "sha512-RnKPL/UxY0slrXtsP/7ShqZAgXSQjohOVyQcXBXZzqaC3KSd+esJhHYtYzTK2obaLv4YZwjhlLupcVolslN03A==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@nteract/transform-plotly/-/transform-plotly-7.0.0.tgz",
+            "integrity": "sha512-RYaXdtLAmL3rL+/WqTn3FgTtwbl7+3ikgx9UfN3nDAPcx50yNuWsurDDWCu8bxbRhORAgzY8VUsDIm9QOIcDAg==",
             "dependencies": {
-                "lodash": "^4.17.4",
-                "plotly.js-dist": "^1.48.3"
+                "lodash.clonedeep": "^4.5.0",
+                "plotly.js-dist": "^2.2.1"
+            },
+            "peerDependencies": {
+                "react": "^16.3.2"
             }
-        },
-        "node_modules/@nteract/transform-plotly/node_modules/plotly.js-dist": {
-            "version": "1.58.5",
-            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.58.5.tgz",
-            "integrity": "sha512-gy4cm5gYeem1eoXeryrSfftDm/CacQUE+W6xPRGiC5PnB/WHDPaex+HVeAGdKEek57ok1j2IkDw3lnXoB0Bfiw=="
         },
         "node_modules/@nteract/transform-vdom": {
             "version": "2.2.5",
@@ -34733,19 +34731,12 @@
             }
         },
         "@nteract/transform-plotly": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@nteract/transform-plotly/-/transform-plotly-6.0.0.tgz",
-            "integrity": "sha512-RnKPL/UxY0slrXtsP/7ShqZAgXSQjohOVyQcXBXZzqaC3KSd+esJhHYtYzTK2obaLv4YZwjhlLupcVolslN03A==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@nteract/transform-plotly/-/transform-plotly-7.0.0.tgz",
+            "integrity": "sha512-RYaXdtLAmL3rL+/WqTn3FgTtwbl7+3ikgx9UfN3nDAPcx50yNuWsurDDWCu8bxbRhORAgzY8VUsDIm9QOIcDAg==",
             "requires": {
-                "lodash": "^4.17.4",
-                "plotly.js-dist": "^1.48.3"
-            },
-            "dependencies": {
-                "plotly.js-dist": {
-                    "version": "1.58.5",
-                    "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.58.5.tgz",
-                    "integrity": "sha512-gy4cm5gYeem1eoXeryrSfftDm/CacQUE+W6xPRGiC5PnB/WHDPaex+HVeAGdKEek57ok1j2IkDw3lnXoB0Bfiw=="
-                }
+                "lodash.clonedeep": "^4.5.0",
+                "plotly.js-dist": "^2.2.1"
             }
         },
         "@nteract/transform-vdom": {

--- a/package.json
+++ b/package.json
@@ -2058,7 +2058,7 @@
         "@nteract/transform-dataresource": "^4.3.5",
         "@nteract/transform-geojson": "^3.2.3",
         "@nteract/transform-model-debug": "^3.2.3",
-        "@nteract/transform-plotly": "^6.0.0",
+        "@nteract/transform-plotly": "^7.0.0",
         "@nteract/transform-vega": "^7.0.0",
         "@nteract/transforms": "^4.4.7",
         "@octokit/rest": "^18.0.6",

--- a/package.json
+++ b/package.json
@@ -2090,7 +2090,7 @@
         "node-stream-zip": "^1.6.0",
         "onigasm": "^2.2.2",
         "pdfkit": "^0.12.1",
-        "plotly.js-dist": "^1.58.4",
+        "plotly.js-dist": "^2.2.1",
         "portfinder": "^1.0.25",
         "re-resizable": "~6.5.5",
         "react": "^16.5.2",


### PR DESCRIPTION
Attempt bumping `plotly.js-dist` module.
Changelogs: 
https://github.com/plotly/plotly.js/releases/tag/v2.0.0
https://github.com/plotly/plotly.js/releases/tag/v2.1.0
https://github.com/plotly/plotly.js/releases/tag/v2.2.0
https://github.com/plotly/plotly.js/releases/tag/v2.2.1

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).

Quite similar to #4262.

FYI - a PR also sent to https://github.com/nteract/outputs/pull/72
Another submodule namely `plugin-error` may require a version bump? See `package-lock` diff.

@rchiodo @IanMatthewHuff
cc: @nicolaskruchten @alexcjohnson
