### PR TITLE
Temporary fix for missing kernel initialization after restarting kernel

### DIFF
--- a/news/2 Fixes/7016.md
+++ b/news/2 Fixes/7016.md
@@ -1,0 +1,1 @@
+Reinitialize kernels after a restart, including resetting current working directory and rerunning startup commands.

--- a/news/2 Fixes/7081.md
+++ b/news/2 Fixes/7081.md
@@ -1,0 +1,1 @@
+Fix restart kernel in native interactive window when executing a #%% cell.

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -525,10 +525,7 @@ export class JupyterNotebookBase implements INotebook {
             await this.session.restart(timeoutMs);
 
             // Rerun our initial setup for the notebook
-            this.ranInitialSetup = false;
-            traceInfo('restartKernel - initialSetup');
-            await this.initialize();
-            traceInfo('restartKernel - initialSetup completed');
+            await this.runInitialSetup();
 
             // Tell our loggers
             this.loggers.forEach((l) => l.onKernelRestarted(this.getNotebookId()));
@@ -538,6 +535,13 @@ export class JupyterNotebookBase implements INotebook {
         }
 
         throw this.getDisposedError();
+    }
+
+    public async runInitialSetup() {
+        this.ranInitialSetup = false;
+        traceInfo('restartKernel - initialSetup');
+        await this.initialize();
+        traceInfo('restartKernel - initialSetup completed');
     }
 
     @captureTelemetry(Telemetry.InterruptJupyterTime)

--- a/src/client/datascience/jupyter/kernels/kernelExecution.ts
+++ b/src/client/datascience/jupyter/kernels/kernelExecution.ts
@@ -159,9 +159,7 @@ export class KernelExecution implements IDisposable {
         }
 
         // Restart the active execution
-        await (this._restartPromise
-            ? this._restartPromise
-            : (this._restartPromise = this.restartExecution(document, notebook.session)));
+        await (this._restartPromise ? this._restartPromise : (this._restartPromise = this.restartExecution(notebook)));
 
         // Done restarting, clear restart promise
         this._restartPromise = undefined;
@@ -277,11 +275,14 @@ export class KernelExecution implements IDisposable {
 
     @captureTelemetry(Telemetry.RestartKernel)
     @captureTelemetry(Telemetry.RestartJupyterTime)
-    private async restartExecution(_document: NotebookDocument, session: IJupyterSession): Promise<void> {
+    private async restartExecution(notebook: INotebook): Promise<void> {
         // Just use the internal session. Pending cells should have been canceled by the caller
-        return session.restart(this.interruptTimeout).catch((exc) => {
+        await notebook.session.restart(this.interruptTimeout).catch((exc) => {
             traceWarning(`Error during restart: ${exc}`);
         });
+
+        // Reinitialize the kernel after a session restart
+        await notebook.runInitialSetup();
     }
 
     private async getKernel(document: NotebookDocument): Promise<IKernel> {

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -203,6 +203,7 @@ export interface INotebook extends IAsyncDisposable {
         cancelToken?: CancellationToken
     ): Promise<INotebookCompletion>;
     restartKernel(timeoutInMs: number): Promise<void>;
+    runInitialSetup(): Promise<void>;
     waitForIdle(timeoutInMs: number): Promise<void>;
     interruptKernel(timeoutInMs: number): Promise<InterruptResult>;
     setLaunchingFile(file: string): Promise<void>;

--- a/src/test/datascience/mockJupyterNotebook.ts
+++ b/src/test/datascience/mockJupyterNotebook.ts
@@ -93,6 +93,9 @@ export class MockJupyterNotebook implements INotebook {
     public clear(_id: string): void {
         noop();
     }
+    public async runInitialSetup(): Promise<void> {
+        noop();
+    }
     public executeObservable(_code: string, _f: string, _line: number): Observable<ICell[]> {
         throw new Error('Method not implemented');
     }


### PR DESCRIPTION
This needs to be in Insiders while I'm working on reworking restarting kernels, otherwise when we put out the recovery build users are going to get the fix with the recovery and then get broken again when the next nightly build is published