### PR TITLE
Fix interactive window placeholder cell updates

### DIFF
--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -426,25 +426,22 @@ export class Kernel implements IKernel {
             }
 
             return chainWithPendingUpdates(notebookDocument, (edit) => {
-                if (notebookDocument.cellCount) {
-                    const placeholderCell = notebookDocument
-                        .getCells()
-                        .find(
-                            (cell) =>
-                                cell.kind === NotebookCellKind.Markup &&
-                                cell.metadata.isInteractiveWindowMessageCell &&
-                                cell.metadata.isPlaceholder
-                        );
-
-                    // If there is a placeholder cell in the notebook, overwrite that
-                    if (placeholderCell !== undefined) {
+                // Overwrite the most recent placeholder cell
+                for (let i = notebookDocument.cellCount - 1; i >= 0; i -= 1) {
+                    const cell = notebookDocument.cellAt(i);
+                    if (
+                        cell.kind === NotebookCellKind.Markup &&
+                        cell.metadata.isInteractiveWindowMessageCell &&
+                        cell.metadata.isPlaceholder
+                    ) {
                         edit.replace(
-                            placeholderCell.document.uri,
-                            new Range(0, 0, placeholderCell.document.lineCount, 0),
+                            cell.document.uri,
+                            new Range(0, 0, cell.document.lineCount, 0),
                             sysInfoMessages.join('  \n')
                         );
-                        edit.replaceNotebookCellMetadata(notebookDocument.uri, placeholderCell.index, {
-                            isInteractiveWindowMessageCell: true
+                        edit.replaceNotebookCellMetadata(notebookDocument.uri, cell.index, {
+                            isInteractiveWindowMessageCell: true,
+                            isPlaceholder: false // replaceNotebookCellMetadata doesn't zero other metadata properties
                         });
                         return;
                     }


### PR DESCRIPTION
@rchiodo found that when restarting a kernel, existing sys info cells get overwritten instead of a new sys info cell with the restart message being appended. The cause appears to be that existing metadata properties aren't being zeroed on the VS Code side (which I assumed that an API with replace in the name would do)

This is a candidate for the August release.