### PR TITLE
Support error links in builtin interactive window

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,6 @@ module.exports = {
         'build/webpack/webpack.extension.dependencies.config.js',
         'build/webpack/common.js',
         'build/webpack/webpack.datascience-ui-viewers.config.js',
-        'build/webpack/webpack.datascience-ui-renderers.config.js',
         'build/webpack/loaders/fixNodeFetch.js',
         'build/webpack/loaders/remarkLoader.js',
         'build/webpack/loaders/jsonloader.js',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -803,7 +803,6 @@ module.exports = {
         'src/client/datascience/interactive-common/showPlotListener.ts',
         'src/client/datascience/interactive-common/debugListener.ts',
         'src/client/datascience/interactive-common/types.ts',
-        'src/client/datascience/interactive-common/linkProvider.ts',
         'src/client/datascience/interactive-common/interactiveWindowMessageListener.ts',
         'src/client/datascience/interactive-common/intellisense/wordHelper.ts',
         'src/client/datascience/interactive-common/intellisense/intellisenseLine.ts',

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,6 +58,5 @@
         // Match what black does.
         "--max-line-length=88"
     ],
-    "typescript.preferences.importModuleSpecifier": "relative",
-    "debug.javascript.usePreview": false
+    "typescript.preferences.importModuleSpecifier": "relative"
 }

--- a/build/webpack/webpack.datascience-ui-renderers.config.js
+++ b/build/webpack/webpack.datascience-ui-renderers.config.js
@@ -4,4 +4,4 @@
 'use strict';
 
 const builder = require('./webpack.datascience-ui.config.builder');
-module.exports = [builder.ipywidgetsKernel, builder.ipywidgetsRenderer];
+module.exports = [builder.ipywidgetsKernel, builder.ipywidgetsRenderer, builder.errorRenderer];

