### PR TITLE
Use LF instead of CRLF

### DIFF
--- a/src/client/debugger/jupyter/kernelDebugAdapter.ts
+++ b/src/client/debugger/jupyter/kernelDebugAdapter.ts
@@ -212,7 +212,9 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
         const cell = this.notebookDocument.cellAt(index);
         if (cell) {
             try {
-                const response = await this.session.customRequest('dumpCell', { code: cell.document.getText() });
+                const response = await this.session.customRequest('dumpCell', {
+                    code: cell.document.getText().replace(/\r\n/g, '\n')
+                });
                 const norm = path.normalize((response as IDumpCellResponse).sourcePath);
                 this.fileToCell.set(norm, cell);
                 this.cellToFile.set(cell.document.uri.toString(), norm);


### PR DESCRIPTION
https://github.com/microsoft/vscode-jupyter/pull/7659 broke Run by Line, we had to do the same change to the code we send to the kernel on cellExecution.ts.

Thanks @DonJayamanne for helping me find this

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
