### PR TITLE
runCurrentCellAndAdvance only advance if jupyter.enableAutoMoveToNextCell

### DIFF
--- a/src/client/datascience/editor-integration/codewatcher.ts
+++ b/src/client/datascience/editor-integration/codewatcher.ts
@@ -339,8 +339,10 @@ export class CodeWatcher implements ICodeWatcher {
             return;
         }
 
-        // Run the cell that matches the current cursor position. Always advance
-        return this.runMatchingCell(this.documentManager.activeTextEditor.selection, true);
+        const advance = this.configService.getSettings(this.documentManager.activeTextEditor.document.uri).enableAutoMoveToNextCell;
+
+        // Run the cell that matches the current cursor position.
+        return this.runMatchingCell(this.documentManager.activeTextEditor.selection, advance);
     }
 
     // telemetry captured on CommandRegistry
@@ -1032,7 +1034,7 @@ export class CodeWatcher implements ICodeWatcher {
         const nextRunCellLens = this.getNextCellLens(range.start);
 
         if (currentRunCellLens) {
-            // Move the next cell if allowed.
+            // Move to the next cell if allowed.
             if (advance) {
                 if (nextRunCellLens) {
                     this.advanceToRange(nextRunCellLens.range);
@@ -1045,7 +1047,7 @@ export class CodeWatcher implements ICodeWatcher {
                 }
             }
 
-            // Run the cell after moving the selection
+            // Run the cell after moving the selection.
             if (this.document) {
                 // Use that to get our code.
                 const code = this.document.getText(currentRunCellLens.range);


### PR DESCRIPTION
For #7967.

Similar question to #7995, since `codeWatcher.runCurrentCellAndAdvance` no longer always advances, should it be renamed to `runCurrentCellAndMaybeAdvance`?

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging.~
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
