### PR TITLE
Remove kernel finder from server start

### DIFF
--- a/src/client/datascience/interactive-common/notebookProvider.ts
+++ b/src/client/datascience/interactive-common/notebookProvider.ts
@@ -106,9 +106,8 @@ export class NotebookProvider implements INotebookProvider {
             ? this.rawNotebookProvider.createNotebook(
                   options.document,
                   resource,
-                  options.disableUI,
-                  options.metadata,
                   options.kernelConnection,
+                  options.disableUI,
                   options.token
               )
             : this.jupyterNotebookProvider.createNotebook(options);

--- a/src/client/datascience/interactive-common/notebookServerProvider.ts
+++ b/src/client/datascience/interactive-common/notebookServerProvider.ts
@@ -78,10 +78,7 @@ export class NotebookServerProvider implements IJupyterServerProvider {
         }
     }
 
-    private async startServer(
-        resource: Resource,
-        token?: CancellationToken
-    ): Promise<INotebookServer | undefined> {
+    private async startServer(resource: Resource, token?: CancellationToken): Promise<INotebookServer | undefined> {
         const serverOptions = await this.getNotebookServerOptions(resource);
         traceInfo(`Checking for server existence.`);
 

--- a/src/client/datascience/interactive-common/notebookServerProvider.ts
+++ b/src/client/datascience/interactive-common/notebookServerProvider.ts
@@ -3,7 +3,6 @@
 
 'use strict';
 
-import type * as nbformat from '@jupyterlab/nbformat';
 import { inject, injectable } from 'inversify';
 import { CancellationToken, ConfigurationTarget } from 'vscode';
 import { IApplicationShell } from '../../common/application/types';
@@ -18,7 +17,6 @@ import { Identifiers, Settings, Telemetry } from '../constants';
 import { JupyterInstallError } from '../jupyter/jupyterInstallError';
 import { JupyterSelfCertsError } from '../jupyter/jupyterSelfCertsError';
 import { JupyterZMQBinariesNotFoundError } from '../jupyter/jupyterZMQBinariesNotFoundError';
-import { KernelConnectionMetadata } from '../jupyter/kernels/types';
 import { JupyterServerSelector } from '../jupyter/serverSelector';
 import { ProgressReporter } from '../progress/progressReporter';
 import {
@@ -47,7 +45,7 @@ export class NotebookServerProvider implements IJupyterServerProvider {
         options: GetServerOptions,
         token?: CancellationToken
     ): Promise<INotebookServer | undefined> {
-        const serverOptions = await this.getNotebookServerOptions(options);
+        const serverOptions = await this.getNotebookServerOptions(options.resource);
 
         // If we are just fetching or only want to create for local, see if exists
         if (options.getOnly || (options.localOnly && !serverOptions.uri)) {
@@ -68,7 +66,7 @@ export class NotebookServerProvider implements IJupyterServerProvider {
 
         if (!this.serverPromise) {
             // Start a server
-            this.serverPromise = this.startServer(options, token);
+            this.serverPromise = this.startServer(options.resource, token);
         }
         try {
             const value = await this.serverPromise;
@@ -81,14 +79,10 @@ export class NotebookServerProvider implements IJupyterServerProvider {
     }
 
     private async startServer(
-        options: {
-            resource: Resource;
-            metadata?: nbformat.INotebookMetadata;
-            kernelConnection?: KernelConnectionMetadata;
-        },
+        resource: Resource,
         token?: CancellationToken
     ): Promise<INotebookServer | undefined> {
-        const serverOptions = await this.getNotebookServerOptions(options);
+        const serverOptions = await this.getNotebookServerOptions(resource);
         traceInfo(`Checking for server existence.`);
 
         // If the URI is 'remote' then the encrypted storage is not working. Ask user again for server URI
@@ -202,11 +196,7 @@ export class NotebookServerProvider implements IJupyterServerProvider {
         }
     }
 
-    private async getNotebookServerOptions(options: {
-        resource: Resource;
-        metadata?: nbformat.INotebookMetadata;
-        kernelConnection?: KernelConnectionMetadata;
-    }): Promise<INotebookServerOptions> {
+    private async getNotebookServerOptions(resource: Resource): Promise<INotebookServerOptions> {
         // Since there's one server per session, don't use a resource to figure out these settings
         let serverURI: string | undefined = await this.serverUriStorage.getUri();
         const useDefaultConfig: boolean | undefined = this.configuration.getSettings(undefined)
@@ -219,11 +209,9 @@ export class NotebookServerProvider implements IJupyterServerProvider {
 
         return {
             uri: serverURI,
-            resource: options.resource,
+            resource,
             skipUsingDefaultConfig: !useDefaultConfig,
             purpose: Identifiers.HistoryPurpose,
-            kernelConnection: options.kernelConnection,
-            metadata: options.metadata,
             allowUI: this.allowUI.bind(this)
         };
     }

--- a/src/client/datascience/jupyter/jupyterNotebookProvider.ts
+++ b/src/client/datascience/jupyter/jupyterNotebookProvider.ts
@@ -40,12 +40,7 @@ export class JupyterNotebookProvider implements IJupyterNotebookProvider {
         });
 
         if (server) {
-            return server.createNotebook(
-                options.resource,
-                options.document,
-                options.kernelConnection,
-                options.token
-            );
+            return server.createNotebook(options.resource, options.document, options.kernelConnection, options.token);
         }
         // We want createNotebook to always return a notebook promise, so if we don't have a server
         // here throw our generic server disposed message that we use in server creatio n

--- a/src/client/datascience/jupyter/jupyterNotebookProvider.ts
+++ b/src/client/datascience/jupyter/jupyterNotebookProvider.ts
@@ -43,7 +43,6 @@ export class JupyterNotebookProvider implements IJupyterNotebookProvider {
             return server.createNotebook(
                 options.resource,
                 options.document,
-                options.metadata,
                 options.kernelConnection,
                 options.token
             );
@@ -57,9 +56,7 @@ export class JupyterNotebookProvider implements IJupyterNotebookProvider {
             getOnly: options.getOnly,
             disableUI: options.disableUI,
             token: options.token,
-            resource: options.resource,
-            metadata: options.metadata,
-            kernelConnection: options.kernelConnection
+            resource: options.resource
         });
         if (server) {
             return server.getNotebook(options.document, options.token);

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -23,11 +23,10 @@ import { BaseJupyterSession, JupyterSessionStartError } from '../baseJupyterSess
 import { Telemetry } from '../constants';
 import { reportAction } from '../progress/decorator';
 import { ReportableAction } from '../progress/types';
-import { trackKernelResourceInformation } from '../telemetry/telemetry';
 import { IJupyterConnection, ISessionWithSocket } from '../types';
 import { JupyterInvalidKernelError } from './jupyterInvalidKernelError';
 import { JupyterWebSockets } from './jupyterWebSocket';
-import { getNameOfKernelConnection, kernelConnectionMetadataHasKernelSpec } from './kernels/helpers';
+import { getNameOfKernelConnection } from './kernels/helpers';
 import { JupyterKernelService } from './kernels/jupyterKernelService';
 import { KernelConnectionMetadata } from './kernels/types';
 
@@ -80,48 +79,6 @@ export class JupyterSession extends BaseJupyterSession {
 
         // Made it this far, we're connected now
         this.connected = true;
-    }
-    public async changeKernel(
-        resource: Resource,
-        kernelConnection: KernelConnectionMetadata,
-        timeoutMS: number
-    ): Promise<void> {
-        this.resource = resource;
-        let newSession: ISessionWithSocket | undefined;
-        // If we are already using this kernel in an active session just return back
-        const currentKernelSpec =
-            this.kernelConnectionMetadata && kernelConnectionMetadataHasKernelSpec(this.kernelConnectionMetadata)
-                ? this.kernelConnectionMetadata.kernelSpec
-                : undefined;
-        const kernelSpecToUse = kernelConnectionMetadataHasKernelSpec(kernelConnection)
-            ? kernelConnection.kernelSpec
-            : undefined;
-        if (this.session && currentKernelSpec && kernelSpecToUse && this.kernelConnectionMetadata) {
-            // If we have selected the same kernel connection, then nothing to do.
-            if (this.kernelConnectionMetadata.id === kernelConnection.id) {
-                traceInfoIfCI(`Kernels are the same, no switching necessary.`);
-                return;
-            }
-        }
-        trackKernelResourceInformation(resource, { kernelConnection });
-        newSession = await this.createNewKernelSession(resource, kernelConnection, timeoutMS);
-
-        // This is just like doing a restart, kill the old session (and the old restart session), and start new ones
-        if (this.session) {
-            this.shutdownSession(this.session, this.statusHandler, false).ignoreErrors();
-            this.restartSessionPromise?.then((r) => this.shutdownSession(r, undefined, true)).ignoreErrors(); // NOSONAR
-        }
-
-        traceInfoIfCI(`Switched notebook kernel to ${kernelSpecToUse?.display_name}`);
-
-        // Update our kernel connection metadata.
-        this.kernelConnectionMetadata = kernelConnection;
-
-        // Save the new session
-        this.setSession(newSession);
-
-        // Listen for session status changes
-        this.session?.statusChanged.connect(this.statusHandler); // NOSONAR
     }
 
     public async createNewKernelSession(

--- a/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
+++ b/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
@@ -3,13 +3,10 @@
 'use strict';
 import '../../../common/extensions';
 
-import type * as nbformat from '@jupyterlab/nbformat';
 import * as vscode from 'vscode';
 import { CancellationToken } from 'vscode-jsonrpc';
-import { IPythonExtensionChecker } from '../../../api/types';
-import { IVSCodeNotebook, IWorkspaceService } from '../../../common/application/types';
-import { traceError, traceInfo, traceInfoIfCI } from '../../../common/logger';
-import { IFileSystem } from '../../../common/platform/types';
+import { IWorkspaceService } from '../../../common/application/types';
+import { traceError, traceInfo } from '../../../common/logger';
 import {
     IAsyncDisposableRegistry,
     IConfigurationService,
@@ -20,8 +17,6 @@ import {
 } from '../../../common/types';
 import { createDeferred, Deferred, sleep } from '../../../common/utils/async';
 import * as localize from '../../../common/utils/localize';
-import { IInterpreterService } from '../../../interpreter/contracts';
-import { isResourceNativeNotebook } from '../../notebook/helpers/helpers';
 import { ProgressReporter } from '../../progress/progressReporter';
 import {
     IJupyterConnection,
@@ -32,8 +27,7 @@ import {
 } from '../../types';
 import { computeWorkingDirectory } from '../jupyterUtils';
 import { getDisplayNameOrNameOfKernelConnection } from '../kernels/helpers';
-import { KernelConnectionMetadata } from '../kernels/types';
-import { ILocalKernelFinder, IRemoteKernelFinder } from '../../kernel-launcher/types';
+import { DefaultKernelConnectionMetadata, KernelConnectionMetadata } from '../kernels/types';
 import { STANDARD_OUTPUT_CHANNEL } from '../../../common/constants';
 import { inject, injectable, named } from 'inversify';
 import { JupyterNotebook } from '../jupyterNotebook';
@@ -63,14 +57,8 @@ export class HostJupyterServer implements INotebookServer {
         @inject(IConfigurationService) private readonly configService: IConfigurationService,
         @inject(IJupyterSessionManagerFactory) private readonly sessionManagerFactory: IJupyterSessionManagerFactory,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
-        @inject(IFileSystem) private readonly fs: IFileSystem,
-        @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
-        @inject(ILocalKernelFinder) private readonly localKernelFinder: ILocalKernelFinder,
-        @inject(IRemoteKernelFinder) private readonly remoteKernelFinder: IRemoteKernelFinder,
         @inject(IOutputChannel) @named(STANDARD_OUTPUT_CHANNEL) private readonly jupyterOutputChannel: IOutputChannel,
         @inject(ProgressReporter) private readonly progressReporter: ProgressReporter,
-        @inject(IPythonExtensionChecker) private readonly extensionChecker: IPythonExtensionChecker,
-        @inject(IVSCodeNotebook) private readonly vscodeNotebook: IVSCodeNotebook,
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry
     ) {
         this.asyncRegistry.push(this);
@@ -93,20 +81,13 @@ export class HostJupyterServer implements INotebookServer {
         resource: Resource,
         document: vscode.NotebookDocument,
         sessionManager: JupyterSessionManager,
-        possibleSession: JupyterSession | undefined,
         configService: IConfigurationService,
-        notebookMetadata?: nbformat.INotebookMetadata,
-        kernelConnection?: KernelConnectionMetadata,
+        kernelConnection: KernelConnectionMetadata,
         cancelToken?: CancellationToken
     ): Promise<INotebook> {
         // See if already exists.
         const existing = await this.getNotebook(document);
         if (existing) {
-            // Dispose the possible session as we don't need it
-            if (possibleSession) {
-                await possibleSession.dispose();
-            }
-
             // Then we can return the existing notebook.
             return existing;
         }
@@ -119,48 +100,20 @@ export class HostJupyterServer implements INotebookServer {
         this.setNotebook(document, notebookPromise.promise);
 
         const getExistingSession = async () => {
-            const { info, changedKernel } = await this.computeLaunchInfo(
-                resource,
-                notebookMetadata,
-                kernelConnection,
-                cancelToken
-            );
+            const info = await this.computeLaunchInfo();
 
             progressDisposable = this.progressReporter.createProgressIndicator(
                 localize.DataScience.connectingToKernel().format(
-                    getDisplayNameOrNameOfKernelConnection(info.kernelConnectionMetadata)
+                    getDisplayNameOrNameOfKernelConnection(kernelConnection)
                 )
             );
-
-            // If we switched kernels, try switching the possible session
-            if (changedKernel && possibleSession && info.kernelConnectionMetadata) {
-                traceInfo(`Changing Kernel to ${JSON.stringify(info.kernelConnectionMetadata.id)}`);
-                await possibleSession.changeKernel(
-                    resource,
-                    info.kernelConnectionMetadata,
-                    this.configService.getSettings(resource).jupyterLaunchTimeout
-                );
-            }
 
             // Figure out the working directory we need for our new notebook. This is only necessary for local.
             const workingDirectory = info.connectionInfo.localLaunch
                 ? await computeWorkingDirectory(resource, this.workspaceService)
                 : '';
-            const sessionDirectoryMatches =
-                info.connectionInfo.localLaunch && possibleSession
-                    ? this.fs.areLocalPathsSame(possibleSession.workingDirectory, workingDirectory)
-                    : true;
-
             // Start a session (or use the existing one if allowed)
-            const session =
-                possibleSession && sessionDirectoryMatches
-                    ? possibleSession
-                    : await sessionManager.startNew(
-                          resource,
-                          info.kernelConnectionMetadata,
-                          workingDirectory,
-                          cancelToken
-                      );
+            const session = await sessionManager.startNew(resource, kernelConnection, workingDirectory, cancelToken);
             traceInfo(`Started session ${this.id}`);
             return { info, session };
         };
@@ -194,92 +147,17 @@ export class HostJupyterServer implements INotebookServer {
         return notebookPromise.promise;
     }
 
-    private async computeLaunchInfo(
-        resource: Resource,
-        notebookMetadata?: nbformat.INotebookMetadata,
-        kernelConnection?: KernelConnectionMetadata,
-        cancelToken?: CancellationToken
-    ): Promise<{ info: INotebookServerLaunchInfo; changedKernel: boolean }> {
+    private async computeLaunchInfo(): Promise<INotebookServerLaunchInfo> {
         // First we need our launch information so we can start a new session (that's what our notebook is really)
         let launchInfo = await this.waitForConnect();
         if (!launchInfo) {
             throw this.getDisposedError();
         }
-        traceInfo(`Compute Launch Info uri = ${resource?.fsPath}, kernelConnection id = ${kernelConnection?.id}`);
-        // Create a copy of launch info, cuz we're modifying it here.
-        // This launch info contains the server connection info (that could be shared across other nbs).
-        // However the kernel info is different. The kernel info is stored as a  property of this, hence create a separate instance for each nb.
-        launchInfo = {
-            ...launchInfo
-        };
-
-        // Determine the interpreter for our resource. If different, we need a different kernel. This is unnecessary in remote
-        const resourceInterpreter =
-            this.extensionChecker.isPythonExtensionInstalled && launchInfo.connectionInfo.localLaunch
-                ? await this.interpreterService.getActiveInterpreter(resource)
-                : undefined;
-
-        // Find a kernel that can be used.
-        // Do this only if we don't have any kernel connection information, or the resource's interpreter is different.
-        let changedKernel = false;
-        if (
-            // For local connections this code path is not executed for native notebooks (hence only for remote).
-            (isResourceNativeNotebook(resource, this.vscodeNotebook, this.fs) &&
-                !launchInfo.connectionInfo.localLaunch) ||
-            !kernelConnection ||
-            notebookMetadata?.kernelspec ||
-            resourceInterpreter?.displayName !== launchInfo.kernelConnectionMetadata?.interpreter?.displayName
-        ) {
-            let kernelInfo: KernelConnectionMetadata | undefined;
-            if (!launchInfo.connectionInfo.localLaunch && kernelConnection?.kind === 'connectToLiveKernel') {
-                traceInfoIfCI(`kernelConnection?.kind === 'connectToLiveKernel'`);
-                kernelInfo = kernelConnection;
-            } else if (!launchInfo.connectionInfo.localLaunch && kernelConnection?.kind === 'startUsingKernelSpec') {
-                traceInfoIfCI(`kernelConnection?.kind === 'startUsingKernelSpec'`);
-                kernelInfo = kernelConnection;
-            } else if (launchInfo.connectionInfo.localLaunch && kernelConnection) {
-                traceInfoIfCI(`launchInfo.connectionInfo.localLaunch && kernelConnection'`);
-                kernelInfo = kernelConnection;
-            } else {
-                kernelInfo = await (launchInfo.connectionInfo.localLaunch
-                    ? this.localKernelFinder.findKernel(resource, notebookMetadata, cancelToken)
-                    : this.remoteKernelFinder.findKernel(
-                          resource,
-                          launchInfo.connectionInfo,
-                          notebookMetadata,
-                          cancelToken
-                      ));
-                traceInfoIfCI(`kernelInfo found ${kernelInfo?.id}`);
-            }
-            if (kernelInfo && kernelInfo.id !== launchInfo.kernelConnectionMetadata?.id) {
-                // Update kernel info if we found a new one.
-                launchInfo.kernelConnectionMetadata = kernelInfo;
-                changedKernel = true;
-            }
-            traceInfo(
-                `Compute Launch Info uri = ${resource?.fsPath}, changed ${changedKernel}, ${launchInfo.kernelConnectionMetadata?.id}`
-            );
-        }
-        if (!changedKernel && kernelConnection && kernelConnection.id !== launchInfo.kernelConnectionMetadata?.id) {
-            // Update kernel info if its different from what was originally provided.
-            traceInfoIfCI(`kernelConnection provided is different from launch info ${kernelConnection.id}`);
-            launchInfo.kernelConnectionMetadata = kernelConnection;
-            changedKernel = true;
-        }
-
-        traceInfo(
-            `Computed Launch Info uri = ${resource?.fsPath}, changed ${changedKernel}, ${launchInfo.kernelConnectionMetadata?.id}`
-        );
-        return { info: launchInfo, changedKernel };
+        return launchInfo;
     }
 
     public async connect(launchInfo: INotebookServerLaunchInfo, cancelToken?: CancellationToken): Promise<void> {
-        traceInfo(
-            `Connecting server ${this.id} kernelSpec ${getDisplayNameOrNameOfKernelConnection(
-                launchInfo.kernelConnectionMetadata,
-                'unknown'
-            )}`
-        );
+        traceInfo(`Connecting server ${this.id}`);
 
         // Save our launch info
         this.launchInfo = launchInfo;
@@ -308,11 +186,15 @@ export class HostJupyterServer implements INotebookServer {
             launchInfo.connectionInfo
         )) as JupyterSessionManager;
 
+        const defaultKernel: DefaultKernelConnectionMetadata = {
+            kind: 'startUsingDefaultKernel',
+            id: ''
+        };
         // Try creating a session just to ensure we're connected. Callers of this function check to make sure jupyter
         // is running and connectable.
         const session = (await this.sessionManager.startNew(
             undefined,
-            launchInfo.kernelConnectionMetadata,
+            defaultKernel,
             launchInfo.connectionInfo.rootDirectory,
             cancelToken,
             launchInfo.disableUI
@@ -320,29 +202,18 @@ export class HostJupyterServer implements INotebookServer {
         const idleTimeout = this.configService.getSettings().jupyterLaunchTimeout;
         // The wait for idle should throw if we can't connect.
         await session.waitForIdle(idleTimeout);
-
-        // For local we want to save this for the next notebook to use.
-        if (this.launchInfo.connectionInfo.localLaunch) {
-            this.savedSession = session;
-        } else {
-            // Otherwise for remote, just get rid of it.
-            await session.dispose();
-        }
+        await session.dispose();
     }
 
     public async createNotebook(
         resource: Resource,
         document: NotebookDocument,
-        notebookMetadata?: nbformat.INotebookMetadata,
-        kernelConnection?: KernelConnectionMetadata,
+        kernelConnection: KernelConnectionMetadata,
         cancelToken?: CancellationToken
     ): Promise<INotebook> {
         if (!this.sessionManager || this.isDisposed) {
             throw new Error(localize.DataScience.sessionDisposed());
         }
-        // If we have a saved session send this into the notebook so we don't create a new one
-        const savedSession = this.savedSession;
-        this.savedSession = undefined;
         const stopWatch = new StopWatch();
         // Create a notebook and return it.
         try {
@@ -350,9 +221,7 @@ export class HostJupyterServer implements INotebookServer {
                 resource,
                 document,
                 this.sessionManager,
-                savedSession,
                 this.configService,
-                notebookMetadata,
                 kernelConnection,
                 cancelToken
             );
@@ -385,9 +254,6 @@ export class HostJupyterServer implements INotebookServer {
                 this.connectionInfoDisconnectHandler.dispose();
                 this.connectionInfoDisconnectHandler = undefined;
             }
-
-            // Destroy the kernel spec
-            await this.destroyKernelSpec();
 
             // Remove the saved session if we haven't passed it onto a notebook
             if (this.savedSession) {
@@ -480,11 +346,6 @@ export class HostJupyterServer implements INotebookServer {
         this.notebooks.set(document.uri.toString(), notebook);
     }
 
-    private async destroyKernelSpec() {
-        if (this.launchInfo) {
-            this.launchInfo.kernelConnectionMetadata = undefined;
-        }
-    }
 
     private logRemoteOutput(output: string) {
         if (this.launchInfo && !this.launchInfo.connectionInfo.localLaunch) {

--- a/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
+++ b/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
@@ -346,7 +346,6 @@ export class HostJupyterServer implements INotebookServer {
         this.notebooks.set(document.uri.toString(), notebook);
     }
 
-
     private logRemoteOutput(output: string) {
         if (this.launchInfo && !this.launchInfo.connectionInfo.localLaunch) {
             this.jupyterOutputChannel.appendLine(output);

--- a/src/client/datascience/jupyter/liveshare/serverCache.ts
+++ b/src/client/datascience/jupyter/liveshare/serverCache.ts
@@ -134,8 +134,6 @@ export class ServerCache implements IAsyncDisposable {
                 options && options.workingDir
                     ? options.workingDir
                     : await calculateWorkingDirectory(this.configService, this.workspace, this.fs),
-            metadata: options?.metadata,
-            kernelConnection: options?.kernelConnection,
             allowUI: options?.allowUI ? options.allowUI : () => false
         };
     }

--- a/src/client/datascience/raw-kernel/rawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/rawNotebookProvider.ts
@@ -81,13 +81,7 @@ export class RawNotebookProviderBase implements IRawNotebookProvider {
         disableUI: boolean,
         cancelToken?: CancellationToken
     ): Promise<INotebook> {
-        return this.createNotebookInstance(
-            resource,
-            document,
-            kernelConnection,
-            disableUI,
-            cancelToken
-        );
+        return this.createNotebookInstance(resource, document, kernelConnection, disableUI, cancelToken);
     }
 
     public async getNotebook(document: NotebookDocument): Promise<INotebook | undefined> {

--- a/src/client/datascience/raw-kernel/rawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/rawNotebookProvider.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
-import type * as nbformat from '@jupyterlab/nbformat';
 import { injectable } from 'inversify';
 import * as uuid from 'uuid/v4';
 import { Event, EventEmitter, NotebookDocument } from 'vscode';
@@ -78,17 +77,15 @@ export class RawNotebookProviderBase implements IRawNotebookProvider {
     public async createNotebook(
         document: NotebookDocument,
         resource: Resource,
-        disableUI: boolean,
-        notebookMetadata: nbformat.INotebookMetadata,
         kernelConnection: KernelConnectionMetadata,
+        disableUI: boolean,
         cancelToken?: CancellationToken
     ): Promise<INotebook> {
         return this.createNotebookInstance(
             resource,
             document,
-            disableUI,
-            notebookMetadata,
             kernelConnection,
+            disableUI,
             cancelToken
         );
     }
@@ -149,9 +146,8 @@ export class RawNotebookProviderBase implements IRawNotebookProvider {
     protected createNotebookInstance(
         _resource: Resource,
         _document: NotebookDocument,
-        _disableUI?: boolean,
-        _notebookMetadata?: nbformat.INotebookMetadata,
         _kernelConnection?: KernelConnectionMetadata,
+        _disableUI?: boolean,
         _cancelToken?: CancellationToken
     ): Promise<INotebook> {
         throw new Error('You forgot to override createNotebookInstance');

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -103,7 +103,6 @@ export interface INotebookExecutionInfo {
 export interface INotebookServerLaunchInfo {
     connectionInfo: IJupyterConnection;
     uri: string | undefined; // Different from the connectionInfo as this is the setting used, not the result
-    kernelConnectionMetadata?: KernelConnectionMetadata;
     workingDir: string | undefined;
     purpose: string | undefined; // Purpose this server is for
     disableUI?: boolean; // True if no UI should be brought up during the launch
@@ -126,8 +125,7 @@ export interface INotebookServer extends IAsyncDisposable {
     createNotebook(
         resource: Resource,
         document: NotebookDocument,
-        notebookMetadata?: nbformat.INotebookMetadata,
-        kernelConnection?: KernelConnectionMetadata,
+        kernelConnection: KernelConnectionMetadata,
         cancelToken?: CancellationToken
     ): Promise<INotebook>;
     getNotebook(document: NotebookDocument, cancelToken?: CancellationToken): Promise<INotebook | undefined>;
@@ -149,9 +147,8 @@ export interface IRawNotebookProvider extends IAsyncDisposable {
     createNotebook(
         document: NotebookDocument,
         resource: Resource,
+        kernelConnection: KernelConnectionMetadata,
         disableUI?: boolean,
-        notebookMetadata?: nbformat.INotebookMetadata,
-        kernelConnection?: KernelConnectionMetadata,
         cancelToken?: CancellationToken
     ): Promise<INotebook>;
     getNotebook(document: NotebookDocument, token?: CancellationToken): Promise<INotebook | undefined>;
@@ -178,7 +175,6 @@ export type ConnectNotebookProviderOptions = {
     localOnly?: boolean;
     token?: CancellationToken;
     resource: Resource;
-    metadata?: nbformat.INotebookMetadata;
 };
 
 export interface INotebookServerOptions {
@@ -188,8 +184,6 @@ export interface INotebookServerOptions {
     skipUsingDefaultConfig?: boolean;
     workingDir?: string;
     purpose: string;
-    metadata?: nbformat.INotebookMetadata;
-    kernelConnection?: KernelConnectionMetadata;
     skipSearchingForKernel?: boolean;
     allowUI(): boolean;
 }
@@ -857,8 +851,6 @@ export type GetServerOptions = {
     localOnly?: boolean;
     token?: CancellationToken;
     resource: Resource;
-    metadata?: nbformat.INotebookMetadata;
-    kernelConnection?: KernelConnectionMetadata;
 };
 
 /**
@@ -870,7 +862,7 @@ export type GetNotebookOptions = {
     getOnly?: boolean;
     disableUI?: boolean;
     metadata?: nbformat.INotebookMetadata;
-    kernelConnection?: KernelConnectionMetadata;
+    kernelConnection: KernelConnectionMetadata;
     token?: CancellationToken;
 };
 

--- a/src/client/debugger/jupyter/debuggingManager.ts
+++ b/src/client/debugger/jupyter/debuggingManager.ts
@@ -21,7 +21,6 @@ import * as path from 'path';
 import { IKernel, IKernelProvider } from '../../datascience/jupyter/kernels/types';
 import { IConfigurationService, IDisposable } from '../../common/types';
 import { KernelDebugAdapter } from './kernelDebugAdapter';
-import { INotebookProvider } from '../../datascience/types';
 import { IExtensionSingleActivationService } from '../../activation/types';
 import { INotebookControllerManager } from '../../datascience/notebook/types';
 import { ContextKey } from '../../common/contextKey';
@@ -55,7 +54,6 @@ export class DebuggingManager implements IExtensionSingleActivationService, IDeb
 
     public constructor(
         @inject(IKernelProvider) private kernelProvider: IKernelProvider,
-        @inject(INotebookProvider) private notebookProvider: INotebookProvider,
         @inject(INotebookControllerManager) private readonly notebookControllerManager: INotebookControllerManager,
         @inject(ICommandManager) private readonly commandManager: ICommandManager,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
@@ -366,14 +364,9 @@ export class DebuggingManager implements IExtensionSingleActivationService, IDeb
             const debug = this.getDebuggerByUri(activeDoc);
 
             if (debug) {
-                const notebook = await this.notebookProvider.getOrCreateNotebook({
-                    resource: debug.document.uri,
-                    document: debug.document,
-                    getOnly: true
-                });
-                if (notebook && notebook.session) {
+                if (kernel?.session) {
                     debug.resolve(session);
-                    const adapter = new KernelDebugAdapter(session, debug.document, notebook.session, this.fs, kernel);
+                    const adapter = new KernelDebugAdapter(session, debug.document, kernel.session, this.fs, kernel);
 
                     if (config.__mode === KernelDebugMode.RunByLine && typeof config.__cellIndex === 'number') {
                         const cell = activeDoc.cellAt(config.__cellIndex);

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -1443,9 +1443,6 @@ export interface IEventNamePropertyMapping {
         resourceType: 'notebook' | 'interactive'; // Whether its a notebook or interactive window.
         language: string; // Language defined in notebook metadata.
         kernelConnectionProvided: boolean; // Whether kernelConnection was provided.
-        notebookMetadataProvided: boolean; // Whether notebook metadata was provided.
-        hasKernelSpecInMetadata: boolean; // Whether we have kernelspec info in the notebook metadata.
-        kernelConnectionFound: boolean; // Whether a kernel connection was found or not.
     };
     [DebuggingTelemetry.clickedOnSetup]: never | undefined;
     [DebuggingTelemetry.closedModal]: never | undefined;

--- a/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
+++ b/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
@@ -9,6 +9,7 @@ import { IWorkspaceService } from '../../../client/common/application/types';
 import { ConfigurationService } from '../../../client/common/configuration/service';
 import { IDisposableRegistry, IJupyterSettings } from '../../../client/common/types';
 import { NotebookProvider } from '../../../client/datascience/interactive-common/notebookProvider';
+import { KernelConnectionMetadata } from '../../../client/datascience/jupyter/kernels/types';
 import { IJupyterNotebookProvider, INotebook, IRawNotebookProvider } from '../../../client/datascience/types';
 
 function Uri(filename: string): vscode.Uri {
@@ -69,7 +70,8 @@ suite('DataScience - NotebookProvider', () => {
 
         const notebook = await notebookProvider.getOrCreateNotebook({
             document: instance(doc),
-            resource: Uri('C:\\\\foo.py')
+            resource: Uri('C:\\\\foo.py'),
+            kernelConnection: instance(mock<KernelConnectionMetadata>())
         });
         expect(notebook).to.not.equal(undefined, 'Provider should return a notebook');
     });
@@ -84,7 +86,8 @@ suite('DataScience - NotebookProvider', () => {
 
         const notebook = await notebookProvider.getOrCreateNotebook({
             document: instance(doc),
-            resource: Uri('C:\\\\foo.py')
+            resource: Uri('C:\\\\foo.py'),
+            kernelConnection: instance(mock<KernelConnectionMetadata>())
         });
         expect(notebook).to.not.equal(undefined, 'Provider should return a notebook');
     });
@@ -99,13 +102,15 @@ suite('DataScience - NotebookProvider', () => {
 
         const notebook = await notebookProvider.getOrCreateNotebook({
             document: instance(doc),
-            resource: Uri('C:\\\\foo.py')
+            resource: Uri('C:\\\\foo.py'),
+            kernelConnection: instance(mock<KernelConnectionMetadata>())
         });
         expect(notebook).to.not.equal(undefined, 'Server should return a notebook');
 
         const notebook2 = await notebookProvider.getOrCreateNotebook({
             document: instance(doc),
-            resource: Uri('C:\\\\foo.py')
+            resource: Uri('C:\\\\foo.py'),
+            kernelConnection: instance(mock<KernelConnectionMetadata>())
         });
         expect(notebook2).to.equal(notebook);
     });

--- a/src/test/datascience/mockJupyterServer.ts
+++ b/src/test/datascience/mockJupyterServer.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { NotebookDocument, Uri } from 'vscode';
 import { TemporaryFile } from '../../client/common/platform/types';
-import { getNameOfKernelConnection } from '../../client/datascience/jupyter/kernels/helpers';
 import {
     IJupyterConnection,
     INotebook,
@@ -14,17 +13,13 @@ import { MockJupyterNotebook } from './mockJupyterNotebook';
 export class MockJupyterServer implements INotebookServer {
     private launchInfo: INotebookServerLaunchInfo | undefined;
     private notebookFile: TemporaryFile | undefined;
-    public connect(launchInfo: INotebookServerLaunchInfo): Promise<void> {
-        if (launchInfo && launchInfo.connectionInfo && launchInfo.kernelConnectionMetadata) {
-            this.launchInfo = launchInfo;
+    public async connect(launchInfo: INotebookServerLaunchInfo): Promise<void> {
+        this.launchInfo = launchInfo;
 
-            // Validate connection info and kernel spec
-            const name = getNameOfKernelConnection(launchInfo.kernelConnectionMetadata);
-            if (launchInfo.connectionInfo.baseUrl && name && /[a-z,A-Z,0-9,-,.,_]+/.test(name)) {
-                return Promise.resolve();
-            }
+        // Validate connection info and kernel spec
+        if (!launchInfo.connectionInfo.baseUrl) {
+            throw new Error('invalid server startup');
         }
-        return Promise.reject('invalid server startup');
     }
 
     public async createNotebook(_resource: Uri): Promise<INotebook> {


### PR DESCRIPTION
**Original issue**: Looked at using the new Python extension API to search for interpreters 
This requires a refactor of how we search for kernels.
Found that kernel finder is used when starting kernel. But that should be unnecessary, we can never start a kernel without ever knowing (user having selected) the kernel from the picker.

Found this was to do with `connect` method that requried kernel specs.

**Fixes**
* We no longer need to pass metadata or kernel spec connection information when starting notebook servers
* The only use case was when connecting to remote, we re-use the session
	* But with little to zero benefit, as we'd need to switch the kernel anyway, and starting kernels is what's slow
* We no longer serach for kernels when starting notebook servers
* As a restul of the above, a lot more code has gone  