### PR TITLE
Rework how restart works for native notebooks

### DIFF
--- a/news/2 Fixes/5996.md
+++ b/news/2 Fixes/5996.md
@@ -1,0 +1,1 @@
+Run all and restarting does not actually interrupt the rest of the running cells.

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -177,6 +177,9 @@ export class Kernel implements IKernel {
         const restartPromise = this.kernelExecution.restart(notebookDocument, this._notebookPromise);
         await restartPromise;
 
+        // Interactive window needs a restart sys info
+        await this.initializeAfterStart(SysInfoReason.Restart, notebookDocument);
+
         // Indicate a restart occurred if it succeeds
         this._onRestarted.fire();
     }

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -172,18 +172,13 @@ export class Kernel implements IKernel {
         if (this.restarting) {
             return this.restarting.promise;
         }
-        if (this.notebook) {
-            this.restarting = createDeferred<void>();
-            try {
-                await this.notebook.restartKernel(this.launchTimeout);
-                await this.initializeAfterStart(SysInfoReason.Restart, notebookDocument);
-                this.restarting.resolve();
-            } catch (ex) {
-                this.restarting.reject(ex);
-            } finally {
-                this.restarting = undefined;
-            }
-        }
+        traceInfo(`Restart requested ${notebookDocument.uri}`);
+        this.startCancellation.cancel();
+        const restartPromise = this.kernelExecution.restart(notebookDocument, this._notebookPromise);
+        await restartPromise;
+
+        // Indicate a restart occurred if it succeeds
+        this._onRestarted.fire();
     }
     private async trackNotebookCellPerceivedColdTime(
         stopWatch: StopWatch,
@@ -325,10 +320,6 @@ export class Kernel implements IKernel {
                 traceInfo(`Kernel got disposed as a result of notebook.onDisposed ${this.notebookUri.toString()}`);
                 this._notebookPromise = undefined;
                 this._onDisposed.fire();
-            });
-            this.notebook.onKernelRestarted(() => {
-                traceInfo(`Notebook Kernel restarted ${this.notebook?.identity}`);
-                this._onRestarted.fire();
             });
             this.notebook.onSessionStatusChanged(
                 (e) => {

--- a/src/client/datascience/jupyter/kernels/kernelExecution.ts
+++ b/src/client/datascience/jupyter/kernels/kernelExecution.ts
@@ -26,8 +26,8 @@ export class KernelExecution implements IDisposable {
     private readonly documentExecutions = new WeakMap<NotebookDocument, CellExecutionQueue>();
     private readonly executionFactory: CellExecutionFactory;
     private readonly disposables: IDisposable[] = [];
-    private readonly kernelRestartHandlerAdded = new WeakSet<IKernel>();
     private _interruptPromise?: Promise<InterruptResult>;
+    private _restartPromise?: Promise<void>;
     constructor(
         private readonly kernelProvider: IKernelProvider,
         errorHandler: IDataScienceErrorHandler,
@@ -47,6 +47,12 @@ export class KernelExecution implements IDisposable {
             return;
         }
         sendKernelTelemetryEvent(cell.notebook.uri, Telemetry.ExecuteNativeCell);
+
+        // If we're restarting, wait for it to finish
+        if (this._restartPromise) {
+            await this._restartPromise;
+        }
+
         const executionQueue = this.getOrCreateCellExecutionQueue(cell.notebook, notebookPromise);
         executionQueue.queueCell(cell);
         await executionQueue.waitForCompletion([cell]);
@@ -56,6 +62,12 @@ export class KernelExecution implements IDisposable {
     @captureTelemetry(VSCodeNativeTelemetry.RunAllCells, undefined, true)
     public async executeAllCells(notebookPromise: Promise<INotebook>, document: NotebookDocument): Promise<void> {
         sendKernelTelemetryEvent(document.uri, Telemetry.ExecuteNativeCell);
+
+        // If we're restarting, wait for it to finish
+        if (this._restartPromise) {
+            await this._restartPromise;
+        }
+
         // Only run code cells that are not already running.
         const cellsThatWeCanRun = document.getCells().filter((cell) => cell.kind === NotebookCellKind.Code);
         if (cellsThatWeCanRun.length === 0) {
@@ -111,6 +123,40 @@ export class KernelExecution implements IDisposable {
 
         return result;
     }
+    /**
+     * Restarts the kernel
+     * If we don't have a kernel (Jupyter Session) available, then just abort all of the cell executions.
+     */
+    public async restart(document: NotebookDocument, notebookPromise?: Promise<INotebook>): Promise<void> {
+        trackKernelResourceInformation(document.uri, { restartKernel: true });
+        const executionQueue = this.documentExecutions.get(document);
+        if (!executionQueue) {
+            return;
+        }
+        // Possible we don't have a notebook.
+        const notebook = notebookPromise ? await notebookPromise.catch(() => undefined) : undefined;
+        traceInfo('Restart kernel execution');
+        // First cancel all the cells & then wait for them to complete.
+        // Both must happen together, we cannot just wait for cells to complete, as its possible
+        // that cell1 has started & cell2 has been queued. If Cell1 completes, then Cell2 will start.
+        // What we want is, if Cell1 completes then Cell2 should not start (it must be cancelled before hand).
+        const pendingCells = executionQueue.cancel().then(() => executionQueue.waitForCompletion());
+
+        if (!notebook) {
+            traceInfo('No notebook to interrupt');
+            this._restartPromise = undefined;
+            await pendingCells;
+            return;
+        }
+
+        // Restart the active execution
+        await (this._restartPromise
+            ? this._restartPromise
+            : (this._restartPromise = this.restartExecution(document, notebook.session)));
+
+        // Done restarting, clear restart promise
+        this._restartPromise = undefined;
+    }
     public dispose() {
         this.disposables.forEach((d) => d.dispose());
     }
@@ -122,9 +168,7 @@ export class KernelExecution implements IDisposable {
         }
 
         // We need to add the handler to kernel immediately (before we resolve the notebook, else its possible user hits restart or the like and we miss that event).
-        const wrappedNotebookPromise = this.getKernel(document)
-            .then((kernel) => this.addKernelRestartHandler(kernel, document))
-            .then(() => notebookPromise);
+        const wrappedNotebookPromise = this.getKernel(document).then(() => notebookPromise);
 
         const newCellExecutionQueue = new CellExecutionQueue(
             wrappedNotebookPromise,
@@ -221,27 +265,16 @@ export class KernelExecution implements IDisposable {
             return result;
         });
     }
-    private addKernelRestartHandler(kernel: IKernel, document: NotebookDocument) {
-        if (this.kernelRestartHandlerAdded.has(kernel)) {
-            return;
-        }
-        this.kernelRestartHandlerAdded.add(kernel);
-        traceInfo('Hooked up kernel restart handler');
-        kernel.onRestarted(
-            () => {
-                // We're only interested in restarts of the kernel associated with this document.
-                const executionQueue = this.documentExecutions.get(document);
-                if (kernel !== this.kernelProvider.get(document) || !executionQueue) {
-                    return;
-                }
 
-                traceInfo('Cancel all executions as Kernel was restarted');
-                return executionQueue.cancel(true);
-            },
-            this,
-            this.disposables
-        );
+    @captureTelemetry(Telemetry.RestartKernel)
+    @captureTelemetry(Telemetry.RestartJupyterTime)
+    private async restartExecution(_document: NotebookDocument, session: IJupyterSession): Promise<void> {
+        // Just use the internal session. Pending cells should have been canceled by the caller
+        return session.restart(this.interruptTimeout).catch((exc) => {
+            traceWarning(`Error during restart: ${exc}`);
+        });
     }
+
     private async getKernel(document: NotebookDocument): Promise<IKernel> {
         let kernel = this.kernelProvider.get(document);
         if (!kernel) {

--- a/src/test/datascience/notebook/interruptRestart.vscode.test.ts
+++ b/src/test/datascience/notebook/interruptRestart.vscode.test.ts
@@ -32,8 +32,7 @@ import {
     waitForExecutionInProgress,
     waitForExecutionCompletedSuccessfully,
     waitForQueuedForExecution,
-    runCell,
-    assertNotHasTextOutputInVSCode
+    runCell
 } from './helper';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, no-invalid-this,  */
@@ -238,23 +237,14 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
         const waitForKernelToRestart = createEventHandler(kernel, 'onRestarted', disposables);
         await commands.executeCommand('jupyter.notebookeditor.restartkernel').then(noop, noop);
 
-        await waitForCondition(
-            async () => {
-                traceCellMessage(cell, 'Step 8 Cell Status');
-                return assertVSCCellIsNotRunning(cell);
-            },
-            15_000,
-            'Execution not cancelled first time.'
-        );
-
         // Wait for kernel to restart before we execute cells again.
-        traceInfo('Step 9 Wait for restart');
+        traceInfo('Step 8 Wait for restart');
         await waitForKernelToRestart.assertFired(15_000);
-        traceInfo('Step 10 Restarted');
+        traceInfo('Step 9 Restarted');
 
         // Confirm last cell is empty
-        const lastCell = vscEditor.document.cellAt(1);
-        assertNotHasTextOutputInVSCode(lastCell, '3', 2, false);
+        const lastCell = vscEditor.document.cellAt(2);
+        assert.equal(lastCell.outputs.length, 0, 'Last cell should not have run');
     });
     test('Interrupt and running cells again should only run the necessary cells', async function () {
         // Interrupts on windows doesn't work well, not as well as on Unix.

--- a/src/test/datascience/notebook/interruptRestart.vscode.test.ts
+++ b/src/test/datascience/notebook/interruptRestart.vscode.test.ts
@@ -156,15 +156,6 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
         const waitForKernelToRestart = createEventHandler(kernel, 'onRestarted', disposables);
         await commands.executeCommand('jupyter.notebookeditor.restartkernel').then(noop, noop);
 
-        await waitForCondition(
-            async () => {
-                traceCellMessage(cell, 'Step 8 Cell Status');
-                return assertVSCCellIsNotRunning(cell);
-            },
-            15_000,
-            'Execution not cancelled first time.'
-        );
-
         // Wait for kernel to restart before we execute cells again.
         traceInfo('Step 9 Wait for restart');
         await waitForKernelToRestart.assertFired(15_000);

--- a/src/test/datascience/notebook/interruptRestart.vscode.test.ts
+++ b/src/test/datascience/notebook/interruptRestart.vscode.test.ts
@@ -13,7 +13,6 @@ import { DataScience } from '../../../client/common/utils/localize';
 import { noop } from '../../../client/common/utils/misc';
 import { Commands } from '../../../client/datascience/constants';
 import { IKernelProvider } from '../../../client/datascience/jupyter/kernels/types';
-import { traceCellMessage } from '../../../client/datascience/notebook/helpers/helpers';
 import { INotebookEditorProvider } from '../../../client/datascience/types';
 import { createEventHandler, getOSType, IExtensionTestApi, OSType, waitForCondition } from '../../common';
 import { IS_REMOTE_NATIVE_TEST } from '../../constants';

--- a/src/test/datascience/notebook/interruptRestart.vscode.test.ts
+++ b/src/test/datascience/notebook/interruptRestart.vscode.test.ts
@@ -198,7 +198,7 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
         traceInfo('Step 1');
         await insertCodeCell('print(1)', { index: 0 });
         await insertCodeCell('import time\nprint(2)\ntime.sleep(60)', { index: 1 });
-        await insertCodeCell('print(3)', { index: 0 });
+        await insertCodeCell('print(3)', { index: 2 });
         const cell = vscEditor.document.cellAt(1);
         // Ensure we click `Yes` when prompted to restart the kernel.
         const appShell = api.serviceContainer.get<IApplicationShell>(IApplicationShell);

--- a/src/test/datascience/notebook/interruptRestart.vscode.test.ts
+++ b/src/test/datascience/notebook/interruptRestart.vscode.test.ts
@@ -157,7 +157,7 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
 
         // Wait for kernel to restart before we execute cells again.
         traceInfo('Step 9 Wait for restart');
-        await waitForKernelToRestart.assertFired(15_000);
+        await waitForKernelToRestart.assertFired(30_000);
         traceInfo('Step 10 Restarted');
 
         // Confirm we can execute a cell (using the new kernel session).
@@ -229,7 +229,7 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
 
         // Wait for kernel to restart before we execute cells again.
         traceInfo('Step 8 Wait for restart');
-        await waitForKernelToRestart.assertFired(15_000);
+        await waitForKernelToRestart.assertFired(30_000);
         traceInfo('Step 9 Restarted');
 
         // Confirm last cell is empty


### PR DESCRIPTION
Fixes: #5996 

Root cause is the mechanism for how restart works was not signalling the cell execution. Refactored how we do restart to match how we do interrrupt.