### PR TITLE
port debugging work (#6505)

### DIFF
--- a/src/client/datascience/baseJupyterSession.ts
+++ b/src/client/datascience/baseJupyterSession.ts
@@ -77,6 +77,13 @@ export abstract class BaseJupyterSession implements IJupyterSession {
     public get isConnected(): boolean {
         return this.connected;
     }
+
+    public get sessionId(): string {
+        if (this._session) {
+            return this._session.id;
+        }
+        return '';
+    }
     protected onStatusChangedEvent: EventEmitter<ServerStatus> = new EventEmitter<ServerStatus>();
     protected statusHandler: Slot<ISessionWithSocket, Kernel.Status>;
     protected connected: boolean = false;

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -322,6 +322,7 @@ export interface IJupyterSession extends IAsyncDisposable {
     readonly status: ServerStatus;
     readonly workingDirectory: string;
     readonly kernelSocket: Observable<KernelSocketInformation | undefined>;
+    readonly sessionId: string;
     restart(timeout: number): Promise<void>;
     interrupt(timeout: number): Promise<void>;
     waitForIdle(timeout: number): Promise<void>;

--- a/src/test/datascience/mockJupyterSession.ts
+++ b/src/test/datascience/mockJupyterSession.ts
@@ -16,6 +16,7 @@ import { ServerStatus } from '../../datascience-ui/interactive-common/mainState'
 import { sleep } from '../core';
 import { MockJupyterRequest } from './mockJupyterRequest';
 import { Resource } from '../../client/common/types';
+import { randomBytes } from 'crypto';
 
 const LineFeedRegEx = /(\r\n|\n)/g;
 
@@ -65,6 +66,10 @@ export class MockJupyterSession implements IJupyterSession {
     }
     public get status(): ServerStatus {
         return this._status;
+    }
+
+    public get sessionId(): string {
+        return randomBytes(8).toString('hex');
     }
 
     public async restart(_timeout: number): Promise<void> {


### PR DESCRIPTION
For #6467
For #6391 its the following:

don't make up a random session ids
delete temp files (the kernel is not doing this)
use IDisposableRegistry
check if we need the vscode.debug.breakpoints on activate

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
