### PR TITLE
Add banner to custom editor

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -506,5 +506,5 @@
     "DataScience.kernelWasNotStarted": "Kernel was not started. A kernel session is needed to start debugging.",
     "DataScience.noNotebookToDebug": "No active notebook document to debug.",
     "DataScience.cantStartDebugging": "Can't start debugging.",
-    "DataScience.customEditorBanner": "This notebook interface will be updated after the 1.59 build of Visual Studio Code.  [Read the blog post for more information](https://aka.ms/vscodeNotebookEditorBanner). "
+    "DataScience.customEditorBanner": "This notebook interface will be updated and the old version will no longer be available after the 1.59 build of Visual Studio Code.  [Read the blog post for more information](https://aka.ms/vscodeNotebookEditorBanner). "
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -506,5 +506,5 @@
     "DataScience.kernelWasNotStarted": "Kernel was not started. A kernel session is needed to start debugging.",
     "DataScience.noNotebookToDebug": "No active notebook document to debug.",
     "DataScience.cantStartDebugging": "Can't start debugging.",
-    "DataScience.customEditorBanner": "This notebook interface will be updated after the 1.59 build of Visual Studio Code.  [More Information](https://aka.ms/vscodeNotebookEditorBanner). "
+    "DataScience.customEditorBanner": "This notebook interface will be updated after the 1.59 build of Visual Studio Code.  [Read the blog post](https://aka.ms/vscodeNotebookEditorBanner). "
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -505,5 +505,6 @@
     "DataScience.interactiveGoToCode": "Go to code",
     "DataScience.kernelWasNotStarted": "Kernel was not started. A kernel session is needed to start debugging.",
     "DataScience.noNotebookToDebug": "No active notebook document to debug.",
-    "DataScience.cantStartDebugging": "Can't start debugging."
+    "DataScience.cantStartDebugging": "Can't start debugging.",
+    "DataScience.customEditorBanner": "This notebook interface will be updated after the 1.59 build of Visual Studio Code.  [More Information](https://aka.ms/vscodeNotebookEditorBanner). "
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -506,5 +506,5 @@
     "DataScience.kernelWasNotStarted": "Kernel was not started. A kernel session is needed to start debugging.",
     "DataScience.noNotebookToDebug": "No active notebook document to debug.",
     "DataScience.cantStartDebugging": "Can't start debugging.",
-    "DataScience.customEditorBanner": "This notebook interface will be updated after the 1.59 build of Visual Studio Code.  [Read the blog post](https://aka.ms/vscodeNotebookEditorBanner). "
+    "DataScience.customEditorBanner": "This notebook interface will be updated after the 1.59 build of Visual Studio Code.  [Read the blog post for more information](https://aka.ms/vscodeNotebookEditorBanner). "
 }

--- a/src/datascience-ui/interactive-common/common.css
+++ b/src/datascience-ui/interactive-common/common.css
@@ -13,9 +13,10 @@ html {
     background: var(--override-background, var(--vscode-editor-background));
     color: var(--override-foreground, var(--vscode-editor-foreground));
     display: grid;
-    grid-template-rows: auto auto 1fr auto;
+    grid-template-rows: auto auto auto 1fr auto;
     grid-template-columns: 1fr;
     grid-template-areas:
+        'banner'
         'toolbar'
         'variable'
         'content'

--- a/src/datascience-ui/native-editor/nativeEditor.less
+++ b/src/datascience-ui/native-editor/nativeEditor.less
@@ -1,6 +1,22 @@
 /* Import common styles and then override them below */
 @import '../interactive-common/common.css';
 
+.custom-editor-banner {
+    border-width: 1px;
+    border-style: solid;
+    border-color: var(--override-badge-background, var(--vscode-badge-background));
+    color: var(--vscode-inputValidation-warningForeground, --vscode-foreground);
+    text-align: center;
+    overflow: hidden;
+    margin: 2px;
+    background-color: var(--vscode-inputValidation-warningBackground);
+    grid-area: banner;
+}
+
+.custom-editor-banner a {
+    color: var(--vscode-textLink-foreground);
+}
+
 .toolbar-panel-button {
     border-width: 1px;
     border-style: solid;

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -109,7 +109,7 @@ export class NativeEditor extends React.Component<INativeEditorProps> {
 ${buildSettingsCss(this.props.settings)}`}</style>
                 </div>
                 <div className="custom-editor-banner">
-                    <BannerTransform data={getLocString('DataScience.customEditorBanner', 'This is going away')}/>
+                    <BannerTransform data={getLocString('DataScience.customEditorBanner', 'This is going away')} />
                 </div>
                 <header ref={this.mainPanelToolbarRef} id="main-panel-toolbar">
                     {this.renderToolbarPanel()}

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -16,6 +16,7 @@ import {
     IMainState
 } from '../interactive-common/mainState';
 import { IMainWithVariables, IStore } from '../interactive-common/redux/store';
+import { getTransform } from '../interactive-common/transforms';
 import { IVariablePanelProps, VariablePanel } from '../interactive-common/variablePanel';
 import { getOSType } from '../react-common/constants';
 import { ErrorBoundary } from '../react-common/errorBoundary';
@@ -98,11 +99,17 @@ export class NativeEditor extends React.Component<INativeEditorProps> {
                 />
             );
 
+        // Use markdown to render the banner
+        const BannerTransform = getTransform('text/markdown');
+
         return (
             <div id="main-panel" role="Main" style={dynamicFont}>
                 <div className="styleSetter">
                     <style>{`${this.props.rootCss ? this.props.rootCss : ''}
 ${buildSettingsCss(this.props.settings)}`}</style>
+                </div>
+                <div className="custom-editor-banner">
+                    <BannerTransform data={getLocString('DataScience.customEditorBanner', 'This is going away')}/>
                 </div>
                 <header ref={this.mainPanelToolbarRef} id="main-panel-toolbar">
                     {this.renderToolbarPanel()}


### PR DESCRIPTION
Show this banner when opening a custom editor. We're deprecating the custom editor in 1.60 release.

![image](https://user-images.githubusercontent.com/19672699/127391578-527ed630-a51b-4f3e-b353-311afb9f94a5.png)
