### PR TITLE
Allow opening the debug console according to user preference when debugging a notebook cell

### DIFF
--- a/src/client/debugger/jupyter/debuggingManager.ts
+++ b/src/client/debugger/jupyter/debuggingManager.ts
@@ -277,7 +277,6 @@ export class DebuggingManager implements IExtensionSingleActivationService, IDeb
             type: pythonKernelDebugAdapter,
             name: path.basename(doc.uri.toString()),
             request: 'attach',
-            internalConsoleOptions: 'neverOpen',
             justMyCode: true,
             // add a property to the config to know if the session is runByLine
             __mode: mode,


### PR DESCRIPTION
We shouldn't override this setting. The default is `openOnFirstSessionStart`