### PR TITLE
Remove unnecessary event from INotebook

### DIFF
--- a/src/client/datascience/ipywidgets/ipyWidgetScriptSource.ts
+++ b/src/client/datascience/ipywidgets/ipyWidgetScriptSource.ts
@@ -23,7 +23,6 @@ import { createDeferred, Deferred } from '../../common/utils/async';
 import { getOSType, OSType } from '../../common/utils/platform';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { ConsoleForegroundColors } from '../../logging/_global';
-import { PythonEnvironment } from '../../pythonEnvironments/info';
 import { sendTelemetryEvent } from '../../telemetry';
 import { Telemetry } from '../constants';
 import { InteractiveWindowMessages, IPyWidgetMessages } from '../interactive-common/interactiveWindowTypes';
@@ -51,7 +50,6 @@ export class IPyWidgetScriptSource implements ILocalResourceUriConverter {
     private jupyterLab?: typeof jupyterlabService;
     private scriptProvider?: IPyWidgetScriptSourceProvider;
     private disposables: IDisposable[] = [];
-    private interpreterForWhichWidgetSourcesWereFetched?: PythonEnvironment;
     /**
      * Key value pair of widget modules along with the version that needs to be loaded.
      */
@@ -241,23 +239,6 @@ export class IPyWidgetScriptSource implements ILocalResourceUriConverter {
             return;
         }
         this.notebook.onDisposed(() => this.dispose());
-        // When changing a kernel, we might have a new interpreter.
-        this.notebook.onKernelChanged(
-            () => {
-                // If underlying interpreter has changed, then refresh list of widget sources.
-                // After all, different kernels have different widgets.
-                if (
-                    this.notebook?.getMatchingInterpreter() &&
-                    this.notebook?.getMatchingInterpreter() === this.interpreterForWhichWidgetSourcesWereFetched
-                ) {
-                    return;
-                }
-                // Let UI know that kernel has changed.
-                this.postEmitter.fire({ message: IPyWidgetMessages.IPyWidgets_onKernelChanged, payload: undefined });
-            },
-            this,
-            this.disposables
-        );
         this.handlePendingRequests();
     }
     private handlePendingRequests() {

--- a/src/client/datascience/jupyter/debuggerVariables.ts
+++ b/src/client/datascience/jupyter/debuggerVariables.ts
@@ -285,7 +285,6 @@ export class DebuggerVariables extends DebugLocationTracker
         const key = notebook.identity.toString();
         if (!this.watchedNotebooks.has(key)) {
             const disposables: Disposable[] = [];
-            disposables.push(notebook.onKernelChanged(this.resetImport.bind(this, key)));
             disposables.push(notebook.onKernelRestarted(this.resetImport.bind(this, key)));
             disposables.push(
                 notebook.onDisposed(() => {

--- a/src/client/datascience/jupyter/jupyterDebugger.ts
+++ b/src/client/datascience/jupyter/jupyterDebugger.ts
@@ -181,7 +181,6 @@ export class JupyterDebugger implements IJupyterDebugger, ICellHashListener {
             };
             disposables.push(notebook.onDisposed(clear));
             disposables.push(notebook.onKernelRestarted(clear));
-            disposables.push(notebook.onKernelChanged(clear));
         }
 
         return result;

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -51,13 +51,9 @@ export class JupyterNotebookBase implements INotebook {
     public get onDidFinishExecuting(): Event<ICell> {
         return this.finishedExecuting.event;
     }
-    public get onKernelChanged(): Event<KernelConnectionMetadata> {
-        return this.kernelChanged.event;
-    }
     public get disposed() {
         return this._disposed;
     }
-    private kernelChanged = new EventEmitter<KernelConnectionMetadata>();
     public get onKernelRestarted(): Event<void> {
         return this.kernelRestarted.event;
     }

--- a/src/client/datascience/jupyter/pythonVariableRequester.ts
+++ b/src/client/datascience/jupyter/pythonVariableRequester.ts
@@ -153,7 +153,6 @@ export class PythonVariablesRequester implements IKernelVariableRequester {
                 disposables.forEach((d) => d.dispose());
             };
             disposables.push(notebook.onDisposed(handler));
-            disposables.push(notebook.onKernelChanged(handler));
             disposables.push(notebook.onKernelRestarted(handler));
 
             // First put the code from our helper files into the notebook
@@ -173,7 +172,6 @@ export class PythonVariablesRequester implements IKernelVariableRequester {
                 disposables.forEach((d) => d.dispose());
             };
             disposables.push(notebook.onDisposed(handler));
-            disposables.push(notebook.onKernelChanged(handler));
             disposables.push(notebook.onKernelRestarted(handler));
 
             await this.runScriptFile(notebook, GetVariableInfo.ScriptPath);

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -180,7 +180,6 @@ export interface INotebook extends IAsyncDisposable {
     readonly session: IJupyterSession; // Temporary. This just makes it easier to write a notebook that works with VS code types.
     onSessionStatusChanged: Event<ServerStatus>;
     onDisposed: Event<void>;
-    onKernelChanged: Event<KernelConnectionMetadata>;
     onKernelRestarted: Event<void>;
     inspect(code: string, offsetInCode?: number, cancelToken?: CancellationToken): Promise<JSONObject>;
     getCompletion(


### PR DESCRIPTION
Code health, came across an event thats not longer relevant (event will never get fired)
When user changes kernels/controllers, the existing INotebook is disposed, hence existing event handlers of INotebook.onDidDispose is sufficient