### PR TITLE
Display better error when raw kernel times out connecting to kernel

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -471,6 +471,7 @@
     "DataScience.stopRunByLine": "Stop",
     "DataScience.couldNotInstallLibrary": "Could not install {0}. If pip is not available, please use the package manager of your choice to manually install this library into your Python environment.",
     "DataScience.rawKernelSessionFailed": "Unable to start session for kernel {0}. Select another kernel to launch with.",
+    "DataScience.rawKernelStartFailedDueToTimeout": "Unable to start Kernel '{0}' due to connection timeout.",
     "DataScience.rawKernelConnectingSession": "Connecting to kernel {0}",
     "DataScience.reloadCustomEditor": "Please reload VS Code to use the custom editor API",
     "DataScience.reloadVSCodeNotebookEditor": "Please reload VS Code to use the Notebook Editor",

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -382,7 +382,7 @@ export namespace DataScience {
     );
     export const rawKernelStartFailedDueToTimeout = localize(
         'DataScience.rawKernelStartFailedDueToTimeout',
-        'Unable to start Kernel \'{0}\' due to connection timeout.'
+        "Unable to start Kernel '{0}' due to connection timeout."
     );
     export const kernelTimeout = localize(
         'DataScience.kernelTimeout',

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -380,6 +380,10 @@ export namespace DataScience {
         'DataScience.sessionStartFailedWithKernel',
         "Failed to start a session for the Kernel '{0}'. \nView Jupyter [log](command:{1}) for further details."
     );
+    export const rawKernelStartFailedDueToTimeout = localize(
+        'DataScience.rawKernelStartFailedDueToTimeout',
+        'Unable to start Kernel \'{0}\' due to connection timeout.'
+    );
     export const kernelTimeout = localize(
         'DataScience.kernelTimeout',
         'Timed out waiting to get a heartbeat from kernel process. \nView Jupyter [log](command:{0}) for further details.'

--- a/src/client/datascience/errorHandler/errorHandler.ts
+++ b/src/client/datascience/errorHandler/errorHandler.ts
@@ -77,7 +77,9 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
                     .showErrorMessage(DataScience.kernelNotInstalled().format(kernelName))
                     .then(noop, noop);
             }
+            this.applicationShell.showErrorMessage(err.message).then(noop, noop);
         } else if (err.message) {
+            // Some errors have localized and/or formatted error messages.
             this.applicationShell.showErrorMessage(err.message).then(noop, noop);
         } else {
             this.applicationShell.showErrorMessage(err.toString()).then(noop, noop);

--- a/src/client/datascience/raw-kernel/rawSession.ts
+++ b/src/client/datascience/raw-kernel/rawSession.ts
@@ -8,9 +8,11 @@ import '../../common/extensions';
 import { traceError, traceInfoIfCI } from '../../common/logger';
 import { IDisposable, Resource } from '../../common/types';
 import { createDeferred, sleep, TimedOutError } from '../../common/utils/async';
+import { DataScience } from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
 import { sendTelemetryEvent } from '../../telemetry';
 import { Telemetry } from '../constants';
+import { getDisplayNameOrNameOfKernelConnection } from '../jupyter/kernels/helpers';
 import { KernelConnectionMetadata } from '../jupyter/kernels/types';
 import { IKernelProcess } from '../kernel-launcher/types';
 import { ISessionWithSocket, KernelSocketInformation } from '../types';
@@ -139,7 +141,8 @@ export class RawSession implements ISessionWithSocket {
         this.connectionStatusChanged.disconnect(handler);
 
         if (result.toString() !== 'connected') {
-            throw new TimedOutError(`Kernel with ${this.id} never connected.`);
+            const displayName = getDisplayNameOrNameOfKernelConnection(this.kernelConnectionMetadata);
+            throw new TimedOutError(DataScience.rawKernelStartFailedDueToTimeout().format(displayName));
         }
     }
 


### PR DESCRIPTION
Basically a more user friendly (& localized) error message than `Kernel with <GUID> never connected`
Something Peng ran into.

Note: this doesn't fix the underlying issue, but lets the user know the kernel didn't start and provides a localized (hopefully) better error message