### PR TITLE
Move export button to `notebook/toolbar` overflow menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -942,7 +942,7 @@
                 },
                 {
                     "command": "jupyter.notebookeditor.export",
-                    "group": "navigation@2",
+                    "group": "Jupyter",
                     "when": "notebookType == 'jupyter-notebook' && isWorkspaceTrusted"
                 },
                 {


### PR DESCRIPTION
For https://github.com/microsoft/vscode-jupyter/issues/6845