### PR TITLE
Add `esc` to clear interactive window input editor contents

### DIFF
--- a/news/2 Fixes/7157.md
+++ b/news/2 Fixes/7157.md
@@ -1,0 +1,1 @@
+Add remappable `esc` keybinding to clear contents of native interactive window input box, bound to `interactive.input.clear` command in VS Code core.

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
             },
             {
                 "key": "escape",
-                "when": "resourceScheme == 'vscode-interactive' && !suggestWidgetVisible",
+                "when": "resourceScheme == 'vscode-interactive' && !editorHoverVisible && !suggestWidgetVisible && !isComposing && !inSnippetMode && !exceptionWidgetVisible && !selectionAnchorSet && !LinkedEditingInputVisible && !renameInputVisible && !editorHasSelection && !accessibilityHelpWidgetVisible && !breakpointWidgetVisible && !findWidgetVisible && !markersNavigationVisible && !parameterHintsVisible && !editorHasMultipleSelections && !notificationToastsVisible",
                 "command": "interactive.input.clear"
             },
             {

--- a/package.json
+++ b/package.json
@@ -198,6 +198,11 @@
                 "command": "interactive.execute"
             },
             {
+                "key": "escape",
+                "when": "resourceScheme == 'vscode-interactive' && !suggestWidgetVisible",
+                "command": "interactive.input.clear"
+            },
+            {
                 "command": "jupyter.insertCellBelowPosition",
                 "key": "ctrl+; s",
                 "when": "editorTextFocus && jupyter.hascodecells && !notebookEditorFocused"


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode-jupyter/issues/7157