### PR TITLE
refactor variable logic out of debugging manager

### DIFF
--- a/src/client/datascience/variablesView/notebookWatcher.ts
+++ b/src/client/datascience/variablesView/notebookWatcher.ts
@@ -16,7 +16,7 @@ import { IFileSystem } from '../../common/platform/types';
 import { IDisposableRegistry } from '../../common/types';
 import { getActiveInteractiveWindow } from '../interactive-window/helpers';
 import { IKernelProvider } from '../jupyter/kernels/types';
-import { getActiveInteractiveWindow, isJupyterNotebook } from '../notebook/helpers/helpers';
+import { isJupyterNotebook } from '../notebook/helpers/helpers';
 import { KernelState, KernelStateEventArgs } from '../notebookExtensibility';
 import { IInteractiveWindowProvider, INotebook, INotebookEditor, INotebookEditorProvider } from '../types';
 import { IActiveNotebookChangedEvent, INotebookWatcher } from './types';

--- a/src/client/datascience/variablesView/variableView.ts
+++ b/src/client/datascience/variablesView/variableView.ts
@@ -38,7 +38,6 @@ import { WebviewViewHost } from '../webviews/webviewViewHost';
 import { INotebookWatcher, IVariableViewPanelMapping } from './types';
 import { VariableViewMessageListener } from './variableViewMessageListener';
 import { ContextKey } from '../../common/contextKey';
-import { IDebuggingManager } from '../../debugger/types';
 
 const variableViewDir = path.join(EXTENSION_ROOT_DIR, 'out', 'datascience-ui', 'viewers');
 
@@ -63,8 +62,7 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
         @unmanaged() private readonly jupyterVariableDataProviderFactory: IJupyterVariableDataProviderFactory,
         @unmanaged() private readonly dataViewerFactory: IDataViewerFactory,
         @unmanaged() private readonly notebookWatcher: INotebookWatcher,
