### PR TITLE
Check if users use conda env without different executables

### DIFF
--- a/src/client/datascience/telemetry/kernelTelemetry.ts
+++ b/src/client/datascience/telemetry/kernelTelemetry.ts
@@ -29,13 +29,13 @@ export function sendKernelListTelemetry(
             case 'startUsingKernelSpec':
                 counters.kernelSpecCount += 1;
                 break;
-            case 'startUsingPythonInterpreter':{
+            case 'startUsingPythonInterpreter': {
                 counters.kernelInterpreterCount += 1;
                 // Sometimes users can have different conda environments but with the same base executable.
                 // This happens when not using the `python` argument when creating environments.
                 // Tody we don't support such environments, lets see if people are using these, if they are then
                 // We know kernels will not start correctly for those environments (even if started, packages might not be located correctly).
-                if (item.interpreter.envType === EnvironmentType.Conda){
+                if (item.interpreter.envType === EnvironmentType.Conda) {
                     if (uniqueCondaInterpreterPaths.has(item.interpreter.path)) {
                         counters.condaEnvsSharingSameInterpreter += 1;
                     } else {

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -1304,7 +1304,7 @@ export interface IEventNamePropertyMapping {
          * Such conda envs don't work today in the extension.
          * Hence users with such environments could hvae issues with starting kernels or packages not getting loaded correctly or at all.
          */
-        condaEnvsSharingSameInterpreter: number
+        condaEnvsSharingSameInterpreter: number;
     } & ResourceSpecificTelemetryProperties;
 
     // Native notebooks events


### PR DESCRIPTION
Sometimes users can have different conda environments but with the same base executable.
This happens when not using the `python` argument when creating environments.
Tody we don't support such environments, lets see if people are using these, if they are then 
We know kernels will not start correctly for those environments (even if started, packages might not be located correctly).