### PR TITLE
Ignore events from IJupyterSession if its not the active session

### DIFF
--- a/src/client/datascience/baseJupyterSession.ts
+++ b/src/client/datascience/baseJupyterSession.ts
@@ -8,8 +8,9 @@ import { Observable } from 'rxjs/Observable';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
 import { Event, EventEmitter } from 'vscode';
 import { WrappedError } from '../common/errors/types';
+import { disposeAllDisposables } from '../common/helpers';
 import { traceError, traceInfo, traceInfoIfCI, traceWarning } from '../common/logger';
-import { Resource } from '../common/types';
+import { IDisposable, Resource } from '../common/types';
 import { createDeferred, sleep, waitForPromise } from '../common/utils/async';
 import * as localize from '../common/utils/localize';
 import { noop } from '../common/utils/misc';
@@ -40,6 +41,7 @@ export class JupyterSessionStartError extends WrappedError {
 export abstract class BaseJupyterSession implements IJupyterSession {
     private _isDisposed?: boolean;
     private readonly _disposed = new EventEmitter<void>();
+    protected readonly disposables: IDisposable[] = [];
     public get disposed() {
         return this._isDisposed === true;
     }
@@ -122,6 +124,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
             this._disposed.dispose();
             this.onStatusChangedEvent.dispose();
         }
+        disposeAllDisposables(this.disposables);
         traceInfo('Shutdown session -- complete');
     }
     public async interrupt(): Promise<void> {

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -8,7 +8,7 @@ import cloneDeep = require('lodash/cloneDeep');
 // This code is based on the examples here:
 // https://www.npmjs.com/package/@jupyterlab/services
 
-export class JupyterNotebookBase implements INotebook {
+export class JupyterNotebook implements INotebook {
     private _executionInfo: INotebookExecutionInfo;
     constructor(public readonly session: IJupyterSession, executionInfo: INotebookExecutionInfo) {
         // Make a copy of the launch info so we can update it in this class

--- a/src/client/datascience/jupyter/kernels/cellExecutionQueue.ts
+++ b/src/client/datascience/jupyter/kernels/cellExecutionQueue.ts
@@ -141,6 +141,13 @@ export class CellExecutionQueue implements Disposable {
                 await this.cancel();
                 break;
             }
+            // If the kernel is dead, then no point trying the rest.
+            if (kernelConnection.status === 'dead' || kernelConnection.status === 'terminating') {
+                this.cancelledOrCompletedWithErrors = true;
+                traceInfo(`Cancel all remaining cells due to dead kernel`);
+                await this.cancel();
+                break;
+            }
         }
     }
 }

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -92,7 +92,7 @@ export class Kernel implements IKernel {
         return this._info;
     }
     get status(): KernelMessage.Status {
-        return this.notebook?.session?.status ?? 'unknown';
+        return this.notebook?.session?.status ?? (this.isKernelDead ? 'dead' : 'unknown');
     }
     get disposed(): boolean {
         return this._disposed === true || this.notebook?.session.disposed === true;
@@ -101,6 +101,13 @@ export class Kernel implements IKernel {
         return this._kernelSocket.asObservable();
     }
     private notebook?: INotebook;
+    /**
+     * If the session died, then ensure the status is set to `dead`.
+     * We need to provide an accurate status.
+     * `unknown` is generally used to indicate jupyter kernel hasn't started.
+     * If a jupyter kernel dies after it has started, then status is set to `dead`.
+     */
+    private isKernelDead?: boolean;
     public get session(): IJupyterSession | undefined {
         return this.notebook?.session;
     }
@@ -235,7 +242,10 @@ export class Kernel implements IKernel {
         traceInfo(`Restart requested ${this.notebookDocument.uri}`);
         this.startCancellation.cancel();
         try {
-            await this.kernelExecution.restart(this._notebookPromise?.then((item) => item.session));
+            // If the notebook died, then start a new notebook.
+            await (this._notebookPromise
+                ? this.kernelExecution.restart(this._notebookPromise?.then((item) => item.session))
+                : this.start({ disableUI: false }));
             traceInfoIfCI(`Restarted ${getDisplayPath(this.notebookDocument.uri)}`);
         } catch (ex) {
             traceError(`Restart failed ${getDisplayPath(this.notebookDocument.uri)}`, ex);
@@ -299,6 +309,7 @@ export class Kernel implements IKernel {
                             this.kernelConnectionMetadata
                         );
                         traceInfo(`Starting Notebook in kernel.ts id = ${this.kernelConnectionMetadata.id}`);
+                        this.isKernelDead = false;
                         this.notebook = await this.notebookProvider.getOrCreateNotebook({
                             document: this.notebookDocument,
                             resource: this.resourceUri,
@@ -417,8 +428,16 @@ export class Kernel implements IKernel {
                 // this.kernelExecution.cancel();
                 // Ignore when notebook is disposed as a result of failed restarts.
                 if (!this._ignoreNotebookDisposedErrors) {
+                    const isActiveNotebookDead = this.notebook === notebook;
+
                     this._notebookPromise = undefined;
-                    this._onDisposed.fire();
+                    this.notebook = undefined;
+
+                    // If the active notebook died, then kernel is dead.
+                    if (isActiveNotebookDead) {
+                        this.isKernelDead = true;
+                        this._onStatusChanged.fire('dead');
+                    }
                 }
             });
             const statusChangeHandler = (status: KernelMessage.Status) => {

--- a/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
+++ b/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
@@ -36,7 +36,7 @@ import { KernelConnectionMetadata } from '../kernels/types';
 import { ILocalKernelFinder, IRemoteKernelFinder } from '../../kernel-launcher/types';
 import { STANDARD_OUTPUT_CHANNEL } from '../../../common/constants';
 import { inject, injectable, named } from 'inversify';
-import { JupyterNotebookBase } from '../jupyterNotebook';
+import { JupyterNotebook } from '../jupyterNotebook';
 import * as uuid from 'uuid/v4';
 import { NotebookDocument } from 'vscode';
 import { noop } from '../../../common/utils/misc';
@@ -170,7 +170,7 @@ export class HostJupyterServer implements INotebookServer {
 
             if (session) {
                 // Create our notebook
-                const notebook = new JupyterNotebookBase(session, info);
+                const notebook = new JupyterNotebook(session, info);
 
                 // Wait for it to be ready
                 traceInfo(`Waiting for idle (session) ${this.id}`);

--- a/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
@@ -42,8 +42,8 @@ import { getResourceType } from '../../common';
 import { getTelemetrySafeLanguage } from '../../../telemetry/helpers';
 import { inject, injectable, named } from 'inversify';
 import { STANDARD_OUTPUT_CHANNEL } from '../../../common/constants';
-import { JupyterNotebookBase } from '../../jupyter/jupyterNotebook';
 import { getDisplayPath } from '../../../common/platform/fs-paths';
+import { JupyterNotebook } from '../../jupyter/jupyterNotebook';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -159,7 +159,7 @@ export class HostRawNotebookProvider extends RawNotebookProviderBase implements 
 
                 if (rawSession.isConnected) {
                     // Create our notebook
-                    const notebook = new JupyterNotebookBase(rawSession, info);
+                    const notebook = new JupyterNotebook(rawSession, info);
 
                     traceInfo(`Finished connecting ${this.id}`);
 

--- a/src/client/datascience/raw-kernel/rawJupyterSession.ts
+++ b/src/client/datascience/raw-kernel/rawJupyterSession.ts
@@ -239,7 +239,7 @@ export class RawJupyterSession extends BaseJupyterSession {
                 .finally(() => {
                     // If we're still terminanting this session,
                     // trigger dead status
-                    if (this.terminatingStatus){
+                    if (this.terminatingStatus) {
                         this.terminatingStatus = 'dead';
                         this.onStatusChangedEvent.fire('dead');
                     }

--- a/src/client/datascience/raw-kernel/rawJupyterSession.ts
+++ b/src/client/datascience/raw-kernel/rawJupyterSession.ts
@@ -32,8 +32,14 @@ It's responsible for translating our IJupyterSession interface into the
 jupyterlabs interface as well as starting up and connecting to a raw session
 */
 export class RawJupyterSession extends BaseJupyterSession {
-    private processExitHandler: IDisposable | undefined;
-    private _disposables: IDisposable[] = [];
+    private processExitHandler = new WeakMap<RawSession, IDisposable>();
+    private isTerminating?: boolean;
+    public get status(): KernelMessage.Status {
+        if (this.isTerminating && super.status !== 'dead') {
+            return 'terminating';
+        }
+        return super.status;
+    }
     constructor(
         private readonly kernelLauncher: IKernelLauncher,
         resource: Resource,
@@ -53,10 +59,6 @@ export class RawJupyterSession extends BaseJupyterSession {
             return this.waitForIdleOnSession(this.session, timeout);
         }
         return Promise.resolve();
-    }
-    public async dispose(): Promise<void> {
-        this._disposables.forEach((d) => d.dispose());
-        await super.dispose();
     }
 
     // Connect to the given kernelspec, which should already have ipykernel installed into its interpreter
@@ -182,16 +184,14 @@ export class RawJupyterSession extends BaseJupyterSession {
     }
 
     protected shutdownSession(
-        session: ISessionWithSocket | undefined,
+        session: RawSession | undefined,
         statusHandler: Slot<ISessionWithSocket, KernelMessage.Status> | undefined,
         isRequestToShutdownRestartSession: boolean | undefined
     ): Promise<void> {
-        // REmove our process exit handler. Kernel is shutting down on purpose
-        // so we don't need to listen.
-        if (this.processExitHandler) {
-            this.processExitHandler.dispose();
-            this.processExitHandler = undefined;
-        }
+        // Remove our process exit handler. Kernel is shutting down on purpose
+        // so we don't need to listen to shutdown anymore.
+        const disposable = session && this.processExitHandler.get(session);
+        disposable?.dispose();
         // We want to know why we got shut down
         const stacktrace = new Error().stack;
         return super.shutdownSession(session, statusHandler, isRequestToShutdownRestartSession).then(() => {
@@ -200,35 +200,44 @@ export class RawJupyterSession extends BaseJupyterSession {
                 stacktrace
             });
             if (session) {
-                return (session as RawSession).kernelProcess.dispose();
+                return session.kernelProcess.dispose();
             }
         });
     }
 
-    protected setSession(session: RawSession) {
+    protected setSession(session: RawSession | undefined) {
         super.setSession(session);
-
-        // When setting the session clear our current exit handler and hook up to the
-        // new session process
-        if (this.processExitHandler) {
-            this.processExitHandler.dispose();
-            this.processExitHandler = undefined;
+        if (!session) {
+            return;
         }
-        if (session?.kernelProcess) {
-            // Watch to see if our process exits
-            this.processExitHandler = session.kernelProcess.exited(({ exitCode, reason }) => {
-                sendTelemetryEvent(Telemetry.RawKernelSessionKernelProcessExited, undefined, {
-                    exitCode,
-                    exitReason: getTelemetrySafeErrorMessageFromPythonTraceback(reason)
-                });
-                traceError(`Raw kernel process exited code: ${exitCode}`);
-                this.shutdown().catch((reason) => {
-                    traceError(`Error shutting down jupyter session: ${reason}`);
-                });
-                // Next code the user executes will show a session disposed message
+        this.isTerminating = undefined;
+        // Watch to see if our process exits
+        // This is the place to do this, after this session has been setup as the active kernel.
+        const disposable = session.kernelProcess.exited(({ exitCode, reason }) => {
+            // If this session is no longer the active session, then we don't need to do anything
+            // with this exit event (could be we're killing it, or restarting).
+            // In the case of restarting, the old session is disposed & a new one created.
+            // When disposing the old kernel we shouldn't fire events about session getting terminated.
+            if (session !== this.session) {
+                return;
+            }
+            sendTelemetryEvent(Telemetry.RawKernelSessionKernelProcessExited, undefined, {
+                exitCode,
+                exitReason: getTelemetrySafeErrorMessageFromPythonTraceback(reason)
             });
-            this._disposables.push(this.processExitHandler);
-        }
+            traceError(`Raw kernel process exited code: ${exitCode}`);
+            // If the raw kernel process dies, then send the terminating event, and shutdown the session.
+            // Afer shutting down the session, the status changes to `dead`
+            this.isTerminating = true;
+            this.onStatusChangedEvent.fire('terminating');
+            this.shutdown()
+                .catch((reason) => {
+                    traceError(`Error shutting down jupyter session: ${reason}`);
+                })
+                .finally(() => (this.isTerminating = undefined));
+        });
+        this.disposables.push(disposable);
+        this.processExitHandler.set(session, disposable);
     }
 
     protected startRestartSession(timeout: number) {
@@ -263,6 +272,7 @@ export class RawJupyterSession extends BaseJupyterSession {
 
         traceInfo(`Starting raw kernel ${getDisplayNameOrNameOfKernelConnection(kernelConnection)}`);
 
+        this.isTerminating = undefined;
         const process = await this.kernelLauncher.launch(
             kernelConnection,
             timeout,

--- a/src/test/datascience/notebook/interruptRestart.vscode.test.ts
+++ b/src/test/datascience/notebook/interruptRestart.vscode.test.ts
@@ -386,7 +386,6 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
         // When we re-run the cells, the execution order shouldl start from 1 all over again
         // If its one, then kernel has restarted.
         await Promise.all([
-            runCell(cell1),
             runAllCellsInActiveNotebook(),
             waitForExecutionCompletedSuccessfully(cell1),
             waitForExecutionCompletedSuccessfully(cell2),

--- a/src/test/datascience/notebook/interruptRestart.vscode.test.ts
+++ b/src/test/datascience/notebook/interruptRestart.vscode.test.ts
@@ -381,7 +381,6 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
             waitForKernelToRestart.assertFired(30_000)
         ]);
         traceInfo('Step 10 Restarted');
-        assert.isUndefined(kernel?.session, 'Kernel.session should be undefined');
 
         // Run the first cell again & this time it should work.
         // When we re-run the cells, the execution order shouldl start from 1 all over again


### PR DESCRIPTION
Looking at failures in this log https://pipelines.actions.githubusercontent.com/KyBlh4sBTj8eoTzBTvt0CAApvyyj3PXuc4Tbg2yHyMGda4Kk7D/_apis/pipelines/1/runs/23088/signedlogcontent/17?urlExpires=2021-11-01T20%3A49%3A54.9664908Z&urlSigningMethod=HMACV1&urlSignature=r0HBCl88NwLJc6y5J0gUQAkbXxqRlsdKN%2Fn4dIzcBmo%3D

**Change 1 - Fix issue found in CI**
This is whats happening:
* When restarting or switching kernels, the old IJupyterSession gets disposed
* When disposing the old IJupyterSession we trigger disposed events and the like
* However this is the old session and its not longer valid, we're starting a whole new IJupyterSession that will replace the old one.

Solution: Ensure we don't handle those events

**Change 2 - When a kernel dies, stop all of the executions**
* No point running cells.
