### PR TITLE
Ensure `launchingFile` exists when setting working directory

### DIFF
--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -965,7 +965,11 @@ export class JupyterNotebookBase implements INotebook {
                 // We should use the launch info directory. It trumps the possible dir
                 this._workingDirectory = suggested;
                 return this.changeDirectoryIfPossible(this._workingDirectory);
-            } else if (launchingFile && (await this.fs.localDirectoryExists(path.dirname(launchingFile)))) {
+            } else if (
+                launchingFile &&
+                (await this.fs.localFileExists(launchingFile)) &&
+                (await this.fs.localDirectoryExists(path.dirname(launchingFile)))
+            ) {
                 // Combine the working directory with this file if possible.
                 this._workingDirectory = expandWorkingDir(
                     this._executionInfo.workingDir,


### PR DESCRIPTION
For https://github.com/microsoft/vscode-jupyter/issues/6549

With fix, interactive window now reflects working directory of the launching file:

![image](https://user-images.githubusercontent.com/30305945/124840356-a0e18500-df3f-11eb-8fac-bfd7a044ba6e.png)



@DonJayamanne I saw that this line actually used to be `launchingFile && await this.fs.localFileExists(launchingFile)` and you changed it to `launchingFile && (await this.fs.localDirectoryExists(path.dirname(launchingFile))` in https://github.com/microsoft/vscode-jupyter/pull/5911/files#diff-a0dd7eee8719435e87b786dfb43d089e73561a33ce842613a2fc7a3894bea959R968 

However relying on `path.dirname` causes problems with setting the current working directory for the interactive window and I would argue that we should always be checking whether the `launchingFile` is valid, since otherwise it's possible for us to end up in states like this: https://github.com/microsoft/vscode-jupyter/issues/6549#issuecomment-875996098

Do you foresee any issues with this change?