--- a/build/webpack/webpack.datascience-ui.config.builder.js
+++ b/build/webpack/webpack.datascience-ui.config.builder.js
@@ -198,9 +198,9 @@ function buildConfiguration(bundle) {
         bundle !== 'ipywidgetsRenderer' && bundle !== 'errorRenderer'
             ? {}
             : {
-                library: 'LIB',
-                libraryTarget: 'var'
-            };
+                  library: 'LIB',
+                  libraryTarget: 'var'
+              };
     if (bundle === 'ipywidgetsRenderer' || bundle === 'ipywidgetsKernel') {
         filesToCopy.push({
             from: path.join(constants.ExtensionRootDir, 'src/datascience-ui/ipywidgets/kernel/require.js'),
@@ -224,76 +224,81 @@ function buildConfiguration(bundle) {
         },
         mode: isProdBuild ? 'production' : 'development', // Leave as is, we'll need to see stack traces when there are errors.
         devtool: isProdBuild ? undefined : 'inline-source-map',
-        optimization: bundle === 'errorRenderer' ? undefined : {
-            minimize: isProdBuild,
-            minimizer: isProdBuild ? [new TerserPlugin({ sourceMap: true })] : [],
-            moduleIds: 'hashed', // (doesn't re-generate bundles unnecessarily) https://webpack.js.org/configuration/optimization/#optimizationmoduleids.
-            splitChunks: {
-                chunks: 'all',
-                cacheGroups: {
-                    // These are bundles that will be created and loaded when page first loads.
-                    // These must be added to the page along with the main entry point.
-                    // Smaller they are, the faster the load in SSH.
-                    // Interactive and native editors will share common code in commons.
-                    commons: {
-                        name: 'commons',
-                        chunks: 'initial',
-                        minChunks: bundle === 'notebook' ? 2 : 1, // We want at least one shared bundle (2 for notebooks, as we want monago split into another).
-                        filename: '[name].initial.bundle.js'
-                    },
-                    // Even though nteract has been split up, some of them are large as nteract alone is large.
-                    // This will ensure nteract (just some of the nteract) goes into a separate bundle.
-                    // Webpack will bundle others separately when loading them asynchronously using `await import(...)`
-                    nteract: {
-                        name: 'nteract',
-                        chunks: 'all',
-                        minChunks: 2,
-                        test(module, _chunks) {
-                            // `module.resource` contains the absolute path of the file on disk.
-                            // Look for `node_modules/monaco...`.
-                            const path = require('path');
-                            return (
-                                module.resource &&
-                                module.resource.includes(`${path.sep}node_modules${path.sep}@nteract`)
-                            );
-                        }
-                    },
-                    // Bundling `plotly` with nteract isn't the best option, as this plotly alone is 6mb.
-                    // This will ensure it is in a seprate bundle, hence small files for SSH scenarios.
-                    plotly: {
-                        name: 'plotly',
-                        chunks: 'all',
-                        minChunks: 1,
-                        test(module, _chunks) {
-                            // `module.resource` contains the absolute path of the file on disk.
-                            // Look for `node_modules/monaco...`.
-                            const path = require('path');
-                            return (
-                                module.resource && module.resource.includes(`${path.sep}node_modules${path.sep}plotly`)
-                            );
-                        }
-                    },
-                    // Monaco is a monster. For SSH again, we pull this into a seprate bundle.
-                    // This is only a solution for SSH.
-                    // Ideal solution would be to dynamically load monaoc `await import`, that way it will benefit UX and SSH.
-                    // This solution doesn't improve UX, as we still need to wait for monaco to load.
-                    monaco: {
-                        name: 'monaco',
-                        chunks: 'all',
-                        minChunks: 1,
-                        test(module, _chunks) {
-                            // `module.resource` contains the absolute path of the file on disk.
-                            // Look for `node_modules/monaco...`.
-                            const path = require('path');
-                            return (
-                                module.resource && module.resource.includes(`${path.sep}node_modules${path.sep}monaco`)
-                            );
-                        }
-                    }
-                }
-            },
-            chunkIds: 'named'
-        },
+        optimization:
+            bundle === 'errorRenderer'
+                ? undefined
+                : {
+                      minimize: isProdBuild,
+                      minimizer: isProdBuild ? [new TerserPlugin({ sourceMap: true })] : [],
+                      moduleIds: 'hashed', // (doesn't re-generate bundles unnecessarily) https://webpack.js.org/configuration/optimization/#optimizationmoduleids.
+                      splitChunks: {
+                          chunks: 'all',
+                          cacheGroups: {
+                              // These are bundles that will be created and loaded when page first loads.
+                              // These must be added to the page along with the main entry point.
+                              // Smaller they are, the faster the load in SSH.
+                              // Interactive and native editors will share common code in commons.
+                              commons: {
+                                  name: 'commons',
+                                  chunks: 'initial',
+                                  minChunks: bundle === 'notebook' ? 2 : 1, // We want at least one shared bundle (2 for notebooks, as we want monago split into another).
+                                  filename: '[name].initial.bundle.js'
+                              },
+                              // Even though nteract has been split up, some of them are large as nteract alone is large.
+                              // This will ensure nteract (just some of the nteract) goes into a separate bundle.
+                              // Webpack will bundle others separately when loading them asynchronously using `await import(...)`
+                              nteract: {
+                                  name: 'nteract',
+                                  chunks: 'all',
+                                  minChunks: 2,
+                                  test(module, _chunks) {
+                                      // `module.resource` contains the absolute path of the file on disk.
+                                      // Look for `node_modules/monaco...`.
+                                      const path = require('path');
+                                      return (
+                                          module.resource &&
+                                          module.resource.includes(`${path.sep}node_modules${path.sep}@nteract`)
+                                      );
+                                  }
+                              },
+                              // Bundling `plotly` with nteract isn't the best option, as this plotly alone is 6mb.
+                              // This will ensure it is in a seprate bundle, hence small files for SSH scenarios.
+                              plotly: {
+                                  name: 'plotly',
+                                  chunks: 'all',
+                                  minChunks: 1,
+                                  test(module, _chunks) {
+                                      // `module.resource` contains the absolute path of the file on disk.
+                                      // Look for `node_modules/monaco...`.
+                                      const path = require('path');
+                                      return (
+                                          module.resource &&
+                                          module.resource.includes(`${path.sep}node_modules${path.sep}plotly`)
+                                      );
+                                  }
+                              },
+                              // Monaco is a monster. For SSH again, we pull this into a seprate bundle.
+                              // This is only a solution for SSH.
+                              // Ideal solution would be to dynamically load monaoc `await import`, that way it will benefit UX and SSH.
+                              // This solution doesn't improve UX, as we still need to wait for monaco to load.
+                              monaco: {
+                                  name: 'monaco',
+                                  chunks: 'all',
+                                  minChunks: 1,
+                                  test(module, _chunks) {
+                                      // `module.resource` contains the absolute path of the file on disk.
+                                      // Look for `node_modules/monaco...`.
+                                      const path = require('path');
+                                      return (
+                                          module.resource &&
+                                          module.resource.includes(`${path.sep}node_modules${path.sep}monaco`)
+                                      );
+                                  }
+                              }
+                          }
+                      },
+                      chunkIds: 'named'
+                  },
         node: {
             fs: 'empty'
         },

--- a/build/webpack/webpack.datascience-ui.config.builder.js
+++ b/build/webpack/webpack.datascience-ui.config.builder.js
@@ -153,6 +153,7 @@ function getPlugins(bundle) {
             });
 
             plugins.push(...(isProdBuild ? [definePlugin] : []));
+            plugins.push(new EsmWebpackPlugin());
             break;
         }
         default:
@@ -194,7 +195,7 @@ function buildConfiguration(bundle) {
         );
     }
     let outputProps =
