### PR TITLE
Throw error instead of returning undefined

### DIFF
--- a/pythonFiles/install_debugpy.py
+++ b/pythonFiles/install_debugpy.py
@@ -9,7 +9,8 @@ from packaging.version import parse as version_parser
 EXTENSION_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEBUGGER_DEST = os.path.join(EXTENSION_ROOT, "pythonFiles", "lib", "python")
 DEBUGGER_PACKAGE = "debugpy"
-DEBUGGER_PYTHON_VERSIONS = ("cp37",)
+DEBUGGER_PYTHON_ABI_VERSIONS = ("cp37",)
+DEBUGGER_VERSION = "1.4.3"  # can also be "latest"
 
 
 def _contains(s, parts=()):
@@ -28,7 +29,7 @@ def _get_debugger_wheel_urls(data, version):
     return list(
         r["url"]
         for r in data["releases"][version]
-        if _contains(r["url"], DEBUGGER_PYTHON_VERSIONS)
+        if _contains(r["url"], DEBUGGER_PYTHON_ABI_VERSIONS)
     )
 
 
@@ -53,10 +54,14 @@ def _download_and_extract(root, url, version):
 
 def main(root):
     data = _get_package_data()
-    latest_version = max(data["releases"].keys(), key=version_parser)
 
-    for url in _get_debugger_wheel_urls(data, latest_version):
-        _download_and_extract(root, url, latest_version)
+    if DEBUGGER_VERSION == "latest":
+        use_version = max(data["releases"].keys(), key=version_parser)
+    else:
+        use_version = DEBUGGER_VERSION
+
+    for url in _get_debugger_wheel_urls(data, use_version):
+        _download_and_extract(root, url, use_version)
 
 
 if __name__ == "__main__":

--- a/src/client/datascience/baseJupyterSession.ts
+++ b/src/client/datascience/baseJupyterSession.ts
@@ -239,35 +239,39 @@ export abstract class BaseJupyterSession implements IJupyterSession {
         content: KernelMessage.IExecuteRequestMsg['content'],
         disposeOnDone?: boolean,
         metadata?: JSONObject
-    ): Kernel.IShellFuture<KernelMessage.IExecuteRequestMsg, KernelMessage.IExecuteReplyMsg> | undefined {
-        return this.session && this.session.kernel
-            ? this.session.kernel.requestExecute(content, disposeOnDone, metadata)
-            : undefined;
+    ): Kernel.IShellFuture<KernelMessage.IExecuteRequestMsg, KernelMessage.IExecuteReplyMsg> {
+        if (!this.session?.kernel) {
+            throw new Error(localize.DataScience.sessionDisposed());
+        }
+        return this.session.kernel.requestExecute(content, disposeOnDone, metadata);
     }
 
     public requestDebug(
         content: KernelMessage.IDebugRequestMsg['content'],
         disposeOnDone?: boolean
-    ): Kernel.IControlFuture<KernelMessage.IDebugRequestMsg, KernelMessage.IDebugReplyMsg> | undefined {
-        return this.session && this.session.kernel
-            ? this.session.kernel.requestDebug(content, disposeOnDone)
-            : undefined;
+    ): Kernel.IControlFuture<KernelMessage.IDebugRequestMsg, KernelMessage.IDebugReplyMsg> {
+        if (!this.session?.kernel) {
+            throw new Error(localize.DataScience.sessionDisposed());
+        }
+        return this.session.kernel.requestDebug(content, disposeOnDone);
     }
 
     public requestInspect(
         content: KernelMessage.IInspectRequestMsg['content']
-    ): Promise<KernelMessage.IInspectReplyMsg | undefined> {
-        return this.session && this.session.kernel
-            ? this.session.kernel.requestInspect(content)
-            : Promise.resolve(undefined);
+    ): Promise<KernelMessage.IInspectReplyMsg> {
+        if (!this.session?.kernel) {
+            throw new Error(localize.DataScience.sessionDisposed());
+        }
+        return this.session.kernel.requestInspect(content);
     }
 
     public requestComplete(
         content: KernelMessage.ICompleteRequestMsg['content']
-    ): Promise<KernelMessage.ICompleteReplyMsg | undefined> {
-        return this.session && this.session.kernel
-            ? this.session.kernel.requestComplete(content)
-            : Promise.resolve(undefined);
+    ): Promise<KernelMessage.ICompleteReplyMsg> {
+        if (!this.session?.kernel) {
+            throw new Error(localize.DataScience.sessionDisposed());
+        }
+        return this.session.kernel.requestComplete(content);
     }
 
     public sendInputReply(content: string) {

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -153,19 +153,23 @@ export class JupyterNotebookBase implements INotebook {
             // Not running, just exit
             deferred.reject(exitError);
         } else {
-            // Ask session for inspect result
-            this.session
-                .requestInspect({ code, cursor_pos: offsetInCode, detail_level: 0 })
-                .then((r) => {
-                    if (r && r.content.status === 'ok') {
-                        deferred.resolve(r.content.data);
-                    } else {
-                        deferred.resolve(undefined);
-                    }
-                })
-                .catch((ex) => {
-                    deferred.reject(ex);
-                });
+            try {
+                // Ask session for inspect result
+                this.session
+                    .requestInspect({ code, cursor_pos: offsetInCode, detail_level: 0 })
+                    .then((r) => {
+                        if (r && r.content.status === 'ok') {
+                            deferred.resolve(r.content.data);
+                        } else {
+                            deferred.resolve(undefined);
+                        }
+                    })
+                    .catch((ex) => {
+                        deferred.reject(ex);
+                    });
+            } catch (ex) {
+                deferred.reject(ex);
+            }
         }
 
         if (cancelToken) {

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -273,17 +273,13 @@ export interface IJupyterSession extends IAsyncDisposable {
         content: KernelMessage.IExecuteRequestMsg['content'],
         disposeOnDone?: boolean,
         metadata?: JSONObject
-    ): Kernel.IShellFuture<KernelMessage.IExecuteRequestMsg, KernelMessage.IExecuteReplyMsg> | undefined;
+    ): Kernel.IShellFuture<KernelMessage.IExecuteRequestMsg, KernelMessage.IExecuteReplyMsg>;
     requestDebug(
         content: KernelMessage.IDebugRequestMsg['content'],
         disposeOnDone?: boolean
-    ): Kernel.IControlFuture<KernelMessage.IDebugRequestMsg, KernelMessage.IDebugReplyMsg> | undefined;
-    requestComplete(
-        content: KernelMessage.ICompleteRequestMsg['content']
-    ): Promise<KernelMessage.ICompleteReplyMsg | undefined>;
-    requestInspect(
-        content: KernelMessage.IInspectRequestMsg['content']
-    ): Promise<KernelMessage.IInspectReplyMsg | undefined>;
+    ): Kernel.IControlFuture<KernelMessage.IDebugRequestMsg, KernelMessage.IDebugReplyMsg>;
+    requestComplete(content: KernelMessage.ICompleteRequestMsg['content']): Promise<KernelMessage.ICompleteReplyMsg>;
+    requestInspect(content: KernelMessage.IInspectRequestMsg['content']): Promise<KernelMessage.IInspectReplyMsg>;
     sendInputReply(content: string): void;
     changeKernel(resource: Resource, kernelConnection: KernelConnectionMetadata, timeoutMS: number): Promise<void>;
     registerCommTarget(

--- a/src/client/debugger/jupyter/kernelDebugAdapter.ts
+++ b/src/client/debugger/jupyter/kernelDebugAdapter.ts
@@ -277,26 +277,24 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
                 arguments: request.arguments
             });
 
