### PR TITLE
Use the kernel to check for ipykernel 6 version, instead of the python installer

### DIFF
--- a/news/2 Fixes/7576.md
+++ b/news/2 Fixes/7576.md
@@ -1,0 +1,1 @@
+Use the kernel to check for ipykernel 6 version, instead of the python installer. This works for both local and remote.

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -164,12 +164,12 @@ export class Kernel implements IKernel {
         await promise;
         return promise;
     }
-    public async executeHidden(code: string) {
+    public async executeHidden(code: string): Promise<nbformat.IOutput[]> {
         const stopWatch = new StopWatch();
         const notebookPromise = this.startNotebook();
         const promise = notebookPromise.then((nb) => executeSilently(nb.session, code));
         this.trackNotebookCellPerceivedColdTime(stopWatch, notebookPromise, promise).catch(noop);
-        await promise;
+        return promise;
     }
     public async start(options: { disableUI?: boolean } = {}): Promise<void> {
         await this.startNotebook(options);

--- a/src/client/datascience/jupyter/kernels/types.ts
+++ b/src/client/datascience/jupyter/kernels/types.ts
@@ -23,6 +23,7 @@ import type {
     InterruptResult,
     KernelSocketInformation
 } from '../../types';
+import type { nbformat } from '@jupyterlab/coreutils';
 
 export type LiveKernelModel = IJupyterKernel & Partial<IJupyterKernelSpec> & { session: Session.IModel };
 
@@ -146,7 +147,7 @@ export interface IKernel extends IAsyncDisposable {
     interrupt(): Promise<InterruptResult>;
     restart(): Promise<void>;
     executeCell(cell: NotebookCell): Promise<NotebookCellRunState>;
-    executeHidden(code: string): Promise<void>;
+    executeHidden(code: string): Promise<nbformat.IOutput[]>;
 }
 
 export type KernelOptions = {


### PR DESCRIPTION
This works for both local and remote.

For #7576

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
