### PR TITLE
Fix interrupt kernel for interactive window

### DIFF
--- a/news/2 Fixes/6983.md
+++ b/news/2 Fixes/6983.md
@@ -1,0 +1,1 @@
+Fix interrupt kernel in native interactive window when executing a #%% cell.

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -509,7 +509,7 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
             );
 
             try {
-                const result = await this.kernel.interrupt(notebookEditor.document);
+                const result = await this.kernel.interruptInteractiveKernel(notebookEditor.document);
                 status.dispose();
 
                 // We timed out, ask the user if they want to restart instead.

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -155,6 +155,23 @@ export class Kernel implements IKernel {
         await interruptResultPromise;
         return interruptResultPromise;
     }
+    /**
+     * This is a temporary method to support interrupting kernels when code cells are executed
+     * outside of the kernelExecution/cellExecution codepath. Do not use!
+     * Should be identical to interrupt method, except for calling into interruptInteractiveKernel.
+     */
+    public async interruptInteractiveKernel(document: NotebookDocument): Promise<InterruptResult> {
+        if (this.restarting) {
+            traceInfo(`Interrupt requested & currently restarting ${document.uri}`);
+            trackKernelResourceInformation(document.uri, { interruptKernel: true });
+            await this.restarting.promise;
+        }
+        traceInfo(`Interrupt requested ${document.uri}`);
+        this.startCancellation.cancel();
+        const interruptResultPromise = this.kernelExecution.interruptInteractiveKernel(document, this._notebookPromise);
+        await interruptResultPromise;
+        return interruptResultPromise;
+    }
     public async dispose(): Promise<void> {
         traceInfo(`Dispose kernel ${this.notebookUri.toString()}`);
         this.restarting = undefined;

--- a/src/client/datascience/jupyter/kernels/kernelExecution.ts
+++ b/src/client/datascience/jupyter/kernels/kernelExecution.ts
@@ -87,6 +87,35 @@ export class KernelExecution implements IDisposable {
             traceInfo('Restore notebook state to idle after completion');
         }
     }
+
+    /**
+     * This is a temporary method to support interrupting kernels when code cells are executed
+     * outside of the kernelExecution/cellExecution codepath. Do not use!
+     */
+    public async interruptInteractiveKernel(document: NotebookDocument, notebookPromise?: Promise<INotebook>): Promise<InterruptResult> {
+        const notebook = notebookPromise ? await notebookPromise.catch(() => undefined) : undefined;
+        if (!notebook) {
+            traceInfo('No notebook to interrupt');
+            this._interruptPromise = undefined;
+            return InterruptResult.Success;
+        }
+        const executionQueue = this.documentExecutions.get(document);
+        // First cancel all the cells & then wait for them to complete.
+        // Both must happen together, we cannot just wait for cells to complete, as its possible
+        // that cell1 has started & cell2 has been queued. If Cell1 completes, then Cell2 will start.
+        // What we want is, if Cell1 completes then Cell2 should not start (it must be cancelled before hand).
+        const pendingCells = executionQueue === undefined ? createDeferred().promise : executionQueue.cancel().then(() => executionQueue.waitForCompletion());
+        // Interrupt the active execution
+        const result = this._interruptPromise
+            ? await this._interruptPromise
+            : await (this._interruptPromise = this.interruptExecution(document, notebook.session, pendingCells));
+
+        // Done interrupting, clear interrupt promise
+        this._interruptPromise = undefined;
+
+        return result;
+    }
+
     /**
      * Interrupts the execution of cells.
      * If we don't have a kernel (Jupyter Session) available, then just abort all of the cell executions.

--- a/src/client/datascience/jupyter/kernels/kernelExecution.ts
+++ b/src/client/datascience/jupyter/kernels/kernelExecution.ts
@@ -92,7 +92,10 @@ export class KernelExecution implements IDisposable {
      * This is a temporary method to support interrupting kernels when code cells are executed
      * outside of the kernelExecution/cellExecution codepath. Do not use!
      */
-    public async interruptInteractiveKernel(document: NotebookDocument, notebookPromise?: Promise<INotebook>): Promise<InterruptResult> {
+    public async interruptInteractiveKernel(
+        document: NotebookDocument,
+        notebookPromise?: Promise<INotebook>
+    ): Promise<InterruptResult> {
         const notebook = notebookPromise ? await notebookPromise.catch(() => undefined) : undefined;
         if (!notebook) {
             traceInfo('No notebook to interrupt');
@@ -104,7 +107,10 @@ export class KernelExecution implements IDisposable {
         // Both must happen together, we cannot just wait for cells to complete, as its possible
         // that cell1 has started & cell2 has been queued. If Cell1 completes, then Cell2 will start.
         // What we want is, if Cell1 completes then Cell2 should not start (it must be cancelled before hand).
-        const pendingCells = executionQueue === undefined ? createDeferred().promise : executionQueue.cancel().then(() => executionQueue.waitForCompletion());
+        const pendingCells =
+            executionQueue === undefined
+                ? createDeferred().promise
+                : executionQueue.cancel().then(() => executionQueue.waitForCompletion());
         // Interrupt the active execution
         const result = this._interruptPromise
             ? await this._interruptPromise

--- a/src/client/datascience/jupyter/kernels/types.ts
+++ b/src/client/datascience/jupyter/kernels/types.ts
@@ -143,6 +143,7 @@ export interface IKernel extends IAsyncDisposable {
     readonly notebook?: INotebook;
     start(options?: { disableUI?: boolean; document: NotebookDocument }): Promise<void>;
     interrupt(document: NotebookDocument): Promise<InterruptResult>;
+    interruptInteractiveKernel(document: NotebookDocument): Promise<InterruptResult>;
     restart(document: NotebookDocument): Promise<void>;
     executeCell(cell: NotebookCell): Promise<void>;
     executeAllCells(document: NotebookDocument): Promise<void>;

--- a/src/client/datascience/notebook/vscodeNotebookController.ts
+++ b/src/client/datascience/notebook/vscodeNotebookController.ts
@@ -414,7 +414,7 @@ export class VSCodeNotebookController implements Disposable {
     private async setAsActiveControllerForTests(notebook: NotebookDocument) {
         // Only when running tests should we force the selection of the kernel.
         // Else the general VS Code behavior is for the user to select a kernel (here we make it look as though use selected it).
-        if (this.context.extensionMode !== ExtensionMode.Test) {
+        if (this.context.extensionMode !== ExtensionMode.Test || notebook.notebookType === InteractiveWindowView) {
             return;
         }
         traceInfoIf(isCI, `Command notebook.selectKernel executing for ${notebook.uri.toString()} ${this.id}`);


### PR DESCRIPTION
Discussed with @DonJayamanne  and while https://github.com/microsoft/vscode-jupyter/pull/7067 is the right fix, it's too risky for the recovery build and would also break the webview interactive window). Since #6983 is a recovery build candidate, this PR is a temporary workaround for the root cause (which is that the interactive window uses executeObservable and that results in the IKernel not being aware of cells executed that way when doing IKernel.interrupt)