### PR TITLE
Fix code indentation being lost on interactive window export

### DIFF
--- a/news/2 Fixes/7088.md
+++ b/news/2 Fixes/7088.md
@@ -1,0 +1,1 @@
+Fix code indentation being lost on interactive window export.

--- a/src/client/datascience/cellFactory.ts
+++ b/src/client/datascience/cellFactory.ts
@@ -204,7 +204,7 @@ export function generateCellsFromNotebookDocument(
         .filter((cell) => !cell.metadata.isInteractiveWindowMessageCell)
         .map((cell) => {
             // Reinstate cell structure + comments from cell metadata
-            let code = cell.document.getText().splitLines();
+            let code = cell.document.getText().splitLines({ trim: false, removeEmptyEntries: false });
             if (cell.metadata.interactiveWindowCellMarker !== undefined) {
                 code.unshift(cell.metadata.interactiveWindowCellMarker + '\n');
             }


### PR DESCRIPTION
For https://github.com/microsoft/vscode-jupyter/issues/7088
