### PR TITLE
Render calls stack only when exist

### DIFF
--- a/src/datascience-ui/error-renderer/index.ts
+++ b/src/datascience-ui/error-renderer/index.ts
@@ -59,17 +59,6 @@ export const activate: ActivationFunction = (_context) => {
             element.appendChild(container);
             container.classList.add('cell-output-text');
 
-            const header = document.createElement('div');
-            const headerMessage =
-                outputItemJson.name && outputItemJson.message
-                    ? `${outputItemJson.name}: ${outputItemJson.message}`
-                    : outputItemJson.name || outputItemJson.message;
-            if (headerMessage) {
-                header.classList.add('output-error-header');
-                header.innerText = headerMessage;
-                container.appendChild(header);
-            }
-
             const metadata: any = outputItem.metadata;
             let traceback: string[] =
                 metadata?.outputType === 'error' && metadata?.transient && Array.isArray(metadata?.transient)
@@ -78,6 +67,7 @@ export const activate: ActivationFunction = (_context) => {
                     ? outputItemJson.stack.map((item: string) => escape(item))
                     : [escape(outputItemJson.stack)];
 
+            // there is traceback
             // Fix links in tracebacks.
             // RegEx `<a href='<file path>?line=<linenumber>'>line number</a>`
             // When we escape, the links would be escaped as well.
@@ -95,6 +85,7 @@ export const activate: ActivationFunction = (_context) => {
                 }
                 return line;
             });
+
             const html = traceback.some((item) => item.trim().length)
                 ? converter.toHtml(traceback.join('\n'))
                 : undefined;
@@ -107,10 +98,22 @@ export const activate: ActivationFunction = (_context) => {
                     handleInnerClick(e, _context);
                 });
             } else {
-                // We can't display nothing (other extesnsions might have differen formats of errors, like Julia, .NET, etc).
-                const tbEle = document.createElement('div');
-                container.appendChild(tbEle);
-                tbEle.innerHTML = traceback.join('<br>');
+                const header = document.createElement('div');
+                const headerMessage =
+                    outputItemJson.name && outputItemJson.message
+                        ? `${outputItemJson.name}: ${outputItemJson.message}`
+                        : outputItemJson.name || outputItemJson.message;
+
+                if (headerMessage) {
+                    header.classList.add('output-error-header');
+                    header.innerText = headerMessage;
+                    container.appendChild(header);
+                } else {
+                    // We can't display nothing (other extesnsions might have differen formats of errors, like Julia, .NET, etc).
+                    const tbEle = document.createElement('div');
+                    container.appendChild(tbEle);
+                    tbEle.innerHTML = traceback.join('<br>');
+                }
             }
         }
     };


### PR DESCRIPTION
For microsoft/vscode#131823

Previously we will render the error output as 

```
${ename}: ${evalue}

${callstack}
```

However when all other notebook editors will only render `callstack` if it exists. We have fixed this in the core renderer and we also need to do this in the error renderer here too.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
