### PR TITLE
Minor fixes for interactive window message & code cells

### DIFF
--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -618,7 +618,7 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
         const isMarkdown = cellMatcher.getCellType(code) === MARKDOWN_LANGUAGE;
         const strippedCode = isMarkdown
             ? generateMarkdownFromCodeLines(code.splitLines()).join('\n')
-            : cellMatcher.stripFirstMarker(code).trimStart();
+            : cellMatcher.stripFirstMarker(code).trim();
         const interactiveWindowCellMarker = cellMatcher.getFirstMarker(code);
 
         // Insert code cell into NotebookDocument

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -344,7 +344,8 @@ export class Kernel implements IKernel {
         }
 
         const message = getSysInfoReasonHeader(reason, this.kernelConnectionMetadata);
-        const sysInfoMessages = [(info.content as KernelMessage.IInfoReply)?.banner.split('\n').join('\n\n')];
+        const bannerMessage = (info.content as KernelMessage.IInfoReply)?.banner || '';
+        const sysInfoMessages = bannerMessage ? bannerMessage.split('\n') : [];
         if (sysInfoMessages) {
             // Connection string only for our initial start, not restart or interrupt
             let connectionString: string = '';
@@ -362,7 +363,7 @@ export class Kernel implements IKernel {
             return chainWithPendingUpdates(notebookDocument, (edit) => {
                 const markdownCell = new NotebookCellData(
                     NotebookCellKind.Markup,
-                    sysInfoMessages.join('\n\n'),
+                    sysInfoMessages.join('  \n'),
                     MARKDOWN_LANGUAGE
                 );
                 markdownCell.metadata = { isSysInfoCell: true };


### PR DESCRIPTION
# Today (webview based)
<img width="582" alt="Screen Shot 2021-07-11 at 16 57 01" src="https://user-images.githubusercontent.com/1948812/125216139-1320d500-e272-11eb-85b9-7481d7e762a1.png">

# Current (too many spaces in info message & trailing spaces in code)
<img width="644" alt="Screen Shot 2021-07-11 at 16 58 19" src="https://user-images.githubusercontent.com/1948812/125216141-14520200-e272-11eb-817d-23184b64ba83.png">

# After the fix
<img width="1137" alt="Screen Shot 2021-07-11 at 18 02 37" src="https://user-images.githubusercontent.com/1948812/125216197-43687380-e272-11eb-97fa-03b93e52edda.png">
