### PR TITLE
Update to latest middleware with token edit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3624,9 +3624,9 @@
             }
         },
         "@vscode/jupyter-lsp-middleware": {
-            "version": "0.2.16",
-            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.16.tgz",
-            "integrity": "sha512-+wJjYUb5HuUs2banNRoZuxFeXr1K6qUJqOYty6DDDMBBLXzp+SS5R2I/skuyEGmZ5KIjdXgG5HWwpKoMszq8Sg==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.17.tgz",
+            "integrity": "sha512-4aaNUpWB3BDj4gG/+awB0vCAQEQOrDbofPEbJ3QdpIZPrndlu6f6mxeDN+yDCZqh+aUU+b3uFGU489bdnCv+Qg==",
             "requires": {
                 "vscode-languageclient": "7.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -1974,7 +1974,7 @@
         "@jupyterlab/services": "^6.1.17",
         "@lumino/widgets": "^1.28.0",
         "@nteract/messaging": "^7.0.0",
-        "@vscode/jupyter-lsp-middleware": "^0.2.16",
+        "@vscode/jupyter-lsp-middleware": "^0.2.17",
         "ansi-to-html": "^0.6.7",
         "arch": "^2.1.0",
         "bootstrap": "^4.3.1",


### PR DESCRIPTION
Fixes #6799 (change log entry is actually already there, so no news entry)

This should fix editing of notebooks to have valid tokens. Not the ideal way to handle it, but should be quick enough with how small cells are.

The npm module was changed here:
https://github.com/microsoft/vscode-jupyter-lsp-middleware/commit/883ee82068a1491a7349b4aa4e682a69f2b50f9d

So that token edits are changed into token range requests. Token edits are theoretically faster, but pylance doesn't seem to have a problem with a new range request every time.