### PR TITLE
Revert work around for not being able to install ipykernel

### DIFF
--- a/src/client/api/pythonApi.ts
+++ b/src/client/api/pythonApi.ts
@@ -12,12 +12,11 @@
 // Licensed under the MIT License.
 
 import { inject, injectable, named } from 'inversify';
-import { CancellationToken, Disposable, env, Event, EventEmitter, Memento, Uri } from 'vscode';
+import { CancellationToken, Disposable, Event, EventEmitter, Memento, Uri } from 'vscode';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../common/application/types';
 import { trackPackageInstalledIntoInterpreter } from '../common/installer/productInstaller';
 import { ProductNames } from '../common/installer/productNames';
 import { InterpreterUri } from '../common/installer/types';
-import { traceWarning } from '../common/logger';
 import {
     GLOBAL_MEMENTO,
     IDisposableRegistry,
@@ -247,15 +246,6 @@ export class PythonInstaller implements IPythonInstaller {
             this.interpreterPackages.trackPackages(resource);
         }
         let action: 'installed' | 'failed' | 'disabled' | 'ignored' = 'installed';
-        if (env.remoteName && reInstallAndUpdate) {
-            // Temporary work around for https://github.com/microsoft/vscode-jupyter/issues/6896
-            traceWarning(
-                `Disabling -U and flag when installing Dependencies in containers for ${ProductNames.get(product)} in ${
-                    isResource(resource) ? resource?.fsPath : resource.path
-                }`
-            );
-            reInstallAndUpdate = false;
-        }
         try {
             const api = await this.apiProvider.getApi();
             const result = await api.install(ProductMapping[product], resource, cancel, reInstallAndUpdate);


### PR DESCRIPTION
For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
