### PR TITLE
Fixed wrong spellings in comments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -619,7 +619,6 @@ module.exports = {
         'src/client/common/utils/multiStepInput.ts',
         'src/client/common/utils/stopWatch.ts',
         'src/client/common/utils/random.ts',
-        'src/client/common/utils/serializers.ts',
         'src/client/common/utils/icons.ts',
         'src/client/common/utils/sysTypes.ts',
         'src/client/common/utils/version.ts',

--- a/src/client/common/utils/serializers.ts
+++ b/src/client/common/utils/serializers.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 /**
- * Serialize ArraBuffer and ArrayBufferView into a fomat such that they are json serializable.
+ * Serialize ArrayBuffer and ArrayBufferView into a format such that they are json serializable.
  *
  * @export
  * @param {(undefined | (ArrayBuffer | ArrayBufferView)[])} buffers

--- a/src/client/datascience/interactive-common/intellisense/intellisenseDocument.ts
+++ b/src/client/datascience/interactive-common/intellisense/intellisenseDocument.ts
@@ -687,7 +687,7 @@ export class IntellisenseDocument implements TextDocument {
     }
 
     private createSerializableRange(start: Position, end: Position): Range {
-        // This funciton is necessary so that the Range can be passed back
+        // This function is necessary so that the Range can be passed back
         // over a remote connection without including all of the extra fields that
         // VS code puts into a Range object.
         const result = {

--- a/src/client/datascience/webviews/webviewHost.ts
+++ b/src/client/datascience/webviews/webviewHost.ts
@@ -215,7 +215,7 @@ export abstract class WebviewHost<IMapping> implements IDisposable {
 
             this.webview = await this.provideWebview(cwd, settings, workspaceFolder, webView);
 
-            // Track to seee if our webview fails to load
+            // Track to see if our webview fails to load
             this._disposables.push(this.webview.loadFailed(this.onWebViewLoadFailed, this));
 
             traceInfo('Webview panel created.');


### PR DESCRIPTION
For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
