### PR TITLE
Ensure resourceUri is mandatory

### DIFF
--- a/src/client/datascience/jupyter/kernels/kernelExecution.ts
+++ b/src/client/datascience/jupyter/kernels/kernelExecution.ts
@@ -247,7 +247,8 @@ export class KernelExecution implements IDisposable {
         if (!kernel) {
             kernel = this.kernelProvider.getOrCreate(document, {
                 metadata: this.metadata,
-                controller: this.controller
+                controller: this.controller,
+                resourceUri: document.uri
             });
         }
         if (!kernel) {

--- a/src/client/datascience/jupyter/kernels/types.ts
+++ b/src/client/datascience/jupyter/kernels/types.ts
@@ -154,8 +154,9 @@ export type KernelOptions = {
     controller: NotebookController;
     /**
      * When creating a kernel for an Interactive window, pass the Uri of the Python file here (to set the working directory, file & the like)
+     * In the case of Notebooks, just pass the uri of the notebook.
      */
-    resourceUri?: Uri;
+    resourceUri: Resource;
 };
 export const IKernelProvider = Symbol('IKernelProvider');
 export interface IKernelProvider extends IAsyncDisposable {

--- a/src/client/datascience/notebook/vscodeNotebookController.ts
+++ b/src/client/datascience/notebook/vscodeNotebookController.ts
@@ -255,7 +255,8 @@ export class VSCodeNotebookController implements Disposable {
         traceInfo(`Execute Cell ${cell.index} ${cell.notebook.uri.toString()}`);
         const kernel = this.kernelProvider.getOrCreate(cell.notebook, {
             metadata: this.kernelConnection,
-            controller: this.controller
+            controller: this.controller,
+            resourceUri: doc.uri
         });
         if (kernel) {
             this.updateKernelInfoInNotebookWhenAvailable(kernel, doc);
@@ -390,7 +391,8 @@ export class VSCodeNotebookController implements Disposable {
         // Unlike webview notebooks we cannot revert to old kernel if kernel switching fails.
         const newKernel = this.kernelProvider.getOrCreate(document, {
             metadata: selectedKernelConnectionMetadata,
-            controller: this.controller
+            controller: this.controller,
+            resourceUri: document.uri // In the case of interactive window, we cannot pass the Uri of notebook, it must be the Py file or undefined.
         });
         traceInfo(`KernelProvider switched kernel to id = ${newKernel?.kernelConnectionMetadata.id}`);
 

--- a/src/client/debugger/jupyter/debuggingManager.ts
+++ b/src/client/debugger/jupyter/debuggingManager.ts
@@ -250,7 +250,8 @@ export class DebuggingManager implements IExtensionSingleActivationService, IDis
         if (!kernel && controller) {
             kernel = this.kernelProvider.getOrCreate(doc, {
                 metadata: controller.connection,
-                controller: controller?.controller
+                controller: controller?.controller,
+                resourceUri: doc.uri
             });
         }
         if (kernel && kernel.status === ServerStatus.NotStarted) {


### PR DESCRIPTION
This makes the resourceUri mandatory, if its optional, we might not pass it.
If its mandatory we have to think about what we're passing into this, (i.e. it forces the user of the API to think about what we're passing)