### PR TITLE
Remaining code cleanup 

### DIFF
--- a/src/client/debugger/jupyter/kernelDebugAdapter.ts
+++ b/src/client/debugger/jupyter/kernelDebugAdapter.ts
@@ -110,7 +110,8 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
                     // If a cell has moved to idle, stop the debug session
                     if (
                         this.configuration.__cellIndex === cellStateChange.cell.index &&
-                        cellStateChange.state === NotebookCellExecutionState.Idle
+                        cellStateChange.state === NotebookCellExecutionState.Idle &&
+                        !this.disconected
                     ) {
                         sendTelemetryEvent(DebuggingTelemetry.endedSession, undefined, { reason: 'normally' });
                         this.disconnect();
@@ -168,11 +169,9 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
     }
 
     public disconnect() {
-        if (!this.disconected) {
-            void this.session.customRequest('disconnect', { restart: false });
-            this.endSession.fire(this.session);
-            this.disconected = true;
-        }
+        void this.session.customRequest('disconnect', { restart: false });
+        this.endSession.fire(this.session);
+        this.disconected = true;
     }
 
     dispose() {

--- a/src/client/debugger/jupyter/kernelDebugAdapter.ts
+++ b/src/client/debugger/jupyter/kernelDebugAdapter.ts
@@ -15,7 +15,6 @@ import {
     NotebookCell,
     NotebookCellExecutionState,
     NotebookCellExecutionStateChangeEvent,
-    NotebookCellKind,
     NotebookDocument,
     notebooks,
     Uri
@@ -61,8 +60,6 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
         private fs: IFileSystem,
         private readonly kernel: IKernel | undefined
     ) {
-        void this.dumpAllCells();
-
         const configuration = this.session.configuration;
         assertIsDebugConfig(configuration);
         this.configuration = configuration;
@@ -199,14 +196,6 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
         args: DebugProtocol.SetBreakpointsArguments
     ): Thenable<DebugProtocol.SetBreakpointsResponse['body']> {
         return this.session.customRequest('setBreakpoints', args);
-    }
-
-    private dumpAllCells() {
-        this.notebookDocument.getCells().forEach((cell) => {
-            if (cell.kind === NotebookCellKind.Code && cell.executionSummary?.success) {
-                void this.dumpCell(cell.index);
-            }
-        });
     }
 
     // Dump content of given cell into a tmp file and return path to file.


### PR DESCRIPTION
-use a 'disconneced' flag to only send the message and event once
-only dump cells that executed succesfully

For #7346

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
