### PR TITLE
Fix native interactive window export to preserve outputs and omit sys info cells

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -350,7 +350,6 @@ module.exports = {
         'src/datascience-ui/react-common/codicon/codicon.ts',
         'src/datascience-ui/react-common/errorBoundary.tsx',
         'src/datascience-ui/common/main.ts',
-        'src/datascience-ui/common/cellFactory.ts',
         'src/datascience-ui/common/index.ts',
         'src/datascience-ui/startPage/index.tsx',
         'src/datascience-ui/startPage/startPage.tsx',

--- a/src/client/datascience/cellFactory.ts
+++ b/src/client/datascience/cellFactory.ts
@@ -209,9 +209,10 @@ export function generateCellsFromNotebookDocument(
                 code.unshift(cell.metadata.interactiveWindowCellMarker + '\n');
             }
             const data = createJupyterCellFromVSCNotebookCell(cell);
-            data.source = cell.kind === NotebookCellKind.Code
-                ? appendLineFeed(code, magicCommandsAsComments ? uncommentMagicCommands : undefined)
-                : appendLineFeed(code);
+            data.source =
+                cell.kind === NotebookCellKind.Code
+                    ? appendLineFeed(code, magicCommandsAsComments ? uncommentMagicCommands : undefined)
+                    : appendLineFeed(code);
             return {
                 data,
                 id: uuid(),

--- a/src/client/datascience/cellFactory.ts
+++ b/src/client/datascience/cellFactory.ts
@@ -4,16 +4,16 @@
 import '../common/extensions';
 
 import * as uuid from 'uuid/v4';
-import { NotebookDocument, Range, TextDocument, Uri } from 'vscode';
+import { NotebookCellKind, NotebookDocument, Range, TextDocument, Uri } from 'vscode';
 
 import { appendLineFeed, parseForComments } from '../../datascience-ui/common';
-import { createCodeCell, createMarkdownCell } from '../../datascience-ui/common/cellFactory';
+import { createCodeCell, createMarkdownCell, uncommentMagicCommands } from '../../datascience-ui/common/cellFactory';
 import { IJupyterSettings, Resource } from '../common/types';
 import { noop } from '../common/utils/misc';
 import { CellMatcher } from './cellMatcher';
 import { Identifiers } from './constants';
 import { CellState, ICell, ICellRange } from './types';
-import { MARKDOWN_LANGUAGE } from '../common/constants';
+import { createJupyterCellFromVSCNotebookCell } from './notebook/helpers/helpers';
 
 function generateCodeCell(
     code: string[],
@@ -208,8 +208,16 @@ export function generateCellsFromNotebookDocument(
             if (cell.metadata.interactiveWindowCellMarker !== undefined) {
                 code.unshift(cell.metadata.interactiveWindowCellMarker + '\n');
             }
-            return cell.document.languageId === MARKDOWN_LANGUAGE
-                ? generateMarkdownCell(appendLineFeed(code), '', 0, uuid(), true)
-                : generateCodeCell(appendLineFeed(code), '', 0, uuid(), magicCommandsAsComments);
+            const data = createJupyterCellFromVSCNotebookCell(cell);
+            data.source = cell.kind === NotebookCellKind.Code
+                ? appendLineFeed(code, magicCommandsAsComments ? uncommentMagicCommands : undefined)
+                : appendLineFeed(code);
+            return {
+                data,
+                id: uuid(),
+                file: '',
+                line: 0,
+                state: CellState.init
+            };
         });
 }

--- a/src/client/datascience/export/exportDialog.ts
+++ b/src/client/datascience/export/exportDialog.ts
@@ -67,7 +67,12 @@ export class ExportDialog implements IExportDialog {
     }
 
     private async getDefaultUri(source: Uri | undefined, targetFileName: string): Promise<Uri> {
-        if (!source || source.scheme === 'file' || source.scheme === 'untitled' || source.scheme === 'vscode-interactive') {
+        if (
+            !source ||
+            source.scheme === 'file' ||
+            source.scheme === 'untitled' ||
+            source.scheme === 'vscode-interactive'
+        ) {
             // Just combine the working directory with the file
             return Uri.file(path.join(await computeWorkingDirectory(source, this.workspaceService), targetFileName));
         }

--- a/src/client/datascience/export/exportDialog.ts
+++ b/src/client/datascience/export/exportDialog.ts
@@ -67,7 +67,7 @@ export class ExportDialog implements IExportDialog {
     }
 
     private async getDefaultUri(source: Uri | undefined, targetFileName: string): Promise<Uri> {
-        if (!source || source.scheme === 'file' || source.scheme === 'untitled') {
+        if (!source || source.scheme === 'file' || source.scheme === 'untitled' || source.scheme === 'vscode-interactive') {
             // Just combine the working directory with the file
             return Uri.file(path.join(await computeWorkingDirectory(source, this.workspaceService), targetFileName));
         }

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -297,7 +297,7 @@ export class Kernel implements IKernel {
                         : DataScience.startingNewKernelHeader(),
                     MARKDOWN_LANGUAGE
                 );
-                markdownCell.metadata = { isSysInfoCell: true, isPlaceholder: true };
+                markdownCell.metadata = { isInteractiveWindowMessageCell: true, isPlaceholder: true };
                 edit.replaceNotebookCells(
                     notebookDocument.uri,
                     new NotebookRange(notebookDocument.cellCount, notebookDocument.cellCount),
@@ -400,7 +400,7 @@ export class Kernel implements IKernel {
 
                     if (
                         lastCell.kind === NotebookCellKind.Markup &&
-                        lastCell.metadata.isSysInfoCell &&
+                        lastCell.metadata.isInteractiveWindowMessageCell &&
                         lastCell.metadata.isPlaceholder
                     ) {
                         edit.replace(
@@ -408,7 +408,7 @@ export class Kernel implements IKernel {
                             new Range(0, 0, lastCell.document.lineCount, 0),
                             sysInfoMessages.join('  \n')
                         );
-                        edit.replaceNotebookCellMetadata(notebookDocument.uri, lastCell.index, { isSysInfoCell: true });
+                        edit.replaceNotebookCellMetadata(notebookDocument.uri, lastCell.index, { isInteractiveWindowMessageCell: true });
                         return;
                     }
                 }

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -408,7 +408,9 @@ export class Kernel implements IKernel {
                             new Range(0, 0, lastCell.document.lineCount, 0),
                             sysInfoMessages.join('  \n')
                         );
-                        edit.replaceNotebookCellMetadata(notebookDocument.uri, lastCell.index, { isInteractiveWindowMessageCell: true });
+                        edit.replaceNotebookCellMetadata(notebookDocument.uri, lastCell.index, {
+                            isInteractiveWindowMessageCell: true
+                        });
                         return;
                     }
                 }

--- a/src/datascience-ui/common/cellFactory.ts
+++ b/src/datascience-ui/common/cellFactory.ts
@@ -9,7 +9,7 @@ const cloneDeep = require('lodash/cloneDeep');
 import '../../client/common/extensions';
 import { appendLineFeed, generateMarkdownFromCodeLines } from './index';
 
-function uncommentMagicCommands(line: string): string {
+export function uncommentMagicCommands(line: string): string {
     // Uncomment lines that are shell assignments (starting with #!),
     // line magic (starting with #!%) or cell magic (starting with #!%%).
     if (/^#\s*!/.test(line)) {


### PR DESCRIPTION
For https://github.com/microsoft/vscode-jupyter/issues/6779

@DonJayamanne FYI, we cannot simply use the notebook serializer to convert NotebookDocument to bytes/string like I initially thought, because we do all kinds of stuff to manipulate the notebook cells before serializing and writing it to disk e.g. inserting change directory, and we would need to rewrite all of that functionality for NotebookCell/NotebookDocument (I started down this path and had touched 10 files after an hour). 

@rebornix had a proposal that we should rewrite our export to deal with nbformat directly rather than ICells, which I agree with. In the meantime this PR is a localized fix for the original problem (export dropping notebook cell outputs) to avoid introducing regressions for native interactive window, but when we create an npm package with shared code for converting NotebookData to nbformat and delete ICell https://github.com/microsoft/vscode-jupyter/issues/6488, this will go away

