### PR TITLE
Fix Go To codelens not appearing

### DIFF
--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -100,7 +100,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     ['workbench.action.files.save']: [Uri];
     ['notebook.selectKernel']: [{ id: string; extension: string }] | [];
     ['undo']: [];
-    ['interactive.open']: [ViewColumn | undefined, Uri | undefined, string | undefined];
+    ['interactive.open']: [{ preserveFocus?: boolean; viewColumn?: ViewColumn }, Uri | undefined, string | undefined];
     ['interactive.execute']: [string];
     [DSCommands.NotebookEditorInterruptKernel]: [Uri];
     [DSCommands.ExportFileAndOutputAsNotebook]: [Uri];

--- a/src/client/datascience/editor-integration/codeLensFactory.ts
+++ b/src/client/datascience/editor-integration/codeLensFactory.ts
@@ -272,6 +272,11 @@ export class CodeLensFactory implements ICodeLensFactory, IInteractiveWindowList
         args.notebook.onDisposed(() => {
             this.notebookData.delete(key);
         });
+        if (args.notebook.onDidFinishExecuting !== undefined) {
+            args.notebook.onDidFinishExecuting((cell: ICell) => {
+                this.updateExecutionCounts(args.identity, cell);
+            });
+        }
     }
 
     private getHashProviders(): ICellHashProvider[] {

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -523,7 +523,7 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
             window.activeNotebookEditor &&
             window.activeNotebookEditor.document === this.notebookDocument
         ) {
-            const notebookRange = new NotebookRange(matchingCell.index, matchingCell.index);
+            const notebookRange = new NotebookRange(matchingCell.index, matchingCell.index + 1);
             window.activeNotebookEditor.selections = [notebookRange];
             window.activeNotebookEditor.revealRange(notebookRange, NotebookEditorRevealType.InCenterIfOutsideViewport);
         }

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -11,8 +11,10 @@ import {
     NotebookCellData,
     NotebookCellKind,
     NotebookDocument,
+    NotebookEditorRevealType,
     NotebookRange,
     Uri,
+    window,
     workspace,
     WorkspaceEdit
 } from 'vscode';
