### PR TITLE
Auto populate starting kernel info in Interactive Window

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -451,6 +451,8 @@
     "DataScience.unhandledMessage": "Unhandled kernel message from a widget: {0} : {1}",
     "DataScience.qgridWidgetScriptVersionCompatibilityWarning": "Unable to load a compatible version of the widget 'qgrid'. Consider downgrading to version 1.1.1.",
     "DataScience.kernelStarted": "Started kernel {0}",
+    "DataScience.kernelStarting": "_Connecting to kernel..._",
+    "DataScience.kernelStartingCustom": "_Connecting to {0}..._",
     "DataScience.libraryRequiredToLaunchJupyterKernelNotInstalledInterpreter": "Running cells with '{0}' requires {1}.",
     "DataScience.libraryRequiredToLaunchJupyterKernelNotInstalledInterpreterAndRequiresUpdate": "Running cells with '{0}' requires {1} installed or requires an update.",
     "DataScience.runByLine": "Run by line (F10)",

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -409,6 +409,8 @@ export namespace DataScience {
     );
     export const restartedKernelHeader = localize('DataScience.restartedKernelHeader', 'Restarted {0}');
     export const startedNewKernelHeader = localize('DataScience.startedNewKernelHeader', 'Started {0}');
+    export const startingNewKernelHeader = localize('DataScience.kernelStarting', '_Connecting to kernel..._');
+    export const startingNewKernelCustomHeader = localize('DataScience.kernelStartingCustom', '_Connecting to {0}..._');
     export const connectKernelHeader = localize('DataScience.connectKernelHeader', 'Connected to {0}');
 
     export const jupyterSelectURIPrompt = localize(

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -50,6 +50,7 @@ import { SysInfoReason } from '../../interactive-common/interactiveWindowTypes';
 import { isCI, MARKDOWN_LANGUAGE } from '../../../common/constants';
 import { InteractiveWindowView } from '../../notebook/constants';
 import { chainWithPendingUpdates } from '../../notebook/helpers/notebookUpdater';
+import { DataScience } from '../../../common/utils/localize';
 
 export class Kernel implements IKernel {
     get connection(): INotebookProviderConnection | undefined {
@@ -291,8 +292,8 @@ export class Kernel implements IKernel {
                 const markdownCell = new NotebookCellData(
                     NotebookCellKind.Markup,
                     kernelConnection.interpreter?.displayName
-                        ? `_Connecting to ${kernelConnection.interpreter?.displayName}..._`
-                        : '_Connecting to kernel ..._',
+                        ? DataScience.startingNewKernelCustomHeader().format(kernelConnection.interpreter?.displayName)
+                        : DataScience.startingNewKernelHeader(),
                     MARKDOWN_LANGUAGE
                 );
                 markdownCell.metadata = { isSysInfoCell: true, isPlaceholder: true };

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -214,7 +214,10 @@ export class Kernel implements IKernel {
                 const stopWatch = new StopWatch();
                 try {
                     try {
-                        await this.populateStartKernelInfoForInteractive(options.document, this.kernelConnectionMetadata);
+                        await this.populateStartKernelInfoForInteractive(
+                            options.document,
+                            this.kernelConnectionMetadata
+                        );
                         traceInfo(`Starting Notebook in kernel.ts id = ${this.kernelConnectionMetadata.id}`);
                         this.notebook = await this.notebookProvider.getOrCreateNotebook({
                             identity: this.uri,
@@ -278,13 +281,18 @@ export class Kernel implements IKernel {
         );
     }
 
-    private async populateStartKernelInfoForInteractive(notebookDocument: NotebookDocument, kernelConnection: KernelConnectionMetadata) {
+    private async populateStartKernelInfoForInteractive(
+        notebookDocument: NotebookDocument,
+        kernelConnection: KernelConnectionMetadata
+    ) {
         if (notebookDocument.notebookType === InteractiveWindowView) {
             // add fake sys info
             await chainWithPendingUpdates(notebookDocument, (edit) => {
                 const markdownCell = new NotebookCellData(
                     NotebookCellKind.Markup,
-                    kernelConnection.interpreter?.displayName ? `_Connecting to ${kernelConnection.interpreter?.displayName}..._` : '_Connecting to kernel ..._',
+                    kernelConnection.interpreter?.displayName
+                        ? `_Connecting to ${kernelConnection.interpreter?.displayName}..._`
+                        : '_Connecting to kernel ..._',
                     MARKDOWN_LANGUAGE
                 );
                 markdownCell.metadata = { isSysInfoCell: true, isPlaceholder: true };
@@ -384,10 +392,18 @@ export class Kernel implements IKernel {
             // Append a markdown cell containing the sys info to the end of the NotebookDocument
             return chainWithPendingUpdates(notebookDocument, (edit) => {
                 if (notebookDocument.cellCount) {
-                    const lastCell = notebookDocument.cellAt(notebookDocument.cellCount - 1)
-                    
-                    if (lastCell.kind === NotebookCellKind.Markup && lastCell.metadata.isSysInfoCell && lastCell.metadata.isPlaceholder) {
-                        edit.replace(lastCell.document.uri, new Range(0, 0, lastCell.document.lineCount, 0), sysInfoMessages.join('  \n'));
+                    const lastCell = notebookDocument.cellAt(notebookDocument.cellCount - 1);
+
+                    if (
+                        lastCell.kind === NotebookCellKind.Markup &&
+                        lastCell.metadata.isSysInfoCell &&
+                        lastCell.metadata.isPlaceholder
+                    ) {
+                        edit.replace(
+                            lastCell.document.uri,
+                            new Range(0, 0, lastCell.document.lineCount, 0),
+                            sysInfoMessages.join('  \n')
+                        );
                         edit.replaceNotebookCellMetadata(notebookDocument.uri, lastCell.index, { isSysInfoCell: true });
                         return;
                     }


### PR DESCRIPTION
Right now there is no progress shown in the interactive window of the kernel. This PR adds placeholder info in the IW when we are launching the kernel.

![recording (13)](https://user-images.githubusercontent.com/876920/125852620-07d4d95b-58c6-4f03-a9f8-c65f0b16f9e0.gif)


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
