### PR TITLE
Don't hide #%% codelenses when a native notebook is active

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -785,7 +785,6 @@ module.exports = {
         'src/client/datascience/ipywidgets/ipywidgetHandler.ts',
         'src/client/datascience/multiplexingDebugService.ts',
         'src/client/datascience/interactive-window/identity.ts',
-        'src/client/datascience/datascience.ts',
         'src/client/datascience/liveshare/liveshare.ts',
         'src/client/datascience/liveshare/serviceProxy.ts',
         'src/client/datascience/liveshare/liveshareProxy.ts',

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -3,11 +3,10 @@ export const MARKDOWN_LANGUAGE = 'markdown';
 export const JUPYTER_LANGUAGE = 'jupyter';
 
 export const NotebookCellScheme = 'vscode-notebook-cell';
-export const PYTHON = [
-    { scheme: 'file', language: PYTHON_LANGUAGE },
-    { scheme: 'untitled', language: PYTHON_LANGUAGE },
-    { scheme: NotebookCellScheme, language: PYTHON_LANGUAGE }
-];
+export const PYTHON_UNTITLED = { scheme: 'untitled', language: PYTHON_LANGUAGE };
+export const PYTHON_FILE = { scheme: 'file', language: PYTHON_LANGUAGE };
+export const PYTHON_CELL = { scheme: NotebookCellScheme, language: PYTHON_LANGUAGE };
+export const PYTHON = [PYTHON_UNTITLED, PYTHON_FILE, PYTHON_CELL];
 export const PYTHON_ALLFILES = [{ language: PYTHON_LANGUAGE }];
 export const GITHUB_ISSUE_MARKDOWN_FILE = [{ language: MARKDOWN_LANGUAGE, scheme: 'untitled', pattern: '**/issue.md' }];
 

--- a/src/client/datascience/datascience.ts
+++ b/src/client/datascience/datascience.ts
@@ -5,7 +5,7 @@ import type { JSONObject } from '@phosphor/coreutils';
 import { inject, injectable } from 'inversify';
 import * as vscode from 'vscode';
 import { ICommandManager, IDocumentManager, IWorkspaceService } from '../common/application/types';
-import { PYTHON_ALLFILES, PYTHON_LANGUAGE } from '../common/constants';
+import { PYTHON_FILE, PYTHON_LANGUAGE, PYTHON_UNTITLED } from '../common/constants';
 import { ContextKey } from '../common/contextKey';
 import '../common/extensions';
 import { IConfigurationService, IDisposable, IDisposableRegistry, IExtensionContext } from '../common/types';
@@ -42,7 +42,7 @@ export class DataScience implements IDataScience {
         this.commandRegistry.register();
 
         this.extensionContext.subscriptions.push(
-            vscode.languages.registerCodeLensProvider(PYTHON_ALLFILES, this.dataScienceCodeLensProvider)
+            vscode.languages.registerCodeLensProvider([PYTHON_FILE, PYTHON_UNTITLED], this.dataScienceCodeLensProvider)
         );
 
         // Set our initial settings and sign up for changes

--- a/src/client/datascience/datascience.ts
+++ b/src/client/datascience/datascience.ts
@@ -10,6 +10,7 @@ import { ContextKey } from '../common/contextKey';
 import '../common/extensions';
 import { IConfigurationService, IDisposable, IDisposableRegistry, IExtensionContext } from '../common/types';
 import { debounceAsync, swallowExceptions } from '../common/utils/decorators';
+import { noop } from '../common/utils/misc';
 import { sendTelemetryEvent } from '../telemetry';
 import { hasCells } from './cellFactory';
 import { CommandRegistry } from './commands/commandRegistry';
@@ -71,7 +72,7 @@ export class DataScience implements IDataScience {
         const settings = this.configuration.getSettings(undefined);
         const ownsSelection = settings.sendSelectionToInteractiveWindow;
         const editorContext = new ContextKey(EditorContexts.OwnsSelection, this.commandManager);
-        editorContext.set(ownsSelection).catch();
+        void editorContext.set(ownsSelection).catch(noop);
     };
 
     private onChangedActiveTextEditor() {
@@ -82,9 +83,9 @@ export class DataScience implements IDataScience {
         if (activeEditor && activeEditor.document.languageId === PYTHON_LANGUAGE) {
             // Inform the editor context that we have cells, fire and forget is ok on the promise here
             // as we don't care to wait for this context to be set and we can't do anything if it fails
-            editorContext.set(hasCells(activeEditor.document, this.configuration.getSettings())).catch();
+            void editorContext.set(hasCells(activeEditor.document, this.configuration.getSettings())).catch(noop);
         } else {
-            editorContext.set(false).catch();
+            void editorContext.set(false).catch(noop);
         }
     }
 

--- a/src/client/datascience/editor-integration/codelensprovider.ts
+++ b/src/client/datascience/editor-integration/codelensprovider.ts
@@ -5,7 +5,6 @@ import { inject, injectable } from 'inversify';
 import * as vscode from 'vscode';
 
 import { ICommandManager, IDebugService, IDocumentManager, IWorkspaceService } from '../../common/application/types';
-import { NotebookCellScheme } from '../../common/constants';
 import { ContextKey } from '../../common/contextKey';
 import { disposeAllDisposables } from '../../common/helpers';
 import { IFileSystem } from '../../common/platform/types';
@@ -65,10 +64,6 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
     // CodeLensProvider interface
     // Some implementation based on DonJayamanne's jupyter extension work
     public provideCodeLenses(document: vscode.TextDocument, _token: vscode.CancellationToken): vscode.CodeLens[] {
-        // Don't show codelenses for notebook cells
-        if (document.uri.scheme === NotebookCellScheme) {
-            return [];
-        }
         // Get the list of code lens for this document.
         return this.getCodeLensTimed(document);
     }

--- a/src/client/datascience/editor-integration/codelensprovider.ts
+++ b/src/client/datascience/editor-integration/codelensprovider.ts
@@ -4,13 +4,8 @@
 import { inject, injectable } from 'inversify';
 import * as vscode from 'vscode';
 
-import {
-    ICommandManager,
-    IDebugService,
-    IDocumentManager,
-    IVSCodeNotebook,
-    IWorkspaceService
-} from '../../common/application/types';
+import { ICommandManager, IDebugService, IDocumentManager, IWorkspaceService } from '../../common/application/types';
+import { NotebookCellScheme } from '../../common/constants';
 import { ContextKey } from '../../common/contextKey';
 import { disposeAllDisposables } from '../../common/helpers';
 import { IFileSystem } from '../../common/platform/types';
@@ -38,7 +33,6 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
         @inject(IDisposableRegistry) disposableRegistry: IDisposableRegistry,
         @inject(IDebugService) private debugService: IDebugService,
         @inject(IFileSystem) private fs: IFileSystem,
-        @inject(IVSCodeNotebook) private readonly vsCodeNotebook: IVSCodeNotebook,
         @inject(IWorkspaceService) workspace: IWorkspaceService
     ) {
         disposableRegistry.push(this);
@@ -71,14 +65,10 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
     // CodeLensProvider interface
     // Some implementation based on DonJayamanne's jupyter extension work
     public provideCodeLenses(document: vscode.TextDocument, _token: vscode.CancellationToken): vscode.CodeLens[] {
-        try {
-            if (this.vsCodeNotebook.activeNotebookEditor) {
-                return [];
-            }
-        } catch {
-            // If vscodenote book fails, just ignore
+        // Don't show codelenses for notebook cells
+        if (document.uri.scheme === NotebookCellScheme) {
+            return [];
         }
-
         // Get the list of code lens for this document.
         return this.getCodeLensTimed(document);
     }

--- a/src/test/datascience/editor-integration/codelensprovider.unit.test.ts
+++ b/src/test/datascience/editor-integration/codelensprovider.unit.test.ts
@@ -123,33 +123,6 @@ suite('DataScienceCodeLensProvider Unit Tests', () => {
         targetCodeWatcher.verifyAll();
         serviceContainer.verifyAll();
     });
-    test('Should not Initialize Code Lenses when a Native Notebook is open', async () => {
-        // Create our document
-        const document = TypeMoq.Mock.ofType<TextDocument>();
-        document.setup((d) => d.fileName).returns(() => 'test.py');
-        document.setup((d) => d.version).returns(() => 1);
-        vscodeNotebook.reset();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        vscodeNotebook.setup((c) => c.activeNotebookEditor).returns(() => ({} as any));
-
-        const targetCodeWatcher = TypeMoq.Mock.ofType<ICodeWatcher>();
-        targetCodeWatcher
-            .setup((tc) => tc.getCodeLenses())
-            .returns(() => [])
-            .verifiable(TypeMoq.Times.never());
-        serviceContainer
-            .setup((c) => c.get(TypeMoq.It.isValue(ICodeWatcher)))
-            .returns(() => targetCodeWatcher.object)
-            .verifiable(TypeMoq.Times.never());
-        documentManager.setup((d) => d.textDocuments).returns(() => [document.object]);
-
-        await codeLensProvider.provideCodeLenses(document.object, tokenSource.token);
-        await codeLensProvider.provideCodeLenses(document.object, tokenSource.token);
-
-        // getCodeLenses should be called twice, but getting the code watcher only once due to same doc
-        targetCodeWatcher.verifyAll();
-        serviceContainer.verifyAll();
-    });
 
     test('Initialize Code Lenses new name / version', async () => {
         // Create our document

--- a/src/test/datascience/editor-integration/codelensprovider.unit.test.ts
+++ b/src/test/datascience/editor-integration/codelensprovider.unit.test.ts
@@ -67,7 +67,6 @@ suite('DataScienceCodeLensProvider Unit Tests', () => {
             disposables,
             debugService.object,
             fileSystem.object,
-            vscodeNotebook.object,
             instance(workspace)
         );
     });

--- a/src/test/datascience/editor-integration/codewatcher.unit.test.ts
+++ b/src/test/datascience/editor-integration/codewatcher.unit.test.ts
@@ -12,7 +12,6 @@ import {
     ICommandManager,
     IDebugService,
     IDocumentManager,
-    IVSCodeNotebook,
     IWorkspaceService
 } from '../../../client/common/application/types';
 import { IFileSystem } from '../../../client/common/platform/types';
@@ -75,7 +74,6 @@ suite('DataScience Code Watcher Unit Tests', () => {
     let tokenSource: CancellationTokenSource;
     let debugService: TypeMoq.IMock<IDebugService>;
     let debugLocationTracker: TypeMoq.IMock<IDebugLocationTracker>;
-    let vscodeNotebook: TypeMoq.IMock<IVSCodeNotebook>;
     const contexts: Map<string, boolean> = new Map<string, boolean>();
     const jupyterSettings = new MockJupyterSettings(undefined);
     const disposables: Disposable[] = [];
@@ -92,7 +90,6 @@ suite('DataScience Code Watcher Unit Tests', () => {
         helper = TypeMoq.Mock.ofType<ICodeExecutionHelper>();
         commandManager = TypeMoq.Mock.ofType<ICommandManager>();
         debugService = TypeMoq.Mock.ofType<IDebugService>();
-        vscodeNotebook = TypeMoq.Mock.ofType<IVSCodeNotebook>();
 
         // Setup default settings
         jupyterSettings.assign({
@@ -125,7 +122,6 @@ suite('DataScience Code Watcher Unit Tests', () => {
             interactiveWindowMode: 'single'
         });
         debugService.setup((d) => d.activeDebugSession).returns(() => undefined);
-        vscodeNotebook.setup((d) => d.activeNotebookEditor).returns(() => undefined);
 
         // Setup the service container to return code watchers
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
@@ -976,7 +972,6 @@ testing2`;
             disposables,
             debugService.object,
             fileSystem.object,
-            vscodeNotebook.object,
             instance(workspace)
         );
 


### PR DESCRIPTION
Fix #6882

Don't skip codelenses when there's an active notebook. 

In addition to hiding codelenses when the native interactive window is active, this code also causes interactive codelenses to vanish when an interactive python file is side-by-side with a Jupyter notebook:
![image](https://user-images.githubusercontent.com/30305945/127414797-aeac35ae-81e2-4189-bd7b-541f8e9b7242.png)
