### PR TITLE
Ensure executionCount is incremented for cells submitted from interactive window input box

### DIFF
--- a/src/client/datascience/editor-integration/cellhashprovider.ts
+++ b/src/client/datascience/editor-integration/cellhashprovider.ts
@@ -108,7 +108,10 @@ export class CellHashProvider implements ICellHashProvider {
             this.executionCount += 1;
 
             // Skip hash on unknown file though
-            if (cell.metadata.interactive?.file !== Identifiers.EmptyFileName) {
+            if (
+                cell.metadata.interactive !== undefined &&
+                cell.metadata.interactive?.file !== Identifiers.EmptyFileName
+            ) {
                 await this.generateHash(cell, this.executionCount);
             }
         }

--- a/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindow.ts
@@ -61,7 +61,6 @@ import { VSCodeNotebookController } from '../notebook/vscodeNotebookController';
 import { updateNotebookMetadata } from '../notebookStorage/baseModel';
 import {
     CellState,
-    ICellHashProvider,
     IInteractiveWindow,
     IInteractiveWindowInfo,
     IInteractiveWindowLoadable,
@@ -132,8 +131,7 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
         private readonly notebookControllerManager: INotebookControllerManager,
         private readonly kernelProvider: IKernelProvider,
         private readonly disposables: IDisposableRegistry,
-        private readonly jupyterDebugger: IJupyterDebugger,
-        private readonly cellHashProvider: ICellHashProvider
+        private readonly jupyterDebugger: IJupyterDebugger
     ) {
         // Set our owner and first submitter
         this._owner = owner;
@@ -431,7 +429,6 @@ export class NativeInteractiveWindow implements IInteractiveWindowLoadable {
             // If the file isn't unknown, set the active kernel's __file__ variable to point to that same file.
             await this.setFileInKernel(file, notebookEditor.document);
 
-            await this.cellHashProvider.addCellHash(notebookCell);
             await this.kernel!.executeCell(notebookCell);
 
             traceInfo(`Finished execution for ${id}`);

--- a/src/client/datascience/interactive-window/nativeInteractiveWindowProvider.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindowProvider.ts
@@ -30,12 +30,7 @@ import { IServiceContainer } from '../../ioc/types';
 import { IExportDialog } from '../export/types';
 import { IKernelProvider } from '../jupyter/kernels/types';
 import { INotebookControllerManager } from '../notebook/types';
-import {
-    IInteractiveWindow,
-    IInteractiveWindowProvider,
-    IJupyterDebugger,
-    INotebookExporter
-} from '../types';
+import { IInteractiveWindow, IInteractiveWindowProvider, IJupyterDebugger, INotebookExporter } from '../types';
 import { NativeInteractiveWindow } from './nativeInteractiveWindow';
 
 // Export for testing

--- a/src/client/datascience/interactive-window/nativeInteractiveWindowProvider.ts
+++ b/src/client/datascience/interactive-window/nativeInteractiveWindowProvider.ts
@@ -31,7 +31,6 @@ import { IExportDialog } from '../export/types';
 import { IKernelProvider } from '../jupyter/kernels/types';
 import { INotebookControllerManager } from '../notebook/types';
 import {
-    ICellHashProvider,
     IInteractiveWindow,
     IInteractiveWindowProvider,
     IJupyterDebugger,
@@ -135,8 +134,7 @@ export class NativeInteractiveWindowProvider implements IInteractiveWindowProvid
             this.notebookControllerManager,
             this.kernelProvider,
             this.disposables,
-            this.serviceContainer.get<IJupyterDebugger>(IJupyterDebugger),
-            this.serviceContainer.get<ICellHashProvider>(ICellHashProvider)
+            this.serviceContainer.get<IJupyterDebugger>(IJupyterDebugger)
         );
         this._windows.push(result);
 

--- a/src/client/datascience/jupyter/kernels/kernelProvider.ts
+++ b/src/client/datascience/jupyter/kernels/kernelProvider.ts
@@ -17,6 +17,7 @@ import {
 import { noop } from '../../../common/utils/misc';
 import { InteractiveWindowView } from '../../notebook/constants';
 import {
+    ICellHashProvider,
     IDataScienceErrorHandler,
     IJupyterServerUriStorage,
     INotebookEditorProvider,
@@ -42,7 +43,8 @@ export class KernelProvider implements IKernelProvider {
         @inject(IFileSystem) private readonly fs: IFileSystem,
         @inject(IJupyterServerUriStorage) private readonly serverStorage: IJupyterServerUriStorage,
         @inject(CellOutputDisplayIdTracker) private readonly outputTracker: CellOutputDisplayIdTracker,
-        @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService
+        @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
+        @inject(ICellHashProvider) private cellHashProvider: ICellHashProvider
     ) {
         this.asyncDisposables.push(this);
     }
@@ -86,7 +88,8 @@ export class KernelProvider implements IKernelProvider {
             options.controller,
             this.configService,
             this.outputTracker,
-            this.workspaceService
+            this.workspaceService,
+            this.cellHashProvider
         );
         kernel.onRestarted(() => this._onDidRestartKernel.fire(kernel));
         this.asyncDisposables.push(kernel);
@@ -126,5 +129,3 @@ export class KernelProvider implements IKernelProvider {
         this.kernelsByNotebook.delete(notebook);
     }
 }
-
-// export class KernelProvider {


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode-jupyter/issues/7156

We were previously only incrementing the executionCounts for interactive cells submitted from a Python file. Need to do this for cells submitted from the interactive window input box too. No news entry because this was caused by https://github.com/microsoft/vscode-jupyter/commit/2b3fdb7ef5eae0bae50adf1b126060b09b857278, which was checked in between stable releases