### PR TITLE
Cancel previous run on a push

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -49,6 +49,15 @@ env:
   VSC_JUPYTER_LOG_KERNEL_OUTPUT: true
 
 jobs:
+  # Make sure to cancel previous runs on a push
+  cancel_previous_runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
   pick_environment:
     name: Pick Environment
     runs-on: ubuntu-latest


### PR DESCRIPTION
We keep running out of machines for actions. I've been freeing up machines by canceling previous runs by hand.
Turns out there's a way to do that automatically.

Following directions here.
https://github.com/marketplace/actions/cancel-workflow-action

