### PR TITLE
Honor `jupyter.stopOnError` when running multiple cells in native interactive window

### DIFF
--- a/src/client/datascience/cellFactory.ts
+++ b/src/client/datascience/cellFactory.ts
@@ -201,7 +201,7 @@ export function generateCellsFromNotebookDocument(
 ): ICell[] {
     return notebookDocument
         .getCells()
-        .filter((cell) => !cell.metadata.isSysInfoCell)
+        .filter((cell) => !cell.metadata.isInteractiveWindowMessageCell)
         .map((cell) => {
             // Reinstate cell structure + comments from cell metadata
             let code = cell.document.getText().splitLines();

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -395,7 +395,7 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
                 (cells: ICell[]) => {
                     // Then send the combined output to the UI
                     const converted = (cells[0].data as nbformat.ICodeCell).outputs.map(cellOutputToVSCCellOutput);
-                    temporaryExecution.replaceOutput(converted).then(() => {
+                    void temporaryExecution.replaceOutput(converted).then(() => {
                         // Scroll to the newly added output. First recompute visibility.
                         // User might have scrolled away while cell was executing.
                         // We don't want to force them back down unless they configured

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -289,10 +289,12 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
         // Add message to the notebook document
         const edit = new WorkspaceEdit();
         const notebookDocument = this.notebookDocument;
+        const markdownCell = new NotebookCellData(NotebookCellKind.Markup, message, MARKDOWN_LANGUAGE);
+        markdownCell.metadata = { isInteractiveWindowMessageCell: true };
         edit.replaceNotebookCells(
             notebookDocument.uri,
             new NotebookRange(notebookDocument.cellCount, notebookDocument.cellCount),
-            [new NotebookCellData(NotebookCellKind.Markup, message, MARKDOWN_LANGUAGE)]
+            [markdownCell]
         );
         await workspace.applyEdit(edit);
     }
@@ -390,20 +392,21 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
 
             // Sign up for cell changes
             observable.subscribe(
-                async (cells: ICell[]) => {
+                (cells: ICell[]) => {
                     // Then send the combined output to the UI
                     const converted = (cells[0].data as nbformat.ICodeCell).outputs.map(cellOutputToVSCCellOutput);
-                    await temporaryExecution.replaceOutput(converted);
-                    // Scroll to the newly added output. First recompute visibility.
-                    // User might have scrolled away while cell was executing.
-                    // We don't want to force them back down unless they configured
-                    // alwaysScrollOnNewCell.
-                    const isInsertedCellVisible = editor?.visibleRanges.find((r) => {
-                        return r.end === this.notebookDocument.cellCount - 1;
+                    temporaryExecution.replaceOutput(converted).then(() => {
+                        // Scroll to the newly added output. First recompute visibility.
+                        // User might have scrolled away while cell was executing.
+                        // We don't want to force them back down unless they configured
+                        // alwaysScrollOnNewCell.
+                        const isInsertedCellVisible = editor?.visibleRanges.find((r) => {
+                            return r.end === this.notebookDocument.cellCount - 1;
+                        });
+                        if (settings.alwaysScrollOnNewCell || isInsertedCellVisible) {
+                            this.revealCell(notebookCell);
+                        }
                     });
-                    if (settings.alwaysScrollOnNewCell || isInsertedCellVisible) {
-                        this.revealCell(notebookCell);
-                    }
                     const executionCount = (cells[0].data as nbformat.ICodeCell).execution_count;
                     if (executionCount) {
                         temporaryExecution.executionOrder = parseInt(executionCount.toString(), 10);
@@ -430,7 +433,9 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
             await finishedAddingCode.promise;
             traceInfo(`Finished execution for ${id}`);
         } finally {
-            await this.jupyterDebugger.stopDebugging(notebook);
+            if (isDebug) {
+                await this.jupyterDebugger.stopDebugging(notebook);
+            }
         }
         return result;
     }

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -367,7 +367,7 @@ export class Kernel implements IKernel {
                     sysInfoMessages.join('  \n'),
                     MARKDOWN_LANGUAGE
                 );
-                markdownCell.metadata = { isSysInfoCell: true };
+                markdownCell.metadata = { isInteractiveWindowMessageCell: true };
                 edit.replaceNotebookCells(
                     notebookDocument.uri,
                     new NotebookRange(notebookDocument.cellCount, notebookDocument.cellCount),


### PR DESCRIPTION
For https://github.com/microsoft/vscode-jupyter/issues/6673

Observable callback can't be async 🤡