### PR TITLE
Return cell state from IKernel.executeCell

### DIFF
--- a/src/client/datascience/jupyter/kernels/cellExecution.ts
+++ b/src/client/datascience/jupyter/kernels/cellExecution.ts
@@ -96,7 +96,7 @@ export class CellExecutionFactory {
  *
  */
 export class CellExecution implements IDisposable {
-    public get result(): Promise<NotebookCellRunState | undefined> {
+    public get result(): Promise<NotebookCellRunState> {
         return this._result.promise;
     }
     /**
@@ -113,7 +113,7 @@ export class CellExecution implements IDisposable {
 
     private stopWatch = new StopWatch();
 
-    private readonly _result = createDeferred<NotebookCellRunState | undefined>();
+    private readonly _result = createDeferred<NotebookCellRunState>();
 
     private started?: boolean;
 

--- a/src/client/datascience/jupyter/kernels/cellExecutionQueue.ts
+++ b/src/client/datascience/jupyter/kernels/cellExecutionQueue.ts
@@ -74,13 +74,13 @@ export class CellExecutionQueue {
      * If cells are cancelled, they are not processed, & that too counts as completion.
      * If no cells are provided, then wait on all cells in the current queue.
      */
-    public async waitForCompletion(cells?: NotebookCell[]): Promise<void> {
+    public async waitForCompletion(cells?: NotebookCell[]): Promise<NotebookCellRunState[]> {
         const cellsToCheck =
             Array.isArray(cells) && cells.length > 0
                 ? this.queueOfCellsToExecute.filter((item) => cells.includes(item.cell))
                 : this.queueOfCellsToExecute;
 
-        await Promise.all(cellsToCheck.map((cell) => cell.result));
+        return Promise.all(cellsToCheck.map((cell) => cell.result));
     }
     private startExecutingCells() {
         if (!this.startedRunningCells) {

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -47,7 +47,7 @@ import {
 } from '../../types';
 import { getSysInfoReasonHeader, isPythonKernelConnection } from './helpers';
 import { KernelExecution } from './kernelExecution';
-import type { IKernel, IKernelProvider, KernelConnectionMetadata } from './types';
+import type { IKernel, IKernelProvider, KernelConnectionMetadata, NotebookCellRunState } from './types';
 import { SysInfoReason } from '../../interactive-common/interactiveWindowTypes';
 import { isCI, MARKDOWN_LANGUAGE } from '../../../common/constants';
 import { InteractiveWindowView } from '../../notebook/constants';
@@ -135,7 +135,7 @@ export class Kernel implements IKernel {
         );
     }
     private perceivedJupyterStartupTelemetryCaptured?: boolean;
-    public async executeCell(cell: NotebookCell): Promise<void> {
+    public async executeCell(cell: NotebookCell): Promise<NotebookCellRunState> {
         const stopWatch = new StopWatch();
         const notebookPromise = this.startNotebook({ disableUI: false, document: cell.notebook });
         if (cell.notebook.notebookType === InteractiveWindowView) {
@@ -144,6 +144,7 @@ export class Kernel implements IKernel {
         const promise = this.kernelExecution.executeCell(notebookPromise, cell);
         this.trackNotebookCellPerceivedColdTime(stopWatch, notebookPromise, promise).catch(noop);
         await promise;
+        return promise;
     }
     public async executeHidden(code: string, file: string, document: NotebookDocument) {
         const stopWatch = new StopWatch();

--- a/src/client/datascience/jupyter/kernels/types.ts
+++ b/src/client/datascience/jupyter/kernels/types.ts
@@ -146,7 +146,7 @@ export interface IKernel extends IAsyncDisposable {
     start(options?: { disableUI?: boolean; document: NotebookDocument }): Promise<void>;
     interrupt(document: NotebookDocument): Promise<InterruptResult>;
     restart(document: NotebookDocument): Promise<void>;
-    executeCell(cell: NotebookCell): Promise<void>;
+    executeCell(cell: NotebookCell): Promise<NotebookCellRunState>;
     executeHidden(code: string, file: string, document: NotebookDocument): Promise<void>;
 }
 


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode-jupyter/issues/7279

Addendum to 5bb6f70d99938b23e7049b0ad4526b9ae47f054a. We can't use executionSummary.success to check the cell execution result, because there's no guarantee that that will be updated timely. Instead, pass the execution result back from cellExecution and read that to determine if execution completed successfully.