### PR TITLE
Remove execCell and execObservable (steps towards removing INotebook)

### DIFF
--- a/src/client/datascience/interactive-window/interactiveWindow.ts
+++ b/src/client/datascience/interactive-window/interactiveWindow.ts
@@ -66,6 +66,7 @@ import { LineQueryRegex, linkCommandAllowList } from '../interactive-common/link
 import { INativeInteractiveWindow } from './types';
 import { generateInteractiveCode } from '../../../datascience-ui/common/cellFactory';
 import { initializeInteractiveOrNotebookTelemetryBasedOnUserAction } from '../telemetry/telemetry';
+import { InteractiveWindowView } from '../notebook/constants';
 
 type InteractiveCellMetadata = {
     inputCollapsed: boolean;
@@ -184,7 +185,9 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
     }
 
     private async createEditorReadyPromise(): Promise<NotebookEditor> {
-        const preferredController = await this.notebookControllerManager.getInteractiveController();
+        const preferredController = await this.notebookControllerManager.getActiveInterpreterOrDefaultController(
+            InteractiveWindowView
+        );
         const controllerId = preferredController ? `${JVSC_EXTENSION_ID}/${preferredController.id}` : undefined;
         traceInfo(`Starting interactive window with controller ID ${controllerId}`);
         const hasOwningFile = this.owner !== undefined;

--- a/src/client/datascience/interactive-window/interactiveWindowCommandListener.ts
+++ b/src/client/datascience/interactive-window/interactiveWindowCommandListener.ts
@@ -4,22 +4,19 @@
 import '../../common/extensions';
 
 import { inject, injectable } from 'inversify';
-import * as uuid from 'uuid/v4';
 import {
     NotebookCell,
     NotebookRange,
     Position,
     Range,
     Selection,
-    TextDocument,
     TextEditor,
     Uri,
     ViewColumn,
     workspace,
     WorkspaceEdit
 } from 'vscode';
-import { CancellationToken, CancellationTokenSource } from 'vscode-jsonrpc';
-import { IApplicationShell, IClipboard, ICommandManager, IDocumentManager } from '../../common/application/types';
+import { IApplicationShell, IClipboard, ICommandManager, IDocumentManager, IVSCodeNotebook } from '../../common/application/types';
 import { CancellationError } from '../../common/cancellation';
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import { traceError, traceInfo } from '../../common/logger';
@@ -28,7 +25,7 @@ import { IConfigurationService, IDisposableRegistry } from '../../common/types';
 import * as localize from '../../common/utils/localize';
 import { captureTelemetry } from '../../telemetry';
 import { CommandSource } from '../../testing/common/constants';
-import { generateCellRangesFromDocument, generateCellsFromDocument } from '../cellFactory';
+import { generateCellsFromDocument } from '../cellFactory';
 import { Commands, Telemetry } from '../constants';
 import { ExportFormat, IExportDialog, IExportManager } from '../export/types';
 import { JupyterInstallError } from '../jupyter/jupyterInstallError';
@@ -37,13 +34,10 @@ import {
     IDataScienceErrorHandler,
     IInteractiveWindowProvider,
     IJupyterExecution,
-    INotebook,
     INotebookEditorProvider,
     INotebookExporter,
-    INotebookProvider,
     IStatusProvider
 } from '../types';
-import { createExportInteractiveIdentity } from './identity';
 import { getActiveInteractiveWindow } from './helpers';
 import { chainWithPendingUpdates } from '../notebook/helpers/notebookUpdater';
 
@@ -54,7 +48,6 @@ export class NativeInteractiveWindowCommandListener implements IDataScienceComma
         @inject(IInteractiveWindowProvider) private interactiveWindowProvider: IInteractiveWindowProvider,
         @inject(INotebookExporter) private jupyterExporter: INotebookExporter,
         @inject(IJupyterExecution) private jupyterExecution: IJupyterExecution,
-        @inject(INotebookProvider) private notebookProvider: INotebookProvider,
         @inject(IDocumentManager) private documentManager: IDocumentManager,
         @inject(IApplicationShell) private applicationShell: IApplicationShell,
         @inject(IFileSystem) private fileSystem: IFileSystem,
@@ -64,8 +57,10 @@ export class NativeInteractiveWindowCommandListener implements IDataScienceComma
         @inject(INotebookEditorProvider) protected ipynbProvider: INotebookEditorProvider,
         @inject(IExportManager) private exportManager: IExportManager,
         @inject(IExportDialog) private exportDialog: IExportDialog,
-        @inject(IClipboard) private clipboard: IClipboard
-    ) {}
+        @inject(IClipboard) private clipboard: IClipboard,
+        @inject(IVSCodeNotebook) private notebook: IVSCodeNotebook,
+        @inject(ICommandManager) private commandManager: ICommandManager
+    ) { }
 
     public register(commandManager: ICommandManager): void {
         let disposable = commandManager.registerCommand(Commands.CreateNewInteractive, () =>
@@ -189,7 +184,11 @@ export class NativeInteractiveWindowCommandListener implements IDataScienceComma
             result = await promise();
             return result;
         } catch (err) {
-            if (!(err instanceof CancellationError)) {
+            if (!(err instanceof Error)) {
+                traceError('listenForErrors', err as any);
+                void this.applicationShell.showErrorMessage(err as any);
+                return;
+            } else if (!(err instanceof CancellationError)) {
                 if (err.message) {
                     traceError(err.message);
                     void this.applicationShell.showErrorMessage(err.message);
@@ -202,14 +201,6 @@ export class NativeInteractiveWindowCommandListener implements IDataScienceComma
             }
         }
         return result;
-    }
-
-    private showInformationMessage(message: string, question?: string): Thenable<string | undefined> {
-        if (question) {
-            return this.applicationShell.showInformationMessage(message, question);
-        } else {
-            return this.applicationShell.showInformationMessage(message);
-        }
     }
 
     @captureTelemetry(Telemetry.ExportPythonFileInteractive, undefined, false)
@@ -270,54 +261,39 @@ export class NativeInteractiveWindowCommandListener implements IDataScienceComma
                 activeEditor.document &&
                 this.fileSystem.arePathsSame(activeEditor.document.uri, file)
             ) {
-                const ranges = generateCellRangesFromDocument(activeEditor.document);
-                if (ranges.length > 0) {
-                    // Ask user for path
-                    const output = await this.showExportDialog(file);
-
-                    // If that worked, we need to start a jupyter server to get our output values.
-                    // In the future we could potentially only update changed cells.
-                    if (output) {
-                        // Create a cancellation source so we can cancel starting the jupyter server if necessary
-                        const cancelSource = new CancellationTokenSource();
-
-                        // Then wait with status that lets the user cancel
-                        await this.waitForStatus(
-                            () => {
-                                try {
-                                    return this.exportCellsWithOutput(
-                                        ranges,
-                                        activeEditor.document,
-                                        output,
-                                        cancelSource.token
-                                    );
-                                } catch (err) {
-                                    if (!(err instanceof CancellationError)) {
-                                        void this.showInformationMessage(
-                                            localize.DataScience.exportDialogFailed().format(err)
-                                        );
-                                    }
-                                }
-                                return Promise.resolve();
-                            },
-                            localize.DataScience.exportingFormat(),
-                            file.fsPath,
-                            () => {
-                                cancelSource.cancel();
-                            }
-                        );
-
-                        // When all done, show a notice that it completed.
-                        const openQuestion1 = localize.DataScience.exportOpenQuestion1();
-                        const selection = await this.applicationShell.showInformationMessage(
-                            localize.DataScience.exportDialogComplete().format(output.fsPath),
-                            openQuestion1
-                        );
-                        if (selection === openQuestion1) {
-                            await this.ipynbProvider.open(output);
-                        }
-                        return output;
+                const cells = generateCellsFromDocument(
+                    activeEditor.document,
+                    this.configuration.getSettings(activeEditor.document.uri)
+                );
+                if (cells) {
+                    // Bring up the export dialog box
+                    const uri = await this.exportDialog.showDialog(ExportFormat.ipynb, file);
+                    if (!uri) {
+                        return;
                     }
+                    await this.waitForStatus(
+                        async () => {
+                            if (uri) {
+                                let directoryChange;
+                                const settings = this.configuration.getSettings(activeEditor.document.uri);
+                                if (settings.changeDirOnImportExport) {
+                                    directoryChange = uri;
+                                }
+
+                                const notebook = await this.jupyterExporter.translateToNotebook(
+                                    cells,
+                                    directoryChange?.fsPath
+                                );
+                                await this.fileSystem.writeFile(uri, JSON.stringify(notebook));
+                            }
+                        },
+                        localize.DataScience.exportingFormat(),
+                        file.fsPath
+                    );
+                    // Next open this notebook & execute it.
+                    await this.notebook.showNotebookDocument(uri, { preserveFocus: false, viewColumn: ViewColumn.Beside });
+                    await this.commandManager.executeCommand('notebook.execute');
+                    return uri;
                 }
             }
         } else {
@@ -328,50 +304,6 @@ export class NativeInteractiveWindowCommandListener implements IDataScienceComma
                 )
             );
         }
