### PR TITLE
Remove kernelspec when starting server

### DIFF
--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IJupyterSession, INotebook, INotebookExecutionInfo } from '../types';
+import { IJupyterSession, INotebook, INotebookProviderConnection } from '../types';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import cloneDeep = require('lodash/cloneDeep');
@@ -9,13 +9,13 @@ import cloneDeep = require('lodash/cloneDeep');
 // https://www.npmjs.com/package/@jupyterlab/services
 
 export class JupyterNotebook implements INotebook {
-    private _executionInfo: INotebookExecutionInfo;
-    constructor(public readonly session: IJupyterSession, executionInfo: INotebookExecutionInfo) {
+    private __connection: INotebookProviderConnection;
+    constructor(public readonly session: IJupyterSession, connectionInfo: INotebookProviderConnection) {
         // Make a copy of the launch info so we can update it in this class
-        this._executionInfo = cloneDeep(executionInfo);
+        this.__connection = cloneDeep(connectionInfo);
     }
 
     public get connection() {
-        return this._executionInfo.connectionInfo;
+        return this.__connection;
     }
 }

--- a/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
+++ b/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
@@ -123,7 +123,7 @@ export class HostJupyterServer implements INotebookServer {
 
             if (session) {
                 // Create our notebook
-                const notebook = new JupyterNotebook(session, info);
+                const notebook = new JupyterNotebook(session, info.connectionInfo);
 
                 // Wait for it to be ready
                 traceInfo(`Waiting for idle (session) ${this.id}`);

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -86,17 +86,6 @@ export enum InterruptResult {
     Restarted = 'restart'
 }
 
-// Information used to execute a notebook
-export interface INotebookExecutionInfo {
-    // Connection to what has provided our notebook, such as a jupyter
-    // server or a raw ZMQ kernel
-    connectionInfo: INotebookProviderConnection;
-    uri: string | undefined; // Different from the connectionInfo as this is the setting used, not the result
-    kernelConnectionMetadata?: KernelConnectionMetadata;
-    workingDir: string | undefined;
-    purpose: string | undefined; // Purpose this server is for
-}
-
 // Information used to launch a jupyter notebook server
 
 // Information used to launch a notebook server
@@ -184,7 +173,6 @@ export interface INotebookServerOptions {
     skipUsingDefaultConfig?: boolean;
     workingDir?: string;
     purpose: string;
-    skipSearchingForKernel?: boolean;
     allowUI(): boolean;
 }
 


### PR DESCRIPTION
A few remaining properties that's no longer required.
Basically we don't need kernelSpecs when starting jupyter server

Debt work.