### PR TITLE
Enable debugging without experimental flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,19 +195,16 @@
             {
                 "command": "jupyter.runByLine",
                 "key": "f10",
-                "mac": "f10",
                 "when": "!jupyter.notebookeditor.debuggingInProgress && !jupyter.notebookeditor.runByLineInProgress"
             },
             {
                 "command": "jupyter.runByLineContinue",
                 "key": "f10",
-                "mac": "f10",
                 "when": "jupyter.notebookeditor.runByLineInProgress"
             },
             {
                 "command": "jupyter.runByLineStop",
                 "key": "ctrl+enter",
-                "mac": "ctrl+enter",
                 "when": "jupyter.notebookeditor.runByLineInProgress"
             }
         ],
@@ -217,7 +214,7 @@
                 "title": "Debug",
                 "icon": "$(bug)",
                 "category": "Jupyter",
-                "enablement": "notebookKernelCount > 0 && !jupyter.notebookeditor.debuggingInProgress && !jupyter.notebookeditor.runByLineInProgress && config.jupyter.experimental.debugging"
+                "enablement": "notebookKernelCount > 0 && !jupyter.notebookeditor.debuggingInProgress && !jupyter.notebookeditor.runByLineInProgress"
             },
             {
                 "command": "jupyter.runByLine",
@@ -237,7 +234,7 @@
                 "title": "Continue",
                 "icon": "$(debug-line-by-line)",
                 "category": "Jupyter",
-                "enablement": "notebookKernelCount > 0 && jupyter.notebookeditor.runByLineInProgress"
+                "enablement": "jupyter.notebookeditor.runByLineInProgress"
             },
             {
                 "command": "jupyter.viewOutput",
@@ -855,7 +852,7 @@
             "notebook/cell/execute": [
                 {
                     "command": "jupyter.runAndDebugCell",
-                    "when": "notebookType == jupyter-notebook && jupyter.ispythonnotebook && notebookCellType == code && isWorkspaceTrusted && !jupyter.notebookeditor.runByLineInProgress && config.jupyter.experimental.debugging"
+                    "when": "notebookType == jupyter-notebook && jupyter.ispythonnotebook && notebookCellType == code && isWorkspaceTrusted && !jupyter.notebookeditor.runByLineInProgress"
                 }
             ],
             "interactive/toolbar": [
@@ -1385,12 +1382,6 @@
                     "default": true,
                     "description": "Enables/disables A/B tests.",
                     "scope": "machine"
-                },
-                "jupyter.experimental.debugging": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Enables the preview debugging experience. Set to true to enable the debugging mode button on native notebooks. Your selected kernel should also have ipykernel 6 installed in order to support debugging. Clicking the button will start a debugging session and will allow you to set and hit breakpoints.",
-                    "scope": "application"
                 },
                 "jupyter.showVariableViewWhenDebugging": {
                     "type": "boolean",


### PR DESCRIPTION
We can get some coverage this week in Insiders

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   ~~[x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).~~
-   ~~[x] Title summarizes what is changing.~~
-   ~~[x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).~~
-   ~~[x] Appropriate comments and documentation strings in the code.~~
-   ~~[x] Has sufficient logging.~~
-   ~~[x] Has telemetry for enhancements.~~
-   ~~[x] Unit tests & system/integration tests are added/updated.~~
-   ~~[x] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~~
-   ~~[x] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~~
