### PR TITLE
Fix placeholder sys info cell not being updated correctly in interactive window

### DIFF
--- a/news/2 Fixes/7280.md
+++ b/news/2 Fixes/7280.md
@@ -1,0 +1,1 @@
+Fix placeholder 'Connecting to...' sys info cell not being overwritten after a kernel connection is established if cells are added to the interactive window first.


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode-jupyter/issues/7280

Root cause is code assumed the placeholder cell was the last one in the notebook document and didn't check any of the other cells, so if you added a cell via the input box while the kernel was starting, it would update the wrong cell. We are still assuming there's only one placeholder cell in the entire interactive window.

We could also just check the first cell, but that seems equally brittle e.g. if on a kernel restart we decide to show the placeholder cell as well, that won't work correctly.