### PR TITLE
Improvements to logging

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -491,7 +491,6 @@ module.exports = {
         'src/client/common/platform/serviceRegistry.ts',
         'src/client/common/platform/errors.ts',
         'src/client/common/platform/fs-temp.ts',
-        'src/client/common/platform/fs-paths.ts',
         'src/client/common/platform/constants.ts',
         'src/client/common/platform/fileSystem.ts',
         'src/client/common/platform/registry.ts',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -707,7 +707,6 @@ module.exports = {
         'src/client/logging/levels.ts',
         'src/client/logging/transports.ts',
         'src/client/logging/util.ts',
-        'src/client/logging/formatters.ts',
         'src/client/logging/trace.ts',
         'src/client/ioc/serviceManager.ts',
         'src/client/ioc/container.ts',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -707,7 +707,6 @@ module.exports = {
         'src/client/logging/levels.ts',
         'src/client/logging/transports.ts',
         'src/client/logging/util.ts',
-        'src/client/logging/trace.ts',
         'src/client/ioc/serviceManager.ts',
         'src/client/ioc/container.ts',
         'src/client/ioc/types.ts',

--- a/package.json
+++ b/package.json
@@ -1427,7 +1427,7 @@
                 },
                 "jupyter.logging.level": {
                     "type": "string",
-                    "default": "debug",
+                    "default": "info",
                     "enum": [
                         "off",
                         "error",

--- a/package.json
+++ b/package.json
@@ -1427,7 +1427,7 @@
                 },
                 "jupyter.logging.level": {
                     "type": "string",
-                    "default": "info",
+                    "default": "debug",
                     "enum": [
                         "off",
                         "error",

--- a/src/client/api/pythonApi.ts
+++ b/src/client/api/pythonApi.ts
@@ -19,6 +19,7 @@ import { trackPackageInstalledIntoInterpreter } from '../common/installer/produc
 import { ProductNames } from '../common/installer/productNames';
 import { InterpreterUri } from '../common/installer/types';
 import { traceInfo, traceInfoIfCI } from '../common/logger';
+import { getDisplayPath } from '../common/platform/fs-paths';
 import {
     GLOBAL_MEMENTO,
     IDisposableRegistry,
@@ -379,7 +380,11 @@ export class InterpreterService implements IInterpreterService {
                 if (isCI) {
                     promise
                         .then((item) =>
-                            traceInfo(`Active Interpreter in Python API for ${resource?.toString()} is ${item?.path}`)
+                            traceInfo(
+                                `Active Interpreter in Python API for ${resource?.toString()} is ${getDisplayPath(
+                                    item?.path
+                                )}`
+                            )
                         )
                         .catch(noop);
                 }

--- a/src/client/common/platform/fs-paths.ts
+++ b/src/client/common/platform/fs-paths.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import * as nodepath from 'path';
+import { Uri } from 'vscode';
 import { getOSType, OSType } from '../utils/platform';
 import { IExecutables, IFileSystemPaths, IFileSystemPathUtils } from './types';
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
@@ -140,5 +141,26 @@ export class FileSystemPathUtils implements IFileSystemPathUtils {
         } else {
             return filename;
         }
+    }
+}
+
+const homePath = untildify('~');
+export function getDisplayPath(filename?: string | Uri) {
+    let file = '';
+    if (typeof filename === 'string') {
+        file = filename;
+    } else if (!filename) {
+        file = '';
+    } else if (filename.scheme === 'file') {
+        file = filename.fsPath;
+    } else {
+        file = filename.toString();
+    }
+    if (!file) {
+        return '';
+    } else if (file.startsWith(homePath)) {
+        return `~${nodepath.sep}${nodepath.relative(homePath, file)}`;
+    } else {
+        return file;
     }
 }

--- a/src/client/common/process/baseDaemon.ts
+++ b/src/client/common/process/baseDaemon.ts
@@ -10,7 +10,7 @@ import * as util from 'util';
 import { MessageConnection, NotificationType, RequestType, RequestType0 } from 'vscode-jsonrpc';
 import { IPlatformService } from '../../common/platform/types';
 import { BaseError } from '../errors/types';
-import { traceError, traceInfo, traceVerbose, traceWarning } from '../logger';
+import { traceError, traceVerbose, traceWarning } from '../logger';
 import { IDisposable } from '../types';
 import { createDeferred, Deferred } from '../utils/async';
 import { noop } from '../utils/misc';
@@ -364,14 +364,15 @@ export abstract class BasePythonDaemon {
             pid?: string;
         }>('log');
         this.connection.onNotification(logNotification, (output) => {
+            // Logging from python code will be displayed only if we have verbose logging turned on.
             const pid = output.pid ? ` (pid: ${output.pid})` : '';
             const msg = `Python Daemon${pid}: ${output.msg}`;
             if (output.level === 'DEBUG' || output.level === 'NOTSET') {
                 traceVerbose(msg);
             } else if (output.level === 'INFO') {
-                traceInfo(msg);
+                traceVerbose(msg);
             } else if (output.level === 'WARN' || output.level === 'WARNING') {
-                traceWarning(msg);
+                traceVerbose(msg);
             } else {
                 traceError(msg);
             }

--- a/src/client/datascience/ipywidgets/notebookIPyWidgetCoordinator.ts
+++ b/src/client/datascience/ipywidgets/notebookIPyWidgetCoordinator.ts
@@ -14,6 +14,7 @@ import { IVSCodeNotebook } from '../../common/application/types';
 import { Cancellation } from '../../common/cancellation';
 import { disposeAllDisposables } from '../../common/helpers';
 import { traceInfo, traceInfoIfCI, traceVerbose } from '../../common/logger';
+import { getDisplayPath } from '../../common/platform/fs-paths';
 import { IAsyncDisposableRegistry, IDisposable, IDisposableRegistry } from '../../common/types';
 import { createDeferred } from '../../common/utils/async';
 import { noop } from '../../common/utils/misc';
@@ -116,7 +117,7 @@ export class NotebookIPyWidgetCoordinator {
             return;
         }
         // Dispost previous message coordinators.
-        traceInfo(`Setting setActiveController for ${notebook.uri}`);
+        traceInfo(`Setting setActiveController for ${getDisplayPath(notebook.uri)}`);
         const previousCoordinators = this.messageCoordinators.get(notebook);
         if (previousCoordinators) {
             this.messageCoordinators.delete(notebook);
@@ -149,15 +150,19 @@ export class NotebookIPyWidgetCoordinator {
         const controller = this.selectedNotebookController.get(notebook);
         if (!controller) {
             traceVerbose(
-                `No controller, hence notebook communications cannot be initialized for editor ${editor.document.uri.toString()}`
+                `No controller, hence notebook communications cannot be initialized for editor ${getDisplayPath(
+                    editor.document.uri
+                )}`
             );
             return;
         }
         if (this.notebookCommunications.has(editor)) {
-            traceVerbose(`notebook communications already initialized for editor ${editor.document.uri.toString()}`);
+            traceVerbose(
+                `notebook communications already initialized for editor ${getDisplayPath(editor.document.uri)}`
+            );
             return;
         }
-        traceVerbose(`Intiailize notebook communications for editor ${editor.document.uri.toString()}`);
+        traceVerbose(`Intiailize notebook communications for editor ${getDisplayPath(editor.document.uri)}`);
         const comms = new NotebookCommunication(editor, controller);
         this.addNotebookDiposables(notebook, [comms]);
         this.notebookCommunications.set(editor, comms);
@@ -171,7 +176,7 @@ export class NotebookIPyWidgetCoordinator {
     ): Promise<void> {
         // Create a handler for this notebook if we don't already have one. Since there's one of the notebookMessageCoordinator's for the
         // entire VS code session, we have a map of notebook document to message coordinator
-        traceVerbose(`Resolving notebook UI Comms (resolve) for ${document.uri.toString()}`);
+        traceVerbose(`Resolving notebook UI Comms (resolve) for ${getDisplayPath(document.uri)}`);
         let promise = this.messageCoordinators.get(document);
         if (promise === undefined) {
             promise = CommonMessageCoordinator.create(document, this.serviceContainer);
@@ -212,12 +217,12 @@ export class NotebookIPyWidgetCoordinator {
         const attachedEditors = this.attachedEditors.get(document) || new Set<NotebookEditor>();
         this.attachedEditors.set(document, attachedEditors);
         if (attachedEditors.has(webview.editor) || this.previouslyInitialized.has(webview.editor)) {
-            traceVerbose(`Coordinator already attached for ${document.uri.toString()}`);
+            traceVerbose(`Coordinator already attached for ${getDisplayPath(document.uri)}`);
             promise.resolve();
         } else {
             attachedEditors.add(webview.editor);
             const disposables: IDisposable[] = [];
-            traceVerbose(`Attach Coordinator for ${document.uri.toString()}`);
+            traceVerbose(`Attach Coordinator for ${getDisplayPath(document.uri)}`);
             // Attach message requests to this webview (should dupe to all of them)
             c.postMessage(
                 (e) => {

--- a/src/client/datascience/jupyter/kernels/helpers.ts
+++ b/src/client/datascience/jupyter/kernels/helpers.ts
@@ -43,6 +43,7 @@ import { SysInfoReason } from '../../interactive-common/interactiveWindowTypes';
 import { isDefaultPythonKernelSpecName } from '../../kernel-launcher/localPythonAndRelatedNonPythonKernelSpecFinder';
 import { executeSilently } from './kernel';
 import { IWorkspaceService } from '../../../common/application/types';
+import { getDisplayPath } from '../../../common/platform/fs-paths';
 
 // Helper functions for dealing with kernels and kernelspecs
 
@@ -405,7 +406,7 @@ export function findPreferredKernel(
     remoteKernelPreferredProvider: PreferredRemoteKernelIdProvider | undefined
 ): KernelConnectionMetadata | undefined {
     traceInfo(
-        `Find preferred kernel for ${resource?.toString()} with metadata ${JSON.stringify(
+        `Find preferred kernel for ${getDisplayPath(resource)} with metadata ${JSON.stringify(
             notebookMetadata || {}
         )} & preferred interpreter ${JSON.stringify(preferredInterpreter || {})}`
     );
@@ -820,7 +821,9 @@ export async function sendTelemetryForPythonKernelExecutable(
                     trackKernelResourceInformation(resource, { interpreterMatchesKernel: match });
                     if (!match) {
                         traceError(
-                            `Interpreter started by kernel does not match expectation, expected ${kernelConnection.interpreter?.path}, got ${sysExecutable}`
+                            `Interpreter started by kernel does not match expectation, expected ${getDisplayPath(
+                                kernelConnection.interpreter?.path
+                            )}, got ${getDisplayPath(sysExecutable)}`
                         );
                     }
                 }

--- a/src/client/datascience/jupyter/kernels/jupyterKernelService.ts
+++ b/src/client/datascience/jupyter/kernels/jupyterKernelService.ts
@@ -10,6 +10,7 @@ import { CancellationToken, CancellationTokenSource } from 'vscode';
 import { Cancellation, wrapCancellationTokens } from '../../../common/cancellation';
 import '../../../common/extensions';
 import { traceDecorators, traceInfo, traceInfoIfCI } from '../../../common/logger';
+import { getDisplayPath } from '../../../common/platform/fs-paths';
 import { IFileSystem } from '../../../common/platform/types';
 
 import { ReadWrite, Resource } from '../../../common/types';
@@ -93,7 +94,9 @@ export class JupyterKernelService {
         // Update the kernel environment to use the interpreter's latest
         if (kernel.kind !== 'connectToLiveKernel' && kernel.kernelSpec && kernel.interpreter && specFile) {
             traceInfoIfCI(
-                `updateKernelEnvironment ${kernel.interpreter.displayName}, ${kernel.interpreter.path} for ${kernel.id}`
+                `updateKernelEnvironment ${kernel.interpreter.displayName}, ${getDisplayPath(
+                    kernel.interpreter.path
+                )} for ${kernel.id}`
             );
             await this.updateKernelEnvironment(kernel.interpreter, kernel.kernelSpec, specFile, token);
         }
@@ -222,7 +225,9 @@ export class JupyterKernelService {
                     // If conda is the first word, its possible its a conda activation command.
                     traceInfo(`Spec argv[0], not updated as it is using conda.`);
                 } else {
-                    traceInfo(`Spec argv[0] updated from '${specModel.argv[0]}' to '${interpreter.path}'`);
+                    traceInfo(
+                        `Spec argv[0] updated from '${specModel.argv[0]}' to '${getDisplayPath(interpreter.path)}'`
+                    );
                     specModel.argv[0] = interpreter.path;
                 }
 

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -61,6 +61,7 @@ import { IPythonExecutionFactory } from '../../../common/process/types';
 import { INotebookControllerManager } from '../../notebook/types';
 import { getResourceType } from '../../common';
 import { Deferred } from '../../../common/utils/async';
+import { getDisplayPath } from '../../../common/platform/fs-paths';
 
 export class Kernel implements IKernel {
     get connection(): INotebookProviderConnection | undefined {
@@ -228,7 +229,7 @@ export class Kernel implements IKernel {
         traceInfo(`Restart requested ${this.notebookDocument.uri}`);
         this.startCancellation.cancel();
         await this.kernelExecution.restart(this._notebookPromise);
-        traceInfoIfCI(`Restarted ${this.notebookDocument.uri}`);
+        traceInfoIfCI(`Restarted ${getDisplayPath(this.notebookDocument.uri)}`);
 
         // Interactive window needs a restart sys info
         await this.initializeAfterStart(SysInfoReason.Restart, this.notebookDocument);

--- a/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
@@ -10,6 +10,7 @@ import { createPromiseFromCancellation, wrapCancellationTokens } from '../../../
 import { isModulePresentInEnvironment } from '../../../common/installer/productInstaller';
 import { ProductNames } from '../../../common/installer/productNames';
 import { traceDecorators, traceInfo } from '../../../common/logger';
+import { getDisplayPath } from '../../../common/platform/fs-paths';
 import {
     GLOBAL_MEMENTO,
     IInstaller,
@@ -58,7 +59,7 @@ export class KernelDependencyService implements IKernelDependencyService {
         token?: CancellationToken,
         disableUI?: boolean
     ): Promise<void> {
-        traceInfo(`installMissingDependencies ${interpreter.path}`);
+        traceInfo(`installMissingDependencies ${getDisplayPath(interpreter.path)}`);
         if (await this.areDependenciesInstalled(interpreter, token)) {
             return;
         }
@@ -104,7 +105,7 @@ export class KernelDependencyService implements IKernelDependencyService {
         }
         throw new IpyKernelNotInstalledError(
             DataScience.ipykernelNotInstalled().format(
-                `${interpreter.displayName || interpreter.path}:${interpreter.path}`
+                `${interpreter.displayName || getDisplayPath(interpreter.path)}:${getDisplayPath(interpreter.path)}`
             ),
             response
         );

--- a/src/client/datascience/jupyter/kernels/kernelProvider.ts
+++ b/src/client/datascience/jupyter/kernels/kernelProvider.ts
@@ -8,6 +8,7 @@ import { Event, EventEmitter, NotebookDocument } from 'vscode';
 import { ServerStatus } from '../../../../datascience-ui/interactive-common/mainState';
 import { IApplicationShell, IVSCodeNotebook, IWorkspaceService } from '../../../common/application/types';
 import { traceInfo, traceWarning } from '../../../common/logger';
+import { getDisplayPath } from '../../../common/platform/fs-paths';
 import { IFileSystem } from '../../../common/platform/types';
 import { IPythonExecutionFactory } from '../../../common/process/types';
 import {
@@ -141,8 +142,10 @@ export class KernelProvider implements IKernelProvider {
                 if (this.kernelsByNotebook.get(notebook)?.kernel === kernel) {
                     this.kernelsByNotebook.delete(notebook);
                     traceInfo(
-                        `Kernel got disposed, hence there is no longer a kernel associated with ${notebook.uri.toString()}`,
-                        kernel.notebookDocument.uri.toString()
+                        `Kernel got disposed, hence there is no longer a kernel associated with ${getDisplayPath(
+                            notebook.uri
+                        )}`,
+                        getDisplayPath(kernel.notebookDocument.uri)
                     );
                 }
                 this.pendingDisposables.delete(kernel);

--- a/src/client/datascience/kernel-launcher/kernelDaemon.ts
+++ b/src/client/datascience/kernel-launcher/kernelDaemon.ts
@@ -89,7 +89,7 @@ export class PythonKernelDaemon extends BasePythonDaemon implements IPythonKerne
             // This is why when we run `execModule` in the Kernel daemon, it finishes (comes back) quickly.
             // However in reality it is running in the background.
             // See `m_exec_module_observable` in `kernel_launcher_daemon.py`.
-            traceVerbose(`Starting kernel from scratch with options ${JSON.stringify(options)}`);
+            traceInfo('Starting kernel from scratch');
             await this.execModule(moduleName, args, options);
         }
 

--- a/src/client/datascience/kernel-launcher/kernelDaemon.ts
+++ b/src/client/datascience/kernel-launcher/kernelDaemon.ts
@@ -6,7 +6,7 @@
 import { ChildProcess } from 'child_process';
 import { Subject } from 'rxjs/Subject';
 import { MessageConnection, NotificationType, RequestType, RequestType0 } from 'vscode-jsonrpc';
-import { traceInfo, traceVerbose } from '../../common/logger';
+import { traceInfo } from '../../common/logger';
 import { IPlatformService } from '../../common/platform/types';
 import { BasePythonDaemon, ExecResponse } from '../../common/process/baseDaemon';
 import { IPythonExecutionService, ObservableExecutionResult, Output, SpawnOptions } from '../../common/process/types';

--- a/src/client/datascience/kernel-launcher/kernelDaemonPool.ts
+++ b/src/client/datascience/kernel-launcher/kernelDaemonPool.ts
@@ -6,6 +6,7 @@
 import { inject, injectable } from 'inversify';
 import { IWorkspaceService } from '../../common/application/types';
 import { traceError, traceInfo } from '../../common/logger';
+import { getDisplayPath } from '../../common/platform/fs-paths';
 import { IFileSystem } from '../../common/platform/types';
 
 import { IPythonExecutionFactory, IPythonExecutionService } from '../../common/process/types';
@@ -155,7 +156,9 @@ export class KernelDaemonPool implements IDisposable {
             .then((d) => {
                 // Prewarm if we support prewarming
                 if ('preWarm' in d) {
-                    d.preWarm().catch(traceError.bind(`Failed to prewarm kernel daemon ${interpreter.path}`));
+                    d.preWarm().catch(
+                        traceError.bind(`Failed to prewarm kernel daemon ${getDisplayPath(interpreter.path)}`)
+                    );
                 }
             })
             .catch((e) => {

--- a/src/client/datascience/kernel-launcher/kernelLauncherDaemon.ts
+++ b/src/client/datascience/kernel-launcher/kernelLauncherDaemon.ts
@@ -7,6 +7,7 @@ import { ChildProcess } from 'child_process';
 import * as fs from 'fs-extra';
 import { inject, injectable } from 'inversify';
 import { traceInfo } from '../../common/logger';
+import { getDisplayPath } from '../../common/platform/fs-paths';
 import { IPythonExecutionFactory, ObservableExecutionResult } from '../../common/process/types';
 import { IDisposable, Resource } from '../../common/types';
 import { noop } from '../../common/utils/misc';
@@ -59,7 +60,7 @@ export class PythonKernelLauncherDaemon implements IDisposable {
                 bypassCondaExecution: true
             });
 
-            traceInfo(`Launching kernel daemon for ${kernelSpec.display_name} # ${interpreter?.path}`);
+            traceInfo(`Launching kernel daemon for ${kernelSpec.display_name} # ${getDisplayPath(interpreter?.path)}`);
             const [executionService, wdExists, env] = await Promise.all([
                 executionServicePromise,
                 fs.pathExists(workingDirectory),
@@ -76,7 +77,7 @@ export class PythonKernelLauncherDaemon implements IDisposable {
         }
 
         const executionServicePromise = this.daemonPool.get(resource, kernelSpec, interpreter);
-        traceInfo(`Launching kernel daemon for ${kernelSpec.display_name} # ${interpreter?.path}`);
+        traceInfo(`Launching kernel daemon for ${kernelSpec.display_name} # ${getDisplayPath(interpreter?.path)}`);
         const [executionService, wdExists, env] = await Promise.all([
             executionServicePromise,
             fs.pathExists(workingDirectory),

--- a/src/client/datascience/kernel-launcher/kernelProcess.ts
+++ b/src/client/datascience/kernel-launcher/kernelProcess.ts
@@ -9,7 +9,7 @@ import { CancellationToken, Event, EventEmitter } from 'vscode';
 import { IPythonExtensionChecker } from '../../api/types';
 import { createPromiseFromCancellation } from '../../common/cancellation';
 import { getTelemetrySafeErrorMessageFromPythonTraceback } from '../../common/errors/errorUtils';
-import { traceDecorators, traceError, traceInfo, traceWarning } from '../../common/logger';
+import { traceDecorators, traceError, traceInfo, traceVerbose, traceWarning } from '../../common/logger';
 import { IFileSystem } from '../../common/platform/types';
 import { IProcessServiceFactory, IPythonExecutionFactory, ObservableExecutionResult } from '../../common/process/types';
 import { Resource } from '../../common/types';
@@ -115,12 +115,18 @@ export class KernelProcess implements IKernelProcess {
         });
 
         exeObs.proc!.stdout?.on('data', (data: Buffer | string) => {
-            traceInfo(`KernelProcess output: ${(data || '').toString()}`);
+            // We get these from execObs.out.subscribe.
+            // Hence log only using traceLevel = verbose.
+            // But only useful if daemon doesn't start for any reason.
+            traceVerbose(`KernelProcess output: ${(data || '').toString()}`);
         });
 
         exeObs.proc!.stderr?.on('data', (data: Buffer | string) => {
+            // We get these from execObs.out.subscribe.
+            // Hence log only using traceLevel = verbose.
+            // But only useful if daemon doesn't start for any reason.
             stderrProc += data.toString();
-            traceInfo(`KernelProcess error: ${(data || '').toString()}`);
+            traceVerbose(`KernelProcess error: ${(data || '').toString()}`);
         });
 
         exeObs.out.subscribe(

--- a/src/client/datascience/kernel-launcher/localKernelSpecFinderBase.ts
+++ b/src/client/datascience/kernel-launcher/localKernelSpecFinderBase.ts
@@ -9,6 +9,7 @@ import { IPythonExtensionChecker } from '../../api/types';
 import { IWorkspaceService } from '../../common/application/types';
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import { traceDecorators, traceError, traceInfo, traceInfoIfCI } from '../../common/logger';
+import { getDisplayPath } from '../../common/platform/fs-paths';
 import { IFileSystem } from '../../common/platform/types';
 import { ReadWrite } from '../../common/types';
 import { testOnlyMethod } from '../../common/utils/decorators';
@@ -152,7 +153,7 @@ export abstract class LocalKernelSpecFinderBase {
         }
         let kernelJson: ReadWrite<IJupyterKernelSpec>;
         try {
-            traceInfo(`Loading kernelspec from ${specPath} for ${interpreter?.path}`);
+            traceInfo(`Loading kernelspec from ${getDisplayPath(specPath)} for ${getDisplayPath(interpreter?.path)}`);
             kernelJson = JSON.parse(await this.fs.readLocalFile(specPath));
         } catch {
             traceError(`Failed to parse kernelspec ${specPath}`);

--- a/src/client/datascience/kernel-launcher/localPythonAndRelatedNonPythonKernelSpecFinder.ts
+++ b/src/client/datascience/kernel-launcher/localPythonAndRelatedNonPythonKernelSpecFinder.ts
@@ -22,6 +22,7 @@ import { LocalKnownPathKernelSpecFinder } from './localKnownPathKernelSpecFinder
 import { captureTelemetry } from '../../telemetry';
 import { Telemetry } from '../constants';
 import { areInterpreterPathsSame } from '../../pythonEnvironments/info/interpreter';
+import { getDisplayPath } from '../../common/platform/fs-paths';
 
 export const isDefaultPythonKernelSpecName = /python\d*.?\d*$/;
 
@@ -191,7 +192,11 @@ export class LocalPythonAndRelatedNonPythonKernelSpecFinder extends LocalKernelS
                         (kernelspec.name.toLowerCase().match(isDefaultPythonKernelSpecName) ||
                             kernelspec.display_name.toLowerCase() === 'python 3 (ipykernel)')
                     ) {
-                        traceInfo(`Hiding default kernel spec ${kernelspec.display_name}, ${kernelspec.argv[0]}`);
+                        traceInfo(
+                            `Hiding default kernel spec ${kernelspec.display_name}, ${getDisplayPath(
+                                kernelspec.argv[0]
+                            )}`
+                        );
                         return false;
                     }
                     return true;
@@ -242,7 +247,9 @@ export class LocalPythonAndRelatedNonPythonKernelSpecFinder extends LocalKernelS
                                 );
                             } catch (ex) {
                                 traceError(
-                                    `Failed to get interpreter details for Kernel Spec ${k.specFile} with interpreter path ${k.metadata?.interpreter?.path}`,
+                                    `Failed to get interpreter details for Kernel Spec ${getDisplayPath(
+                                        k.specFile
+                                    )} with interpreter path ${getDisplayPath(k.metadata?.interpreter?.path)}`,
                                     ex
                                 );
                                 return;

--- a/src/client/datascience/notebook/intellisense/jupyterCompletionProvider.ts
+++ b/src/client/datascience/notebook/intellisense/jupyterCompletionProvider.ts
@@ -16,6 +16,7 @@ import { ServerStatus } from '../../../../datascience-ui/interactive-common/main
 import { IVSCodeNotebook } from '../../../common/application/types';
 import { createPromiseFromCancellation } from '../../../common/cancellation';
 import { traceError, traceInfoIfCI } from '../../../common/logger';
+import { getDisplayPath } from '../../../common/platform/fs-paths';
 import { sleep } from '../../../common/utils/async';
 import { isNotebookCell } from '../../../common/utils/misc';
 import { Settings } from '../../constants';
@@ -46,7 +47,7 @@ export class JupyterCompletionProvider implements CompletionItemProvider {
             this.interactiveWindowProvider
         );
         if (!notebookDocument) {
-            traceError(`Notebook not found for Cell ${document.uri.toString()}`);
+            traceError(`Notebook not found for Cell ${getDisplayPath(document.uri)}`);
             return [];
         }
 
@@ -58,11 +59,11 @@ export class JupyterCompletionProvider implements CompletionItemProvider {
             getOnly: true
         });
         if (token.isCancellationRequested) {
-            traceInfoIfCI(`Getting completions cancelled for ${notebookDocument.uri.toString()}`);
+            traceInfoIfCI(`Getting completions cancelled for ${getDisplayPath(notebookDocument.uri)}`);
             return [];
         }
         if (!notebook) {
-            traceError(`Live Notebook not available for ${notebookDocument.uri.toString()}`);
+            traceError(`Live Notebook not available for ${getDisplayPath(notebookDocument.uri)}`);
             return [];
         }
         const emptyResult: INotebookCompletion = { cursor: { end: 0, start: 0 }, matches: [], metadata: {} };
@@ -76,7 +77,7 @@ export class JupyterCompletionProvider implements CompletionItemProvider {
                 if (token.isCancellationRequested) {
                     return;
                 }
-                traceInfoIfCI(`Notebook completions request timed out for Cell ${document.uri.toString()}`);
+                traceInfoIfCI(`Notebook completions request timed out for Cell ${getDisplayPath(document.uri)}`);
                 return emptyResult;
             })
         ]);

--- a/src/client/datascience/notebook/notebookControllerManager.ts
+++ b/src/client/datascience/notebook/notebookControllerManager.ts
@@ -51,6 +51,7 @@ import { NoPythonKernelsNotebookController } from './noPythonKernelsNotebookCont
 import { getTelemetrySafeVersion } from '../../telemetry/helpers';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { KernelFilterService } from './kernelFilter/kernelFilterService';
+import { getDisplayPath } from '../../common/platform/fs-paths';
 
 /**
  * This class tracks notebook documents that are open and the provides NotebookControllers for
@@ -257,7 +258,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
             traceWarning(`Unable to create a controller for ${notebookType} without an active interpreter.`);
             return;
         }
-        traceInfo(`Creating controller for ${notebookType} with interpreter ${activeInterpreter.path}`);
+        traceInfo(`Creating controller for ${notebookType} with interpreter ${getDisplayPath(activeInterpreter.path)}`);
         return this.getOrCreateControllerForActiveInterpreter(activeInterpreter, notebookType);
     }
     private async createDefaultRemoteController() {
@@ -387,7 +388,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
         );
 
         // Prep so that we can track the selected controller for this document
-        traceInfoIfCI(`Clear controller mapping for ${document.uri.toString()}`);
+        traceInfoIfCI(`Clear controller mapping for ${getDisplayPath(document.uri)}`);
         const loadControllersPromise = this.loadNotebookControllers();
 
         if (
@@ -433,14 +434,16 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
                     return;
                 }
                 if (!preferredConnection) {
-                    traceInfoIfCI(`PreferredConnection not found for NotebookDocument: ${document.uri.toString()}`);
+                    traceInfoIfCI(
+                        `PreferredConnection not found for NotebookDocument: ${getDisplayPath(document.uri)}`
+                    );
                     return;
                 }
 
                 traceInfo(
-                    `PreferredConnection: ${
-                        preferredConnection.id
-                    } found for NotebookDocument: ${document.uri.toString()}`
+                    `PreferredConnection: ${preferredConnection.id} found for NotebookDocument: ${getDisplayPath(
+                        document.uri
+                    )}`
                 );
             }
             // Wait for our controllers to be loaded before we try to set a preferred on
@@ -451,14 +454,18 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
             );
 
             if (targetController) {
-                traceInfo(`TargetController found ID: ${targetController.id} for document ${document.uri.toString()}`);
+                traceInfo(
+                    `TargetController found ID: ${targetController.id} for document ${getDisplayPath(document.uri)}`
+                );
                 await targetController.updateNotebookAffinity(document, NotebookControllerAffinity.Preferred);
 
                 // Save in our map so we can find it in test code.
                 this.preferredControllers.set(document, targetController);
             } else {
                 traceInfoIfCI(
-                    `TargetController not found ID: ${preferredConnection?.id} for document ${document.uri.toString()}`
+                    `TargetController not found ID: ${preferredConnection?.id} for document ${getDisplayPath(
+                        document.uri
+                    )}`
                 );
             }
         } catch (ex) {

--- a/src/client/datascience/notebook/notebookDisposeService.ts
+++ b/src/client/datascience/notebook/notebookDisposeService.ts
@@ -8,6 +8,7 @@ import { NotebookDocument } from 'vscode';
 import { IExtensionSingleActivationService } from '../../activation/types';
 import { IVSCodeNotebook } from '../../common/application/types';
 import { traceInfo } from '../../common/logger';
+import { getDisplayPath } from '../../common/platform/fs-paths';
 import { IDisposableRegistry } from '../../common/types';
 import { noop } from '../../common/utils/misc';
 import { IKernelProvider } from '../jupyter/kernels/types';
@@ -23,7 +24,7 @@ export class NotebookDisposeService implements IExtensionSingleActivationService
         this.vscNotebook.onDidCloseNotebookDocument(this.onDidCloseNotebookDocument, this, this.disposables);
     }
     private onDidCloseNotebookDocument(document: NotebookDocument) {
-        traceInfo(`Notebook Closed ${document.uri.toString()}`);
+        traceInfo(`Notebook Closed ${getDisplayPath(document.uri)}`);
         const kernel = this.kernelProvider.get(document);
         if (kernel) {
             traceInfo(

--- a/src/client/datascience/notebook/outputs/plotSaveHandler.ts
+++ b/src/client/datascience/notebook/outputs/plotSaveHandler.ts
@@ -6,6 +6,7 @@ import { DataScience } from '../../../common/utils/localize';
 import * as path from 'path';
 import { saveSvgToPdf } from '../../plotting/plotViewer';
 import { traceError } from '../../../common/logger';
+import { getDisplayPath } from '../../../common/platform/fs-paths';
 
 const svgMimeType = 'image/svg+xml';
 const imageExtensionForMimeType: Record<string, string> = {
@@ -29,10 +30,10 @@ export class PlotSaveHandler {
         }
         const output = getOutputItem(notebook, outputId, mimeType);
         if (!output) {
-            return traceError(`Nolot to save ${notebook.uri.toString()}, id: ${outputId} for ${mimeType}`);
+            return traceError(`Nolot to save ${getDisplayPath(notebook.uri)}, id: ${outputId} for ${mimeType}`);
         }
         if (!(mimeType.toLowerCase() in imageExtensionForMimeType)) {
-            return traceError(`Unsupported MimeType ${notebook.uri.toString()}, id: ${outputId} for ${mimeType}`);
+            return traceError(`Unsupported MimeType ${getDisplayPath(notebook.uri)}, id: ${outputId} for ${mimeType}`);
         }
 
         const saveLocation = await this.getSaveTarget(output, mimeType);

--- a/src/client/datascience/notebook/outputs/plotViewHandler.ts
+++ b/src/client/datascience/notebook/outputs/plotViewHandler.ts
@@ -2,6 +2,7 @@ import sizeOf from 'image-size';
 import { inject, injectable } from 'inversify';
 import { NotebookCellOutputItem, NotebookDocument } from 'vscode';
 import { traceError } from '../../../common/logger';
+import { getDisplayPath } from '../../../common/platform/fs-paths';
 import { IPlotViewerProvider } from '../../types';
 
 const svgMimeType = 'image/svg+xml';
@@ -22,7 +23,7 @@ export class PlotViewHandler {
             const pngOutput = getOutputItem(notebook, outputId, pngMimeType);
 
             if (!pngOutput) {
-                return traceError(`No SVG or PNG Plot to open ${notebook.uri.toString()}, id: ${outputId}`);
+                return traceError(`No SVG or PNG Plot to open ${getDisplayPath(notebook.uri)}, id: ${outputId}`);
             }
 
             // If we did find a PNG wrap it in an SVG element so that we can display it

--- a/src/client/datascience/notebook/vscodeNotebookController.ts
+++ b/src/client/datascience/notebook/vscodeNotebookController.ts
@@ -19,6 +19,7 @@ import { ICommandManager, IDocumentManager, IVSCodeNotebook, IWorkspaceService }
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import { disposeAllDisposables } from '../../common/helpers';
 import { traceInfo, traceInfoIfCI } from '../../common/logger';
+import { getDisplayPath } from '../../common/platform/fs-paths';
 import {
     IConfigurationService,
     IDisposable,
@@ -167,7 +168,7 @@ export class VSCodeNotebookController implements Disposable {
     }
 
     public async updateNotebookAffinity(notebook: NotebookDocument, affinity: NotebookControllerAffinity) {
-        traceInfo(`Setting controller affinity for ${notebook.uri.toString()} ${this.id}`);
+        traceInfo(`Setting controller affinity for ${getDisplayPath(notebook.uri)} ${this.id}`);
         this.controller.updateNotebookAffinity(notebook, affinity);
     }
 
@@ -217,7 +218,7 @@ export class VSCodeNotebookController implements Disposable {
             return;
         }
 
-        traceInfoIfCI(`Notebook Controller set ${event.notebook.uri.toString()}, ${this.id}`);
+        traceInfoIfCI(`Notebook Controller set ${getDisplayPath(event.notebook.uri)}, ${this.id}`);
         this.associatedDocuments.add(event.notebook);
 
         // Now actually handle the change
@@ -282,7 +283,7 @@ export class VSCodeNotebookController implements Disposable {
     }
 
     private executeCell(doc: NotebookDocument, cell: NotebookCell) {
-        traceInfo(`Execute Cell ${cell.index} ${cell.notebook.uri.toString()}`);
+        traceInfo(`Execute Cell ${cell.index} ${getDisplayPath(cell.notebook.uri)}`);
         const kernel = this.kernelProvider.getOrCreate(cell.notebook, {
             metadata: this.kernelConnection,
             controller: this.controller,

--- a/src/client/datascience/notebookStorage/preferredRemoteKernelIdProvider.ts
+++ b/src/client/datascience/notebookStorage/preferredRemoteKernelIdProvider.ts
@@ -5,6 +5,7 @@ import { inject, injectable, named } from 'inversify';
 import { cloneDeep } from 'lodash';
 import { Memento, Uri } from 'vscode';
 import { traceInfo } from '../../common/logger';
+import { getDisplayPath } from '../../common/platform/fs-paths';
 import { GLOBAL_MEMENTO, ICryptoUtils, IMemento } from '../../common/types';
 import { sendTelemetryEvent } from '../../telemetry';
 import { Telemetry } from '../constants';
@@ -32,7 +33,7 @@ export class PreferredRemoteKernelIdProvider {
             // Not using a map as we're only going to store the last 40 items.
             const fileHash = this.crypto.createHash(uri.toString(), 'string');
             const entry = list.find((l) => l.fileHash === fileHash);
-            traceInfo(`Preferred kernel for ${uri.toString()} is ${entry?.kernelId}`);
+            traceInfo(`Preferred kernel for ${getDisplayPath(uri)} is ${entry?.kernelId}`);
             return entry?.kernelId;
         }
     }
@@ -59,7 +60,7 @@ export class PreferredRemoteKernelIdProvider {
         while (list.length > MaximumKernelIdListSize) {
             list.shift();
         }
-        traceInfo(`Preferred kernel for ${uri.toString()} is ${id}`);
+        traceInfo(`Preferred kernel for ${getDisplayPath(uri)} is ${id}`);
         await this.globalMemento.update(ActiveKernelIdList, list);
     }
 }

--- a/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
@@ -9,7 +9,7 @@ import { CancellationToken } from 'vscode-jsonrpc';
 
 import { IPythonExtensionChecker } from '../../../api/types';
 import { IWorkspaceService } from '../../../common/application/types';
-import { traceError, traceInfo } from '../../../common/logger';
+import { traceError, traceInfo, traceVerbose } from '../../../common/logger';
 import { IFileSystem } from '../../../common/platform/types';
 import { IAsyncDisposableRegistry, IConfigurationService, IOutputChannel, Resource } from '../../../common/types';
 import { createDeferred } from '../../../common/utils/async';
@@ -37,6 +37,7 @@ import { getTelemetrySafeLanguage } from '../../../telemetry/helpers';
 import { inject, injectable, named } from 'inversify';
 import { STANDARD_OUTPUT_CHANNEL } from '../../../common/constants';
 import { JupyterNotebookBase } from '../../jupyter/jupyterNotebook';
+import { getDisplayPath } from '../../../common/platform/fs-paths';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -73,13 +74,13 @@ export class HostRawNotebookProvider extends RawNotebookProviderBase implements 
         kernelConnection?: KernelConnectionMetadata,
         cancelToken?: CancellationToken
     ): Promise<INotebook> {
-        traceInfo(`Creating raw notebook for ${document.uri.toString()}`);
+        traceInfo(`Creating raw notebook for ${getDisplayPath(document.uri)}`);
         const notebookPromise = createDeferred<INotebook>();
         this.setNotebook(document, notebookPromise.promise);
         let progressDisposable: vscode.Disposable | undefined;
         let rawSession: RawJupyterSession | undefined;
 
-        traceInfo(`Getting preferred kernel for ${document.uri.toString()}`);
+        traceInfo(`Getting preferred kernel for ${getDisplayPath(document.uri)}`);
         try {
             const kernelConnectionProvided = !!kernelConnection;
             if (
@@ -105,7 +106,7 @@ export class HostRawNotebookProvider extends RawNotebookProviderBase implements 
                   )
                 : undefined;
 
-            traceInfo(`Computing working directory ${document.uri.toString()}`);
+            traceInfo(`Computing working directory ${getDisplayPath(document.uri)}`);
             const workingDirectory = await computeWorkingDirectory(resource, this.workspaceService);
             const launchTimeout = this.configService.getSettings().jupyterLaunchTimeout;
 
@@ -136,8 +137,8 @@ export class HostRawNotebookProvider extends RawNotebookProviderBase implements 
                 if (!kernelConnectionProvided) {
                     trackKernelResourceInformation(resource, { kernelConnection: kernelConnectionMetadata });
                 }
-                traceInfo(
-                    `Connecting to raw session for ${document.uri.toString()} with connection ${JSON.stringify(
+                traceVerbose(
+                    `Connecting to raw session for ${getDisplayPath(document.uri)} with connection ${JSON.stringify(
                         kernelConnectionMetadata
                     )}`
                 );

--- a/src/client/logging/_global.ts
+++ b/src/client/logging/_global.ts
@@ -122,7 +122,7 @@ export namespace traceDecorators {
     const DEFAULT_OPTS: TraceOptions = TraceOptions.Arguments | TraceOptions.ReturnValue;
 
     export function verbose(message: string, opts: TraceOptions = DEFAULT_OPTS) {
-        return createTracingDecorator([globalLogger], { message, opts });
+        return createTracingDecorator([globalLogger], { message, opts, level: LogLevel.Trace });
     }
     export function error(message: string) {
         const opts = DEFAULT_OPTS;
@@ -131,7 +131,7 @@ export namespace traceDecorators {
     }
     export function info(message: string) {
         const opts = TraceOptions.None;
-        return createTracingDecorator([globalLogger], { message, opts });
+        return createTracingDecorator([globalLogger], { message, opts, level: LogLevel.Info });
     }
     export function warn(message: string) {
         const opts = DEFAULT_OPTS;

--- a/src/client/logging/formatters.ts
+++ b/src/client/logging/formatters.ts
@@ -32,6 +32,7 @@ function normalizeLevel(name: LogLevelName): string {
             return norm;
         }
     }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if ((name as any) === 'silly') {
         return 'Verbose';
     }

--- a/src/client/logging/formatters.ts
+++ b/src/client/logging/formatters.ts
@@ -6,7 +6,7 @@ import { format } from 'winston';
 import { isTestExecution } from '../common/constants';
 import { getLevel, LogLevel, LogLevelName } from './levels';
 
-const TIMESTAMP = 'YYYY-MM-DD HH:mm:ss';
+const TIMESTAMP = 'HH:mm:ss';
 
 // Knobs used when creating a formatter.
 export type FormatterOptions = {

--- a/src/client/logging/formatters.ts
+++ b/src/client/logging/formatters.ts
@@ -32,6 +32,9 @@ function normalizeLevel(name: LogLevelName): string {
             return norm;
         }
     }
+    if ((name as any) === 'silly') {
+        return 'Verbose';
+    }
     return `${name.substring(0, 1).toUpperCase()}${name.substring(1).toLowerCase()}`;
 }
 

--- a/src/client/logging/levels.ts
+++ b/src/client/logging/levels.ts
@@ -18,13 +18,13 @@ export enum LogLevel {
     Debug = 10,
     Trace = 5
 }
-export type LogLevelName = 'ERROR' | 'WARNING' | 'INFORMATION' | 'DEBUG' | 'TRACE';
+export type LogLevelName = 'ERROR' | 'WARNING' | 'INFORMATION' | 'DEBUG' | 'DEBUG-TRACE';
 const logLevelMap: { [K in LogLevel]: LogLevelName } = {
     [LogLevel.Error]: 'ERROR',
     [LogLevel.Warn]: 'WARNING',
     [LogLevel.Info]: 'INFORMATION',
     [LogLevel.Debug]: 'DEBUG',
-    [LogLevel.Trace]: 'TRACE'
+    [LogLevel.Trace]: 'DEBUG-TRACE'
 };
 // This can be used for winston.LoggerOptions.levels.
 export const configLevels: winston.config.AbstractConfigSetLevels = {
@@ -32,7 +32,7 @@ export const configLevels: winston.config.AbstractConfigSetLevels = {
     WARNING: 1,
     INFORMATION: 2,
     DEBUG: 4,
-    TRACE: 5
+    'DEBUG-TRACE': 5
 };
 
 //======================

--- a/src/client/logging/levels.ts
+++ b/src/client/logging/levels.ts
@@ -18,13 +18,13 @@ export enum LogLevel {
     Debug = 10,
     Trace = 5
 }
-export type LogLevelName = 'ERROR' | 'WARNING' | 'INFORMATION' | 'DEBUG' | 'DEBUG-TRACE';
+export type LogLevelName = 'ERROR' | 'WARNING' | 'INFORMATION' | 'DEBUG' | 'TRACE';
 const logLevelMap: { [K in LogLevel]: LogLevelName } = {
     [LogLevel.Error]: 'ERROR',
     [LogLevel.Warn]: 'WARNING',
     [LogLevel.Info]: 'INFORMATION',
     [LogLevel.Debug]: 'DEBUG',
-    [LogLevel.Trace]: 'DEBUG-TRACE'
+    [LogLevel.Trace]: 'TRACE'
 };
 // This can be used for winston.LoggerOptions.levels.
 export const configLevels: winston.config.AbstractConfigSetLevels = {
@@ -32,7 +32,7 @@ export const configLevels: winston.config.AbstractConfigSetLevels = {
     WARNING: 1,
     INFORMATION: 2,
     DEBUG: 4,
-    'DEBUG-TRACE': 5
+    TRACE: 5
 };
 
 //======================
@@ -40,13 +40,13 @@ export const configLevels: winston.config.AbstractConfigSetLevels = {
 
 // The level names from winston/config.npm.
 // See: https://www.npmjs.com/package/winston#logging-levels
-type NPMLogLevelName = 'error' | 'warn' | 'info' | 'verbose' | 'debug';
+type NPMLogLevelName = 'error' | 'warn' | 'info' | 'silly' | 'debug';
 const npmLogLevelMap: { [K in LogLevel]: NPMLogLevelName } = {
     [LogLevel.Error]: 'error',
     [LogLevel.Warn]: 'warn',
     [LogLevel.Info]: 'info',
     [LogLevel.Debug]: 'debug',
-    [LogLevel.Trace]: 'verbose'
+    [LogLevel.Trace]: 'silly'
 };
 
 //======================

--- a/src/client/logging/levels.ts
+++ b/src/client/logging/levels.ts
@@ -40,7 +40,7 @@ export const configLevels: winston.config.AbstractConfigSetLevels = {
 
 // The level names from winston/config.npm.
 // See: https://www.npmjs.com/package/winston#logging-levels
-type NPMLogLevelName = 'error' | 'warn' | 'info' | 'silly' | 'debug';
+type NPMLogLevelName = 'error' | 'warn' | 'info' | 'verbose' | 'debug' | 'silly';
 const npmLogLevelMap: { [K in LogLevel]: NPMLogLevelName } = {
     [LogLevel.Error]: 'error',
     [LogLevel.Warn]: 'warn',

--- a/src/client/logging/levels.ts
+++ b/src/client/logging/levels.ts
@@ -40,13 +40,13 @@ export const configLevels: winston.config.AbstractConfigSetLevels = {
 
 // The level names from winston/config.npm.
 // See: https://www.npmjs.com/package/winston#logging-levels
-type NPMLogLevelName = 'error' | 'warn' | 'info' | 'verbose' | 'debug' | 'silly';
+type NPMLogLevelName = 'error' | 'warn' | 'info' | 'verbose' | 'debug';
 const npmLogLevelMap: { [K in LogLevel]: NPMLogLevelName } = {
     [LogLevel.Error]: 'error',
     [LogLevel.Warn]: 'warn',
     [LogLevel.Info]: 'info',
     [LogLevel.Debug]: 'debug',
-    [LogLevel.Trace]: 'silly'
+    [LogLevel.Trace]: 'verbose'
 };
 
 //======================

--- a/src/client/logging/logger.ts
+++ b/src/client/logging/logger.ts
@@ -121,7 +121,7 @@ function getLevelName(level: LogLevel, levels: winston.config.AbstractConfigSetL
         return levelName;
     } else if (isConsole) {
         // XXX Hard-coding this is fragile:
-        return 'silly';
+        return 'verbose';
     } else {
         return resolveLevelName(LogLevel.Info, levels) || 'info';
     }

--- a/src/client/logging/logger.ts
+++ b/src/client/logging/logger.ts
@@ -121,7 +121,7 @@ function getLevelName(level: LogLevel, levels: winston.config.AbstractConfigSetL
         return levelName;
     } else if (isConsole) {
         // XXX Hard-coding this is fragile:
-        return 'verbose';
+        return 'silly';
     } else {
         return resolveLevelName(LogLevel.Info, levels) || 'info';
     }

--- a/src/client/logging/trace.ts
+++ b/src/client/logging/trace.ts
@@ -66,7 +66,11 @@ function logResult(loggers: ILogger[], info: LogInfo, traced: TraceInfo, call?: 
     const formatted = formatMessages(info, traced, call);
     if (traced.err === undefined) {
         // The call did not fail.
-        if (!info.level || info.level > LogLevel.Error) {
+        if (info.level && info.level === LogLevel.Error) {
+            // No errors, hence nothing to log.
+        } else if (info.level) {
+            logToAll(loggers, info.level, [formatted]);
+        } else {
             logToAll(loggers, LogLevel.Info, [formatted]);
         }
     } else {

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -272,6 +272,7 @@ import { HostJupyterExecution } from '../../client/datascience/jupyter/liveshare
 import { HostJupyterServer } from '../../client/datascience/jupyter/liveshare/hostJupyterServer';
 import { HostRawNotebookProvider } from '../../client/datascience/raw-kernel/liveshare/hostRawNotebookProvider';
 import { CellHashProviderFactory } from '../../client/datascience/editor-integration/cellHashProviderFactory';
+import { getDisplayPath } from '../../client/common/platform/fs-paths';
 
 export class DataScienceIocContainer extends UnitTestIocContainer {
     public get workingInterpreter() {
@@ -888,7 +889,9 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
                     this.forceSettingsChanged(undefined, list[0].path, {});
 
                     // Log this all the time. Useful in determining why a test may not pass.
-                    const message = `Setting interpreter to ${list[0].displayName || list[0].path} -> ${list[0].path}`;
+                    const message = `Setting interpreter to ${
+                        list[0].displayName || getDisplayPath(list[0].path)
+                    } -> ${getDisplayPath(list[0].path)}`;
                     traceInfo(message);
                     // eslint-disable-next-line no-console
                     console.log(message);
@@ -1197,7 +1200,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
 
     private async hasFunctionalDependencies(interpreter: PythonEnvironment): Promise<boolean | undefined> {
         try {
-            traceInfo(`Checking ${interpreter.path} for functional dependencies ...`);
+            traceInfo(`Checking ${getDisplayPath(interpreter.path)} for functional dependencies ...`);
             const dependencyChecker = this.serviceManager.get<JupyterInterpreterDependencyService>(
                 JupyterInterpreterDependencyService
             );
@@ -1211,13 +1214,13 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
                         allowEnvironmentFetchExceptions: true
                     });
                 const result = await pythonProcess.isModuleInstalled('livelossplot'); // Should we check all dependencies?
-                traceInfo(`${interpreter.path} has jupyter with livelossplot indicating : ${result}`);
+                traceInfo(`${getDisplayPath(interpreter.path)} has jupyter with livelossplot indicating : ${result}`);
                 return result;
             } else {
                 traceInfo(`${JSON.stringify(interpreter)} is missing jupyter.`);
             }
         } catch (ex) {
-            traceError(`Exception attempting dependency list for ${interpreter.path}: `, ex);
+            traceError(`Exception attempting dependency list for ${getDisplayPath(interpreter.path)}: `, ex);
             return false;
         }
     }

--- a/src/test/datascience/interactiveWindow.vscode.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.test.ts
@@ -8,6 +8,7 @@ import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { IPythonApiProvider } from '../../client/api/types';
 import { traceInfo, traceInfoIfCI } from '../../client/common/logger';
+import { getDisplayPath } from '../../client/common/platform/fs-paths';
 import { IDisposable } from '../../client/common/types';
 import { InteractiveWindowProvider } from '../../client/datascience/interactive-window/interactiveWindowProvider';
 import { INotebookControllerManager } from '../../client/datascience/notebook/types';
@@ -73,7 +74,7 @@ suite('Interactive window', async function () {
         assert.equal(
             controller?.connection.interpreter?.path,
             activeInterpreter?.path,
-            `Controller does not match active interpreter for ${notebookDocument?.uri.toString()}`
+            `Controller does not match active interpreter for ${getDisplayPath(notebookDocument?.uri)}`
         );
 
         // Verify sys info cell
@@ -116,7 +117,7 @@ suite('Interactive window', async function () {
         assert.equal(
             controller?.connection.interpreter?.path,
             activeInterpreter?.path,
-            `Controller does not match active interpreter for ${notebookDocument?.uri.toString()}`
+            `Controller does not match active interpreter for ${getDisplayPath(notebookDocument?.uri)}`
         );
 
         async function verifyCells() {

--- a/src/test/datascience/kernel-launcher/kernelFinder.vscode.test.ts
+++ b/src/test/datascience/kernel-launcher/kernelFinder.vscode.test.ts
@@ -14,6 +14,7 @@ import { IExtensionTestApi } from '../../common';
 import { initialize } from '../../initialize';
 import { traceInfo } from '../../../client/common/logger';
 import { areInterpreterPathsSame } from '../../../client/pythonEnvironments/info/interpreter';
+import { getDisplayPath } from '../../../client/common/platform/fs-paths';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, no-invalid-this */
 suite('DataScience - Kernels Finder', () => {
@@ -61,7 +62,9 @@ suite('DataScience - Kernels Finder', () => {
 
         assert.isTrue(
             areInterpreterPathsSame(kernelSpec.interpreter.path.toLowerCase(), interpreter?.path.toLocaleLowerCase()),
-            `No interpreter found, kernelspec interpreter is ${kernelSpec.interpreter.path} but expected ${interpreter?.path}`
+            `No interpreter found, kernelspec interpreter is ${getDisplayPath(
+                kernelSpec.interpreter.path
+            )} but expected ${getDisplayPath(interpreter?.path)}`
         );
     });
     test('Interpreter kernel returned if kernelspec metadata not provided', async () => {
@@ -78,7 +81,9 @@ suite('DataScience - Kernels Finder', () => {
         }
         assert.isTrue(
             areInterpreterPathsSame(kernelSpec.interpreter.path.toLowerCase(), interpreter?.path.toLocaleLowerCase()),
-            `No interpreter found, kernelspec interpreter is ${kernelSpec.interpreter.path} but expected ${interpreter?.path}`
+            `No interpreter found, kernelspec interpreter is ${getDisplayPath(
+                kernelSpec.interpreter.path
+            )} but expected ${getDisplayPath(interpreter?.path)}`
         );
     });
     test('Can find a Python kernel based on language', async () => {

--- a/src/test/datascience/notebook/executionService.vscode.test.ts
+++ b/src/test/datascience/notebook/executionService.vscode.test.ts
@@ -51,6 +51,7 @@ import {
     hasErrorOutput,
     translateCellErrorOutput
 } from '../../../client/datascience/notebook/helpers/helpers';
+import { getDisplayPath } from '../../../client/common/platform/fs-paths';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const expectedPromptMessageSuffix = `requires ${ProductNames.get(Product.ipykernel)!} to be installed.`;
@@ -282,7 +283,9 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         );
 
         // Interrupt the kernel).
-        traceInfo(`Interrupt requested for ${vscodeNotebook.activeNotebookEditor?.document?.uri.toString()} in test`);
+        traceInfo(
+            `Interrupt requested for ${getDisplayPath(vscodeNotebook.activeNotebookEditor?.document?.uri)} in test`
+        );
         await commands.executeCommand(
             'jupyter.notebookeditor.interruptkernel',
             vscodeNotebook.activeNotebookEditor?.document.uri


### PR DESCRIPTION
Stop displaying user names in logs (I find lots of users strip out the first few parts of the logs as it contains their user names)
* This change ensures we use `~` where possible in our logs (minimizing displaying user names in logs)
	* As a resuult the text is also smaller
* CHanged some of the logging levels to verbose (logging environment variables is unnecessary, i don't think we've used this)