### PR TITLE
Fix markdown cells cancelling execution in native interactive window

### DIFF
--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -400,7 +400,7 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
             observable.subscribe(
                 (cells: ICell[]) => {
                     // Then send the combined output to the UI
-                    const converted = (cells[0].data as nbformat.ICodeCell).outputs.map(cellOutputToVSCCellOutput);
+                    const converted = (cells[0].data as nbformat.ICodeCell).outputs?.map(cellOutputToVSCCellOutput);
                     void temporaryExecution.replaceOutput(converted).then(() => {
                         // Scroll to the newly added output. First recompute visibility.
                         // User might have scrolled away while cell was executing.

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -419,7 +419,7 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
                         if (executionCount) {
                             temporaryExecution.executionOrder = parseInt(executionCount.toString(), 10);
                         }
-    
+
                         // Any errors will move our result to false (if allowed)
                         if (this.configuration.getSettings(owningResource).stopOnError) {
                             result = result && cells.find((c) => c.state === CellState.error) === undefined;

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -399,28 +399,31 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
             // Sign up for cell changes
             observable.subscribe(
                 (cells: ICell[]) => {
-                    // Then send the combined output to the UI
-                    const converted = (cells[0].data as nbformat.ICodeCell).outputs?.map(cellOutputToVSCCellOutput);
-                    void temporaryExecution.replaceOutput(converted).then(() => {
-                        // Scroll to the newly added output. First recompute visibility.
-                        // User might have scrolled away while cell was executing.
-                        // We don't want to force them back down unless they configured
-                        // alwaysScrollOnNewCell.
-                        const isInsertedCellVisible = editor?.visibleRanges.find((r) => {
-                            return r.end === this.notebookDocument.cellCount - 1;
+                    const cell = cells[0].data;
+                    if (cell.cell_type === 'code') {
+                        // Then send the combined output to the UI
+                        const converted = cell.outputs.map(cellOutputToVSCCellOutput);
+                        void temporaryExecution.replaceOutput(converted).then(() => {
+                            // Scroll to the newly added output. First recompute visibility.
+                            // User might have scrolled away while cell was executing.
+                            // We don't want to force them back down unless they configured
+                            // alwaysScrollOnNewCell.
+                            const isInsertedCellVisible = editor?.visibleRanges.find((r) => {
+                                return r.end === this.notebookDocument.cellCount - 1;
+                            });
+                            if (settings.alwaysScrollOnNewCell || isInsertedCellVisible) {
+                                this.revealCell(notebookCell);
+                            }
                         });
-                        if (settings.alwaysScrollOnNewCell || isInsertedCellVisible) {
-                            this.revealCell(notebookCell);
+                        const executionCount = cell.execution_count;
+                        if (executionCount) {
+                            temporaryExecution.executionOrder = parseInt(executionCount.toString(), 10);
                         }
-                    });
-                    const executionCount = (cells[0].data as nbformat.ICodeCell).execution_count;
-                    if (executionCount) {
-                        temporaryExecution.executionOrder = parseInt(executionCount.toString(), 10);
-                    }
-
-                    // Any errors will move our result to false (if allowed)
-                    if (this.configuration.getSettings(owningResource).stopOnError) {
-                        result = result && cells.find((c) => c.state === CellState.error) === undefined;
+    
+                        // Any errors will move our result to false (if allowed)
+                        if (this.configuration.getSettings(owningResource).stopOnError) {
+                            result = result && cells.find((c) => c.state === CellState.error) === undefined;
+                        }
                     }
                 },
                 (error) => {


### PR DESCRIPTION
Accessing `outputs` causes a TypeError here, so the execution promise never completes, which is why execution halts at a markdown cell. Note, I will refactor the NativeInteractiveWindow to not use observables at all and instead use the native notebooks codepath, this is just to unblock the scenario @greazer found