### PR TITLE
Update RBL context keys for active editor

### DIFF
--- a/src/client/debugger/jupyter/debuggingManager.ts
+++ b/src/client/debugger/jupyter/debuggingManager.ts
@@ -72,6 +72,17 @@ export class DebuggingManager implements IExtensionSingleActivationService, IDeb
         this.runByLineInProgress = new ContextKey(EditorContexts.RunByLineInProgress, this.commandManager);
         this.updateToolbar(false);
         this.updateCellToolbar(false);
+
+        this.disposables.push(this.vscNotebook.onDidChangeActiveNotebookEditor(
+            (e?: NotebookEditor) => {
+                if (e) {
+                    this.updateCellToolbar(this.isDebugging(e.document));
+                    this.updateToolbar(this.isDebugging(e.document));
+                }
+            },
+            this,
+            this.disposables
+        ));
     }
 
     public async activate() {

--- a/src/client/debugger/jupyter/debuggingManager.ts
+++ b/src/client/debugger/jupyter/debuggingManager.ts
@@ -73,16 +73,18 @@ export class DebuggingManager implements IExtensionSingleActivationService, IDeb
         this.updateToolbar(false);
         this.updateCellToolbar(false);
 
-        this.disposables.push(this.vscNotebook.onDidChangeActiveNotebookEditor(
-            (e?: NotebookEditor) => {
-                if (e) {
-                    this.updateCellToolbar(this.isDebugging(e.document));
-                    this.updateToolbar(this.isDebugging(e.document));
-                }
-            },
-            this,
-            this.disposables
-        ));
+        this.disposables.push(
+            this.vscNotebook.onDidChangeActiveNotebookEditor(
+                (e?: NotebookEditor) => {
+                    if (e) {
+                        this.updateCellToolbar(this.isDebugging(e.document));
+                        this.updateToolbar(this.isDebugging(e.document));
+                    }
+                },
+                this,
+                this.disposables
+            )
+        );
     }
 
     public async activate() {


### PR DESCRIPTION
For #7218

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   ~~[x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).~~
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
