### PR TITLE
Load kernels from cache and kernel for active interpreter

### DIFF
--- a/src/client/datascience/kernel-launcher/localKernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/localKernelFinder.ts
@@ -30,6 +30,7 @@ import { IFileSystem } from '../../common/platform/types';
 import { noop } from '../../common/utils/misc';
 import { createPromiseFromCancellation } from '../../common/cancellation';
 
+const GlobalKernelSpecsCacheKey = 'JUPYTER_GLOBAL_KERNELSPECS';
 // This class searches for a kernel that matches the given kernel name.
 // First it searches on a global persistent state, then on the installed python interpreters,
 // and finally on the default locations that jupyter installs kernels on.
@@ -160,7 +161,7 @@ export class LocalKernelFinder implements ILocalKernelFinder {
 
         const kernels = this.filterKernels(nonPythonKernelSpecs.concat(pythonRelatedKernelSpecs));
         this.lastFetchedKernelsWithoutCache = kernels;
-        this.globalState.update('JUPYTER_GLOBAL_KERNELSPECS', kernels).then(noop, (ex) => {
+        this.globalState.update(GlobalKernelSpecsCacheKey, kernels).then(noop, (ex) => {
             console.error('Failed to update global kernel cache', ex);
         });
         return kernels;
@@ -171,7 +172,7 @@ export class LocalKernelFinder implements ILocalKernelFinder {
     ): Promise<LocalKernelConnectionMetadata[]> {
         const values = this.lastFetchedKernelsWithoutCache.length
             ? this.lastFetchedKernelsWithoutCache
-            : this.globalState.get<LocalKernelConnectionMetadata[]>('JUPYTER_GLOBAL_KERNELSPECS', []);
+            : this.globalState.get<LocalKernelConnectionMetadata[]>(GlobalKernelSpecsCacheKey, []);
         const validValues: LocalKernelConnectionMetadata[] = [];
         const promise = Promise.all(
             values.map(async (item) => {

--- a/src/client/datascience/kernel-launcher/localKernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/localKernelFinder.ts
@@ -178,6 +178,7 @@ export class LocalKernelFinder implements ILocalKernelFinder {
                 let somethingIsInvalid = false;
                 const promises: Promise<void>[] = [];
                 if (item.interpreter?.path) {
+                    // Possible the interpreter no longer exists, in such cases, exclude this cached kernel from the list.
                     promises.push(
                         this.fs
                             .localFileExists(item.interpreter.path)
@@ -190,6 +191,7 @@ export class LocalKernelFinder implements ILocalKernelFinder {
                     );
                 }
                 if (item.kind === 'startUsingKernelSpec' && item.kernelSpec?.specFile) {
+                    // Possible the kernelspec file no longer exists, in such cases, exclude this cached kernel from the list.
                     promises.push(
                         this.fs
                             .localFileExists(item.kernelSpec.specFile)

--- a/src/client/datascience/kernel-launcher/localKernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/localKernelFinder.ts
@@ -3,12 +3,12 @@
 'use strict';
 
 import type { nbformat } from '@jupyterlab/coreutils';
-import { inject, injectable } from 'inversify';
-import { CancellationToken } from 'vscode';
+import { inject, injectable, named } from 'inversify';
+import { CancellationToken, Memento } from 'vscode';
 import { IPythonExtensionChecker } from '../../api/types';
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import { traceDecorators, traceError, traceInfo } from '../../common/logger';
-import { IExtensions, Resource } from '../../common/types';
+import { GLOBAL_MEMENTO, IExtensions, IMemento, Resource } from '../../common/types';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { Telemetry } from '../constants';
@@ -17,11 +17,7 @@ import {
     getDisplayNameOrNameOfKernelConnection,
     getLanguageInNotebookMetadata
 } from '../jupyter/kernels/helpers';
-import {
-    KernelSpecConnectionMetadata,
-    LocalKernelConnectionMetadata,
-    PythonKernelConnectionMetadata
-} from '../jupyter/kernels/types';
+import { LocalKernelConnectionMetadata } from '../jupyter/kernels/types';
 import { ILocalKernelFinder } from './types';
 import { getResourceType } from '../common';
 import { isPythonNotebook } from '../notebook/helpers/helpers';
@@ -30,12 +26,16 @@ import { sendKernelListTelemetry } from '../telemetry/kernelTelemetry';
 import { LocalPythonAndRelatedNonPythonKernelSpecFinder } from './localPythonAndRelatedNonPythonKernelSpecFinder';
 import { LocalKnownPathKernelSpecFinder } from './localKnownPathKernelSpecFinder';
 import { JupyterPaths } from './jupyterPaths';
+import { IFileSystem } from '../../common/platform/types';
+import { noop } from '../../common/utils/misc';
+import { createPromiseFromCancellation } from '../../common/cancellation';
 
 // This class searches for a kernel that matches the given kernel name.
 // First it searches on a global persistent state, then on the installed python interpreters,
 // and finally on the default locations that jupyter installs kernels on.
 @injectable()
 export class LocalKernelFinder implements ILocalKernelFinder {
+    private lastFetchedKernelsWithoutCache: LocalKernelConnectionMetadata[] = [];
     constructor(
         @inject(IInterpreterService) private interpreterService: IInterpreterService,
         @inject(IPythonExtensionChecker) private readonly extensionChecker: IPythonExtensionChecker,
@@ -43,7 +43,9 @@ export class LocalKernelFinder implements ILocalKernelFinder {
         @inject(LocalKnownPathKernelSpecFinder) private readonly nonPythonkernelFinder: LocalKnownPathKernelSpecFinder,
         @inject(LocalPythonAndRelatedNonPythonKernelSpecFinder)
         private readonly pythonKernelFinder: LocalPythonAndRelatedNonPythonKernelSpecFinder,
-        @inject(JupyterPaths) private readonly jupyterPaths: JupyterPaths
+        @inject(JupyterPaths) private readonly jupyterPaths: JupyterPaths,
+        @inject(IMemento) @named(GLOBAL_MEMENTO) private readonly globalState: Memento,
+        @inject(IFileSystem) private readonly fs: IFileSystem
     ) {}
     @traceDecorators.verbose('Find kernel spec')
     @captureTelemetry(Telemetry.KernelFinderPerf)
@@ -59,7 +61,7 @@ export class LocalKernelFinder implements ILocalKernelFinder {
                 : getTelemetrySafeLanguage(getLanguageInNotebookMetadata(notebookMetadata) || '');
         try {
             // Get list of all of the specs
-            const kernels = await this.listKernels(resource, cancelToken);
+            const kernels = await this.listKernels(resource, cancelToken, 'useCache');
             const isPythonNbOrInteractiveWindow = isPythonNotebook(notebookMetadata) || resourceType === 'interactive';
             // Always include the interpreter in the search if we can
             const preferredInterpreter =
@@ -110,18 +112,32 @@ export class LocalKernelFinder implements ILocalKernelFinder {
     /**
      * Search all our local file system locations for installed kernel specs and return them
      */
-    @captureTelemetry(Telemetry.KernelListingPerf, { kind: 'local' })
     @traceDecorators.error('List kernels failed')
     public async listKernels(
         resource: Resource,
-        cancelToken?: CancellationToken
+        cancelToken?: CancellationToken,
+        useCache: 'useCache' | 'ignoreCache' = 'ignoreCache'
     ): Promise<LocalKernelConnectionMetadata[]> {
-        let [nonPythonKernelSpecs, pythonRelatedKernelSpecs] = await Promise.all([
-            this.nonPythonkernelFinder.listKernelSpecs(false, cancelToken),
-            this.pythonKernelFinder.listKernelSpecs(resource, cancelToken)
-        ]);
+        const kernelsFromCachePromise =
+            useCache === 'ignoreCache' ? Promise.resolve([]) : this.listValidKernelsFromGlobalCache(cancelToken);
+        const kernelsWithoutCachePromise = this.listKernelsWithoutCache(resource, cancelToken);
+        let kernels: LocalKernelConnectionMetadata[] = [];
+        if (useCache === 'ignoreCache') {
+            kernels = await kernelsWithoutCachePromise;
+        } else {
+            let kernelsFromCache: LocalKernelConnectionMetadata[] | undefined;
+            kernelsFromCachePromise.then((items) => (kernelsFromCache = items)).catch(noop);
+            await Promise.race([kernelsFromCachePromise, kernelsWithoutCachePromise]);
+            // If we finish the cache first, and we don't have any items, in the cache, then load without cache.
+            if (Array.isArray(kernelsFromCache) && kernelsFromCache.length > 0) {
+                kernels = kernelsFromCache;
+            } else {
+                kernels = await kernelsWithoutCachePromise;
+            }
+        }
 
-        const kernels = this.filterKernels(nonPythonKernelSpecs.concat(pythonRelatedKernelSpecs));
+        //
+        kernels = this.filterKernels(kernels);
         sendKernelListTelemetry(resource, kernels);
         return kernels;
     }
@@ -131,8 +147,81 @@ export class LocalKernelFinder implements ILocalKernelFinder {
     public async getKernelSpecRootPath(): Promise<string | undefined> {
         return this.jupyterPaths.getKernelSpecRootPath();
     }
-    private filterKernels(kernels: (KernelSpecConnectionMetadata | PythonKernelConnectionMetadata)[]) {
+
+    @captureTelemetry(Telemetry.KernelListingPerf, { kind: 'local' })
+    private async listKernelsWithoutCache(
+        resource: Resource,
+        cancelToken?: CancellationToken
+    ): Promise<LocalKernelConnectionMetadata[]> {
+        let [nonPythonKernelSpecs, pythonRelatedKernelSpecs] = await Promise.all([
+            this.nonPythonkernelFinder.listKernelSpecs(false, cancelToken),
+            this.pythonKernelFinder.listKernelSpecs(resource, cancelToken)
+        ]);
+
+        const kernels = this.filterKernels(nonPythonKernelSpecs.concat(pythonRelatedKernelSpecs));
+        this.lastFetchedKernelsWithoutCache = kernels;
+        this.globalState.update('JUPYTER_GLOBAL_KERNELSPECS', kernels).then(noop, (ex) => {
+            console.error('Failed to update global kernel cache', ex);
+        });
+        return kernels;
+    }
+
+    private async listValidKernelsFromGlobalCache(
+        cancelToken?: CancellationToken
+    ): Promise<LocalKernelConnectionMetadata[]> {
+        const values = this.lastFetchedKernelsWithoutCache.length
+            ? this.lastFetchedKernelsWithoutCache
+            : this.globalState.get<LocalKernelConnectionMetadata[]>('JUPYTER_GLOBAL_KERNELSPECS', []);
+        const validValues: LocalKernelConnectionMetadata[] = [];
+        const promise = Promise.all(
+            values.map(async (item) => {
+                let somethingIsInvalid = false;
+                const promises: Promise<void>[] = [];
+                if (item.interpreter?.path) {
+                    promises.push(
+                        this.fs
+                            .localFileExists(item.interpreter.path)
+                            .then((exists) => {
+                                if (!exists) {
+                                    somethingIsInvalid = true;
+                                }
+                            })
+                            .catch(noop)
+                    );
+                }
+                if (item.kind === 'startUsingKernelSpec' && item.kernelSpec?.specFile) {
+                    promises.push(
+                        this.fs
+                            .localFileExists(item.kernelSpec.specFile)
+                            .then((exists) => {
+                                if (!exists) {
+                                    somethingIsInvalid = true;
+                                }
+                            })
+                            .catch(noop)
+                    );
+                }
+                await Promise.all(promises);
+                if (!somethingIsInvalid) {
+                    validValues.push(item);
+                }
+            })
+        );
+        if (cancelToken) {
+            await Promise.race([
+                promise,
+                createPromiseFromCancellation({ token: cancelToken, cancelAction: 'resolve', defaultValue: undefined })
+            ]);
+        } else {
+            await promise;
+        }
+        return validValues;
+    }
+    private filterKernels(kernels: LocalKernelConnectionMetadata[]) {
         return kernels.filter(({ kernelSpec }) => {
+            if (!kernelSpec) {
+                return true;
+            }
             // Disable xeus python for now.
             if (kernelSpec.argv[0].toLowerCase().endsWith('xpython')) {
                 traceInfo(`Hiding xeus kernelspec`);

--- a/src/client/datascience/kernel-launcher/types.ts
+++ b/src/client/datascience/kernel-launcher/types.ts
@@ -58,8 +58,15 @@ export interface ILocalKernelFinder {
         option?: nbformat.INotebookMetadata,
         cancelToken?: CancellationToken
     ): Promise<LocalKernelConnectionMetadata | undefined>;
-    listNonPythonKernels(cancelToken?: CancellationToken): Promise<LocalKernelConnectionMetadata[]>;
-    listKernels(resource: Resource, cancelToken?: CancellationToken): Promise<LocalKernelConnectionMetadata[]>;
+    listNonPythonKernels(
+        cancelToken?: CancellationToken,
+        useCache?: 'useCache' | 'ignoreCache'
+    ): Promise<LocalKernelConnectionMetadata[]>;
+    listKernels(
+        resource: Resource,
+        cancelToken?: CancellationToken,
+        useCache?: 'useCache' | 'ignoreCache'
+    ): Promise<LocalKernelConnectionMetadata[]>;
     getKernelSpecRootPath(): Promise<string | undefined>;
 }
 

--- a/src/client/datascience/notebook/notebookControllerManager.ts
+++ b/src/client/datascience/notebook/notebookControllerManager.ts
@@ -60,7 +60,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
 
     // Promise to resolve when we have loaded our controllers
     private controllersPromise?: Promise<void>;
-    private activeInterpreterControllerPromise: Promise<VSCodeNotebookController | undefined>;
+    private activeInterpreterControllerPromise?: Promise<VSCodeNotebookController | undefined>;
     // Listing of the controllers that we have registered
     private registeredControllers = new Map<string, VSCodeNotebookController>();
 

--- a/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
@@ -278,7 +278,7 @@ import { getInterpreterHash } from '../../../client/pythonEnvironments/info/inte
                 ),
                 jupyterPaths,
                 instance(memeto),
-                fs
+                instance(fs)
             );
         });
         teardown(() => {

--- a/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
@@ -28,7 +28,7 @@ import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnviro
 import { IPythonExtensionChecker } from '../../../client/api/types';
 import { PYTHON_LANGUAGE } from '../../../client/common/constants';
 import { arePathsSame } from '../../common';
-import { Uri } from 'vscode';
+import { Memento, Uri } from 'vscode';
 import { IExtensions } from '../../../client/common/types';
 import { LocalKnownPathKernelSpecFinder } from '../../../client/datascience/kernel-launcher/localKnownPathKernelSpecFinder';
 import { JupyterPaths } from '../../../client/datascience/kernel-launcher/jupyterPaths';
@@ -260,6 +260,9 @@ import { getInterpreterHash } from '../../../client/pythonEnvironments/info/inte
                 jupyterPaths,
                 instance(extensionChecker)
             );
+            const memeto = mock<Memento>();
+            when(memeto.get('JUPYTER_GLOBAL_KERNELSPECS', anything())).thenReturn([]);
+            when(memeto.update('JUPYTER_GLOBAL_KERNELSPECS', anything())).thenResolve();
             kernelFinder = new LocalKernelFinder(
                 instance(interpreterService),
                 instance(extensionChecker),
@@ -273,7 +276,9 @@ import { getInterpreterHash } from '../../../client/pythonEnvironments/info/inte
                     instance(extensionChecker),
                     nonPythonKernelSpecFinder
                 ),
-                jupyterPaths
+                jupyterPaths,
+                instance(memeto),
+                fs
             );
         });
         teardown(() => {


### PR DESCRIPTION
Part of #5861
* Load controller ASAP for Active Interpreter
* Load controllers from cache (whilst fetching real controllers & updating the list after we get them)

# First time users
* We load active interpreter as kernel fast
* We load all other kernels (as we do today, which is a little slow)
# Users coming back
* We load kernels from cache
* We load kernels without cache in the background, and as its made available, we add those.
	* I.e. if a user as a new environment, and that gets picked up by the kernel discovery it will be added subsequently to the list of kernels (but that's a little slower).