### PR TITLE
Display exec path of non-python kernels

### DIFF
--- a/src/client/datascience/jupyter/kernels/helpers.ts
+++ b/src/client/datascience/jupyter/kernels/helpers.ts
@@ -165,12 +165,17 @@ export function getKernelPathFromKernelConnection(kernelConnection?: KernelConne
     const kernelSpec = kernelConnectionMetadataHasKernelSpec(kernelConnection)
         ? kernelConnection.kernelSpec
         : undefined;
-    if (kernelConnection.kind === 'startUsingPythonInterpreter' || (kernelConnection.kind === 'startUsingKernelSpec' && kernelConnection.kernelSpec.language === PYTHON_LANGUAGE)){
+    if (
+        kernelConnection.kind === 'startUsingPythonInterpreter' ||
+        (kernelConnection.kind === 'startUsingKernelSpec' && kernelConnection.kernelSpec.language === PYTHON_LANGUAGE)
+    ) {
         return kernelSpec?.metadata?.interpreter?.path || kernelSpec?.interpreterPath || kernelSpec?.path;
     } else {
         // For non python kernels, give preference to the executable path in the kernelspec
         // E.g. if we have a rust kernel, we should show the path to the rust executable not the interpreter (such as conda env that owns the rust runtime).
-        return model?.path || kernelSpec?.path || kernelSpec?.metadata?.interpreter?.path || kernelSpec?.interpreterPath;
+        return (
+            model?.path || kernelSpec?.path || kernelSpec?.metadata?.interpreter?.path || kernelSpec?.interpreterPath
+        );
     }
 }
 


### PR DESCRIPTION
For non-python kernels we were still displaying the interpreter paths instad of the paths of the executable.
E.g. if you have a java kernel installed as part of a conda envioronment, we'd display the path of the conda enviroment in the dropdown list, instead of displaying the path to the java executable.

Came across this bug in demo today, will add news entry and issue for this.