-    }
-
-    private async exportCellsWithOutput(
-        ranges: { range: Range; title: string }[],
-        document: TextDocument,
-        file: Uri,
-        cancelToken: CancellationToken
-    ): Promise<void> {
-        let notebook: INotebook | undefined;
-        try {
-            const settings = this.configuration.getSettings(document.uri);
-            // Create a new notebook
-            notebook = await this.notebookProvider.getOrCreateNotebook({
-                identity: createExportInteractiveIdentity(),
-                resource: file
-            });
-            // If that works, then execute all of the cells.
-            const cells = Array.prototype.concat(
-                ...(await Promise.all(
-                    ranges.map((r) => {
-                        const code = document.getText(r.range);
-                        return notebook
-                            ? notebook.execute(code, document.fileName, r.range.start.line, uuid(), cancelToken)
-                            : [];
-                    })
-                ))
-            );
-            // Then save them to the file
-            let directoryChange;
-            if (settings.changeDirOnImportExport) {
-                directoryChange = file;
-            }
-            const notebookJson = await this.jupyterExporter.translateToNotebook(cells, directoryChange?.fsPath);
-            await this.fileSystem.writeFile(file, JSON.stringify(notebookJson));
-        } finally {
-            if (notebook) {
-                await notebook.dispose();
-            }
-        }
-    }
-
-    private async showExportDialog(file: Uri): Promise<Uri | undefined> {
-        // Bring up the save file dialog box
-        return this.exportDialog.showDialog(ExportFormat.ipynb, file);
     }
 
     private async expandAllCells(uri?: Uri) {

--- a/src/client/datascience/interactive-window/interactiveWindowCommandListener.ts
+++ b/src/client/datascience/interactive-window/interactiveWindowCommandListener.ts
@@ -16,7 +16,13 @@ import {
     workspace,
     WorkspaceEdit
 } from 'vscode';
-import { IApplicationShell, IClipboard, ICommandManager, IDocumentManager, IVSCodeNotebook } from '../../common/application/types';
+import {
+    IApplicationShell,
+    IClipboard,
+    ICommandManager,
+    IDocumentManager,
+    IVSCodeNotebook
+} from '../../common/application/types';
 import { CancellationError } from '../../common/cancellation';
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import { traceError, traceInfo } from '../../common/logger';
@@ -60,7 +66,7 @@ export class NativeInteractiveWindowCommandListener implements IDataScienceComma
         @inject(IClipboard) private clipboard: IClipboard,
         @inject(IVSCodeNotebook) private notebook: IVSCodeNotebook,
         @inject(ICommandManager) private commandManager: ICommandManager
-    ) { }
+    ) {}
 
     public register(commandManager: ICommandManager): void {
         let disposable = commandManager.registerCommand(Commands.CreateNewInteractive, () =>
@@ -291,7 +297,10 @@ export class NativeInteractiveWindowCommandListener implements IDataScienceComma
                         file.fsPath
                     );
                     // Next open this notebook & execute it.
-                    await this.notebook.showNotebookDocument(uri, { preserveFocus: false, viewColumn: ViewColumn.Beside });
+                    await this.notebook.showNotebookDocument(uri, {
+                        preserveFocus: false,
+                        viewColumn: ViewColumn.Beside
+                    });
                     await this.commandManager.executeCommand('notebook.execute');
                     return uri;
                 }

