### PR TITLE
Don't register our jupyter-notebook serializer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1974,18 +1974,6 @@
                 ]
             }
         ],
-        "notebooks": [
-            {
-                "type": "jupyter-notebook",
-                "displayName": "Jupyter Notebook (preview)",
-                "selector": [
-                    {
-                        "filenamePattern": "*.ipynb"
-                    }
-                ],
-                "priority": "option"
-            }
-        ],
         "notebookRenderer": [
             {
                 "id": "jupyter-ipywidget-renderer",

--- a/src/client/datascience/notebook/integration.ts
+++ b/src/client/datascience/notebook/integration.ts
@@ -7,15 +7,12 @@ import { IExtensionSingleActivationService } from '../../activation/types';
 import {
     IApplicationEnvironment,
     ICommandManager,
-    IVSCodeNotebook,
     IWorkspaceService
 } from '../../common/application/types';
 import { NotebookCellScheme, PYTHON_LANGUAGE, UseVSCodeNotebookEditorApi } from '../../common/constants';
-import { traceError } from '../../common/logger';
 import { GLOBAL_MEMENTO, IDisposableRegistry, IMemento } from '../../common/types';
 import { noop } from '../../common/utils/misc';
 import { JupyterNotebookView } from './constants';
-import { NotebookSerializer } from './notebookSerializer';
 import { NotebookCellStateTracker } from './helpers/helpers';
 import { NotebookCompletionProvider } from './intellisense/completionProvider';
 
@@ -28,10 +25,8 @@ export const HAS_EXTENSION_CONFIGURED_CELL_TOOLBAR_SETTING = 'CELL_TOOLBAR_SETTI
 @injectable()
 export class NotebookIntegration implements IExtensionSingleActivationService {
     constructor(
-        @inject(IVSCodeNotebook) private readonly vscNotebook: IVSCodeNotebook,
         @inject(UseVSCodeNotebookEditorApi) private readonly useNativeNb: boolean,
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
-        @inject(NotebookSerializer) private readonly notebookSerializer: NotebookSerializer,
         @inject(IApplicationEnvironment) private readonly env: IApplicationEnvironment,
         @inject(IWorkspaceService) private readonly workspace: IWorkspaceService,
         @inject(ICommandManager) private readonly commandManager: ICommandManager,
@@ -56,27 +51,6 @@ export class NotebookIntegration implements IExtensionSingleActivationService {
             // Possible user was in experiment, then they opted out. In this case we need to revert the changes made to the settings file.
             // Again, this is temporary code.
             await this.disableNotebooks();
-        }
-        if (this.useNativeNb) {
-            try {
-                this.disposables.push(
-                    this.vscNotebook.registerNotebookSerializer(JupyterNotebookView, this.notebookSerializer, {
-                        transientOutputs: false,
-                        transientCellMetadata: {
-                            breakpointMargin: true,
-                            inputCollapsed: true,
-                            outputCollapsed: true,
-                            custom: false
-                        }
-                    })
-                );
-            } catch (ex) {
-                // If something goes wrong, and we're not in Insiders & not using the NativeEditor experiment, then swallow errors.
-                traceError('Failed to register VS Code Notebook API', ex);
-                if (this.useNativeNb) {
-                    throw ex;
-                }
-            }
         }
     }
 

--- a/src/client/datascience/notebook/integration.ts
+++ b/src/client/datascience/notebook/integration.ts
@@ -4,11 +4,7 @@
 import { inject, injectable, named } from 'inversify';
 import { ConfigurationTarget, languages, Memento } from 'vscode';
 import { IExtensionSingleActivationService } from '../../activation/types';
-import {
-    IApplicationEnvironment,
-    ICommandManager,
-    IWorkspaceService
-} from '../../common/application/types';
+import { IApplicationEnvironment, ICommandManager, IWorkspaceService } from '../../common/application/types';
 import { NotebookCellScheme, PYTHON_LANGUAGE, UseVSCodeNotebookEditorApi } from '../../common/constants';
 import { GLOBAL_MEMENTO, IDisposableRegistry, IMemento } from '../../common/types';
 import { noop } from '../../common/utils/misc';

--- a/src/test/datascience/notebook/integration.vscode.test.ts
+++ b/src/test/datascience/notebook/integration.vscode.test.ts
@@ -6,14 +6,12 @@
 import { assert } from 'chai';
 import { Memento, workspace, WorkspaceConfiguration } from 'vscode';
 import {
-    IVSCodeNotebook,
     IApplicationEnvironment,
     IWorkspaceService,
     ICommandManager
 } from '../../../client/common/application/types';
 import { UseVSCodeNotebookEditorApi } from '../../../client/common/constants';
 import { GLOBAL_MEMENTO, IDisposableRegistry, IMemento } from '../../../client/common/types';
-import { NotebookSerializer } from '../../../client/datascience/notebook/notebookSerializer';
 import {
     HAS_EXTENSION_CONFIGURED_CELL_TOOLBAR_SETTING,
     NotebookIntegration
@@ -43,10 +41,8 @@ suite('VS Code notebook integration', () => {
         const memento = api.serviceManager.get<Memento>(IMemento, GLOBAL_MEMENTO);
         await memento.update(HAS_EXTENSION_CONFIGURED_CELL_TOOLBAR_SETTING, false);
         notebookIntegration = (new NotebookIntegration(
-            api.serviceManager.get(IVSCodeNotebook),
             api.serviceManager.get(UseVSCodeNotebookEditorApi),
             api.serviceManager.get(IDisposableRegistry),
-            api.serviceManager.get(NotebookSerializer),
             api.serviceManager.get(IApplicationEnvironment),
             api.serviceManager.get(IWorkspaceService),
             api.serviceManager.get(ICommandManager),

--- a/src/test/datascience/notebook/integration.vscode.test.ts
+++ b/src/test/datascience/notebook/integration.vscode.test.ts
@@ -5,11 +5,7 @@
 
 import { assert } from 'chai';
 import { Memento, workspace, WorkspaceConfiguration } from 'vscode';
-import {
-    IApplicationEnvironment,
-    IWorkspaceService,
-    ICommandManager
-} from '../../../client/common/application/types';
+import { IApplicationEnvironment, IWorkspaceService, ICommandManager } from '../../../client/common/application/types';
 import { UseVSCodeNotebookEditorApi } from '../../../client/common/constants';
 import { GLOBAL_MEMENTO, IDisposableRegistry, IMemento } from '../../../client/common/types';
 import {


### PR DESCRIPTION
Temporary. We'll delete our copy of the code in favor of a shared npm package for create new and export.