### PR TITLE
Stop starting default kernel when starting jupyter

### DIFF
--- a/src/client/datascience/jupyter/kernels/helpers.ts
+++ b/src/client/datascience/jupyter/kernels/helpers.ts
@@ -16,7 +16,6 @@ import { isCI, PYTHON_LANGUAGE } from '../../../common/constants';
 import { IConfigurationService, IPathUtils, Resource } from '../../../common/types';
 import { EnvironmentType, PythonEnvironment } from '../../../pythonEnvironments/info';
 import {
-    DefaultKernelConnectionMetadata,
     IKernel,
     KernelConnectionMetadata,
     KernelSpecConnectionMetadata,
@@ -56,10 +55,7 @@ export function findIndexOfConnectionFile(kernelSpec: Readonly<IJupyterKernelSpe
     return kernelSpec.argv.findIndex((arg) => arg.includes(connectionFilePlaceholder));
 }
 
-type ConnectionWithKernelSpec =
-    | KernelSpecConnectionMetadata
-    | PythonKernelConnectionMetadata
-    | DefaultKernelConnectionMetadata;
+type ConnectionWithKernelSpec = KernelSpecConnectionMetadata | PythonKernelConnectionMetadata;
 export function kernelConnectionMetadataHasKernelSpec(
     connectionMetadata: KernelConnectionMetadata
 ): connectionMetadata is ConnectionWithKernelSpec {
@@ -188,8 +184,7 @@ function getOldFormatDisplayNameOrNameOfKernelConnection(kernelConnection: Kerne
     const interpeterName =
         kernelConnection.kind === 'startUsingPythonInterpreter' ? kernelConnection.interpreter.displayName : undefined;
 
-    const defaultKernelName = kernelConnection.kind === 'startUsingDefaultKernel' ? 'Python 3' : undefined;
-    return displayName || name || interpeterName || defaultKernelName || '';
+    return displayName || name || interpeterName || '';
 }
 
 export function getNameOfKernelConnection(

--- a/src/client/datascience/jupyter/kernels/types.ts
+++ b/src/client/datascience/jupyter/kernels/types.ts
@@ -58,24 +58,6 @@ export type KernelSpecConnectionMetadata = Readonly<{
     id: string;
 }>;
 /**
- * Connection metadata for Kernels started using default kernel.
- * Here we tell Jupyter to start a session and let it decide what kernel is to be started.
- * (could apply to either local or remote sessions when dealing with Jupyter Servers).
- */
-export type DefaultKernelConnectionMetadata = Readonly<{
-    /**
-     * This will be empty as we do not have a kernel spec.
-     * Left for type compatibility with other types that have kernel spec property.
-     */
-    kernelSpec?: IJupyterKernelSpec;
-    /**
-     * Python interpreter will be used for intellisense & the like.
-     */
-    interpreter?: PythonEnvironment;
-    kind: 'startUsingDefaultKernel';
-    id: string;
-}>;
-/**
  * Connection metadata for Kernels started using Python interpreter.
  * These are not necessarily raw (it could be plain old Jupyter Kernels, where we register Python interpreter as a kernel).
  * We can have KernelSpec information here as well, however that is totally optional.
@@ -95,16 +77,14 @@ export type PythonKernelConnectionMetadata = Readonly<{
 export type KernelConnectionMetadata =
     | Readonly<LiveKernelConnectionMetadata>
     | Readonly<KernelSpecConnectionMetadata>
-    | Readonly<PythonKernelConnectionMetadata>
-    | Readonly<DefaultKernelConnectionMetadata>;
+    | Readonly<PythonKernelConnectionMetadata>;
 
 /**
  * Connection metadata for local kernels. Makes it easier to not have to check for the live connection type.
  */
 export type LocalKernelConnectionMetadata =
     | Readonly<KernelSpecConnectionMetadata>
-    | Readonly<PythonKernelConnectionMetadata>
-    | Readonly<DefaultKernelConnectionMetadata>;
+    | Readonly<PythonKernelConnectionMetadata>;
 
 export interface IKernelSpecQuickPickItem<T extends KernelConnectionMetadata = KernelConnectionMetadata>
     extends QuickPickItem {

--- a/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
+++ b/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
@@ -27,7 +27,7 @@ import {
 } from '../../types';
 import { computeWorkingDirectory } from '../jupyterUtils';
 import { getDisplayNameOrNameOfKernelConnection } from '../kernels/helpers';
-import { DefaultKernelConnectionMetadata, KernelConnectionMetadata } from '../kernels/types';
+import { KernelConnectionMetadata } from '../kernels/types';
 import { STANDARD_OUTPUT_CHANNEL } from '../../../common/constants';
 import { inject, injectable, named } from 'inversify';
 import { JupyterNotebook } from '../jupyterNotebook';
@@ -36,7 +36,6 @@ import { noop } from '../../../common/utils/misc';
 import { Telemetry } from '../../constants';
 import { sendKernelTelemetryEvent } from '../../telemetry/telemetry';
 import { StopWatch } from '../../../common/utils/stopWatch';
-import { JupyterSession } from '../jupyterSession';
 import { JupyterSessionManager } from '../jupyterSessionManager';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -146,7 +145,7 @@ export class HostJupyterServer implements INotebookServer {
         return launchInfo;
     }
 
-    public async connect(launchInfo: INotebookServerLaunchInfo, cancelToken?: CancellationToken): Promise<void> {
+    public async connect(launchInfo: INotebookServerLaunchInfo, _cancelToken?: CancellationToken): Promise<void> {
         traceInfo(`Connecting server ${this.id}`);
 
         // Save our launch info

--- a/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
+++ b/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
@@ -175,24 +175,6 @@ export class HostJupyterServer implements INotebookServer {
         this.sessionManager = (await this.sessionManagerFactory.create(
             launchInfo.connectionInfo
         )) as JupyterSessionManager;
-
-        const defaultKernel: DefaultKernelConnectionMetadata = {
-            kind: 'startUsingDefaultKernel',
-            id: ''
-        };
-        // Try creating a session just to ensure we're connected. Callers of this function check to make sure jupyter
-        // is running and connectable.
-        const session = (await this.sessionManager.startNew(
-            undefined,
-            defaultKernel,
-            launchInfo.connectionInfo.rootDirectory,
-            cancelToken,
-            launchInfo.disableUI
-        )) as JupyterSession;
-        const idleTimeout = this.configService.getSettings().jupyterLaunchTimeout;
-        // The wait for idle should throw if we can't connect.
-        await session.waitForIdle(idleTimeout);
-        await session.dispose();
     }
 
     public async createNotebook(

--- a/src/client/datascience/notebook/emptyNotebookCellLanguageService.ts
+++ b/src/client/datascience/notebook/emptyNotebookCellLanguageService.ts
@@ -46,10 +46,6 @@ export class EmptyNotebookCellLanguageService implements IExtensionSingleActivat
         if (!isJupyterNotebook(document)) {
             return;
         }
-        // If connecting to a default kernel of Jupyter server, then we don't know the language of the kernel.
-        if (connection.kind === 'startUsingDefaultKernel') {
-            return;
-        }
         const editor = this.notebook.notebookEditors.find((item) => item.document === document);
         if (!editor) {
             return;

--- a/src/client/datascience/notebook/kernelFilter/kernelFilterService.ts
+++ b/src/client/datascience/notebook/kernelFilter/kernelFilterService.ts
@@ -29,7 +29,7 @@ export class KernelFilterService implements IDisposable {
     }
     public isKernelHidden(kernelConnection: KernelConnectionMetadata): boolean {
         const hiddenList = this.getFilters();
-        if (kernelConnection.kind === 'connectToLiveKernel' || kernelConnection.kind == 'startUsingDefaultKernel') {
+        if (kernelConnection.kind === 'connectToLiveKernel') {
             return false;
         }
         return hiddenList.some((item) => {
@@ -93,7 +93,7 @@ export class KernelFilterService implements IDisposable {
         this._onDidChange.fire();
     }
     private translateConnectionToFilter(connection: KernelConnectionMetadata): KernelFilter | undefined {
-        if (connection.kind === 'connectToLiveKernel' || connection.kind === 'startUsingDefaultKernel') {
+        if (connection.kind === 'connectToLiveKernel') {
             traceError('Hiding default or live kernels via filter is not supported');
             return;
         }

--- a/src/client/datascience/notebook/notebookControllerManager.ts
+++ b/src/client/datascience/notebook/notebookControllerManager.ts
@@ -529,10 +529,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
                 .filter(([id]) => !this.registeredControllers.has(id))
                 .forEach(([id, viewType]) => {
                     let hideController = false;
-                    if (
-                        kernelConnection.kind === 'connectToLiveKernel' ||
-                        kernelConnection.kind === 'startUsingDefaultKernel'
-                    ) {
+                    if (kernelConnection.kind === 'connectToLiveKernel') {
                         if (viewType === InteractiveWindowView && doNotHideInteractiveKernel) {
                             hideController = false;
                         } else {

--- a/src/client/datascience/telemetry/kernelTelemetry.ts
+++ b/src/client/datascience/telemetry/kernelTelemetry.ts
@@ -25,7 +25,6 @@ export function sendKernelListTelemetry(
             case 'connectToLiveKernel':
                 counters.kernelLiveCount += 1;
                 break;
-            case 'startUsingDefaultKernel':
             case 'startUsingKernelSpec':
                 counters.kernelSpecCount += 1;
                 break;


### PR DESCRIPTION
For #8185
Miguel ran into this today, updated Mac to Monterey, and then things stopped working, then deleted envioronments, and the default kernlespec was pointing to a non-existent Python and there was nothing he could do.

Temporary work around was for him to update kernelspec.json to point to `python` instead of the non-existent conda env.
Btw - this wasn't a kernelspec we created.

