### PR TITLE
temp fix for run by line after interrupting

### DIFF
--- a/src/client/debugger/jupyter/kernelDebugAdapter.ts
+++ b/src/client/debugger/jupyter/kernelDebugAdapter.ts
@@ -28,7 +28,7 @@ import { traceError, traceVerbose } from '../../common/logger';
 import { IFileSystem } from '../../common/platform/types';
 import { IKernelDebugAdapter } from '../types';
 import { IDisposable } from '../../common/types';
-import { Commands } from '../../datascience/constants';
+import { Commands, Identifiers } from '../../datascience/constants';
 import { IKernel } from '../../datascience/jupyter/kernels/types';
 import { sendTelemetryEvent } from '../../telemetry';
 import { DebuggingTelemetry } from '../constants';
@@ -474,7 +474,7 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
         // executing this code restarts debugpy and fixes https://github.com/microsoft/vscode-jupyter/issues/7251
         if (this.kernel) {
             const code = 'import debugpy\ndebugpy.debug_this_thread()';
-            await this.kernel.executeHidden(code, '', this.notebookDocument);
+            await this.kernel.executeHidden(code, Identifiers.EmptyFileName, this.notebookDocument);
         }
 
         // put breakpoint at the beginning of the cell


### PR DESCRIPTION
For #7251

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