--- a/src/client/datascience/ipywidgets/localWidgetScriptSourceProvider.ts
+++ b/src/client/datascience/ipywidgets/localWidgetScriptSourceProvider.ts
@@ -82,8 +82,7 @@ export class LocalWidgetScriptSourceProvider implements IWidgetScriptSourceProvi
             const widgetScriptSource: WidgetScriptSource = { moduleName, scriptUri, source: 'local' };
             return widgetScriptSource;
         });
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return Promise.all(mappedFiles as any);
+        return Promise.all(mappedFiles);
     }
     private async getSysPrefixOfKernel() {
         const kernelConnectionMetadata = this.notebook.getKernelConnection();

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -1,30 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import type { nbformat } from '@jupyterlab/coreutils';
 import type { Kernel, KernelMessage } from '@jupyterlab/services';
 import type { JSONObject } from '@phosphor/coreutils';
 import { Observable } from 'rxjs/Observable';
-import { Subscriber } from 'rxjs/Subscriber';
 import * as path from 'path';
 import { Disposable, Event, EventEmitter, Uri } from 'vscode';
 import { CancellationToken } from 'vscode-jsonrpc';
 import { ServerStatus } from '../../../datascience-ui/interactive-common/mainState';
-import { IApplicationShell, IWorkspaceService } from '../../common/application/types';
+import { IWorkspaceService } from '../../common/application/types';
 import { CancellationError, createPromiseFromCancellation } from '../../common/cancellation';
 import '../../common/extensions';
-import { traceError, traceInfo, traceInfoIf, traceWarning } from '../../common/logger';
+import { traceError, traceInfo, traceInfoIf } from '../../common/logger';
 
-import { IConfigurationService, IDisposableRegistry, Resource } from '../../common/types';
-import { createDeferred, Deferred } from '../../common/utils/async';
+import { IDisposableRegistry, Resource } from '../../common/types';
+import { createDeferred } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
-import { noop } from '../../common/utils/misc';
-import { StopWatch } from '../../common/utils/stopWatch';
-import { sendTelemetryEvent } from '../../telemetry';
-import { generateCells } from '../cellFactory';
-import { CellMatcher } from '../cellMatcher';
-import { CodeSnippets, Telemetry } from '../constants';
+import { CodeSnippets } from '../constants';
 import {
-    CellState,
     ICell,
     IJupyterSession,
     INotebook,
@@ -37,116 +29,17 @@ import { KernelConnectionMetadata } from './kernels/types';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import cloneDeep = require('lodash/cloneDeep');
-import { concatMultilineString, formatStreamText, splitMultilineString } from '../../../datascience-ui/common';
 import { IFileSystem } from '../../common/platform/types';
-import { RefBool } from '../../common/refBool';
 import { PythonEnvironment } from '../../pythonEnvironments/info';
-import { handleTensorBoardDisplayDataOutput } from '../notebook/helpers/executionHelpers';
 import { getInterpreterFromKernelConnectionMetadata, isPythonKernelConnection } from './kernels/helpers';
 import { executeSilently } from './kernels/kernel';
 import { isCI } from '../../common/constants';
 
-class CellSubscriber {
-    public get startTime(): number {
-        return this._startTime;
-    }
-
-    public get onCanceled(): Event<void> {
-        return this.canceledEvent.event;
-    }
-
-    public get promise(): Promise<CellState> {
-        return this.deferred.promise;
-    }
-
-    public get cell(): ICell {
-        return this.cellRef;
-    }
-    public executionState?: Kernel.Status;
-    private deferred: Deferred<CellState> = createDeferred<CellState>();
-    private cellRef: ICell;
-    private subscriber: Subscriber<ICell>;
-    private promiseComplete: (self: CellSubscriber) => void;
-    private canceledEvent: EventEmitter<void> = new EventEmitter<void>();
-    private _startTime: number;
-
-    constructor(cell: ICell, subscriber: Subscriber<ICell>, promiseComplete: (self: CellSubscriber) => void) {
-        this.cellRef = cell;
-        this.subscriber = subscriber;
-        this.promiseComplete = promiseComplete;
-        this._startTime = Date.now();
-    }
-
-    public isValid(sessionStartTime: number | undefined) {
-        return sessionStartTime && this.startTime >= sessionStartTime;
-    }
-
-    public next(sessionStartTime: number | undefined) {
-        // Tell the subscriber first
-        if (this.isValid(sessionStartTime)) {
-            this.subscriber.next(this.cellRef);
-        }
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public error(sessionStartTime: number | undefined, err: any) {
-        if (this.isValid(sessionStartTime)) {
-            this.subscriber.error(err);
-        }
-    }
-
-    public complete(sessionStartTime: number | undefined) {
-        if (this.isValid(sessionStartTime)) {
-            if (this.cellRef.state !== CellState.error) {
-                this.cellRef.state = CellState.finished;
-            }
-            this.subscriber.next(this.cellRef);
-        }
-        this.subscriber.complete();
-
-        // Then see if we're finished or not.
-        this.attemptToFinish();
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public reject(e: any) {
-        if (!this.deferred.completed) {
-            this.cellRef.state = CellState.error;
-            this.subscriber.next(this.cellRef);
-            this.subscriber.complete();
-            this.deferred.reject(e);
-            this.promiseComplete(this);
-        }
-    }
-
-    public cancel() {
-        this.canceledEvent.fire();
-        if (!this.deferred.completed) {
-            this.cellRef.state = CellState.error;
-            this.subscriber.next(this.cellRef);
-            this.subscriber.complete();
-            this.deferred.resolve();
-            this.promiseComplete(this);
-        }
-    }
-
-    private attemptToFinish() {
-        if (
-            !this.deferred.completed &&
-            (this.cell.state === CellState.finished || this.cell.state === CellState.error)
-        ) {
-            this.deferred.resolve(this.cell.state);
-            this.promiseComplete(this);
-        }
-    }
-}
 
 // This code is based on the examples here:
 // https://www.npmjs.com/package/@jupyterlab/services
 
 export class JupyterNotebookBase implements INotebook {
-    private sessionStartTime: number;
-    private pendingCellSubscriptions: CellSubscriber[] = [];
     private _resource: Resource;
     private _identity: Uri;
     private _disposed: boolean = false;
@@ -173,7 +66,6 @@ export class JupyterNotebookBase implements INotebook {
     private disposedEvent = new EventEmitter<void>();
     private finishedExecuting = new EventEmitter<ICell>();
     private sessionStatusChanged: Disposable | undefined;
-    private ioPubListeners = new Set<(msg: KernelMessage.IIOPubMessage, requestId: string) => void>();
     public get kernelSocket(): Observable<KernelSocketInformation | undefined> {
         return this.session.kernelSocket;
     }
@@ -183,18 +75,13 @@ export class JupyterNotebookBase implements INotebook {
 
     constructor(
         private readonly _session: IJupyterSession,
-        private configService: IConfigurationService,
         private disposableRegistry: IDisposableRegistry,
         executionInfo: INotebookExecutionInfo,
         resource: Resource,
         identity: Uri,
-        private getDisposedError: () => Error,
         private workspace: IWorkspaceService,
-        private applicationService: IApplicationShell,
         private fs: IFileSystem
     ) {
-        this.sessionStartTime = Date.now();
-
         const statusChangeHandler = (status: ServerStatus) => {
             if (this.onStatusChangedEvent) {
                 this.onStatusChangedEvent.fire(status);
@@ -227,11 +114,9 @@ export class JupyterNotebookBase implements INotebook {
 
             try {
                 traceInfo(`Shutting down session ${this.identity.toString()}`);
-                if (this.session) {
-                    await this.session
-                        .dispose()
-                        .catch(traceError.bind('Failed to dispose session from JupyterNotebook'));
-                }
+                await this.session
+                    .dispose()
+                    .catch(traceError.bind('Failed to dispose session from JupyterNotebook'));
             } catch (exc) {
                 traceError(`Exception shutting down session `, exc);
             }
@@ -248,10 +133,7 @@ export class JupyterNotebookBase implements INotebook {
     }
 
     public get status(): ServerStatus {
-        if (this.session) {
-            return this.session.status;
-        }
-        return ServerStatus.NotStarted;
+        return this.session.status;
     }
 
     public get resource(): Resource {
@@ -262,45 +144,8 @@ export class JupyterNotebookBase implements INotebook {
     }
 
     public waitForIdle(timeoutMs: number): Promise<void> {
-        return this.session ? this.session.waitForIdle(timeoutMs) : Promise.resolve();
+        return this.session.waitForIdle(timeoutMs);
     }
-
-    public execute(
-        code: string,
-        file: string,
-        line: number,
-        id: string,
-        cancelToken?: CancellationToken
-    ): Promise<ICell[]> {
-        // Create a deferred that we'll fire when we're done
-        const deferred = createDeferred<ICell[]>();
-
-        // Attempt to evaluate this cell in the jupyter notebook.
-        const observable = this.executeObservable(code, file, line, id);
-        let output: ICell[];
-
-        observable.subscribe(
-            (cells: ICell[]) => {
-                output = cells;
-            },
-            (error) => {
-                deferred.reject(error);
-            },
-            () => {
-                deferred.resolve(output);
-            }
-        );
-
-        if (cancelToken && cancelToken.onCancellationRequested) {
-            this.disposableRegistry.push(
-                cancelToken.onCancellationRequested(() => deferred.reject(new CancellationError()))
-            );
-        }
-
-        // Wait for the execution to finish
-        return deferred.promise;
-    }
-
     public inspect(code: string, offsetInCode = 0, cancelToken?: CancellationToken): Promise<JSONObject> {
         // Create a deferred that will fire when the request completes
         const deferred = createDeferred<JSONObject>();
@@ -340,30 +185,6 @@ export class JupyterNotebookBase implements INotebook {
         return this.updateWorkingDirectoryAndPath(file);
     }
 
-    public executeObservable(code: string, file: string, line: number, id: string): Observable<ICell[]> {
-        // Create an observable and wrap the result so we can time it.
-        const stopWatch = new StopWatch();
-        const result = this.executeObservableImpl(code, file, line, id);
-        return new Observable<ICell[]>((subscriber) => {
-            result.subscribe(
-                (cells) => {
-                    subscriber.next(cells);
-                    cells.forEach((cell) => {
-                        if (cell.state === CellState.finished || cell.state === CellState.error) {
-                            this.finishedExecuting.fire(cell);
-                        }
-                    });
-                },
-                (error) => {
-                    subscriber.error(error);
-                },
-                () => {
-                    subscriber.complete();
-                    sendTelemetryEvent(Telemetry.ExecuteCellTime, stopWatch.elapsedTime);
-                }
-            );
-        });
-    }
     public fireRestart() {
         this.kernelRestarted.fire();
     }
@@ -372,49 +193,43 @@ export class JupyterNotebookBase implements INotebook {
         offsetInCode: number,
         cancelToken?: CancellationToken
     ): Promise<INotebookCompletion> {
-        if (this.session) {
-            // If server is busy, then don't delay code completion.
-            if (this.session.status === ServerStatus.Busy) {
-                return {
-                    matches: [],
-                    cursor: { start: 0, end: 0 },
-                    metadata: {}
-                };
-            }
-            const result = await Promise.race([
-                this.session!.requestComplete({
-                    code: cellCode,
-                    cursor_pos: offsetInCode
-                }),
-                createPromiseFromCancellation({ defaultValue: undefined, cancelAction: 'resolve', token: cancelToken })
-            ]);
-            traceInfoIf(
-                isCI,
-                `Got jupyter notebook completions. Is cancel? ${cancelToken?.isCancellationRequested}: ${
-                    result ? JSON.stringify(result) : 'empty'
-                }`
-            );
-            if (result && result.content) {
-                if ('matches' in result.content) {
-                    return {
-                        matches: result.content.matches,
-                        cursor: {
-                            start: result.content.cursor_start,
-                            end: result.content.cursor_end
-                        },
-                        metadata: result.content.metadata
-                    };
-                }
-            }
+        // If server is busy, then don't delay code completion.
+        if (this.session.status === ServerStatus.Busy) {
             return {
                 matches: [],
                 cursor: { start: 0, end: 0 },
                 metadata: {}
             };
         }
-
-        // Default is just say session was disposed
-        throw new Error(localize.DataScience.sessionDisposed());
+        const result = await Promise.race([
+            this.session.requestComplete({
+                code: cellCode,
+                cursor_pos: offsetInCode
+            }),
+            createPromiseFromCancellation({ defaultValue: undefined, cancelAction: 'resolve', token: cancelToken })
+        ]);
+        traceInfoIf(
+            isCI,
+            `Got jupyter notebook completions. Is cancel? ${cancelToken?.isCancellationRequested}: ${result ? JSON.stringify(result) : 'empty'
+            }`
+        );
+        if (result && result.content) {
+            if ('matches' in result.content) {
+                return {
+                    matches: result.content.matches,
+                    cursor: {
+                        start: result.content.cursor_start,
+                        end: result.content.cursor_end
+                    },
+                    metadata: result.content.metadata
+                };
+            }
+        }
+        return {
+            matches: [],
+            cursor: { start: 0, end: 0 },
+            metadata: {}
+        };
     }
 
     public getMatchingInterpreter(): PythonEnvironment | undefined {
@@ -428,133 +243,20 @@ export class JupyterNotebookBase implements INotebook {
         targetName: string,
         callback: (comm: Kernel.IComm, msg: KernelMessage.ICommOpenMsg) => void | PromiseLike<void>
     ) {
-        if (this.session) {
-            this.session.registerCommTarget(targetName, callback);
-        } else {
-            throw new Error(localize.DataScience.sessionDisposed());
-        }
+        this.session.registerCommTarget(targetName, callback);
     }
     public registerMessageHook(
         msgId: string,
         hook: (msg: KernelMessage.IIOPubMessage) => boolean | PromiseLike<boolean>
     ): void {
-        if (this.session) {
-            return this.session.registerMessageHook(msgId, hook);
-        } else {
-            throw new Error(localize.DataScience.sessionDisposed());
-        }
+        return this.session.registerMessageHook(msgId, hook);
     }
     public removeMessageHook(
         msgId: string,
         hook: (msg: KernelMessage.IIOPubMessage) => boolean | PromiseLike<boolean>
     ): void {
-        if (this.session) {
-            return this.session.removeMessageHook(msgId, hook);
-        } else {
-            throw new Error(localize.DataScience.sessionDisposed());
-        }
+        return this.session.removeMessageHook(msgId, hook);
     }
-    private executeObservableImpl(code: string, file: string, line: number, id: string): Observable<ICell[]> {
-        // If we have a session, execute the code now.
-        if (this.session) {
-            // Generate our cells ahead of time
-            const cells = generateCells(this.configService.getSettings(this.resource), code, file, line, true, id);
-
-            // Might have more than one (markdown might be split)
-            if (cells.length > 1) {
-                // We need to combine results
-                return this.combineObservables(
-                    this.executeMarkdownObservable(cells[0]),
-                    this.executeCodeObservable(cells[1])
-                );
-            } else if (cells.length > 0) {
-                // Either markdown or or code
-                return this.combineObservables(
-                    cells[0].data.cell_type === 'code'
-                        ? this.executeCodeObservable(cells[0])
-                        : this.executeMarkdownObservable(cells[0])
-                );
-            }
-        }
-
-        traceError('No session during execute observable');
-
-        // Can't run because no session
-        return new Observable<ICell[]>((subscriber) => {
-            subscriber.error(this.getDisposedError());
-            subscriber.complete();
-        });
-    }
-
-    private generateRequest = (
-        code: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        metadata?: Record<string, any>
-    ): Kernel.IShellFuture<KernelMessage.IExecuteRequestMsg, KernelMessage.IExecuteReplyMsg> | undefined => {
-        //traceInfo(`Executing code in jupyter : ${code}`);
-        try {
-            const cellMatcher = new CellMatcher(this.configService.getSettings(this.resource));
-            return this.session
-                ? this.session.requestExecute(
-                      {
-                          // Remove the cell marker if we have one.
-                          code: cellMatcher.stripFirstMarker(code.replace(/\r\n/g, '\n')),
-                          stop_on_error: false,
-                          allow_stdin: true, // Allow when silent too in case runStartupCommands asks for a password
-                          store_history: true // Silent actually means don't output anything. Store_history is what affects execution_count
-                      },
-                      false, // Dispose only silent futures. Otherwise update_display_data doesn't find a future for a previous cell.
-                      metadata
-                  )
-                : undefined;
-        } catch (exc) {
-            // Any errors generating a request should just be logged. User can't do anything about it.
-            traceError(exc);
-        }
-
-        return undefined;
-    };
-
-    private combineObservables = (...args: Observable<ICell>[]): Observable<ICell[]> => {
-        return new Observable<ICell[]>((subscriber) => {
-            // When all complete, we have our results
-            const results: Record<string, ICell> = {};
-
-            args.forEach((o) => {
-                o.subscribe(
-                    (c) => {
-                        results[c.id] = c;
-
-                        // Convert to an array
-                        const array = Object.keys(results).map((k: string) => {
-                            return results[k];
-                        });
-
-                        // Update our subscriber of our total results if we have that many
-                        if (array.length === args.length) {
-                            subscriber.next(array);
-
-                            // Complete when everybody is finished
-                            if (array.every((a) => a.state === CellState.finished || a.state === CellState.error)) {
-                                subscriber.complete();
-                            }
-                        }
-                    },
-                    (e) => {
-                        subscriber.error(e);
-                    }
-                );
-            });
-        });
-    };
-
-    private executeMarkdownObservable = (cell: ICell): Observable<ICell> => {
-        // Markdown doesn't need any execution
-        return new Observable<ICell>((subscriber) => {
-            subscriber.next(cell);
-            subscriber.complete();
-        });
-    };
 
     private async updateWorkingDirectoryAndPath(launchingFile?: string): Promise<void> {
         traceInfo('UpdateWorkingDirectoryAndPath in Jupyter Notebook');
@@ -596,69 +298,6 @@ export class JupyterNotebookBase implements INotebook {
         }
     };
 
-    private handleIOPub(subscriber: CellSubscriber, clearState: RefBool, msg: KernelMessage.IIOPubMessage) {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        const jupyterLab = require('@jupyterlab/services') as typeof import('@jupyterlab/services');
-
-        // Create a trimming function. Only trim user output. Silent output requires the full thing
-        const trimFunc = this.trimOutput.bind(this);
-        let shouldUpdateSubscriber = true;
-        try {
-            if (jupyterLab.KernelMessage.isExecuteResultMsg(msg)) {
-                this.handleExecuteResult(msg as KernelMessage.IExecuteResultMsg, clearState, subscriber.cell, trimFunc);
-            } else if (jupyterLab.KernelMessage.isExecuteInputMsg(msg)) {
-                this.handleExecuteInput(msg as KernelMessage.IExecuteInputMsg, clearState, subscriber.cell);
-            } else if (jupyterLab.KernelMessage.isStatusMsg(msg)) {
-                // If there is no change in the status, then there's no need to update the subscriber.
-                // Else we end up sending a number of messages unnecessarily uptream.
-                const statusMsg = msg as KernelMessage.IStatusMsg;
-                if (statusMsg.content.execution_state === subscriber.executionState) {
-                    shouldUpdateSubscriber = false;
-                }
-                subscriber.executionState = statusMsg.content.execution_state;
-                this.handleStatusMessage(statusMsg, clearState, subscriber.cell);
-            } else if (jupyterLab.KernelMessage.isStreamMsg(msg)) {
-                this.handleStreamMesssage(msg as KernelMessage.IStreamMsg, clearState, subscriber.cell, trimFunc);
-            } else if (jupyterLab.KernelMessage.isDisplayDataMsg(msg)) {
-                this.handleDisplayData(msg as KernelMessage.IDisplayDataMsg, clearState, subscriber.cell);
-            } else if (jupyterLab.KernelMessage.isUpdateDisplayDataMsg(msg)) {
-                // No new data to update UI, hence do not send updates.
-                shouldUpdateSubscriber = false;
-            } else if (jupyterLab.KernelMessage.isClearOutputMsg(msg)) {
-                this.handleClearOutput(msg as KernelMessage.IClearOutputMsg, clearState, subscriber.cell);
-            } else if (jupyterLab.KernelMessage.isErrorMsg(msg)) {
-                this.handleError(msg as KernelMessage.IErrorMsg, clearState, subscriber.cell);
-            } else if (jupyterLab.KernelMessage.isCommOpenMsg(msg)) {
-                // No new data to update UI, hence do not send updates.
-                shouldUpdateSubscriber = false;
-            } else if (jupyterLab.KernelMessage.isCommMsgMsg(msg)) {
-                // No new data to update UI, hence do not send updates.
-                shouldUpdateSubscriber = false;
-            } else if (jupyterLab.KernelMessage.isCommCloseMsg(msg)) {
-                // No new data to update UI, hence do not send updates.
-                shouldUpdateSubscriber = false;
-            } else {
-                traceWarning(`Unknown message ${msg.header.msg_type} : hasData=${'data' in msg.content}`);
-            }
-
-            // Set execution count, all messages should have it
-            if ('execution_count' in msg.content && typeof msg.content.execution_count === 'number') {
-                subscriber.cell.data.execution_count = msg.content.execution_count as number;
-            }
-
-            // Tell all of the listeners about the event.
-            [...this.ioPubListeners].forEach((l) => l(msg, msg.header.msg_id));
-
-            // Show our update if any new output.
-            if (shouldUpdateSubscriber) {
-                subscriber.next(this.sessionStartTime);
-            }
-        } catch (err) {
-            // If not a restart error, then tell the subscriber
-            subscriber.error(this.sessionStartTime, err);
-        }
-    }
-
     private checkForExit(): Error | undefined {
         if (this._executionInfo && this._executionInfo.connectionInfo && !this._executionInfo.connectionInfo.valid) {
             if (this._executionInfo.connectionInfo.type === 'jupyter') {
@@ -670,377 +309,5 @@ export class JupyterNotebookBase implements INotebook {
                 }
             }
         }
-
-        return undefined;
-    }
-
-    private handleInputRequest(_subscriber: CellSubscriber, msg: KernelMessage.IStdinMessage) {
-        // Ask the user for input
-        if (msg.content && 'prompt' in msg.content) {
-            const hasPassword = msg.content.password !== null && (msg.content.password as boolean);
-            void this.applicationService
-                .showInputBox({
-                    prompt: msg.content.prompt ? msg.content.prompt.toString() : '',
-                    ignoreFocusOut: true,
-                    password: hasPassword
-                })
-                .then((v) => {
-                    this.session.sendInputReply(v || '');
-                }, noop);
-        }
-    }
-
-    private handleReply(subscriber: CellSubscriber, clearState: RefBool, msg: KernelMessage.IShellControlMessage) {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        const jupyterLab = require('@jupyterlab/services') as typeof import('@jupyterlab/services');
-
-        // Create a trimming function. Only trim user output. Silent output requires the full thing
-        const trimFunc = this.trimOutput.bind(this);
-
-        if (jupyterLab.KernelMessage.isExecuteReplyMsg(msg)) {
-            this.handleExecuteReply(msg, clearState, subscriber.cell, trimFunc);
-
-            // Set execution count, all messages should have it
-            if ('execution_count' in msg.content && typeof msg.content.execution_count === 'number') {
-                subscriber.cell.data.execution_count = msg.content.execution_count as number;
-            }
-
-            // Send this event.
-            subscriber.next(this.sessionStartTime);
-        }
-    }
-
-    // eslint-disable-next-line
-    private handleCodeRequest = (subscriber: CellSubscriber) => {
-        // Generate a new request if we still can
-        if (subscriber.isValid(this.sessionStartTime)) {
-            // Double check process is still running
-            const exitError = this.checkForExit();
-            if (exitError) {
-                // Not running, just exit
-                subscriber.error(this.sessionStartTime, exitError);
-                subscriber.complete(this.sessionStartTime);
-            } else {
-                const request = this.generateRequest(concatMultilineString(subscriber.cell.data.source), {
-                    ...subscriber.cell.data.metadata,
-                    ...{ cellId: subscriber.cell.id }
-                });
-
-                // Transition to the busy stage
-                subscriber.cell.state = CellState.executing;
-
-                // Make sure our connection doesn't go down
-                let exitHandlerDisposable: Disposable | undefined;
-                if (this._executionInfo && this._executionInfo.connectionInfo) {
-                    // If the server crashes, cancel the current observable
-                    exitHandlerDisposable = this._executionInfo.connectionInfo.disconnected((c) => {
-                        const str = c ? c.toString() : '';
-                        // Only do an error if we're not disposed. If we're disposed we already shutdown.
-                        if (!this._disposed) {
-                            subscriber.error(
-                                this.sessionStartTime,
-                                new Error(localize.DataScience.jupyterServerCrashed().format(str))
-                            );
-                        }
-                        subscriber.complete(this.sessionStartTime);
-                    });
-                }
-
-                // Keep track of our clear state
-                const clearState = new RefBool(false);
-
-                // Listen to the reponse messages and update state as we go
-                if (request) {
-                    // Stop handling the request if the subscriber is canceled.
-                    subscriber.onCanceled(() => {
-                        request.onIOPub = noop;
-                        request.onStdin = noop;
-                        request.onReply = noop;
-                    });
-
-                    // Listen to messages.
-                    request.onIOPub = this.handleIOPub.bind(this, subscriber, clearState);
-                    request.onStdin = this.handleInputRequest.bind(this, subscriber);
-                    request.onReply = this.handleReply.bind(this, subscriber, clearState);
-
-                    // When the request finishes we are done
-                    request.done
-                        .then(() => subscriber.complete(this.sessionStartTime))
-                        .catch((e) => {
-                            // @jupyterlab/services throws a `Canceled` error when the kernel is interrupted.
-                            // Such an error must be ignored.
-                            if (e && e instanceof Error && e.message === 'Canceled') {
-                                subscriber.complete(this.sessionStartTime);
-                            } else {
-                                subscriber.error(this.sessionStartTime, e);
-                            }
-                        })
-                        .finally(() => {
-                            if (exitHandlerDisposable) {
-                                exitHandlerDisposable.dispose();
-                            }
-                        })
-                        .ignoreErrors();
-                } else {
-                    subscriber.error(this.sessionStartTime, this.getDisposedError());
-                }
-            }
-        } else {
-            const sessionDate = new Date(this.sessionStartTime!);
-            const cellDate = new Date(subscriber.startTime);
-            traceInfo(
-                `Session start time is newer than cell : \r\n${sessionDate.toTimeString()}\r\n${cellDate.toTimeString()}`
-            );
-
-            // Otherwise just set to an error
-            this.handleInterrupted(subscriber.cell);
-            subscriber.cell.state = CellState.error;
-            subscriber.complete(this.sessionStartTime);
-        }
-    };
-
-    private executeCodeObservable(cell: ICell): Observable<ICell> {
-        return new Observable<ICell>((subscriber) => {
-            // Tell our listener. NOTE: have to do this asap so that markdown cells don't get
-            // run before our cells.
-            subscriber.next(cell);
-
-            // Wrap the subscriber and save it. It is now pending and waiting completion. Have to do this
-            // synchronously so it happens before interruptions.
-            const cellSubscriber = new CellSubscriber(cell, subscriber, (self: CellSubscriber) => {
-                // Subscriber completed, remove from subscriptions.
-                this.pendingCellSubscriptions = this.pendingCellSubscriptions.filter((p) => p !== self);
-            });
-            this.pendingCellSubscriptions.push(cellSubscriber);
-
-            // Now send our real request. This should call back on the cellsubscriber when it's done.
-            this.handleCodeRequest(cellSubscriber);
-        });
-    }
-
-    private addToCellData = (
-        cell: ICell,
-        output: nbformat.IExecuteResult | nbformat.IDisplayData | nbformat.IStream | nbformat.IError,
-        clearState: RefBool
-    ) => {
-        const data: nbformat.ICodeCell = cell.data as nbformat.ICodeCell;
-
-        // Clear if necessary
-        if (clearState.value) {
-            data.outputs = [];
-            clearState.update(false);
-        }
-
-        // Append to the data.
-        data.outputs = [...data.outputs, output];
-        cell.data = data;
-    };
-
-    // See this for docs on the messages:
-    // https://jupyter-client.readthedocs.io/en/latest/messaging.html#messaging-in-jupyter
-    private handleExecuteResult(
-        msg: KernelMessage.IExecuteResultMsg,
-        clearState: RefBool,
-        cell: ICell,
-        trimFunc: (str: string) => string
-    ) {
-        // Check our length on text output
-        if (msg.content.data && msg.content.data.hasOwnProperty('text/plain')) {
-            msg.content.data['text/plain'] = splitMultilineString(
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                trimFunc(concatMultilineString(msg.content.data['text/plain'] as any))
-            );
-        }
-
-        this.addToCellData(
-            cell,
-            {
-                output_type: 'execute_result',
-                data: msg.content.data,
-                metadata: msg.content.metadata,
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                transient: msg.content.transient as any, // NOSONAR
-                execution_count: msg.content.execution_count
-            },
-            clearState
-        );
-    }
-
-    private handleExecuteReply(
-        msg: KernelMessage.IExecuteReplyMsg,
-        clearState: RefBool,
-        cell: ICell,
-        trimFunc: (str: string) => string
-    ) {
-        const reply = msg.content as KernelMessage.IExecuteReply;
-        if (reply.payload) {
-            reply.payload.forEach((o) => {
-                if (o.data && o.data.hasOwnProperty('text/plain')) {
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    const str = concatMultilineString((o.data as any)['text/plain']); // NOSONAR
-                    const data = trimFunc(str);
-                    this.addToCellData(
-                        cell,
-                        {
-                            // Mark as stream output so the text is formatted because it likely has ansi codes in it.
-                            output_type: 'stream',
-                            text: splitMultilineString(data),
-                            name: 'stdout',
-                            metadata: {},
-                            execution_count: reply.execution_count
-                        },
-                        clearState
-                    );
-                }
-            });
-        }
-    }
-
-    private handleExecuteInput(msg: KernelMessage.IExecuteInputMsg, _clearState: RefBool, cell: ICell) {
-        cell.data.execution_count = msg.content.execution_count;
-    }
-
-    private handleStatusMessage(msg: KernelMessage.IStatusMsg, _clearState: RefBool, _cell: ICell) {
-        traceInfo(`Kernel switching to ${msg.content.execution_state}`);
-    }
-
-    private handleStreamMesssage(
-        msg: KernelMessage.IStreamMsg,
-        clearState: RefBool,
-        cell: ICell,
-        trimFunc: (str: string) => string
-    ) {
-        const data: nbformat.ICodeCell = cell.data as nbformat.ICodeCell;
-        let originalTextLength = 0;
-        let trimmedTextLength = 0;
-
-        // Clear output if waiting for a clear
-        if (clearState.value) {
-            data.outputs = [];
-            clearState.update(false);
-        }
-
-        // Might already have a stream message. If so, just add on to it.
-        const existing =
-            data.outputs.length > 0 && data.outputs[data.outputs.length - 1].output_type === 'stream'
-                ? data.outputs[data.outputs.length - 1]
-                : undefined;
-        if (existing) {
-            const originalText = formatStreamText(
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                `${concatMultilineString(existing.text as any)}${concatMultilineString(msg.content.text)}`
-            );
-            originalTextLength = originalText.length;
-            const newText = trimFunc(originalText);
-            trimmedTextLength = newText.length;
-            existing.text = splitMultilineString(newText);
-        } else {
-            const originalText = formatStreamText(concatMultilineString(msg.content.text));
-            originalTextLength = originalText.length;
-            // Create a new stream entry
-            const output: nbformat.IStream = {
-                output_type: 'stream',
-                name: msg.content.name,
-                text: [trimFunc(originalText)]
-            };
-            data.outputs = [...data.outputs, output];
-            trimmedTextLength = output.text[0].length;
-            cell.data = data;
-        }
-
-        // If the output was trimmed, we add the 'outputPrepend' metadata tag.
-        // Later, the react side will display a message letting the user know
-        // the output is trimmed and what setting changes that.
-        // * If data.metadata.tags is undefined, define it so the following
-        //   code is can rely on it being defined.
-        if (trimmedTextLength < originalTextLength) {
-            if (data.metadata.tags === undefined) {
-                data.metadata.tags = [];
-            }
-            data.metadata.tags = data.metadata.tags.filter((t) => t !== 'outputPrepend');
-            data.metadata.tags.push('outputPrepend');
-        }
-    }
-
-    private handleDisplayData(msg: KernelMessage.IDisplayDataMsg, clearState: RefBool, cell: ICell) {
-        const newData = handleTensorBoardDisplayDataOutput(msg.content.data);
-        const output: nbformat.IDisplayData = {
-            output_type: 'display_data',
-            data: newData,
-            metadata: msg.content.metadata,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            transient: msg.content.transient as any // NOSONAR
-        };
-        this.addToCellData(cell, output, clearState);
-    }
-
-    private handleClearOutput(msg: KernelMessage.IClearOutputMsg, clearState: RefBool, cell: ICell) {
-        // If the message says wait, add every message type to our clear state. This will
-        // make us wait for this type of output before we clear it.
-        if (msg && msg.content.wait) {
-            clearState.update(true);
-        } else {
-            // Clear all outputs and start over again.
-            const data: nbformat.ICodeCell = cell.data as nbformat.ICodeCell;
-            data.outputs = [];
-        }
-    }
-
-    private handleInterrupted(cell: ICell) {
-        this.handleError(
-            {
-                channel: 'iopub',
-                parent_header: {},
-                metadata: {},
-                header: { username: '', version: '', session: '', msg_id: '', msg_type: 'error', date: '' },
-                content: {
-                    ename: 'KeyboardInterrupt',
-                    evalue: '',
-                    // Does this need to be translated? All depends upon if jupyter does or not
-                    traceback: [
-                        '[1;31m---------------------------------------------------------------------------[0m',
-                        '[1;31mKeyboardInterrupt[0m: '
-                    ]
-                }
-            },
-            new RefBool(false),
-            cell
-        );
-    }
-
-    private handleError(msg: KernelMessage.IErrorMsg, clearState: RefBool, cell: ICell) {
-        const output: nbformat.IError = {
-            output_type: 'error',
-            ename: msg.content.ename,
-            evalue: msg.content.evalue,
-            traceback: msg.content.traceback
-        };
-        if (msg.content.hasOwnProperty('transient')) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            output.transient = (msg.content as any).transient;
-        }
-        this.addToCellData(cell, output, clearState);
-        cell.state = CellState.error;
-
-        // In the error scenario, we want to stop all other pending cells.
-        if (this.configService.getSettings(this.resource).stopOnError) {
-            this.pendingCellSubscriptions.forEach((c) => {
-                if (c.cell.id !== cell.id) {
-                    c.cancel();
-                }
-            });
-        }
-    }
-
-    // We have a set limit for the number of output text characters that we display by default
-    // trim down strings to that limit, assuming at this point we have compressed down to a single string
-    private trimOutput(outputString: string): string {
-        const outputLimit = this.configService.getSettings(this.resource).textOutputLimit;
-
-        if (!outputLimit || outputLimit === 0 || outputString.length <= outputLimit) {
-            return outputString;
-        }
-
-        return outputString.substr(outputString.length - outputLimit);
     }
 }

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -35,7 +35,6 @@ import { getInterpreterFromKernelConnectionMetadata, isPythonKernelConnection } 
 import { executeSilently } from './kernels/kernel';
 import { isCI } from '../../common/constants';
 
-
 // This code is based on the examples here:
 // https://www.npmjs.com/package/@jupyterlab/services
 
@@ -114,9 +113,7 @@ export class JupyterNotebookBase implements INotebook {
 
             try {
                 traceInfo(`Shutting down session ${this.identity.toString()}`);
-                await this.session
-                    .dispose()
-                    .catch(traceError.bind('Failed to dispose session from JupyterNotebook'));
+                await this.session.dispose().catch(traceError.bind('Failed to dispose session from JupyterNotebook'));
             } catch (exc) {
                 traceError(`Exception shutting down session `, exc);
             }
@@ -210,7 +207,8 @@ export class JupyterNotebookBase implements INotebook {
         ]);
         traceInfoIf(
             isCI,
-            `Got jupyter notebook completions. Is cancel? ${cancelToken?.isCancellationRequested}: ${result ? JSON.stringify(result) : 'empty'
+            `Got jupyter notebook completions. Is cancel? ${cancelToken?.isCancellationRequested}: ${
+                result ? JSON.stringify(result) : 'empty'
             }`
         );
         if (result && result.content) {

--- a/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
+++ b/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
@@ -146,11 +146,11 @@ export class HostJupyterServer extends JupyterServerBase implements INotebookSer
                 possibleSession && sessionDirectoryMatches
                     ? possibleSession
                     : await sessionManager.startNew(
-                        resource,
-                        info.kernelConnectionMetadata,
-                        workingDirectory,
-                        cancelToken
-                    );
+                          resource,
+                          info.kernelConnectionMetadata,
+                          workingDirectory,
+                          cancelToken
+                      );
             traceInfo(`Started session ${this.id}`);
             return { info, session };
         };
@@ -242,11 +242,11 @@ export class HostJupyterServer extends JupyterServerBase implements INotebookSer
                 kernelInfo = await (launchInfo.connectionInfo.localLaunch
                     ? this.localKernelFinder.findKernel(resource, notebookMetadata, cancelToken)
                     : this.remoteKernelFinder.findKernel(
-                        resource,
-                        launchInfo.connectionInfo,
-                        notebookMetadata,
-                        cancelToken
-                    ));
+                          resource,
+                          launchInfo.connectionInfo,
+                          notebookMetadata,
+                          cancelToken
+                      ));
                 traceInfoIf(isCI, `kernelInfo found ${kernelInfo?.id}`);
             }
             if (kernelInfo && kernelInfo.id !== launchInfo.kernelConnectionMetadata?.id) {

--- a/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
+++ b/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
@@ -7,7 +7,7 @@ import { nbformat } from '@jupyterlab/coreutils';
 import * as vscode from 'vscode';
 import { CancellationToken } from 'vscode-jsonrpc';
 import { IPythonExtensionChecker } from '../../../api/types';
-import { IApplicationShell, IVSCodeNotebook, IWorkspaceService } from '../../../common/application/types';
+import { IVSCodeNotebook, IWorkspaceService } from '../../../common/application/types';
 import { traceInfo, traceInfoIf } from '../../../common/logger';
 import { IFileSystem } from '../../../common/platform/types';
 import {
@@ -49,7 +49,6 @@ export class HostJupyterServer extends JupyterServerBase implements INotebookSer
         @inject(IConfigurationService) configService: IConfigurationService,
         @inject(IJupyterSessionManagerFactory) sessionManager: IJupyterSessionManagerFactory,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
-        @inject(IApplicationShell) private readonly appService: IApplicationShell,
         @inject(IFileSystem) private readonly fs: IFileSystem,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(ILocalKernelFinder) private readonly localKernelFinder: ILocalKernelFinder,
@@ -147,11 +146,11 @@ export class HostJupyterServer extends JupyterServerBase implements INotebookSer
                 possibleSession && sessionDirectoryMatches
                     ? possibleSession
                     : await sessionManager.startNew(
-                          resource,
-                          info.kernelConnectionMetadata,
-                          workingDirectory,
-                          cancelToken
-                      );
+                        resource,
+                        info.kernelConnectionMetadata,
+                        workingDirectory,
+                        cancelToken
+                    );
             traceInfo(`Started session ${this.id}`);
             return { info, session };
         };
@@ -163,14 +162,11 @@ export class HostJupyterServer extends JupyterServerBase implements INotebookSer
                 // Create our notebook
                 const notebook = new JupyterNotebookBase(
                     session,
-                    configService,
                     disposableRegistry,
                     info,
                     resource,
                     identity,
-                    this.getDisposedError.bind(this),
                     this.workspaceService,
-                    this.appService,
                     this.fs
                 );
 
@@ -246,11 +242,11 @@ export class HostJupyterServer extends JupyterServerBase implements INotebookSer
                 kernelInfo = await (launchInfo.connectionInfo.localLaunch
                     ? this.localKernelFinder.findKernel(resource, notebookMetadata, cancelToken)
                     : this.remoteKernelFinder.findKernel(
-                          resource,
-                          launchInfo.connectionInfo,
-                          notebookMetadata,
-                          cancelToken
-                      ));
+                        resource,
+                        launchInfo.connectionInfo,
+                        notebookMetadata,
+                        cancelToken
+                    ));
                 traceInfoIf(isCI, `kernelInfo found ${kernelInfo?.id}`);
             }
             if (kernelInfo && kernelInfo.id !== launchInfo.kernelConnectionMetadata?.id) {

--- a/src/client/datascience/notebook/notebookControllerManager.ts
+++ b/src/client/datascience/notebook/notebookControllerManager.ts
@@ -98,11 +98,13 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
         this.disposables.push(this._onNotebookControllerSelected);
         this.isLocalLaunch = isLocalLaunch(this.configuration);
     }
-    public async getInteractiveController(): Promise<VSCodeNotebookController | undefined> {
+    public async getActiveInterpreterOrDefaultController(
+        notebookType: typeof JupyterNotebookView | typeof InteractiveWindowView
+    ): Promise<VSCodeNotebookController | undefined> {
         if (this.isLocalLaunch) {
-            return this.createActiveInterpreterController(InteractiveWindowView);
+            return this.createActiveInterpreterController(notebookType);
         } else {
-            return this.createDefaultRemoteControllerForInteractiveWindow();
+            return this.createDefaultRemoteController();
         }
     }
 
@@ -209,7 +211,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
         }
         return this.getOrCreateController(activeInterpreter, notebookType);
     }
-    private async createDefaultRemoteControllerForInteractiveWindow() {
+    private async createDefaultRemoteController() {
         // Get all remote kernels
         await this.loadNotebookControllers();
         const controllers = this.registeredNotebookControllers();

--- a/src/client/datascience/notebook/types.ts
+++ b/src/client/datascience/notebook/types.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Event, NotebookDocument, NotebookEditor, Uri } from 'vscode';
+import { InteractiveWindowView, JupyterNotebookView } from './constants';
 import { VSCodeNotebookController } from './vscodeNotebookController';
 
 export const INotebookKernelResolver = Symbol('INotebookKernelResolver');
@@ -12,7 +13,9 @@ export interface INotebookControllerManager {
     getSelectedNotebookController(document: NotebookDocument): VSCodeNotebookController | undefined;
     // Marked test only, just for tests to access registered controllers
     registeredNotebookControllers(): VSCodeNotebookController[];
-    getInteractiveController(): Promise<VSCodeNotebookController | undefined>;
+    getActiveInterpreterOrDefaultController(
+        notebookType: typeof JupyterNotebookView | typeof InteractiveWindowView
+    ): Promise<VSCodeNotebookController | undefined>;
     getPreferredNotebookController(document: NotebookDocument): VSCodeNotebookController | undefined;
 }
 export enum CellOutputMimeTypes {

--- a/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
@@ -108,8 +108,8 @@ export class HostRawNotebookProvider extends RawNotebookProviderBase implements 
 
             progressDisposable = !disableUI
                 ? this.progressReporter.createProgressIndicator(
-                    localize.DataScience.connectingToKernel().format(displayName)
-                )
+                      localize.DataScience.connectingToKernel().format(displayName)
+                  )
                 : undefined;
 
             traceInfo(`Computing working directory ${identity.toString()}`);

--- a/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import { CancellationToken } from 'vscode-jsonrpc';
 
 import { IPythonExtensionChecker } from '../../../api/types';
-import { IApplicationShell, IWorkspaceService } from '../../../common/application/types';
+import { IWorkspaceService } from '../../../common/application/types';
 import { traceError, traceInfo } from '../../../common/logger';
 import { IFileSystem } from '../../../common/platform/types';
 import {
@@ -55,7 +55,6 @@ export class HostRawNotebookProvider extends RawNotebookProviderBase implements 
         @inject(IAsyncDisposableRegistry) asyncRegistry: IAsyncDisposableRegistry,
         @inject(IConfigurationService) private readonly configService: IConfigurationService,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
-        @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(IFileSystem) private readonly fs: IFileSystem,
         @inject(IKernelLauncher) private readonly kernelLauncher: IKernelLauncher,
         @inject(ILocalKernelFinder) private readonly localKernelFinder: ILocalKernelFinder,
@@ -109,8 +108,8 @@ export class HostRawNotebookProvider extends RawNotebookProviderBase implements 
 
             progressDisposable = !disableUI
                 ? this.progressReporter.createProgressIndicator(
-                      localize.DataScience.connectingToKernel().format(displayName)
-                  )
+                    localize.DataScience.connectingToKernel().format(displayName)
+                )
                 : undefined;
 
             traceInfo(`Computing working directory ${identity.toString()}`);
@@ -159,14 +158,11 @@ export class HostRawNotebookProvider extends RawNotebookProviderBase implements 
                     // Create our notebook
                     const notebook = new JupyterNotebookBase(
                         rawSession,
-                        this.configService,
                         this.disposableRegistry,
                         info,
                         resource,
                         identity,
-                        this.getDisposedError.bind(this),
                         this.workspaceService,
-                        this.appShell,
                         this.fs
                     );
 

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -181,8 +181,6 @@ export interface INotebook extends IAsyncDisposable {
     onDisposed: Event<void>;
     onKernelChanged: Event<KernelConnectionMetadata>;
     onKernelRestarted: Event<void>;
-    executeObservable(code: string, file: string, line: number, id: string, silent: boolean): Observable<ICell[]>;
-    execute(code: string, file: string, line: number, id: string, cancelToken?: CancellationToken): Promise<ICell[]>;
     inspect(code: string, offsetInCode?: number, cancelToken?: CancellationToken): Promise<JSONObject>;
     getCompletion(
         cellCode: string,

--- a/src/test/datascience/notebook/executionService.mock.vscode.test.ts
+++ b/src/test/datascience/notebook/executionService.mock.vscode.test.ts
@@ -121,9 +121,6 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         const observableResult = new Subject();
         observableResult.next();
         observableResult.complete();
-        when(inotebook.executeObservable(anything(), anything(), anything(), anything(), anything())).thenReturn(
-            observableResult.asObservable() as any
-        );
         const kernelSocket = new Subject<KernelSocketInformation>();
         kernelSocket.next();
         kernelSocket.complete();


### PR DESCRIPTION
In this PR we remove execCell & execObservable from INotebook & use IKernel directly.
I.e. re-use existing code in IKernel
Part of https://github.com/microsoft/vscode-jupyter/issues/6950