### PR TITLE
Update to fix for diags in notebooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3624,9 +3624,9 @@
             }
         },
         "@vscode/jupyter-lsp-middleware": {
-            "version": "0.2.22",
-            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.22.tgz",
-            "integrity": "sha512-oRQwQLqR6SIoIc/iRMNPzOAYiuuYf6DR2+58zW0DniFJEK9f5TEh4ZmfkhGGhLKoe6S1y2lFrKIjvXzWLzaqeA==",
+            "version": "0.2.23",
+            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.23.tgz",
+            "integrity": "sha512-wgyA/FohRh42VDzPMwYJy9AB+mRziisqXBVk0UgpcIwhrAfV4bwD/M8dmXnLf/tQwOxdl5C+b4NZRb5JXAU6wA==",
             "requires": {
                 "sha.js": "^2.4.11",
                 "vscode-languageclient": "7.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3624,9 +3624,9 @@
             }
         },
         "@vscode/jupyter-lsp-middleware": {
-            "version": "0.2.21",
-            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.21.tgz",
-            "integrity": "sha512-yJJRdGtgS25b4M/6evk7/nTsar3E0v0zeJwnS1FYZRL/Ue7hvbKTQBrO4t1mFbrRsh3q0xJzDp1DO2d13jR7uQ==",
+            "version": "0.2.22",
+            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.22.tgz",
+            "integrity": "sha512-oRQwQLqR6SIoIc/iRMNPzOAYiuuYf6DR2+58zW0DniFJEK9f5TEh4ZmfkhGGhLKoe6S1y2lFrKIjvXzWLzaqeA==",
             "requires": {
                 "sha.js": "^2.4.11",
                 "vscode-languageclient": "7.0.0"

--- a/package.json
+++ b/package.json
@@ -1986,7 +1986,7 @@
         "@jupyterlab/services": "^6.1.17",
         "@lumino/widgets": "^1.28.0",
         "@nteract/messaging": "^7.0.0",
-        "@vscode/jupyter-lsp-middleware": "^0.2.21",
+        "@vscode/jupyter-lsp-middleware": "^0.2.22",
         "ansi-to-html": "^0.6.7",
         "arch": "^2.1.0",
         "bootstrap": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1986,7 +1986,7 @@
         "@jupyterlab/services": "^6.1.17",
         "@lumino/widgets": "^1.28.0",
         "@nteract/messaging": "^7.0.0",
-        "@vscode/jupyter-lsp-middleware": "^0.2.22",
+        "@vscode/jupyter-lsp-middleware": "^0.2.23",
         "ansi-to-html": "^0.6.7",
         "arch": "^2.1.0",
         "bootstrap": "^4.3.1",


### PR DESCRIPTION
Found a bug in parsing diagnostics for notebooks. Middleware wasn't setting its 'notebookUri' correctly.

Fixed in lsp-middleware already. This takes that fix in.