### PR TITLE
Fix cell debugging for IW with ipykernel 5

### DIFF
--- a/src/client/datascience/editor-integration/cellhashprovider.ts
+++ b/src/client/datascience/editor-integration/cellhashprovider.ts
@@ -301,6 +301,11 @@ export class CellHashProvider implements ICellHashProvider {
             stripped[lastLinePos] = `${stripped[lastLinePos]}\n`;
         }
 
+        // We also don't send \r\n to jupyter. Remove from the stripped lines
+        for (let i = 0; i < stripped.length; i++) {
+            stripped[i] = stripped[i].replace(/\r\n/g, '\n');
+        }
+
         return { stripped, trueStartLine };
     }
 


### PR DESCRIPTION
Fixes #7650

This finishes fixing #7650 so that it works for ipykernel 5 as well. 

We had made a change to remove all '/r' chars from code sent to jupyter, but failed to make the same change in the hash computation.

