### PR TITLE
Fire `onDidChangeViewState` for interactive window

### DIFF
--- a/news/2 Fixes/7249.md
+++ b/news/2 Fixes/7249.md
@@ -1,0 +1,1 @@
+Code cell submissions should go to active window in 'multiple' mode.


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode-jupyter/issues/7249

The interactive window used to be a webview panel so it had its own view state change event. Needed to hook that event up to `window.onDidChangeActiveNotebookEditor` as we're now working with an editor instead. Comparing `NotebookEditor`s here instead of comparing stringified URIs should be safe because they're fat objects so shouldn't be recreated in the extension host. 