### PR TITLE
Remove redundant call

### DIFF
--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -364,10 +364,6 @@ export class Kernel implements IKernel {
             traceInfoIf(isCI, 'Step I');
             await this.disableJedi();
             traceInfoIf(isCI, 'Step J');
-            if (this.resourceUri) {
-                await this.notebook.setLaunchingFile(this.resourceUri.fsPath);
-                traceInfoIf(isCI, 'Step K');
-            }
 
             // For Python notebook initialize matplotlib
             await this.initializeMatplotLib();

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -358,7 +358,7 @@ export class Kernel implements IKernel {
         if (isPythonKernelConnection(this.kernelConnectionMetadata)) {
             // Change our initial directory and path
             traceInfoIf(isCI, 'Step D');
-            await this.updateWorkingDirectoryAndPath();
+            await this.updateWorkingDirectoryAndPath(this.resourceUri?.fsPath);
             traceInfoIf(isCI, 'Step H');
 
             traceInfoIf(isCI, 'Step I');

--- a/src/test/telemetry/importTracker.unit.test.ts
+++ b/src/test/telemetry/importTracker.unit.test.ts
@@ -45,7 +45,7 @@ suite('Import Tracker', () => {
             }
 
             Reporter.properties.pop(); // HASHED_PACKAGE_PERF
-            expect(Reporter.properties).to.deep.equal(hashes.map((hash) => ({ hashedName: hash })));
+            expect(Reporter.properties).to.deep.equal(hashes.map((hash) => ({ hashedNamev2: hash })));
         }
 
         public sendTelemetryEvent(eventName: string, properties?: {}, measures?: {}) {


### PR DESCRIPTION
Found that we were executing the same code twice (came across this when adding some logging to identify cause of a flaky test).