### PR TITLE
Fix spec generation to include env

### DIFF
--- a/news/2 Fixes/7186.md
+++ b/news/2 Fixes/7186.md
@@ -1,0 +1,1 @@
+Fixes kernel spec generation (on Mac M1/Non ZMQ supported machines) to include the appropriate environment.

--- a/src/client/datascience/jupyter/kernels/jupyterKernelService.ts
+++ b/src/client/datascience/jupyter/kernels/jupyterKernelService.ts
@@ -69,33 +69,35 @@ export class JupyterKernelService {
             );
         }
 
+        var specFile: string | undefined = undefined;
+
         // If the spec file doesn't exist or is not defined, we need to register this kernel
         if (kernel.kind !== 'connectToLiveKernel' && kernel.kernelSpec && kernel.interpreter) {
-            if (!kernel.kernelSpec.specFile || !(await this.fs.localFileExists(kernel.kernelSpec.specFile))) {
-                await this.registerKernel(kernel, token);
+            // Default to the kernel spec file.
+            specFile = kernel.kernelSpec.specFile;
+
+            if (!specFile || !(await this.fs.localFileExists(specFile))) {
+                specFile = await this.registerKernel(kernel, token);
             }
             // Special case. If the original spec file came from an interpreter, we may need to register a kernel
-            else if (kernel.interpreter && kernel.kernelSpec.specFile) {
+            else if (kernel.interpreter && specFile) {
                 // See if the specfile we started with (which might be the one registered in the interpreter)
                 // doesn't match the name of the spec file
-                if (
-                    path.basename(path.dirname(kernel.kernelSpec.specFile)).toLowerCase() !=
-                    kernel.kernelSpec.name.toLowerCase()
-                ) {
+                if (path.basename(path.dirname(specFile)).toLowerCase() != kernel.kernelSpec.name.toLowerCase()) {
                     // This means the specfile for the kernelspec will not be found by jupyter. We need to
                     // register it
-                    await this.registerKernel(kernel, token);
+                    specFile = await this.registerKernel(kernel, token);
                 }
             }
         }
 
         // Update the kernel environment to use the interpreter's latest
-        if (kernel.kind !== 'connectToLiveKernel' && kernel.kernelSpec && kernel.interpreter) {
+        if (kernel.kind !== 'connectToLiveKernel' && kernel.kernelSpec && kernel.interpreter && specFile) {
             traceInfoIf(
                 isCI,
                 `updateKernelEnvironment ${kernel.interpreter.displayName}, ${kernel.interpreter.path} for ${kernel.id}`
             );
-            await this.updateKernelEnvironment(kernel.interpreter, kernel.kernelSpec, token);
+            await this.updateKernelEnvironment(kernel.interpreter, kernel.kernelSpec, specFile, token);
         }
     }
 
@@ -122,7 +124,7 @@ export class JupyterKernelService {
     private async registerKernel(
         kernel: LocalKernelConnectionMetadata,
         cancelToken?: CancellationToken
-    ): Promise<void> {
+    ): Promise<string | undefined> {
         // Get the global kernel location
         const root = await this.kernelFinder.getKernelSpecRootPath();
 
@@ -136,7 +138,7 @@ export class JupyterKernelService {
 
         // If this file already exists, we can just exit
         if (await this.fs.localFileExists(kernelSpecFilePath)) {
-            return;
+            return kernelSpecFilePath;
         }
 
         // If it doesn't exist, see if we had an original spec file that's different.
@@ -185,20 +187,22 @@ export class JupyterKernelService {
         }
 
         sendTelemetryEvent(Telemetry.RegisterAndUseInterpreterAsKernel);
+        return kernelSpecFilePath;
     }
     private async updateKernelEnvironment(
         interpreter: PythonEnvironment | undefined,
         kernel: IJupyterKernelSpec,
+        specFile: string,
         cancelToken?: CancellationToken,
         forceWrite?: boolean
     ) {
         const kernelSpecRootPath = await this.kernelFinder.getKernelSpecRootPath();
         const specedKernel = kernel as JupyterKernelSpec;
-        if (specedKernel.specFile && kernelSpecRootPath) {
+        if (specFile && kernelSpecRootPath) {
             // Spec file may not be the same as the original spec file path.
-            const kernelSpecFilePath = specedKernel.specFile.includes(specedKernel.name)
-                ? specedKernel.specFile
-                : path.join(kernelSpecRootPath, specedKernel.name, 'kernel.json');
+            const kernelSpecFilePath = specFile.includes(kernel.name)
+                ? specFile
+                : path.join(kernelSpecRootPath, kernel.name, 'kernel.json');
 
             // Make sure the file exists
             if (!(await this.fs.localFileExists(kernelSpecFilePath))) {


### PR DESCRIPTION
Fixes: #7186 - I was looking at this anyway so just decided to fix it.

Root cause was no specFile in the KernelSpec. Likely regressed somewhere. We know the specFile when we register though, so changing code to pass it along then.

Testing for this would have been easy to add in the functional tests. Added another item to https://github.com/microsoft/vscode-jupyter/issues/7028 to cover this scenario.