-        @unmanaged() private readonly commandManager: ICommandManager,
-        @unmanaged() private readonly debuggingManager: IDebuggingManager
+        @unmanaged() private readonly commandManager: ICommandManager
     ) {
         super(
             configuration,
@@ -81,7 +79,7 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
         this.notebookWatcher.onDidExecuteActiveNotebook(this.activeNotebookExecuted, this, this.disposables);
         this.notebookWatcher.onDidChangeActiveNotebook(this.activeNotebookChanged, this, this.disposables);
         this.notebookWatcher.onDidRestartActiveNotebook(this.activeNotebookRestarted, this, this.disposables);
-        this.debuggingManager.onDidFireVariablesEvent(this.sendRefreshMessage, this, this.disposables);
+        this.variables.refreshRequired(this.sendRefreshMessage, this, this.disposables);
 
         this.dataViewerChecker = new DataViewerChecker(configuration, appShell);
     }

--- a/src/client/datascience/variablesView/variableViewProvider.ts
+++ b/src/client/datascience/variablesView/variableViewProvider.ts
@@ -13,7 +13,6 @@ import {
 import { isTestExecution } from '../../common/constants';
 import { IConfigurationService, IDisposableRegistry } from '../../common/types';
 import { createDeferred, Deferred } from '../../common/utils/async';
-import { IDebuggingManager } from '../../debugger/types';
 import { Identifiers } from '../constants';
 import { IDataViewerFactory } from '../data-viewing/types';
 import { ICodeCssGenerator, IJupyterVariableDataProviderFactory, IJupyterVariables, IThemeFinder } from '../types';
@@ -57,8 +56,7 @@ export class VariableViewProvider implements IVariableViewProvider {
         private readonly jupyterVariableDataProviderFactory: IJupyterVariableDataProviderFactory,
         @inject(IDataViewerFactory) private readonly dataViewerFactory: IDataViewerFactory,
         @inject(INotebookWatcher) private readonly notebookWatcher: INotebookWatcher,
-        @inject(ICommandManager) private readonly commandManager: ICommandManager,
-        @inject(IDebuggingManager) private readonly debuggingManager: IDebuggingManager
+        @inject(ICommandManager) private readonly commandManager: ICommandManager
     ) {}
 
     public async resolveWebviewView(
@@ -81,8 +79,7 @@ export class VariableViewProvider implements IVariableViewProvider {
             this.jupyterVariableDataProviderFactory,
             this.dataViewerFactory,
             this.notebookWatcher,
-            this.commandManager,
-            this.debuggingManager
+            this.commandManager
         );
 
         // If someone is waiting for the variable view resolve that here

--- a/src/client/debugger/jupyter/debugControllers.ts
+++ b/src/client/debugger/jupyter/debugControllers.ts
@@ -13,7 +13,7 @@ import { Commands } from '../../datascience/constants';
 import { IKernel } from '../../datascience/jupyter/kernels/types';
 import { sendTelemetryEvent } from '../../telemetry';
 import { DebuggingTelemetry } from '../constants';
-import { DebuggingDelegate, IKernelDebugAdapter } from '../types';
+import { DebuggingDelegate, IKernelDebugAdapter, KernelDebugMode } from '../types';
 
 export class DebugCellController implements DebuggingDelegate {
     constructor(
@@ -65,6 +65,11 @@ export class RunByLineController implements DebuggingDelegate {
 
     public stop(): void {
         this.debugAdapter.disconnect();
+    }
+
+    public getMode(): KernelDebugMode {
+        const config = this.debugAdapter.getConfiguration();
+        return config.__mode;
     }
 
     public async willSendEvent(msg: DebugProtocolMessage): Promise<boolean> {

--- a/src/client/debugger/jupyter/helper.ts
+++ b/src/client/debugger/jupyter/helper.ts
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { DebugProtocol } from 'vscode-debugprotocol';
+import { IKernelDebugAdapterConfig, KernelDebugMode } from '../types';
+
+export function assertIsDebugConfig(thing: unknown): asserts thing is IKernelDebugAdapterConfig {
+    const config = thing as IKernelDebugAdapterConfig;
+    if (
+        typeof config.__mode === 'undefined' ||
+        ((config.__mode === KernelDebugMode.Cell || config.__mode === KernelDebugMode.RunByLine) &&
+            typeof config.__cellIndex === 'undefined')
+    ) {
+        throw new Error('Invalid launch configuration');
+    }
+}
+
+export function getMessageSourceAndHookIt(
+    msg: DebugProtocol.ProtocolMessage,
+    sourceHook: (source: DebugProtocol.Source | undefined) => void
+): void {
+    switch (msg.type) {
+        case 'event':
+            const event = msg as DebugProtocol.Event;
+            switch (event.event) {
+                case 'output':
+                    sourceHook((event as DebugProtocol.OutputEvent).body.source);
+                    break;
+                case 'loadedSource':
+                    sourceHook((event as DebugProtocol.LoadedSourceEvent).body.source);
+                    break;
+                case 'breakpoint':
+                    sourceHook((event as DebugProtocol.BreakpointEvent).body.breakpoint.source);
+                    break;
+                default:
+                    break;
+            }
+            break;
+        case 'request':
+            const request = msg as DebugProtocol.Request;
+            switch (request.command) {
+                case 'setBreakpoints':
+                    sourceHook((request.arguments as DebugProtocol.SetBreakpointsArguments).source);
+                    break;
+                case 'breakpointLocations':
+                    sourceHook((request.arguments as DebugProtocol.BreakpointLocationsArguments).source);
+                    break;
+                case 'source':
+                    sourceHook((request.arguments as DebugProtocol.SourceArguments).source);
+                    break;
+                case 'gotoTargets':
+                    sourceHook((request.arguments as DebugProtocol.GotoTargetsArguments).source);
+                    break;
+                default:
+                    break;
+            }
+            break;
+        case 'response':
+            const response = msg as DebugProtocol.Response;
+            if (response.success && response.body) {
+                switch (response.command) {
+                    case 'stackTrace':
+                        (response as DebugProtocol.StackTraceResponse).body.stackFrames.forEach((frame) =>
+                            sourceHook(frame.source)
+                        );
+                        break;
+                    case 'loadedSources':
+                        (response as DebugProtocol.LoadedSourcesResponse).body.sources.forEach((source) =>
+                            sourceHook(source)
+                        );
+                        break;
+                    case 'scopes':
+                        (response as DebugProtocol.ScopesResponse).body.scopes.forEach((scope) =>
+                            sourceHook(scope.source)
+                        );
+                        break;
+                    case 'setFunctionBreakpoints':
+                        (response as DebugProtocol.SetFunctionBreakpointsResponse).body.breakpoints.forEach((bp) =>
+                            sourceHook(bp.source)
+                        );
+                        break;
+                    case 'setBreakpoints':
+                        (response as DebugProtocol.SetBreakpointsResponse).body.breakpoints.forEach((bp) =>
+                            sourceHook(bp.source)
+                        );
+                        break;
+                    default:
+                        break;
+                }
+            }
+            break;
+    }
+}

--- a/src/client/debugger/types.ts
+++ b/src/client/debugger/types.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { DebugProtocolMessage, DebugSession, Event, NotebookDocument } from 'vscode';
+import { DebugConfiguration, DebugProtocolMessage, DebugSession, Event, NotebookCell, NotebookDocument } from 'vscode';
 import { DebugProtocol } from 'vscode-debugprotocol';
 
 export type ConsoleType = 'internalConsole' | 'integratedTerminal' | 'externalTerminal';
@@ -14,12 +14,15 @@ export interface IKernelDebugAdapter {
     disconnect(): void;
     onDidEndSession: Event<DebugSession>;
     dumpCell(index: number): Promise<void>;
+    getConfiguration(): IKernelDebugAdapterConfig;
 }
 
 export const IDebuggingManager = Symbol('IDebuggingManager');
 export interface IDebuggingManager {
-    readonly onDidFireVariablesEvent: Event<void>;
     isDebugging(notebook: NotebookDocument): boolean;
+    getDebugMode(notebook: NotebookDocument): KernelDebugMode | undefined;
+    getDebugSession(notebook: NotebookDocument): Promise<DebugSession> | undefined;
+    getDebugCell(notebook: NotebookDocument): NotebookCell | undefined;
 }
 
 export interface DebuggingDelegate {
@@ -32,4 +35,34 @@ export interface DebuggingDelegate {
      * Called for every request sent from the client to the debug adapter.
      */
     willSendRequest(request: DebugProtocol.Request): Promise<void>;
+}
+
+export interface dumpCellResponse {
+    sourcePath: string; // filename for the dumped source
+}
+
+export interface debugInfoResponse {
+    isStarted: boolean; // whether the debugger is started,
+    hashMethod: string; // the hash method for code cell. Default is 'Murmur2',
+    hashSeed: string; // the seed for the hashing of code cells,
+    tmpFilePrefix: string; // prefix for temporary file names
+    tmpFileSuffix: string; // suffix for temporary file names
+    breakpoints: debugInfoResponseBreakpoint[]; // breakpoints currently registered in the debugger.
+    stoppedThreads: number[]; // threads in which the debugger is currently in a stopped state
+}
+
+export interface debugInfoResponseBreakpoint {
+    source: string; // source file
+    breakpoints: DebugProtocol.SourceBreakpoint[]; // list of breakpoints for that source file
+}
+
+export enum KernelDebugMode {
+    RunByLine,
+    Cell,
+    Everything
+}
+
+export interface IKernelDebugAdapterConfig extends DebugConfiguration {
+    __mode: KernelDebugMode;
+    __cellIndex?: number;
 }

--- a/src/client/debugger/types.ts
+++ b/src/client/debugger/types.ts
@@ -4,10 +4,7 @@
 import { DebugConfiguration, DebugProtocolMessage, DebugSession, Event, NotebookCell, NotebookDocument } from 'vscode';
 import { DebugProtocol } from 'vscode-debugprotocol';
 
-export type ConsoleType = 'internalConsole' | 'integratedTerminal' | 'externalTerminal';
-
 export interface IKernelDebugAdapter {
-    debugSession: DebugSession;
     stepIn(threadId: number): Thenable<DebugProtocol.StepInResponse['body']>;
     stackTrace(args: DebugProtocol.StackTraceArguments): Thenable<DebugProtocol.StackTraceResponse['body']>;
     setBreakpoints(args: DebugProtocol.SetBreakpointsArguments): Thenable<DebugProtocol.SetBreakpointsResponse['body']>;


### PR DESCRIPTION
-move interfaces to types.ts
-move functions to helper.ts
-move variable view logic to debuggerVariables and variable view
-only call scopes and variables for the first stack and scope

For #7365

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
