### PR TITLE
Dispose kernel on selecting non-jupyter controller

### DIFF
--- a/src/client/datascience/jupyter/kernels/kernelProvider.ts
+++ b/src/client/datascience/jupyter/kernels/kernelProvider.ts
@@ -135,6 +135,7 @@ export class KernelProvider implements IKernelProvider {
                         kernel.notebookDocument.uri.toString()
                     );
                 }
+                this.pendingDisposables.delete(kernel);
             },
             this,
             this.disposables

--- a/src/client/datascience/notebook/vscodeNotebookController.ts
+++ b/src/client/datascience/notebook/vscodeNotebookController.ts
@@ -179,6 +179,12 @@ export class VSCodeNotebookController implements Disposable {
             return;
         }
         if (!event.selected) {
+            // If user has selectd another controller, then kill the current kernel.
+            // Possible user selected a controller that's not contributed by us at all.
+            const kernel = this.kernelProvider.get(event.notebook);
+            if (kernel?.kernelConnectionMetadata.id === this.kernelConnection.id) {
+                void kernel.dispose();
+            }
             this.associatedDocuments.delete(event.notebook);
             return;
         }


### PR DESCRIPTION
Came across this while working on https://github.com/microsoft/vscode-jupyter/issues/6543
If user runs a cell then we start our kernel, now if user selects another controller (not ours), then our kernel is still alive (only shutdown after we close the notebook or vscode)