### PR TITLE
RBL bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1520,7 +1520,8 @@
                         "error",
                         "warn",
                         "info",
-                        "debug"
+                        "debug",
+                        "verbose"
                     ],
                     "description": "The logging level the extension logs at.",
                     "scope": "machine"

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -273,6 +273,9 @@ function convertSettingTypeToLogLevel(setting: LoggingLevelSettingType | undefin
         case 'debug': {
             return LogLevel.Debug;
         }
+        case 'verbose': {
+            return LogLevel.Trace;
+        }
         default: {
             return LogLevel.Error;
         }

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -186,7 +186,7 @@ export interface IWatchableJupyterSettings extends IJupyterSettings {
     readonly onDidChange: Event<void>;
 }
 
-export type LoggingLevelSettingType = 'off' | 'error' | 'warn' | 'info' | 'debug';
+export type LoggingLevelSettingType = 'off' | 'error' | 'warn' | 'info' | 'debug' | 'verbose';
 
 export interface ILoggingSettings {
     readonly level: LogLevel | 'off';

--- a/src/client/datascience/commands/activeEditorContext.ts
+++ b/src/client/datascience/commands/activeEditorContext.ts
@@ -79,6 +79,9 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
             this,
             this.disposables
         );
+        if (this.vscNotebook.activeNotebookEditor) {
+            this.onDidChangeActiveNotebookEditor(this.vscNotebook.activeNotebookEditor);
+        }
         this.vscNotebook.onDidChangeActiveNotebookEditor(this.onDidChangeActiveNotebookEditor, this, this.disposables);
 
         // Do we already have python file opened.

--- a/src/client/debugger/jupyter/kernelDebugAdapter.ts
+++ b/src/client/debugger/jupyter/kernelDebugAdapter.ts
@@ -25,7 +25,7 @@ import * as path from 'path';
 import { IJupyterSession } from '../../datascience/types';
 import { KernelMessage } from '@jupyterlab/services';
 import { ICommandManager } from '../../common/application/types';
-import { traceError } from '../../common/logger';
+import { traceError, traceVerbose } from '../../common/logger';
 import { IFileSystem } from '../../common/platform/types';
 import { IKernelDebugAdapter } from '../types';
 import { IDisposable } from '../../common/types';
@@ -202,6 +202,12 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
             this,
             this.disposables
         );
+
+        this.disposables.push(this.onDidSendMessage((msg) => this.trace('to client', JSON.stringify(msg))));
+    }
+
+    private trace(tag: string, msg: string) {
+        traceVerbose(`[Debug] ${tag}: ${msg}`);
     }
 
     async handleMessage(message: DebugProtocol.ProtocolMessage) {
@@ -342,6 +348,7 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
             }
         });
 
