### PR TITLE
Fix flakey run by line test

### DIFF
--- a/src/test/datascience/.vscode/settings.json
+++ b/src/test/datascience/.vscode/settings.json
@@ -11,7 +11,7 @@
     "python.linting.mypyEnabled": false,
     "python.linting.banditEnabled": false,
     "python.formatting.provider": "yapf",
-    "python.pythonPath": "/home/don/samples/pySamples/crap/.venv/bin/python",
+    "python.pythonPath": "python",
     "jupyter.experiments.optInto": ["NativeNotebookEditor"],
     // Do not set this to "Microsoft", else it will result in LS being downloaded on CI
     // and that slows down tests significantly. We have other tests on CI for testing
@@ -30,5 +30,5 @@
     "jupyter.magicCommandsAsComments": false,
     // Python experiments have to be on for insiders to work
     "python.experiments.enabled": true,
-    "python.defaultInterpreterPath": "/home/don/samples/pySamples/crap/.venv/bin/python"
+    "python.defaultInterpreterPath": "python"
 }

--- a/src/test/datascience/debugger.vscode.test.ts
+++ b/src/test/datascience/debugger.vscode.test.ts
@@ -198,9 +198,12 @@ suite('VSCode Notebook - Run By Line', function () {
     });
 
     test('Run a second time after interrupt', async function () {
-        await insertCodeCell('import time\nfor i in range(0,50):  time.sleep(.1)\n  print(1)\nprint(3)', {
-            index: 0
-        });
+        await insertCodeCell(
+            'import time\nfor i in range(0,50):\n  time.sleep(.1)\n  print("sleepy")\nprint("final output")',
+            {
+                index: 0
+            }
+        );
         const doc = vscodeNotebook.activeNotebookEditor?.document!;
         const cell = doc.getCells()[0];
 
@@ -216,18 +219,21 @@ suite('VSCode Notebook - Run By Line', function () {
             defaultNotebookTestTimeout,
             'DebugSession should end1'
         );
-        assert.isFalse(getCellOutputs(cell).includes('3'), `Final line did run even with an interrupt`);
+        assert.isFalse(getCellOutputs(cell).includes('final output'), `Final line did run even with an interrupt`);
 
         // Start over and make sure we can execute all lines
         void commandManager.executeCommand(Commands.RunByLine, cell);
         const { debugAdapter: debugAdapter2 } = await getDebugSessionAndAdapter(debuggingManager, doc);
         await waitForStoppedEvent(debugAdapter2!);
-        await commandManager.executeCommand(Commands.RunByLineNext, cell);
-        await waitForStoppedEvent(debugAdapter2!);
-        await commandManager.executeCommand(Commands.RunByLineNext, cell);
-        await waitForStoppedEvent(debugAdapter2!);
-        await commandManager.executeCommand(Commands.RunByLineNext, cell);
-        assert.isTrue(getCellOutputs(cell).includes('1'), `Lines not running`);
+        await waitForCondition(
+            async () => {
+                await commandManager.executeCommand(Commands.RunByLineNext, cell);
+                await waitForStoppedEvent(debugAdapter2!);
+                return getCellOutputs(cell).includes('sleepy');
+            },
+            defaultNotebookTestTimeout,
+            'Print during time loop is not working'
+        );
         await commandManager.executeCommand(Commands.RunByLineStop);
         await waitForCondition(
             async () => !debug.activeDebugSession,

--- a/src/test/datascience/debugger.vscode.test.ts
+++ b/src/test/datascience/debugger.vscode.test.ts
@@ -198,7 +198,9 @@ suite('VSCode Notebook - Run By Line', function () {
     });
 
     test('Run a second time after interrupt', async function () {
-        await insertCodeCell('print(1)\nprint(2)\nprint(3)', { index: 0 });
+        await insertCodeCell('import time\nfor i in range(0,50):  time.sleep(.1)\n  print(1)\nprint(3)', {
+            index: 0
+        });
         const doc = vscodeNotebook.activeNotebookEditor?.document!;
         const cell = doc.getCells()[0];
 
@@ -225,16 +227,12 @@ suite('VSCode Notebook - Run By Line', function () {
         await commandManager.executeCommand(Commands.RunByLineNext, cell);
         await waitForStoppedEvent(debugAdapter2!);
         await commandManager.executeCommand(Commands.RunByLineNext, cell);
+        assert.isTrue(getCellOutputs(cell).includes('1'), `Lines not running`);
+        await commandManager.executeCommand(Commands.RunByLineStop);
         await waitForCondition(
             async () => !debug.activeDebugSession,
             defaultNotebookTestTimeout,
             'DebugSession should end2'
         );
-        await waitForCondition(
-            async () => !!cell.outputs.length,
-            defaultNotebookTestTimeout,
-            'Cell should have output'
-        );
-        assert.isTrue(getCellOutputs(cell).includes('3'), `Final line did not run`);
     });
 });


### PR DESCRIPTION
`Run a second time after interrupt` test has been flakey lately. Sometimes we get an interrupt, sometimes we don't. This should make it more robust.