### PR TITLE
Hide toolbar when as non-jupyter kernel is picked

### DIFF
--- a/src/client/datascience/commands/activeEditorContext.ts
+++ b/src/client/datascience/commands/activeEditorContext.ts
@@ -125,6 +125,11 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
             this,
             this.disposables
         );
+        this.controllers.onNotebookControllerSelectionChanged(
+            () => this.updateSelectedKernelContext(),
+            this,
+            this.disposables
+        );
         this.updateSelectedKernelContext();
     }
 

--- a/src/client/datascience/notebook/types.ts
+++ b/src/client/datascience/notebook/types.ts
@@ -11,6 +11,7 @@ export const INotebookKernelResolver = Symbol('INotebookKernelResolver');
 export const INotebookControllerManager = Symbol('INotebookControllerManager');
 export interface INotebookControllerManager {
     readonly onNotebookControllerSelected: Event<{ notebook: NotebookDocument; controller: VSCodeNotebookController }>;
+    readonly onNotebookControllerSelectionChanged: Event<void>;
     readonly kernelConnections: Promise<Readonly<KernelConnectionMetadata>[]>;
     loadNotebookControllers(): Promise<void>;
     getSelectedNotebookController(document: NotebookDocument): VSCodeNotebookController | undefined;

--- a/src/client/datascience/notebook/vscodeNotebookController.ts
+++ b/src/client/datascience/notebook/vscodeNotebookController.ts
@@ -58,6 +58,7 @@ export class VSCodeNotebookController implements Disposable {
         notebook: NotebookDocument;
         controller: VSCodeNotebookController;
     }>;
+    private readonly _onNotebookControllerSelectionChanged = new EventEmitter<void>();
     private readonly _onDidDispose = new EventEmitter<void>();
     private readonly disposables: IDisposable[] = [];
     private notebookKernels = new WeakMap<NotebookDocument, IKernel>();
@@ -81,6 +82,9 @@ export class VSCodeNotebookController implements Disposable {
 
     get onNotebookControllerSelected() {
         return this._onNotebookControllerSelected.event;
+    }
+    get onNotebookControllerSelectionChanged() {
+        return this._onNotebookControllerSelectionChanged.event;
     }
     get onDidReceiveMessage() {
         return this.controller.onDidReceiveMessage;
@@ -154,6 +158,7 @@ export class VSCodeNotebookController implements Disposable {
         if (!this.isDisposed) {
             this.isDisposed = true;
             this._onNotebookControllerSelected.dispose();
+            this._onNotebookControllerSelectionChanged.dispose();
             this.controller.dispose();
         }
         this._onDidDispose.fire();
@@ -197,6 +202,7 @@ export class VSCodeNotebookController implements Disposable {
                 void kernel.dispose();
             }
             this.associatedDocuments.delete(event.notebook);
+            this._onNotebookControllerSelectionChanged.fire();
             return;
         }
         // We're only interested in our Notebooks.
@@ -217,6 +223,7 @@ export class VSCodeNotebookController implements Disposable {
 
         // If this NotebookController was selected, fire off the event
         this._onNotebookControllerSelected.fire({ notebook: event.notebook, controller: this });
+        this._onNotebookControllerSelectionChanged.fire();
     }
     /**
      * Scenario 1:


### PR DESCRIPTION
For #6543

Currently you have to tab across editors, this ensures we hide toolbars as soon as a kernel is selected, instead of having to wait till the user tabs off/on.