### PR TITLE
Ensure we display the original ipynb file name in kernel picker 

### DIFF
--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -30,6 +30,31 @@ import { getNameOfKernelConnection } from './kernels/helpers';
 import { JupyterKernelService } from './kernels/jupyterKernelService';
 import { KernelConnectionMetadata } from './kernels/types';
 
+const jvscIdentifier = '-jvsc-';
+function getRemoteIPynbSuffix(): string {
+    return `${jvscIdentifier}${uuid()}`;
+}
+
+/**
+ * When creating remote sessions, we generate bogus names for the notebook.
+ * These names are prefixed with the same local file name, and a random suffix.
+ * However the random part does contain an identifier, and we can stip this off
+ * to get the original local ipynb file name.
+ */
+export function removeNotebookSuffixAddedByExtension(notebookPath: string) {
+    if (notebookPath.includes(jvscIdentifier)) {
+        const guidRegEx = /[a-f0-9]$/;
+        if (
+            notebookPath
+                .substring(notebookPath.lastIndexOf(jvscIdentifier) + jvscIdentifier.length)
+                .search(guidRegEx) !== -1
+        ) {
+            return `${notebookPath.substring(0, notebookPath.lastIndexOf(jvscIdentifier))}.ipynb`;
+        }
+    }
+    return notebookPath;
+}
+// function is
 export class JupyterSession extends BaseJupyterSession {
     constructor(
         resource: Resource,
@@ -180,7 +205,7 @@ export class JupyterSession extends BaseJupyterSession {
 
         // Generate a more descriptive name
         const newName = this.resource
-            ? `${path.basename(this.resource.fsPath, '.ipynb')}-${uuid()}.ipynb`
+            ? `${path.basename(this.resource.fsPath, '.ipynb')}${getRemoteIPynbSuffix()}.ipynb`
             : `${DataScience.defaultNotebookName()}-${uuid()}.ipynb`;
 
         try {

--- a/src/client/datascience/jupyter/kernels/helpers.ts
+++ b/src/client/datascience/jupyter/kernels/helpers.ts
@@ -44,6 +44,7 @@ import { isDefaultPythonKernelSpecName } from '../../kernel-launcher/localPython
 import { executeSilently } from './kernel';
 import { IWorkspaceService } from '../../../common/application/types';
 import { getDisplayPath } from '../../../common/platform/fs-paths';
+import { removeNotebookSuffixAddedByExtension } from '../jupyterSession';
 
 // Helper functions for dealing with kernels and kernelspecs
 
@@ -200,7 +201,9 @@ export function getKernelConnectionPath(
     workspaceService: IWorkspaceService
 ) {
     if (kernelConnection?.kind === 'connectToLiveKernel') {
-        return kernelConnection.kernelModel?.notebook?.path || kernelConnection.kernelModel?.model?.path || '';
+        return removeNotebookSuffixAddedByExtension(
+            kernelConnection.kernelModel?.notebook?.path || kernelConnection.kernelModel?.model?.path || ''
+        );
     }
     const kernelPath = getKernelPathFromKernelConnection(kernelConnection);
     // If we have just one workspace folder opened, then ensure to use relative paths


### PR DESCRIPTION
For #8186
## Note: this is a short term fix, to remove the GUID

When we start sessions against a remote kernel, we create paths on the server which contains a GUID.
Once we reload VS Code, we end up displaying this GUID see below
![image](https://user-images.githubusercontent.com/1948812/140573786-ce47840c-2c97-443d-a106-e7c884b06e81.png)

**Solution**
* Strip out the GUID portion
* We can use a memento and create a mapping between the original resource & the generated file, however that means we need to create memento and that could grow very large & now we need to maintain that.
* The proposed fix is a simple & quick solution

**Proposed fix**
![image](https://user-images.githubusercontent.com/1948812/140573924-010a9ea0-37cb-4759-8755-78401ad0d620.png)
