### PR TITLE
Update title on interactive window creation.

### DIFF
--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -100,7 +100,12 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     ['workbench.action.files.save']: [Uri];
     ['notebook.selectKernel']: [{ id: string; extension: string }] | [];
     ['undo']: [];
-    ['interactive.open']: [{ preserveFocus?: boolean; viewColumn?: ViewColumn }, Uri | undefined, string | undefined];
+    ['interactive.open']: [
+        { preserveFocus?: boolean; viewColumn?: ViewColumn },
+        Uri | undefined,
+        string | undefined,
+        string | undefined
+    ];
     ['interactive.execute']: [string];
     [DSCommands.NotebookEditorInterruptKernel]: [Uri];
     [DSCommands.ExportFileAndOutputAsNotebook]: [Uri];

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -75,7 +75,7 @@ import {
     IStatusProvider,
     WebViewViewChangeEventArgs
 } from '../types';
-import { createInteractiveIdentity } from './identity';
+import { createInteractiveIdentity, getInteractiveWindowTitle } from './identity';
 import { cellOutputToVSCCellOutput } from '../notebook/helpers/helpers';
 import { generateMarkdownFromCodeLines } from '../../../datascience-ui/common';
 import { chainWithPendingUpdates } from '../notebook/helpers/notebookUpdater';
@@ -179,7 +179,8 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
             // Keep focus on the owning file if there is one
             { viewColumn: ViewColumn.Beside, preserveFocus: hasOwningFile },
             undefined,
-            controllerId
+            controllerId,
+            this.owner && this.mode === 'perFile' ? getInteractiveWindowTitle(this.owner) : undefined
         )) as unknown) as INativeInteractiveWindow;
         const notebookDocument = workspace.notebookDocuments.find(
             (doc) => doc.uri.toString() === notebookUri.toString()
@@ -313,6 +314,7 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
             'interactive.open',
             { preserveFocus: true },
             this.notebookUri,
+            undefined,
             undefined
         );
     }
@@ -821,7 +823,8 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
             'interactive.open',
             { preserveFocus: true },
             notebookDocument.uri,
-            this.notebookController?.id
+            this.notebookController?.id,
+            undefined
         );
 
         // Strip #%% and store it in the cell metadata so we can reconstruct the cell structure when exporting to Python files


### PR DESCRIPTION
When `jupyter.interactiveWindowMode` is set to `perFile`, we use the name of the python file as title. Upstream fix is https://github.com/microsoft/vscode/commit/af612856c93db8c2a6eb3d977fa5ee299d036282

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
