### PR TITLE
Remove unused IKernel.executeAllCells API

### DIFF
--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -549,7 +549,6 @@ export enum NativeMouseCommandTelemetry {
  */
 export enum VSCodeNativeTelemetry {
     AddCell = 'DATASCIENCE.VSCODE_NATIVE.INSERT_CELL',
-    RunAllCells = 'DATASCIENCE.VSCODE_NATIVE.RUN_ALL',
     DeleteCell = 'DATASCIENCE.VSCODE_NATIVE.DELETE_CELL',
     MoveCell = 'DATASCIENCE.VSCODE_NATIVE.MOVE_CELL',
     ChangeToCode = 'DATASCIENCE.VSCODE_NATIVE.CHANGE_TO_CODE', // Not guaranteed to work see, https://github.com/microsoft/vscode/issues/100042

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -140,13 +140,6 @@ export class Kernel implements IKernel {
         this.trackNotebookCellPerceivedColdTime(stopWatch, notebookPromise, promise).catch(noop);
         await promise;
     }
-    public async executeAllCells(document: NotebookDocument): Promise<void> {
-        const stopWatch = new StopWatch();
-        const notebookPromise = this.startNotebook({ disableUI: false, document });
-        const promise = this.kernelExecution.executeAllCells(notebookPromise, document);
-        this.trackNotebookCellPerceivedColdTime(stopWatch, notebookPromise, promise).catch(noop);
-        await promise;
-    }
     public async executeHidden(code: string, file: string, document: NotebookDocument) {
         const stopWatch = new StopWatch();
         const notebookPromise = this.startNotebook({ disableUI: false, document });

--- a/src/client/datascience/jupyter/kernels/types.ts
+++ b/src/client/datascience/jupyter/kernels/types.ts
@@ -147,7 +147,6 @@ export interface IKernel extends IAsyncDisposable {
     interrupt(document: NotebookDocument): Promise<InterruptResult>;
     restart(document: NotebookDocument): Promise<void>;
     executeCell(cell: NotebookCell): Promise<void>;
-    executeAllCells(document: NotebookDocument): Promise<void>;
     executeHidden(code: string, file: string, document: NotebookDocument): Promise<void>;
 }
 

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -1298,7 +1298,6 @@ export interface IEventNamePropertyMapping {
     [VSCodeNativeTelemetry.MoveCell]: never | undefined;
     [VSCodeNativeTelemetry.ChangeToCode]: never | undefined;
     [VSCodeNativeTelemetry.ChangeToMarkdown]: never | undefined;
-    [VSCodeNativeTelemetry.RunAllCells]: never | undefined;
     [Telemetry.VSCNotebookCellTranslationFailed]: {
         isErrorOutput: boolean; // Whether we're trying to translate an error output when we shuldn't be.
     };


### PR DESCRIPTION
`executeAllCells` doesn't seem to be used anywhere.