### PR TITLE
Only trim leading empty lines, not tabs, when submitting #%% cells to the interactive window

### DIFF
--- a/news/2 Fixes/7303.md
+++ b/news/2 Fixes/7303.md
@@ -1,0 +1,1 @@
+Preserve leading tab characters on code lines for #%% cells submitted to interactive window.

--- a/src/client/datascience/interactive-window/interactiveWindow.ts
+++ b/src/client/datascience/interactive-window/interactiveWindow.ts
@@ -59,7 +59,7 @@ import {
     WebViewViewChangeEventArgs
 } from '../types';
 import { createInteractiveIdentity, getInteractiveWindowTitle } from './identity';
-import { generateMarkdownFromCodeLines } from '../../../datascience-ui/common';
+import { generateMarkdownFromCodeLines, removeLinesFromFrontAndBack } from '../../../datascience-ui/common';
 import { chainWithPendingUpdates } from '../notebook/helpers/notebookUpdater';
 import { LineQueryRegex, linkCommandAllowList } from '../interactive-common/linkProvider';
 import { INativeInteractiveWindow } from './types';
@@ -627,7 +627,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         const isMarkdown = cellMatcher.getCellType(code) === MARKDOWN_LANGUAGE;
         const strippedCode = isMarkdown
             ? generateMarkdownFromCodeLines(code.splitLines()).join('')
-            : cellMatcher.stripFirstMarker(code).trim();
+            : removeLinesFromFrontAndBack(cellMatcher.stripFirstMarker(code));
         const interactiveWindowCellMarker = cellMatcher.getFirstMarker(code);
 
         // Insert cell into NotebookDocument

--- a/src/test/datascience/interactiveWindow.vscode.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.test.ts
@@ -242,6 +242,28 @@ for i in range(10):
         );
     });
 
+    test('Leading and trailing empty lines in #%% cell are trimmed', async () => {
+        const actualCode = `    print('foo')
+
+
+
+    print('bar')`;
+        const codeWithWhitespace = `    # %%
+
+
+
+${actualCode}
+
+
+
+
+`;
+        const { activeInteractiveWindow: interactiveWindow } = await submitFromPythonFile(codeWithWhitespace);
+        const lastCell = await waitForLastCellToComplete(interactiveWindow);
+        const actualCellText = lastCell.document.getText();
+        assert.equal(actualCellText, actualCode);
+    });
+
     // todo@joyceerhl
     // test('Verify CWD', () => { });
     // test('Multiple executes go to last active window', async () => { });


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode-jupyter/issues/2552

The webview interactive window used to trim the code to display in the UI https://github.com/microsoft/vscode-jupyter/blob/8f50e87f45943fe486cfbb1c61bbe9d5719ece91/src/datascience-ui/history-react/redux/reducers/creation.ts#L30-L31 so we lost this in the transition to the native interactive window. We 'fixed' this by trimming the code that we put into the `NotebookCell`, which caused #2552 since we removed all leading whitespace, not just leading empty lines https://github.com/microsoft/vscode-jupyter/blob/3aa51df81793c2e45c30b5ec8324f16f26d4db4f/src/client/datascience/interactive-window/nativeInteractiveWindow.ts#L627

Since the cellhashprovider works with a copy of the original, unmodified source code, and not the actual `document.getText()`, this shouldn't cause (new) issues with debugging cells in the IW.