@@ -194,7 +196,12 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
     }
 
     public async show(): Promise<void> {
-        await this.commandManager.executeCommand('interactive.open', undefined, this.notebookUri, undefined);
+        await this.commandManager.executeCommand(
+            'interactive.open',
+            { preserveFocus: true },
+            this.notebookUri,
+            undefined
+        );
     }
 
     public dispose() {
@@ -265,7 +272,8 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
 
     private async submitCodeImpl(code: string, fileUri: Uri, line: number, isDebug: boolean) {
         await this.updateOwners(fileUri);
-        const notebookCell = await this.addNotebookCell(code, fileUri, line);
+        const id = uuid();
+        const notebookCell = await this.addNotebookCell(code, fileUri, line, id);
         const notebook = this.kernel?.notebook;
         if (!notebook) {
             return false;
@@ -289,7 +297,6 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
             await this.setFileInKernel(file, this.notebookDocument);
 
             const owningResource = this.owningResource;
-            const id = uuid();
             const observable = this.kernel!.notebook!.executeObservable(code, file, line, id, false);
             const temporaryExecution = this.notebookController!.controller.createNotebookCellExecution(notebookCell);
             temporaryExecution?.start();
@@ -501,12 +508,29 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
         await workspace.applyEdit(edit);
     }
 
-    public scrollToCell(_id: string): void {
-        throw new Error('Method not implemented.');
+    public async scrollToCell(id: string): Promise<void> {
+        const matchingCell = this.notebookDocument.getCells().find((cell) => cell.metadata.executionId === id);
+        await this.commandManager.executeCommand(
+            'interactive.open',
+            { preserveFocus: false },
+            this.notebookUri,
+            undefined
+        );
+        if (
+            matchingCell &&
+            window.activeNotebookEditor &&
+            window.activeNotebookEditor.document === this.notebookDocument
+        ) {
+            window.activeNotebookEditor.revealRange(
+                new NotebookRange(matchingCell.index, matchingCell.index),
+                NotebookEditorRevealType.InCenterIfOutsideViewport
+            );
+        }
     }
 
-    public hasCell(_id: string): Promise<boolean> {
-        throw new Error('Method not implemented.');
+    // TODO this does not need to be async since we no longer need to roundtrip to the UI
+    public async hasCell(id: string): Promise<boolean> {
+        return this.notebookDocument.getCells().find((cell) => cell.metadata.executionId === id) !== undefined;
     }
 
     public get owningResource(): Resource {
@@ -596,7 +620,7 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
         await this.show();
     }
 
-    private async addNotebookCell(code: string, file: Uri, line: number): Promise<NotebookCell> {
+    private async addNotebookCell(code: string, file: Uri, line: number, id: string): Promise<NotebookCell> {
         // Ensure we have a controller to execute code against
         if (!this.notebookController) {
             await this.commandManager.executeCommand('notebook.selectKernel');
@@ -604,10 +628,10 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
         await this.initialControllerSelected.promise;
         await this.kernelLoadPromise;
 
-        // ensure editor is opened/focused
+        // ensure editor is opened but not focused
         await this.commandManager.executeCommand(
             'interactive.open',
-            undefined,
+            { preserveFocus: true },
             this.notebookDocument.uri,
             this.notebookController?.id
         );
@@ -636,7 +660,8 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
             interactive: {
                 file: file.fsPath,
                 line: line
-            }
+            },
+            executionId: id
         };
         edit.replaceNotebookCells(
             this.notebookDocument.uri,

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -525,10 +525,7 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
         ) {
             const notebookRange = new NotebookRange(matchingCell.index, matchingCell.index);
             window.activeNotebookEditor.selections = [notebookRange];
-            window.activeNotebookEditor.revealRange(
-                notebookRange,
-                NotebookEditorRevealType.InCenterIfOutsideViewport
-            );
+            window.activeNotebookEditor.revealRange(notebookRange, NotebookEditorRevealType.InCenterIfOutsideViewport);
         }
     }
 

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -510,6 +510,8 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
 
     public async scrollToCell(id: string): Promise<void> {
         const matchingCell = this.notebookDocument.getCells().find((cell) => cell.metadata.executionId === id);
+        // Activate the interactive window's editor group
+        // This should make activeNotebookEditor.document the interactive window NotebookDocument
         await this.commandManager.executeCommand(
             'interactive.open',
             { preserveFocus: false },
@@ -521,8 +523,10 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
             window.activeNotebookEditor &&
             window.activeNotebookEditor.document === this.notebookDocument
         ) {
+            const notebookRange = new NotebookRange(matchingCell.index, matchingCell.index);
+            window.activeNotebookEditor.selections = [notebookRange];
             window.activeNotebookEditor.revealRange(
-                new NotebookRange(matchingCell.index, matchingCell.index),
+                notebookRange,
                 NotebookEditorRevealType.InCenterIfOutsideViewport
             );
         }

--- a/src/client/datascience/interactive-window/nativeInteractiveWindowProvider.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindowProvider.ts
@@ -118,9 +118,11 @@ export class NativeInteractiveWindowProvider implements IInteractiveWindowProvid
         // kernel picker quickpick UI
         const preferredControllerId = await this.getControllerForInteractiveWindow();
 
+        const hasOwningFile = resource !== undefined;
         const { notebookUri } = (await this.commandManager.executeCommand(
             'interactive.open',
-            ViewColumn.Beside,
+            // Keep focus on the owning file if there is one
+            { viewColumn: ViewColumn.Beside, preserveFocus: hasOwningFile },
             undefined,
             preferredControllerId
         )) as INativeInteractiveWindow;

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -167,6 +167,9 @@ export class JupyterNotebookBase implements INotebook {
     public get onDisposed(): Event<void> {
         return this.disposedEvent.event;
     }
+    public get onDidFinishExecuting(): Event<ICell> {
+        return this.finishedExecuting.event;
+    }
     public get onKernelChanged(): Event<KernelConnectionMetadata> {
         return this.kernelChanged.event;
     }
@@ -183,6 +186,7 @@ export class JupyterNotebookBase implements INotebook {
     private readonly kernelRestarted = new EventEmitter<void>();
     private readonly kernelInterrupted = new EventEmitter<void>();
     private disposedEvent = new EventEmitter<void>();
+    private finishedExecuting = new EventEmitter<ICell>();
     private sessionStatusChanged: Disposable | undefined;
     private initializedMatplotlib = false;
     private ioPubListeners = new Set<(msg: KernelMessage.IIOPubMessage, requestId: string) => void>();
@@ -466,6 +470,11 @@ export class JupyterNotebookBase implements INotebook {
             result.subscribe(
                 (cells) => {
                     subscriber.next(cells);
+                    cells.forEach((cell) => {
+                        if (cell.state === CellState.finished || cell.state === CellState.error) {
+                            this.finishedExecuting.fire(cell);
+                        }
+                    });
                 },
                 (error) => {
                     subscriber.error(error);

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -184,6 +184,7 @@ export interface INotebook extends IAsyncDisposable {
     onKernelChanged: Event<KernelConnectionMetadata>;
     onKernelRestarted: Event<void>;
     onKernelInterrupted: Event<void>;
+    onDidFinishExecuting?: Event<ICell>;
     clear(id: string): void;
     executeObservable(code: string, file: string, line: number, id: string, silent: boolean): Observable<ICell[]>;
     execute(


### PR DESCRIPTION
For https://github.com/microsoft/vscode-jupyter/issues/6496

This PR requires upstream changes to VS Code to fully work (https://github.com/microsoft/vscode/pull/128274, https://github.com/microsoft/vscode/pull/128373), because extensions need a way to activate an already-visible interactive window (and then thereafter we can use `activeNotebookEditor.revealRange` to scroll to the right cell). The go-to-cell behavior in the current webview interactive window activates the interactive window panel when scrolling to the matching cell.