### PR TITLE
Re-run initialization when changing kernels in iw

### DIFF
--- a/news/2 Fixes/7941.md
+++ b/news/2 Fixes/7941.md
@@ -1,0 +1,1 @@
+Ensure `__file__` is set when changing kernels in Interactive Window.


### PR DESCRIPTION
For #7941
Changing controllers doesn't re-run the initialization scripts in interactive window