### PR TITLE
Collapse code cell input in native interactive window by default

### DIFF
--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -760,6 +760,7 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
             isMarkdown ? MARKDOWN_LANGUAGE : language
         );
         notebookCellData.metadata = {
+            inputCollapsed: true,
             interactiveWindowCellMarker,
             interactive: {
                 file: file.fsPath,


### PR DESCRIPTION
Given https://github.com/microsoft/vscode/commit/d0c212ce1e49aaafd898e2cc64caa4b0ac726c9b we now have the ability to show just the first line of a code cell, hence adopting collapsed code cell inputs for code submitted from the interactive script.

With this change, current behavior:
![image](https://user-images.githubusercontent.com/30305945/126212110-f14dcdc5-0f52-4e63-a9f4-ce10786f4d9f.png)
