### PR TITLE
`Ctrl+Enter` in native notebooks should put cell into command mode immediately, then run the cell.

### DIFF
--- a/news/2 Fixes/6582.md
+++ b/news/2 Fixes/6582.md
@@ -1,0 +1,1 @@
+`Ctrl+Enter` in native notebooks should put cell into command mode immediately, then run the cell.

--- a/src/client/datascience/commands/notebookCommands.ts
+++ b/src/client/datascience/commands/notebookCommands.ts
@@ -59,8 +59,8 @@ export class NotebookCommands implements IDisposable {
 
     private executeCell() {
         void this.commandManager
-            .executeCommand('notebook.cell.execute')
-            .then(() => this.commandManager.executeCommand('notebook.cell.quitEdit'));
+            .executeCommand('notebook.cell.quitEdit')
+            .then(() => this.commandManager.executeCommand('notebook.cell.execute'));
     }
 
     private renderMarkdownAndSelectBelow() {


### PR DESCRIPTION
For #6582 
