### PR TITLE
Add setting for supporting pylance handling notebook intellisense

### DIFF
--- a/news/3 Code Health/8096.md
+++ b/news/3 Code Health/8096.md
@@ -1,0 +1,1 @@
+Add setting to allow usage of experimental pylance intellisense in notebooks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3624,9 +3624,9 @@
             }
         },
         "@vscode/jupyter-lsp-middleware": {
-            "version": "0.2.17",
-            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.17.tgz",
-            "integrity": "sha512-4aaNUpWB3BDj4gG/+awB0vCAQEQOrDbofPEbJ3QdpIZPrndlu6f6mxeDN+yDCZqh+aUU+b3uFGU489bdnCv+Qg==",
+            "version": "0.2.18",
+            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.18.tgz",
+            "integrity": "sha512-IySB0yuU1+erzOCm6r1WvODzHErd8JZ2NlqfH+d+XdiqQbVfFJohivUzsrvCK62/HBPc3SQ1vuQ1Gx7Z4D267A==",
             "requires": {
                 "vscode-languageclient": "7.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -1859,6 +1859,12 @@
                     "default": true,
                     "description": "Append a new empty cell to an interactive window file on running the currently last cell.",
                     "scope": "resource"
+                },
+                "jupyter.pylanceHandlesNotebooks": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Determines if pylance's experimental notebook support is used or not",
+                    "scope": "machine"
                 }
             }
         },
@@ -1974,7 +1980,7 @@
         "@jupyterlab/services": "^6.1.17",
         "@lumino/widgets": "^1.28.0",
         "@nteract/messaging": "^7.0.0",
-        "@vscode/jupyter-lsp-middleware": "^0.2.17",
+        "@vscode/jupyter-lsp-middleware": "^0.2.18",
         "ansi-to-html": "^0.6.7",
         "arch": "^2.1.0",
         "bootstrap": "^4.3.1",

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -97,6 +97,7 @@ export class JupyterSettings implements IWatchableJupyterSettings {
     public verboseLogging: boolean = false;
     public showVariableViewWhenDebugging: boolean = true;
     public newCellOnRunLast: boolean = true;
+    public pylanceHandlesNotebooks: boolean = false;
 
     public variableTooltipFields: IVariableTooltipFields = {
         python: {

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -177,6 +177,7 @@ export interface IJupyterSettings {
     readonly variableTooltipFields: IVariableTooltipFields;
     readonly showVariableViewWhenDebugging: boolean;
     readonly newCellOnRunLast: boolean;
+    readonly pylanceHandlesNotebooks?: boolean;
 }
 
 export interface IVariableTooltipFields {


### PR DESCRIPTION
Fixes #8076

Modify creation of the middleware portion to use the 'pylance' middleware based on a setting. Prerequisite for pylance to start on their own version of notebook intellisense