-        bundle !== 'ipywidgetsRenderer'
+        bundle !== 'ipywidgetsRenderer' && bundle !== 'errorRenderer'
             ? {}
             : {
                 library: 'LIB',
@@ -223,7 +224,7 @@ function buildConfiguration(bundle) {
         },
         mode: isProdBuild ? 'production' : 'development', // Leave as is, we'll need to see stack traces when there are errors.
         devtool: isProdBuild ? undefined : 'inline-source-map',
-        optimization: {
+        optimization: bundle === 'errorRenderer' ? undefined : {
             minimize: isProdBuild,
             minimizer: isProdBuild ? [new TerserPlugin({ sourceMap: true })] : [],
             moduleIds: 'hashed', // (doesn't re-generate bundles unnecessarily) https://webpack.js.org/configuration/optimization/#optimizationmoduleids.

--- a/build/webpack/webpack.datascience-ui.config.builder.js
+++ b/build/webpack/webpack.datascience-ui.config.builder.js
@@ -43,6 +43,10 @@ function getEntry(bundle) {
             return {
                 ipywidgetsRenderer: [`./src/datascience-ui/ipywidgets/renderer/index.ts`]
             };
+        case 'errorRenderer':
+            return {
+                errorRenderer: [`./src/datascience-ui/error-renderer/index.ts`]
+            };
         default:
             throw new Error(`Bundle not supported ${bundle}`);
     }
@@ -141,6 +145,16 @@ function getPlugins(bundle) {
             plugins.push(...(isProdBuild ? [definePlugin] : []));
             break;
         }
+        case 'errorRenderer': {
+            const definePlugin = new webpack.DefinePlugin({
+                'process.env': {
+                    NODE_ENV: JSON.stringify('production')
+                }
+            });
+
+            plugins.push(...(isProdBuild ? [definePlugin] : []));
+            break;
+        }
         default:
             throw new Error(`Bundle not supported ${bundle}`);
     }
@@ -183,9 +197,9 @@ function buildConfiguration(bundle) {
         bundle !== 'ipywidgetsRenderer'
             ? {}
             : {
-                  library: 'LIB',
-                  libraryTarget: 'var'
-              };
+                library: 'LIB',
+                libraryTarget: 'var'
+            };
     if (bundle === 'ipywidgetsRenderer' || bundle === 'ipywidgetsKernel') {
         filesToCopy.push({
             from: path.join(constants.ExtensionRootDir, 'src/datascience-ui/ipywidgets/kernel/require.js'),
@@ -392,3 +406,4 @@ exports.notebooks = buildConfiguration('notebook');
 exports.viewers = buildConfiguration('viewers');
 exports.ipywidgetsKernel = buildConfiguration('ipywidgetsKernel');
 exports.ipywidgetsRenderer = buildConfiguration('ipywidgetsRenderer');
+exports.errorRenderer = buildConfiguration('errorRenderer');

--- a/package.json
+++ b/package.json
@@ -1938,6 +1938,15 @@
                 ]
             },
             {
+                "id": "jupyter-error-renderer",
+                "entrypoint": "./out/datascience-ui/error-renderer/index.js",
+                "displayName": "Jupyter Error Renderer",
+                "requiresMessaging": "always",
+                "mimeTypes": [
+                    "application/vnd.code.notebook.error"
+                ]
+            },
+            {
                 "id": "jupyter-notebook-renderer",
                 "entrypoint": "./out/client_renderer/renderers.js",
                 "displayName": "Jupyter Notebook Renderer",

--- a/package.json
+++ b/package.json
@@ -1939,7 +1939,7 @@
             },
             {
                 "id": "jupyter-error-renderer",
-                "entrypoint": "./out/datascience-ui/error-renderer/index.js",
+                "entrypoint": "./out/datascience-ui/errorRenderer/errorRenderer.js",
                 "displayName": "Jupyter Error Renderer",
                 "requiresMessaging": "always",
                 "mimeTypes": [

--- a/src/client/datascience/interactive-common/linkProvider.ts
+++ b/src/client/datascience/interactive-common/linkProvider.ts
@@ -18,7 +18,10 @@ export const LineQueryRegex = /line=(\d+)/;
 
 // The following list of commands represent those that can be executed
 // in a markdown cell using the syntax: https://command:[my.vscode.command].
-export const linkCommandAllowList = ['jupyter.latestExtension', 'jupyter.enableLoadingWidgetScriptsFromThirdPartySource'];
+export const linkCommandAllowList = [
+    'jupyter.latestExtension',
+    'jupyter.enableLoadingWidgetScriptsFromThirdPartySource'
+];
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-floating-promises */

--- a/src/client/datascience/interactive-common/linkProvider.ts
+++ b/src/client/datascience/interactive-common/linkProvider.ts
@@ -21,6 +21,8 @@ export const LineQueryRegex = /line=(\d+)/;
 export const linkCommandAllowList = ['jupyter.latestExtension', 'jupyter.enableLoadingWidgetScriptsFromThirdPartySource'];
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-floating-promises */
+
 @injectable()
 export class LinkProvider implements IInteractiveWindowListener {
     private postEmitter: EventEmitter<{ message: string; payload: any }> = new EventEmitter<{

--- a/src/client/datascience/interactive-common/linkProvider.ts
+++ b/src/client/datascience/interactive-common/linkProvider.ts
@@ -14,11 +14,11 @@ import { noop } from '../../common/utils/misc';
 import { IInteractiveWindowListener } from '../types';
 import { InteractiveWindowMessages } from './interactiveWindowTypes';
 
-const LineQueryRegex = /line=(\d+)/;
+export const LineQueryRegex = /line=(\d+)/;
 
 // The following list of commands represent those that can be executed
 // in a markdown cell using the syntax: https://command:[my.vscode.command].
-const linkCommandAllowList = ['jupyter.latestExtension', 'jupyter.enableLoadingWidgetScriptsFromThirdPartySource'];
+export const linkCommandAllowList = ['jupyter.latestExtension', 'jupyter.enableLoadingWidgetScriptsFromThirdPartySource'];
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 @injectable()

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -16,7 +16,13 @@ import {
     Uri,
     window,
     workspace,
-    WorkspaceEdit
+    WorkspaceEdit,
+    notebooks,
+    Position,
+    Range,
+    Selection,
+    commands,
+    TextEditorRevealType
 } from 'vscode';
 import { IPythonExtensionChecker } from '../../api/types';
 import {
@@ -46,7 +52,7 @@ import { generateCellsFromNotebookDocument } from '../cellFactory';
 import { CellMatcher } from '../cellMatcher';
 import { Commands, defaultNotebookFormat, EditorContexts, Identifiers } from '../constants';
 import { ExportFormat, IExportDialog } from '../export/types';
-import { INotebookIdentity, ISubmitNewCell } from '../interactive-common/interactiveWindowTypes';
+import { INotebookIdentity, InteractiveWindowMessages, ISubmitNewCell } from '../interactive-common/interactiveWindowTypes';
 import { JupyterKernelPromiseFailedError } from '../jupyter/kernels/jupyterKernelPromiseFailedError';
 import { IKernel, IKernelProvider, KernelConnectionMetadata } from '../jupyter/kernels/types';
 import { INotebookControllerManager } from '../notebook/types';
@@ -67,6 +73,7 @@ import {
 import { createInteractiveIdentity } from './identity';
 import { cellOutputToVSCCellOutput } from '../notebook/helpers/helpers';
 import { generateMarkdownFromCodeLines } from '../../../datascience-ui/common';
+import { LineQueryRegex, linkCommandAllowList } from '../interactive-common/linkProvider';
 
 export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
     public get onDidChangeViewState(): Event<void> {
@@ -145,6 +152,29 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
         if (controller !== undefined) {
             this.registerKernel(this.notebookDocument, controller);
             this.initialControllerSelected.resolve();
+
+            const messageChannel = notebooks.createRendererMessaging('jupyter-error-renderer');
+            this.disposables.push(messageChannel.onDidReceiveMessage(e => {
+                const message = e.message;
+                if (message.message === InteractiveWindowMessages.OpenLink) {
+                    const href = message.payload;
+                    if (href.startsWith('file')) {
+                        this.openFile(href);
+                    } else if (href.startsWith('https://command:')) {
+                        const temp: string = href.split(':')[2];
+                        const params: string[] = temp.includes('/?') ? temp.split('/?')[1].split(',') : [];
+                        let command = temp.split('/?')[0];
+                        if (command.endsWith('/')) {
+                            command = command.substring(0, command.length - 1);
+                        }
+                        if (linkCommandAllowList.includes(command)) {
+                            commands.executeCommand(command, params);
+                        }
+                    } else {
+                        this.applicationShell.openUrl(href);
+                    }
+                }
+            }));
         }
 
         // Ensure we hear about any controller changes so we can update our cache accordingly
@@ -183,6 +213,40 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
                 this.closedEvent.fire(this);
             }
         });
+    }
+
+    private openFile(fileUri: string) {
+        const uri = Uri.parse(fileUri);
+        let selection: Range = new Range(new Position(0, 0), new Position(0, 0));
+        if (uri.query) {
+            // Might have a line number query on the file name
+            const lineMatch = LineQueryRegex.exec(uri.query);
+            if (lineMatch) {
+                const lineNumber = parseInt(lineMatch[1], 10);
+                selection = new Range(new Position(lineNumber, 0), new Position(lineNumber, 0));
+            }
+        }
+
+        // Show the matching editor if there is one
+        let editor = this.documentManager.visibleTextEditors.find((e) => this.fs.arePathsSame(e.document.uri, uri));
+        if (editor) {
+            this.documentManager
+                .showTextDocument(editor.document, { selection, viewColumn: editor.viewColumn })
+                .then((e) => {
+                    e.revealRange(selection, TextEditorRevealType.InCenter);
+                });
+        } else {
+            // Not a visible editor, try opening otherwise
+            this.commandManager.executeCommand('vscode.open', uri).then(() => {
+                // See if that opened a text document
+                editor = this.documentManager.visibleTextEditors.find((e) => this.fs.arePathsSame(e.document.uri, uri));
+                if (editor) {
+                    // Force the selection to change
+                    editor.revealRange(selection);
+                    editor.selection = new Selection(selection.start, selection.start);
+                }
+            });
+        }
     }
 
     private registerKernel(notebookDocument: NotebookDocument, controller: VSCodeNotebookController) {

--- a/src/datascience-ui/error-renderer/index.ts
+++ b/src/datascience-ui/error-renderer/index.ts
@@ -1,15 +1,70 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// import './styles.css';
-import { ActivationFunction, OutputItem } from 'vscode-notebook-renderer';
+import './styles.css';
+import { ActivationFunction, OutputItem, RendererContext } from 'vscode-notebook-renderer';
+import ansiToHtml from 'ansi-to-html';
+
+const handleInnerClick = (event: MouseEvent, context: RendererContext<any>) => {
+    if (!event || !event.view || !event.view.document) {
+        return;
+    }
+
+    for (const pathElement of event.composedPath()) {
+        const node: any = pathElement;
+        if (node.tagName && node.tagName.toLowerCase() === 'a' && node.href && node.href.indexOf('file') === 0) {
+            if (context.postMessage) {
+                context.postMessage({
+                    message: 'open_link',
+                    payload: node.href
+                });
+                event.preventDefault();
+                return;
+            }
+        }
+    }
+};
 
 export const activate: ActivationFunction = (_context) => {
-    console.log('Jupyter Error Output Renderer Activated');
     return {
         renderOutputItem(outputItem: OutputItem, element: HTMLElement) {
-            element.innerText = outputItem.text();
-            console.error('Rendering error output on notebook open is not supported.');
+            console.log(outputItem.metadata);
+            const converter = new ansiToHtml({
+                fg: 'var(--vscode-terminal-foreground)',
+                bg: 'var(--vscode-terminal-background)',
+                colors: [
+                    'var(--vscode-terminal-ansiBlack)', // 0
+                    'var(--vscode-terminal-ansiBrightRed)', // 1
+                    'var(--vscode-terminal-ansiGreen)', // 2
+                    'var(--vscode-terminal-ansiYellow)', // 3
+                    'var(--vscode-terminal-ansiBrightBlue)', // 4
+                    'var(--vscode-terminal-ansiMagenta)', // 5
+                    'var(--vscode-terminal-ansiCyan)', // 6
+                    'var(--vscode-terminal-ansiBrightBlack)', // 7
+                    'var(--vscode-terminal-ansiWhite)', // 8
+                    'var(--vscode-terminal-ansiRed)', // 9
+                    'var(--vscode-terminal-ansiBrightGreen)', // 10
+                    'var(--vscode-terminal-ansiBrightYellow)', // 11
+                    'var(--vscode-terminal-ansiBlue)', // 12
+                    'var(--vscode-terminal-ansiBrightMagenta)', // 13
+                    'var(--vscode-terminal-ansiBrightCyan)', // 14
+                    'var(--vscode-terminal-ansiBrightWhite)' // 15
+                ]
+            });
+            const metadata: any = outputItem.metadata;
+            const outputItemJson = outputItem.json();
+            console.log(outputItem.json());
+            const traceback: string[] = metadata?.outputType === 'error' && metadata?.transient && Array.isArray(metadata?.transient)
+                ? metadata?.transient
+                : (Array.isArray(outputItemJson.stack) ? outputItemJson.stack : [outputItemJson.stack]);
+            const html = traceback ? converter.toHtml(traceback.join('\n')) : outputItemJson.message;
+            const container = document.createElement('div');
+            container.classList.add('cell-output-text');
+            container.innerHTML = html;
+            element.appendChild(container);
+            container.addEventListener('click', e => {
+                handleInnerClick(e, _context);
+            });
         },
         disposeOutputItem() {
         }

--- a/src/datascience-ui/error-renderer/index.ts
+++ b/src/datascience-ui/error-renderer/index.ts
@@ -57,15 +57,18 @@ export const activate: ActivationFunction = (_context) => {
             const metadata: any = outputItem.metadata;
             const outputItemJson = outputItem.json();
             console.log(outputItem.json());
-            const traceback: string[] = metadata?.outputType === 'error' && metadata?.transient && Array.isArray(metadata?.transient)
-                ? metadata?.transient
-                : (Array.isArray(outputItemJson.stack) ? outputItemJson.stack.map((item: string) => escape(item)) : [escape(outputItemJson.stack)]);
+            const traceback: string[] =
+                metadata?.outputType === 'error' && metadata?.transient && Array.isArray(metadata?.transient)
+                    ? metadata?.transient
+                    : Array.isArray(outputItemJson.stack)
+                    ? outputItemJson.stack.map((item: string) => escape(item))
+                    : [escape(outputItemJson.stack)];
             const html = traceback ? converter.toHtml(traceback.join('\n')) : outputItemJson.message;
             const container = document.createElement('div');
             container.classList.add('cell-output-text');
             container.innerHTML = html;
             element.appendChild(container);
-            container.addEventListener('click', e => {
+            container.addEventListener('click', (e) => {
                 handleInnerClick(e, _context);
             });
         }

--- a/src/datascience-ui/error-renderer/index.ts
+++ b/src/datascience-ui/error-renderer/index.ts
@@ -5,6 +5,8 @@ import './styles.css';
 import { ActivationFunction, OutputItem, RendererContext } from 'vscode-notebook-renderer';
 import ansiToHtml from 'ansi-to-html';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 const handleInnerClick = (event: MouseEvent, context: RendererContext<any>) => {
     if (!event || !event.view || !event.view.document) {
         return;
@@ -65,8 +67,6 @@ export const activate: ActivationFunction = (_context) => {
             container.addEventListener('click', e => {
                 handleInnerClick(e, _context);
             });
-        },
-        disposeOutputItem() {
         }
     };
 };

--- a/src/datascience-ui/error-renderer/index.ts
+++ b/src/datascience-ui/error-renderer/index.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// import './styles.css';
+import { ActivationFunction, OutputItem } from 'vscode-notebook-renderer';
+
+export const activate: ActivationFunction = (_context) => {
+    console.log('Jupyter Error Output Renderer Activated');
+    return {
+        renderOutputItem(outputItem: OutputItem, element: HTMLElement) {
+            element.innerText = outputItem.text();
+            console.error('Rendering error output on notebook open is not supported.');
+        },
+        disposeOutputItem() {
+        }
+    };
+};

--- a/src/datascience-ui/error-renderer/index.ts
+++ b/src/datascience-ui/error-renderer/index.ts
@@ -4,6 +4,7 @@
 import './styles.css';
 import { ActivationFunction, OutputItem, RendererContext } from 'vscode-notebook-renderer';
 import ansiToHtml from 'ansi-to-html';
+import escape from 'lodash/escape';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -58,7 +59,7 @@ export const activate: ActivationFunction = (_context) => {
             console.log(outputItem.json());
             const traceback: string[] = metadata?.outputType === 'error' && metadata?.transient && Array.isArray(metadata?.transient)
                 ? metadata?.transient
-                : (Array.isArray(outputItemJson.stack) ? outputItemJson.stack : [outputItemJson.stack]);
+                : (Array.isArray(outputItemJson.stack) ? outputItemJson.stack.map((item: string) => escape(item)) : [escape(outputItemJson.stack)]);
             const html = traceback ? converter.toHtml(traceback.join('\n')) : outputItemJson.message;
             const container = document.createElement('div');
             container.classList.add('cell-output-text');

--- a/src/datascience-ui/error-renderer/styles.css
+++ b/src/datascience-ui/error-renderer/styles.css
@@ -2,6 +2,8 @@
     white-space: pre-wrap;
     word-break: break-all;
     overflow-x: hidden;
+    font-size: var(--notebook-cell-output-font-size);
+    padding: 4px 8px;
 }
 
 .cell-output-text {

--- a/src/datascience-ui/error-renderer/styles.css
+++ b/src/datascience-ui/error-renderer/styles.css
@@ -1,0 +1,15 @@
+.cell-output-text {
+    white-space: pre-wrap;
+    word-break: break-all;
+    overflow-x: hidden;
+}
+
+.cell-output-text {
+    white-space: pre-wrap;
+    font-family: var(--vscode-editor-font-family);
+    font-weight: var(--vscode-editor-font-weight);
+}
+
+b {
+    font-weight: 500;
+}


### PR DESCRIPTION
For #6465.

Added a renderer for error output, which will render error/traceback with `ansi-to-html`. We add a modified traceback info to the outputs' transient metadata by https://github.com/microsoft/vscode-jupyter/blob/b368ea9326c13d6497e0f070d89d810d4ff86416/src/client/datascience/editor-integration/cellhashprovider.ts#L134-L147

which will be used by the new output renderer to use as the traceback data for rendering.