+        this.trace('to kernel', JSON.stringify(message));
         if (message.type === 'request') {
             this.sendMessage.fire(message);
             const request = debugRequest(message as DebugProtocol.Request, this.jupyterSession.sessionId);

--- a/src/client/debugger/jupyter/kernelDebugAdapter.ts
+++ b/src/client/debugger/jupyter/kernelDebugAdapter.ts
@@ -228,10 +228,8 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
         // clean temp files
         this.cellToFile.forEach((tempPath) => {
             const norm = path.normalize(tempPath);
-            const dir = path.dirname(norm);
             try {
                 void this.fs.deleteLocalFile(norm);
-                void this.fs.deleteLocalDirectory(dir);
             } catch {
                 traceError('Error deleting temporary debug files');
             }

--- a/src/client/debugger/jupyter/kernelDebugAdapter.ts
+++ b/src/client/debugger/jupyter/kernelDebugAdapter.ts
@@ -20,7 +20,6 @@ import {
     debug
 } from 'vscode';
 import { DebugProtocol } from 'vscode-debugprotocol';
-import { randomBytes } from 'crypto';
 import * as path from 'path';
 import { IJupyterSession } from '../../datascience/types';
 import { KernelMessage } from '@jupyterlab/services';
@@ -33,53 +32,6 @@ import { Commands } from '../../datascience/constants';
 import { IKernel } from '../../datascience/jupyter/kernels/types';
 import { sendTelemetryEvent } from '../../telemetry';
 import { DebuggingTelemetry } from '../constants';
-
-const debugRequest = (message: DebugProtocol.Request, jupyterSessionId: string): KernelMessage.IDebugRequestMsg => {
-    return {
-        channel: 'control',
-        header: {
-            msg_id: randomBytes(8).toString('hex'),
-            date: new Date().toISOString(),
-            version: '5.2',
-            msg_type: 'debug_request',
-            username: 'vscode',
-            session: jupyterSessionId
-        },
-        metadata: {},
-        parent_header: {},
-        content: {
-            seq: message.seq,
-            type: 'request',
-            command: message.command,
-            arguments: message.arguments
-        }
-    };
-};
-
-const debugResponse = (message: DebugProtocol.Response, jupyterSessionId: string): KernelMessage.IDebugReplyMsg => {
-    return {
-        channel: 'control',
-        header: {
-            msg_id: randomBytes(8).toString('hex'),
-            date: new Date().toISOString(),
-            version: '5.2',
-            msg_type: 'debug_reply',
-            username: 'vscode',
-            session: jupyterSessionId
-        },
-        metadata: {},
-        parent_header: {},
-        content: {
-            seq: message.seq,
-            type: 'response',
-            request_seq: message.request_seq,
-            success: message.success,
-            command: message.command,
-            message: message.message,
-            body: message.body
-        }
-    };
-};
 
 interface dumpCellResponse {
     sourcePath: string; // filename for the dumped source
@@ -165,12 +117,15 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
 
         this.jupyterSession.onIOPubMessage((msg: KernelMessage.IIOPubMessage) => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const content = msg.content as any;
-            if (content.event === 'stopped') {
-                this.threadId = content.body.threadId;
-                // We want to get the variables for the variable view every time we stop
-                // This call starts that
-                this.stackTrace();
+            const anyMsg = msg as any;
+
+            if (anyMsg.header.msg_type === 'debug_event') {
+                if (anyMsg.content.event === 'stopped') {
+                    this.threadId = anyMsg.content.body.threadId;
+                    // We want to get the variables for the variable view every time we stop
+                    // This call starts that
+                    this.stackTrace();
+                }
                 this.sendMessage.fire(msg.content);
             }
         });
@@ -308,22 +263,6 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
     private async debugInfo(): Promise<void> {
         const response = await this.session.customRequest('debugInfo');
 
-        // If there's breakpoints at this point, send a message to VS Code to keep them
-        (response as debugInfoResponse).breakpoints.forEach((breakpoint) => {
-            const message: DebugProtocol.SetBreakpointsRequest = {
-                seq: 0,
-                type: 'request',
-                command: 'setBreakpoints',
-                arguments: {
-                    source: {
-                        path: breakpoint.source
-                    },
-                    breakpoints: breakpoint.breakpoints
-                }
-            };
-            this.sendMessage.fire(message);
-        });
-
         // If there's stopped threads at this point, continue them all
         (response as debugInfoResponse).stoppedThreads.forEach((thread: number) => {
             this.jupyterSession.requestDebug({
@@ -350,26 +289,24 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
 
         this.trace('to kernel', JSON.stringify(message));
         if (message.type === 'request') {
-            this.sendMessage.fire(message);
-            const request = debugRequest(message as DebugProtocol.Request, this.jupyterSession.sessionId);
+            const request = message as DebugProtocol.Request;
             const control = this.jupyterSession.requestDebug({
-                seq: request.content.seq,
+                seq: request.seq,
                 type: 'request',
-                command: request.content.command,
-                arguments: request.content.arguments
+                command: request.command,
+                arguments: request.arguments
             });
 
             if (control) {
                 control.onReply = (msg) => this.controlCallback(msg.content as DebugProtocol.ProtocolMessage);
-                control.onIOPub = (msg) => this.controlCallback(msg.content as DebugProtocol.ProtocolMessage);
             }
         } else if (message.type === 'response') {
             // responses of reverse requests
-            const response = debugResponse(message as DebugProtocol.Response, this.jupyterSession.sessionId);
+            const response = message as DebugProtocol.Response;
             this.jupyterSession.requestDebug({
-                seq: response.content.seq,
+                seq: response.seq,
                 type: 'request',
-                command: response.content.command
+                command: response.command
             });
         } else {
             // cannot send via iopub, no way to handle events even if they existed
@@ -500,24 +437,6 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
     }
 
     private async initializeExecute(seq: number) {
-        const response = await this.session.customRequest('debugInfo');
-
-        // If there's breakpoints at this point, send a message to VS Code to delete them
-        (response as debugInfoResponse).breakpoints.forEach((breakpoint) => {
-            const message: DebugProtocol.SetBreakpointsRequest = {
-                seq: 0,
-                type: 'request',
-                command: 'setBreakpoints',
-                arguments: {
-                    source: {
-                        path: breakpoint.source
-                    },
-                    breakpoints: []
-                }
-            };
-            this.sendMessage.fire(message);
-        });
-
         // put breakpoint at the beginning of the cell
         const cellIndex = Number(this.configuration.__cellIndex);
         const cell = this.notebookDocument.cellAt(cellIndex);
@@ -551,7 +470,7 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
         }
 
         // Run cell
-        await this.commandManager.executeCommand('notebook.cell.execute', {
+        void this.commandManager.executeCommand('notebook.cell.execute', {
             ranges: [{ start: cell.index, end: cell.index + 1 }],
             document: cell.document.uri
         });

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -112,7 +112,11 @@ async function activateLegacy(
     // We should start logging using the log level as soon as possible, so set it as soon as we can access the level.
     // `IConfigurationService` may depend any of the registered types, so doing it after all registrations are finished.
     // XXX Move this *after* abExperiments is activated?
-    setLoggingLevel(configuration.getSettings().logging.level);
+    const settings = configuration.getSettings();
+    setLoggingLevel(settings.logging.level);
+    settings.onDidChange(() => {
+        setLoggingLevel(settings.logging.level);
+    });
 
     // Register datascience types after experiments have loaded.
     // To ensure we can register types based on experiments.

--- a/src/client/logging/_global.ts
+++ b/src/client/logging/_global.ts
@@ -80,7 +80,7 @@ export function log(logLevel: LogLevel, ...args: Arguments) {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function logVerbose(...args: any[]) {
-    log(LogLevel.Info, ...args);
+    log(LogLevel.Trace, ...args);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Here are a few fixes for assorted RBL bugs, described in #7218. I can split these into multiple PRs if you want, but they are small changes. You can see them in the individual commits.

- Update context keys on startup so I don't have to close and reopen the notebook to get the RBL button to show up
- Forward all debug events to client, some were being lost
- Avoid sending messages to the wrong place (like requests to client)
- Don't block the configurationDone event on execution, the target didn't receive it
- Only show the "Starting" popup when RBL will be slow to start
- Don't leak listeners from the debug adapter, which led to strange behavior
- Don't delete the temp directory containing ipykernel cell contents, this spammed errors and might work around a bug where RBL gets stuck and won't start