-            if (control) {
-                control.onReply = (msg) => {
-                    const message = msg.content as DebugProtocol.ProtocolMessage;
-                    getMessageSourceAndHookIt(message, (source) => {
-                        if (source && source.path) {
-                            const cell = this.fileToCell.get(source.path);
-                            if (cell) {
-                                source.name = path.basename(cell.document.uri.path);
-                                if (cell.index >= 0) {
-                                    source.name += `, Cell ${cell.index + 1}`;
-                                }
-                                source.path = cell.document.uri.toString();
+            control.onReply = (msg) => {
+                const message = msg.content as DebugProtocol.ProtocolMessage;
+                getMessageSourceAndHookIt(message, (source) => {
+                    if (source && source.path) {
+                        const cell = this.fileToCell.get(source.path);
+                        if (cell) {
+                            source.name = path.basename(cell.document.uri.path);
+                            if (cell.index >= 0) {
+                                source.name += `, Cell ${cell.index + 1}`;
                             }
+                            source.path = cell.document.uri.toString();
                         }
-                    });
+                    }
+                });
 
-                    this.trace('response', JSON.stringify(message));
-                    this.sendMessage.fire(message);
-                };
-            }
+                this.trace('response', JSON.stringify(message));
+                this.sendMessage.fire(message);
+            };
         } else if (message.type === 'response') {
             // responses of reverse requests
             const response = message as DebugProtocol.Response;

--- a/src/test/datascience/mockJupyterSession.ts
+++ b/src/test/datascience/mockJupyterSession.ts
@@ -153,8 +153,8 @@ export class MockJupyterSession implements IJupyterSession {
     public requestDebug(
         _content: KernelMessage.IDebugRequestMsg['content'],
         _disposeOnDone?: boolean
-    ): Kernel.IControlFuture<KernelMessage.IDebugRequestMsg, KernelMessage.IDebugReplyMsg> | undefined {
-        return undefined;
+    ): Kernel.IControlFuture<KernelMessage.IDebugRequestMsg, KernelMessage.IDebugReplyMsg> {
+        throw new Error('Not implemented');
     }
 
     public requestInspect(
@@ -196,7 +196,7 @@ export class MockJupyterSession implements IJupyterSession {
 
     public async requestComplete(
         _content: KernelMessage.ICompleteRequestMsg['content']
-    ): Promise<KernelMessage.ICompleteReplyMsg | undefined> {
+    ): Promise<KernelMessage.ICompleteReplyMsg> {
         await sleep(this.completionTimeout);
 
         return {


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-jupyter/pull/7795
Basically ensure IJupyterSession to line up with the Jupyter lab API
With this change, its similar to Jupyter Lab services API, hence switching over to the other is easier.