### PR TITLE
Use Object instead of using a flag to hide startup progress UI

### DIFF
--- a/src/client/datascience/displayOptions.ts
+++ b/src/client/datascience/displayOptions.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Event, EventEmitter } from 'vscode';
+import { IDisplayOptions } from './types';
+
+export class DisplayOptions implements IDisplayOptions {
+    private _disableUI: boolean;
+    public get disableUI(): boolean {
+        return this._disableUI;
+    }
+    public set disableUI(value: boolean) {
+        this._disableUI = value;
+    }
+    private _event = new EventEmitter<void>();
+    public get onDidChangeDisableUI(): Event<void> {
+        return this._event.event;
+    }
+    constructor(disableUI: boolean) {
+        this._disableUI = disableUI;
+    }
+    public dispose() {
+        this._event.dispose();
+    }
+}

--- a/src/client/datascience/interactive-common/notebookProvider.ts
+++ b/src/client/datascience/interactive-common/notebookProvider.ts
@@ -66,13 +66,13 @@ export class NotebookProvider implements INotebookProvider {
                   options.document,
                   options.resource,
                   options.kernelConnection,
-                  options.disableUI,
+                  options.ui,
                   options.token
               )
             : this.jupyterNotebookProvider.createNotebook(options);
 
         sendKernelTelemetryWhenDone(options.resource, Telemetry.NotebookStart, promise, undefined, {
-            disableUI: options.disableUI
+            disableUI: options.ui.disableUI === true
         });
 
         return promise;

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -119,7 +119,6 @@ export class JupyterExecutionBase implements IJupyterExecution {
             let result: INotebookServer | undefined;
             let connection: IJupyterConnection | undefined;
             traceInfo(`Connecting to server`);
-            const allowUI = !options || options.allowUI();
             const kernelSpecCancelSource = new CancellationTokenSource();
             if (cancelToken) {
                 cancelToken.onCancellationRequested(() => {
@@ -212,7 +211,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
             sendTelemetryEvent(Telemetry.JupyterStartTimeout, stopWatch.elapsedTime, {
                 timeout: stopWatch.elapsedTime
             });
-            if (allowUI) {
+            if (!options.ui.disableUI) {
                 this.appShell
                     .showErrorMessage(localize.DataScience.jupyterStartTimedout(), localize.Common.openOutputPanel())
                     .then((selection) => {

--- a/src/client/datascience/jupyter/jupyterSessionManager.ts
+++ b/src/client/datascience/jupyter/jupyterSessionManager.ts
@@ -29,6 +29,7 @@ import { sleep } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
 import { SessionDisposedError } from '../errors/sessionDisposedError';
 import {
+    IDisplayOptions,
     IJupyterConnection,
     IJupyterKernel,
     IJupyterKernelSpec,
@@ -174,8 +175,8 @@ export class JupyterSessionManager implements IJupyterSessionManager {
         resource: Resource,
         kernelConnection: KernelConnectionMetadata,
         workingDirectory: string,
-        cancelToken?: CancellationToken,
-        disableUI?: boolean
+        ui: IDisplayOptions,
+        cancelToken?: CancellationToken
     ): Promise<JupyterSession> {
         if (
             !this.connInfo ||
@@ -203,7 +204,7 @@ export class JupyterSessionManager implements IJupyterSessionManager {
             this.configService.getSettings(resource).jupyterInterruptTimeout
         );
         try {
-            await session.connect(cancelToken, disableUI);
+            await session.connect({ token: cancelToken, ui });
         } finally {
             if (!session.isConnected) {
                 await session.dispose();

--- a/src/client/datascience/jupyter/kernels/jupyterKernelService.ts
+++ b/src/client/datascience/jupyter/kernels/jupyterKernelService.ts
@@ -22,7 +22,7 @@ import { Telemetry } from '../../constants';
 import { ILocalKernelFinder } from '../../kernel-launcher/types';
 import { reportAction } from '../../progress/decorator';
 import { ReportableAction } from '../../progress/types';
-import { IJupyterKernelSpec, IKernelDependencyService } from '../../types';
+import { IDisplayOptions, IJupyterKernelSpec, IKernelDependencyService } from '../../types';
 import { cleanEnvironment } from './helpers';
 import { JupyterKernelSpec } from './jupyterKernelSpec';
 import { KernelConnectionMetadata, LocalKernelConnectionMetadata } from './types';
@@ -52,8 +52,8 @@ export class JupyterKernelService {
     public async ensureKernelIsUsable(
         resource: Resource,
         kernel: KernelConnectionMetadata,
-        cancelToken?: CancellationToken,
-        disableUI?: boolean
+        ui: IDisplayOptions,
+        cancelToken?: CancellationToken
     ): Promise<void> {
         // If we wish to wait for installation to complete, we must provide a cancel token.
         const tokenSource = new CancellationTokenSource();
@@ -61,12 +61,7 @@ export class JupyterKernelService {
 
         // If we have an interpreter, make sure it has the correct dependencies installed
         if (kernel.kind !== 'connectToLiveKernel' && kernel.interpreter) {
-            await this.kernelDependencyService.installMissingDependencies(
-                resource,
-                kernel.interpreter,
-                token,
-                disableUI
-            );
+            await this.kernelDependencyService.installMissingDependencies(resource, kernel.interpreter, ui, token);
         }
 
         var specFile: string | undefined = undefined;

--- a/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
@@ -29,7 +29,12 @@ import { getTelemetrySafeHashedString } from '../../../telemetry/helpers';
 import { getResourceType } from '../../common';
 import { Telemetry } from '../../constants';
 import { IpyKernelNotInstalledError } from '../../errors/ipyKernelNotInstalledError';
-import { IInteractiveWindowProvider, IKernelDependencyService, KernelInterpreterDependencyResponse } from '../../types';
+import {
+    IDisplayOptions,
+    IInteractiveWindowProvider,
+    IKernelDependencyService,
+    KernelInterpreterDependencyResponse
+} from '../../types';
 import { selectKernel } from './kernelSelector';
 
 /**
@@ -56,8 +61,8 @@ export class KernelDependencyService implements IKernelDependencyService {
     public async installMissingDependencies(
         resource: Resource,
         interpreter: PythonEnvironment,
-        token?: CancellationToken,
-        disableUI?: boolean
+        ui: IDisplayOptions,
+        token?: CancellationToken
     ): Promise<void> {
         traceInfo(`installMissingDependencies ${getDisplayPath(interpreter.path)}`);
         if (await this.areDependenciesInstalled(interpreter, token)) {
@@ -70,7 +75,7 @@ export class KernelDependencyService implements IKernelDependencyService {
         // Cache the install run
         let promise = this.installPromises.get(interpreter.path);
         if (!promise) {
-            promise = this.runInstaller(resource, interpreter, token, disableUI);
+            promise = this.runInstaller(resource, interpreter, ui, token);
             this.installPromises.set(interpreter.path, promise);
         }
 
@@ -120,11 +125,11 @@ export class KernelDependencyService implements IKernelDependencyService {
     private async runInstaller(
         resource: Resource,
         interpreter: PythonEnvironment,
-        token?: CancellationToken,
-        disableUI?: boolean
+        ui: IDisplayOptions,
+        token?: CancellationToken
     ): Promise<KernelInterpreterDependencyResponse> {
         // If there's no UI, then cancel installation.
-        if (disableUI) {
+        if (ui.disableUI) {
             return KernelInterpreterDependencyResponse.uiHidden;
         }
         const installerToken = wrapCancellationTokens(token);

--- a/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
+++ b/src/client/datascience/jupyter/liveshare/hostJupyterServer.ts
@@ -31,6 +31,7 @@ import { sendKernelTelemetryEvent } from '../../telemetry/telemetry';
 import { StopWatch } from '../../../common/utils/stopWatch';
 import { JupyterSessionManager } from '../jupyterSessionManager';
 import { SessionDisposedError } from '../../errors/sessionDisposedError';
+import { DisplayOptions } from '../../displayOptions';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 @injectable()
@@ -95,9 +96,20 @@ export class HostJupyterServer implements INotebookServer {
                 ? await computeWorkingDirectory(resource, this.workspaceService)
                 : '';
             // Start a session (or use the existing one if allowed)
-            const session = await sessionManager.startNew(resource, kernelConnection, workingDirectory, cancelToken);
-            traceInfo(`Started session for kernel ${kernelConnection.id}`);
-            return { connection, session };
+            const ui = new DisplayOptions(false);
+            try {
+                const session = await sessionManager.startNew(
+                    resource,
+                    kernelConnection,
+                    workingDirectory,
+                    ui,
+                    cancelToken
+                );
+                traceInfo(`Started session for kernel ${kernelConnection.id}`);
+                return { connection, session };
+            } finally {
+                ui.dispose();
+            }
         };
 
         try {

--- a/src/client/datascience/jupyter/liveshare/serverCache.ts
+++ b/src/client/datascience/jupyter/liveshare/serverCache.ts
@@ -130,7 +130,7 @@ export class ServerCache implements IAsyncDisposable {
                 options && options.workingDir
                     ? options.workingDir
                     : await calculateWorkingDirectory(this.configService, this.workspace, this.fs),
-            allowUI: options.allowUI
+            ui: options.ui
         };
     }
 

--- a/src/client/datascience/jupyter/serverPreload.ts
+++ b/src/client/datascience/jupyter/serverPreload.ts
@@ -60,17 +60,10 @@ export class ServerPreload implements IExtensionSingleActivationService {
         try {
             traceInfo(`Attempting to start a server because of preload conditions ...`);
 
-            // Check if we are already connected
-            let providerConnection = await this.notebookProvider.connect({
-                getOnly: true,
-                disableUI: true,
-                resource: undefined
-            });
-
             // If it didn't start, attempt for local and if allowed.
-            if (!providerConnection && !this.configService.getSettings(undefined).disableJupyterAutoStart) {
+            if (!this.configService.getSettings(undefined).disableJupyterAutoStart) {
                 // Local case, try creating one
-                providerConnection = await this.notebookProvider.connect({
+                await this.notebookProvider.connect({
                     getOnly: false,
                     resource: undefined,
                     disableUI: true,

--- a/src/client/datascience/kernel-launcher/kernelLauncher.ts
+++ b/src/client/datascience/kernel-launcher/kernelLauncher.ts
@@ -18,7 +18,7 @@ import { IProcessServiceFactory, IPythonExecutionFactory } from '../../common/pr
 import { IDisposableRegistry, Resource } from '../../common/types';
 import { Telemetry } from '../constants';
 import { KernelSpecConnectionMetadata, PythonKernelConnectionMetadata } from '../jupyter/kernels/types';
-import { IKernelDependencyService } from '../types';
+import { IDisplayOptions, IKernelDependencyService } from '../types';
 import { KernelDaemonPool } from './kernelDaemonPool';
 import { KernelEnvironmentVariablesService } from './kernelEnvVarsService';
 import { KernelProcess } from './kernelProcess';
@@ -98,8 +98,8 @@ export class KernelLauncher implements IKernelLauncher {
         timeout: number,
         resource: Resource,
         workingDirectory: string,
-        cancelToken?: CancellationToken,
-        disableUI?: boolean
+        ui: IDisplayOptions,
+        cancelToken?: CancellationToken
     ): Promise<IKernelProcess> {
         const promise = (async () => {
             // If this is a python interpreter, make sure it has ipykernel
@@ -107,8 +107,8 @@ export class KernelLauncher implements IKernelLauncher {
                 await this.kernelDependencyService.installMissingDependencies(
                     resource,
                     kernelConnectionMetadata.interpreter,
-                    cancelToken,
-                    disableUI
+                    ui,
+                    cancelToken
                 );
                 if (cancelToken?.isCancellationRequested) {
                     throw new CancellationError();

--- a/src/client/datascience/kernel-launcher/types.ts
+++ b/src/client/datascience/kernel-launcher/types.ts
@@ -13,7 +13,7 @@ import {
     LocalKernelConnectionMetadata,
     PythonKernelConnectionMetadata
 } from '../jupyter/kernels/types';
-import { INotebookProviderConnection } from '../types';
+import { IDisplayOptions, INotebookProviderConnection } from '../types';
 
 export const IKernelLauncher = Symbol('IKernelLauncher');
 export interface IKernelLauncher {
@@ -22,8 +22,8 @@ export interface IKernelLauncher {
         timeout: number,
         resource: Resource,
         workingDirectory: string,
-        cancelToken?: CancellationToken,
-        disableUI?: boolean
+        ui: IDisplayOptions,
+        cancelToken?: CancellationToken
     ): Promise<IKernelProcess>;
 }
 

--- a/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
@@ -29,6 +29,7 @@ import { IKernelLauncher } from '../../kernel-launcher/types';
 import { ProgressReporter } from '../../progress/progressReporter';
 import {
     ConnectNotebookProviderOptions,
+    IDisplayOptions,
     INotebook,
     IRawConnection,
     IRawNotebookProvider,
@@ -100,7 +101,7 @@ export class HostRawNotebookProvider implements IRawNotebookProvider {
         document: vscode.NotebookDocument,
         resource: Resource,
         kernelConnection: KernelConnectionMetadata,
-        disableUI: boolean,
+        ui: IDisplayOptions,
         cancelToken?: CancellationToken
     ): Promise<INotebook> {
         traceInfo(`Creating raw notebook for ${getDisplayPath(document.uri)}`);
@@ -126,7 +127,7 @@ export class HostRawNotebookProvider implements IRawNotebookProvider {
             // We need to locate kernelspec and possible interpreter for this launch based on resource and notebook metadata
             const displayName = getDisplayNameOrNameOfKernelConnection(kernelConnection);
 
-            const progressDisposable = !disableUI
+            const progressDisposable = !ui.disableUI
                 ? this.progressReporter.createProgressIndicator(
                       localize.DataScience.connectingToKernel().format(displayName)
                   )
@@ -160,7 +161,7 @@ export class HostRawNotebookProvider implements IRawNotebookProvider {
                     kernelConnection
                 )}`
             );
-            await rawSession.connect(cancelToken, disableUI);
+            await rawSession.connect({ token: cancelToken, ui });
 
             if (rawSession.isConnected) {
                 // Create our notebook

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -52,6 +52,11 @@ export interface IDataScienceCommandListener {
     register(commandManager: ICommandManager): void;
 }
 
+export interface IDisplayOptions {
+    disableUI: boolean;
+    onDidChangeDisableUI: Event<void>;
+}
+
 export interface IRawConnection {
     readonly type: 'raw';
     readonly localLaunch: true;
@@ -122,7 +127,7 @@ export interface IRawNotebookProvider extends IAsyncDisposable {
         document: NotebookDocument,
         resource: Resource,
         kernelConnection: KernelConnectionMetadata,
-        disableUI?: boolean,
+        ui: IDisplayOptions,
         cancelToken?: CancellationToken
     ): Promise<INotebook>;
 }
@@ -157,7 +162,7 @@ export interface INotebookServerOptions {
     resource: Resource;
     skipUsingDefaultConfig?: boolean;
     workingDir?: string;
-    allowUI(): boolean;
+    ui: IDisplayOptions;
 }
 
 export const IJupyterExecution = Symbol('IJupyterExecution');
@@ -261,8 +266,8 @@ export interface IJupyterSessionManager extends IAsyncDisposable {
         resource: Resource,
         kernelConnection: KernelConnectionMetadata,
         workingDirectory: string,
-        cancelToken?: CancellationToken,
-        disableUI?: boolean
+        ui: IDisplayOptions,
+        cancelToken?: CancellationToken
     ): Promise<IJupyterSession>;
     getKernelSpecs(): Promise<IJupyterKernelSpec[]>;
     getRunningKernels(): Promise<IJupyterKernel[]>;
@@ -835,7 +840,13 @@ type WebViewViewState = {
 };
 export type WebViewViewChangeEventArgs = { current: WebViewViewState; previous: WebViewViewState };
 
-export type GetServerOptions = ConnectNotebookProviderOptions;
+export type GetServerOptions = {
+    getOnly?: boolean;
+    ui: IDisplayOptions;
+    localOnly?: boolean;
+    token?: CancellationToken;
+    resource: Resource;
+};
 
 /**
  * Options for getting a notebook
@@ -843,7 +854,7 @@ export type GetServerOptions = ConnectNotebookProviderOptions;
 export type NotebookCreationOptions = {
     resource: Resource;
     document: NotebookDocument;
-    disableUI?: boolean;
+    ui: IDisplayOptions;
     kernelConnection: KernelConnectionMetadata;
     token?: CancellationToken;
 };
@@ -952,8 +963,8 @@ export interface IKernelDependencyService {
     installMissingDependencies(
         resource: Resource,
         interpreter: PythonEnvironment,
-        token?: CancellationToken,
-        disableUI?: boolean
+        ui: IDisplayOptions,
+        token?: CancellationToken
     ): Promise<void>;
     areDependenciesInstalled(interpreter: PythonEnvironment, _token?: CancellationToken): Promise<boolean>;
 }

--- a/src/test/datascience/execution.unit.test.ts
+++ b/src/test/datascience/execution.unit.test.ts
@@ -39,6 +39,7 @@ import {
     Product
 } from '../../client/common/types';
 import { EXTENSION_ROOT_DIR } from '../../client/constants';
+import { DisplayOptions } from '../../client/datascience/displayOptions';
 import { JupyterInterpreterDependencyService } from '../../client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService';
 import { JupyterInterpreterOldCacheStateStore } from '../../client/datascience/jupyter/interpreter/jupyterInterpreterOldCacheStateStore';
 import { JupyterInterpreterService } from '../../client/datascience/jupyter/interpreter/jupyterInterpreterService';
@@ -1009,10 +1010,12 @@ suite('Jupyter Execution', async () => {
         await assert.eventually.equal(jupyterExecutionFactory.isNotebookSupported(), true, 'Notebook not supported');
         const usableInterpreter = await jupyterExecutionFactory.getUsableJupyterPython();
         assert.isOk(usableInterpreter, 'Usable interpreter not found');
+        const ui = new DisplayOptions(true);
         await assert.isFulfilled(
-            jupyterExecutionFactory.connectToNotebookServer({ allowUI: () => false, resource: undefined }),
+            jupyterExecutionFactory.connectToNotebookServer({ ui, resource: undefined }),
             'Should be able to start a server'
         );
+        ui.dispose();
     }).timeout(10000);
 
     test('Includes correct args for running in docker', async () => {
@@ -1026,19 +1029,23 @@ suite('Jupyter Execution', async () => {
         await assert.eventually.equal(jupyterExecutionFactory.isNotebookSupported(), true, 'Notebook not supported');
         const usableInterpreter = await jupyterExecutionFactory.getUsableJupyterPython();
         assert.isOk(usableInterpreter, 'Usable interpreter not found');
+        const ui = new DisplayOptions(true);
         await assert.isFulfilled(
-            jupyterExecutionFactory.connectToNotebookServer({ allowUI: () => false, resource: undefined }),
+            jupyterExecutionFactory.connectToNotebookServer({ ui, resource: undefined }),
             'Should be able to start a server'
         );
+        ui.dispose();
     }).timeout(10000);
 
     test('Failing notebook throws exception', async () => {
         const execution = createExecution(missingNotebookPython);
         when(interpreterService.getInterpreters(anything())).thenResolve([missingNotebookPython]);
+        const ui = new DisplayOptions(true);
         await assert.isRejected(
-            execution.connectToNotebookServer({ allowUI: () => false, resource: undefined }),
+            execution.connectToNotebookServer({ ui, resource: undefined }),
             'Running cells requires jupyter.'
         );
+        ui.dispose();
     }).timeout(10000);
 
     test('Missing kernel python still finds interpreter', async () => {

--- a/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
+++ b/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
@@ -8,6 +8,7 @@ import { PythonExtensionChecker } from '../../../client/api/pythonApi';
 import { IWorkspaceService } from '../../../client/common/application/types';
 import { ConfigurationService } from '../../../client/common/configuration/service';
 import { IJupyterSettings } from '../../../client/common/types';
+import { DisplayOptions } from '../../../client/datascience/displayOptions';
 import { NotebookProvider } from '../../../client/datascience/interactive-common/notebookProvider';
 import { KernelConnectionMetadata } from '../../../client/datascience/jupyter/kernels/types';
 import { IJupyterNotebookProvider, INotebook, IRawNotebookProvider } from '../../../client/datascience/types';
@@ -67,7 +68,8 @@ suite('DataScience - NotebookProvider', () => {
         const notebook = await notebookProvider.createNotebook({
             document: instance(doc),
             resource: Uri('C:\\\\foo.py'),
-            kernelConnection: instance(mock<KernelConnectionMetadata>())
+            kernelConnection: instance(mock<KernelConnectionMetadata>()),
+            ui: new DisplayOptions(false)
         });
         expect(notebook).to.not.equal(undefined, 'Provider should return a notebook');
     });
@@ -82,14 +84,16 @@ suite('DataScience - NotebookProvider', () => {
         const notebook = await notebookProvider.createNotebook({
             document: instance(doc),
             resource: Uri('C:\\\\foo.py'),
-            kernelConnection: instance(mock<KernelConnectionMetadata>())
+            kernelConnection: instance(mock<KernelConnectionMetadata>()),
+            ui: new DisplayOptions(false)
         });
         expect(notebook).to.not.equal(undefined, 'Server should return a notebook');
 
         const notebook2 = await notebookProvider.createNotebook({
             document: instance(doc),
             resource: Uri('C:\\\\foo.py'),
-            kernelConnection: instance(mock<KernelConnectionMetadata>())
+            kernelConnection: instance(mock<KernelConnectionMetadata>()),
+            ui: new DisplayOptions(false)
         });
         expect(notebook2).to.equal(notebook);
     });

--- a/src/test/datascience/interactive-common/notebookServerProvider.unit.test.ts
+++ b/src/test/datascience/interactive-common/notebookServerProvider.unit.test.ts
@@ -6,6 +6,7 @@ import { anything, instance, mock, verify, when } from 'ts-mockito';
 import * as typemoq from 'typemoq';
 import { IApplicationShell } from '../../../client/common/application/types';
 import { IConfigurationService, IWatchableJupyterSettings } from '../../../client/common/types';
+import { DisplayOptions } from '../../../client/datascience/displayOptions';
 import { NotebookServerProvider } from '../../../client/datascience/interactive-common/notebookServerProvider';
 import { JupyterServerSelector } from '../../../client/datascience/jupyter/serverSelector';
 import { JupyterServerUriStorage } from '../../../client/datascience/jupyter/serverUriStorage';
@@ -73,7 +74,11 @@ suite('DataScience - NotebookServerProvider', () => {
     test('NotebookServerProvider - Get Only - no server', async () => {
         when(jupyterExecution.getServer(anything())).thenResolve(undefined);
 
-        const server = await serverProvider.getOrCreateServer({ getOnly: true, resource: undefined });
+        const server = await serverProvider.getOrCreateServer({
+            getOnly: true,
+            resource: undefined,
+            ui: new DisplayOptions(false)
+        });
         expect(server).to.equal(undefined, 'Server expected to be undefined');
         verify(jupyterExecution.getServer(anything())).once();
     });
@@ -83,7 +88,11 @@ suite('DataScience - NotebookServerProvider', () => {
         when((notebookServer as any).then).thenReturn(undefined);
         when(jupyterExecution.getServer(anything())).thenResolve(instance(notebookServer));
 
-        const server = await serverProvider.getOrCreateServer({ getOnly: true, resource: undefined });
+        const server = await serverProvider.getOrCreateServer({
+            getOnly: true,
+            resource: undefined,
+            ui: new DisplayOptions(false)
+        });
         expect(server).to.not.equal(undefined, 'Server expected to be defined');
         verify(jupyterExecution.getServer(anything())).once();
     });
@@ -94,7 +103,11 @@ suite('DataScience - NotebookServerProvider', () => {
         when(jupyterExecution.connectToNotebookServer(anything(), anything())).thenResolve(notebookServer.object);
 
         // Disable UI just lets us skip mocking the progress reporter
-        const server = await serverProvider.getOrCreateServer({ getOnly: false, disableUI: true, resource: undefined });
+        const server = await serverProvider.getOrCreateServer({
+            getOnly: false,
+            ui: new DisplayOptions(true),
+            resource: undefined
+        });
         expect(server).to.not.equal(undefined, 'Server expected to be defined');
     });
 });

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -22,6 +22,7 @@ import { ReadWrite, Resource } from '../../../client/common/types';
 import { createDeferred, Deferred } from '../../../client/common/utils/async';
 import { DataScience } from '../../../client/common/utils/localize';
 import { noop } from '../../../client/common/utils/misc';
+import { DisplayOptions } from '../../../client/datascience/displayOptions';
 import { JupyterSession } from '../../../client/datascience/jupyter/jupyterSession';
 import { JupyterKernelService } from '../../../client/datascience/jupyter/kernels/jupyterKernelService';
 import { KernelConnectionMetadata, LiveKernelModel } from '../../../client/datascience/jupyter/kernels/types';
@@ -151,7 +152,7 @@ suite('DataScience - JupyterSession', () => {
         (mockKernelSpec as any).kernelSpec = specOrModel;
         mockKernelSpec.kind = kind;
 
-        await jupyterSession.connect();
+        await jupyterSession.connect({ ui: new DisplayOptions(false) });
     }
     teardown(async () => jupyterSession.dispose().catch(noop));
 

--- a/src/test/datascience/jupyter/kernels/jupyterKernelService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/jupyterKernelService.unit.test.ts
@@ -19,6 +19,7 @@ import { EnvironmentType } from '../../../../client/pythonEnvironments/info';
 import { EXTENSION_ROOT_DIR } from '../../../../client/constants';
 import * as path from 'path';
 import { arePathsSame } from '../../../common';
+import { DisplayOptions } from '../../../../client/datascience/displayOptions';
 
 // eslint-disable-next-line
 suite('DataScience - JupyterKernelService', () => {
@@ -302,7 +303,7 @@ suite('DataScience - JupyterKernelService', () => {
     test('Dependencies checked on all kernels with interpreters', async () => {
         await Promise.all(
             kernels.map(async (k) => {
-                await kernelService.ensureKernelIsUsable(undefined, k, undefined, true);
+                await kernelService.ensureKernelIsUsable(undefined, k, new DisplayOptions(true), undefined);
             })
         );
         verify(
@@ -321,7 +322,12 @@ suite('DataScience - JupyterKernelService', () => {
             'kernel.json'
         );
         when(fs.localFileExists(anything())).thenResolve(false);
-        await kernelService.ensureKernelIsUsable(undefined, kernelsWithInvalidName[0], undefined, true);
+        await kernelService.ensureKernelIsUsable(
+            undefined,
+            kernelsWithInvalidName[0],
+            new DisplayOptions(true),
+            undefined
+        );
         verify(fs.writeLocalFile(kernelSpecPath, anything())).once();
     });
 
@@ -341,7 +347,7 @@ suite('DataScience - JupyterKernelService', () => {
         });
         await Promise.all(
             kernelsWithInterpreters.map(async (k) => {
-                await kernelService.ensureKernelIsUsable(undefined, k, undefined, true);
+                await kernelService.ensureKernelIsUsable(undefined, k, new DisplayOptions(true), undefined);
             })
         );
         assert.equal(updateCount, kernelsWithInterpreters.length, 'Updates to spec files did not occur');
@@ -362,7 +368,7 @@ suite('DataScience - JupyterKernelService', () => {
         });
         await Promise.all(
             kernelsWithoutInterpreters.map(async (k) => {
-                await kernelService.ensureKernelIsUsable(undefined, k, undefined, true);
+                await kernelService.ensureKernelIsUsable(undefined, k, new DisplayOptions(true), undefined);
             })
         );
         assert.equal(updateCount, 0, 'Should not have updated spec files when no interpreter metadata');

--- a/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
@@ -91,7 +91,11 @@ suite('DataScience - Kernel Dependency Service', () => {
                 when(appShell.showErrorMessage(anything(), anything())).thenResolve(Common.install() as any);
 
                 await assert.isRejected(
-                    dependencyService.installMissingDependencies(Uri.file('one.ipynb'), interpreter, new DisplayOptions(false)),
+                    dependencyService.installMissingDependencies(
+                        Uri.file('one.ipynb'),
+                        interpreter,
+                        new DisplayOptions(false)
+                    ),
                     'IPyKernel not installed into interpreter'
                 );
 
@@ -138,7 +142,11 @@ suite('DataScience - Kernel Dependency Service', () => {
                     Common.install() as any
                 );
 
-                const promise = dependencyService.installMissingDependencies(resource, interpreter, new DisplayOptions(false));
+                const promise = dependencyService.installMissingDependencies(
+                    resource,
+                    interpreter,
+                    new DisplayOptions(false)
+                );
 
                 await assert.isRejected(promise, 'Install failed - kaboom');
             });
@@ -153,7 +161,11 @@ suite('DataScience - Kernel Dependency Service', () => {
                     DataScience.selectKernel() as any
                 );
 
-                const promise = dependencyService.installMissingDependencies(resource, interpreter, new DisplayOptions(false));
+                const promise = dependencyService.installMissingDependencies(
+                    resource,
+                    interpreter,
+                    new DisplayOptions(false)
+                );
 
                 await assert.isRejected(promise, 'IPyKernel not installed into interpreter name:abc');
 
@@ -170,7 +182,11 @@ suite('DataScience - Kernel Dependency Service', () => {
                 when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
                 when(appShell.showErrorMessage(anything(), anything(), anything(), anything())).thenResolve();
 
-                const promise = dependencyService.installMissingDependencies(resource, interpreter, new DisplayOptions(false));
+                const promise = dependencyService.installMissingDependencies(
+                    resource,
+                    interpreter,
+                    new DisplayOptions(false)
+                );
 
                 await assert.isRejected(promise, 'IPyKernel not installed into interpreter name:abc');
                 verify(cmdManager.executeCommand('notebook.selectKernel', anything())).never();

--- a/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
@@ -10,6 +10,7 @@ import { IApplicationShell, ICommandManager, IVSCodeNotebook } from '../../../..
 import { IInstaller, InstallerResponse, Product } from '../../../../client/common/types';
 import { Common, DataScience } from '../../../../client/common/utils/localize';
 import { getResourceType } from '../../../../client/datascience/common';
+import { DisplayOptions } from '../../../../client/datascience/displayOptions';
 import { KernelDependencyService } from '../../../../client/datascience/jupyter/kernels/kernelDependencyService';
 import { IInteractiveWindow, IInteractiveWindowProvider } from '../../../../client/datascience/types';
 import { IServiceContainer } from '../../../../client/ioc/types';
@@ -73,7 +74,7 @@ suite('DataScience - Kernel Dependency Service', () => {
             test('Check if ipykernel is installed', async () => {
                 when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(true);
 
-                await dependencyService.installMissingDependencies(resource, interpreter);
+                await dependencyService.installMissingDependencies(resource, interpreter, new DisplayOptions(false));
 
                 verify(installer.isInstalled(Product.ipykernel, interpreter)).once();
                 verify(installer.isInstalled(anything(), anything())).once();
@@ -81,7 +82,7 @@ suite('DataScience - Kernel Dependency Service', () => {
             test('Do not prompt if if ipykernel is installed', async () => {
                 when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(true);
 
-                await dependencyService.installMissingDependencies(resource, interpreter);
+                await dependencyService.installMissingDependencies(resource, interpreter, new DisplayOptions(false));
 
                 verify(appShell.showErrorMessage(anything(), anything(), anything())).never();
             });
@@ -90,7 +91,7 @@ suite('DataScience - Kernel Dependency Service', () => {
                 when(appShell.showErrorMessage(anything(), anything())).thenResolve(Common.install() as any);
 
                 await assert.isRejected(
-                    dependencyService.installMissingDependencies(Uri.file('one.ipynb'), interpreter),
+                    dependencyService.installMissingDependencies(Uri.file('one.ipynb'), interpreter, new DisplayOptions(false)),
                     'IPyKernel not installed into interpreter'
                 );
 
@@ -108,7 +109,7 @@ suite('DataScience - Kernel Dependency Service', () => {
                     Common.install() as any
                 );
 
-                await dependencyService.installMissingDependencies(resource, interpreter);
+                await dependencyService.installMissingDependencies(resource, interpreter, new DisplayOptions(false));
             });
             test('Install ipykernel second time should result in a re-install', async () => {
                 when(memento.get(anything(), anything())).thenReturn(true);
@@ -123,7 +124,7 @@ suite('DataScience - Kernel Dependency Service', () => {
                     Common.reInstall() as any
                 );
 
-                await dependencyService.installMissingDependencies(resource, interpreter);
+                await dependencyService.installMissingDependencies(resource, interpreter, new DisplayOptions(false));
             });
             test('Bubble installation errors', async () => {
                 when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
@@ -137,7 +138,7 @@ suite('DataScience - Kernel Dependency Service', () => {
                     Common.install() as any
                 );
 
-                const promise = dependencyService.installMissingDependencies(resource, interpreter);
+                const promise = dependencyService.installMissingDependencies(resource, interpreter, new DisplayOptions(false));
 
                 await assert.isRejected(promise, 'Install failed - kaboom');
             });
@@ -152,7 +153,7 @@ suite('DataScience - Kernel Dependency Service', () => {
                     DataScience.selectKernel() as any
                 );
 
-                const promise = dependencyService.installMissingDependencies(resource, interpreter);
+                const promise = dependencyService.installMissingDependencies(resource, interpreter, new DisplayOptions(false));
 
                 await assert.isRejected(promise, 'IPyKernel not installed into interpreter name:abc');
 
@@ -169,7 +170,7 @@ suite('DataScience - Kernel Dependency Service', () => {
                 when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
                 when(appShell.showErrorMessage(anything(), anything(), anything(), anything())).thenResolve();
 
-                const promise = dependencyService.installMissingDependencies(resource, interpreter);
+                const promise = dependencyService.installMissingDependencies(resource, interpreter, new DisplayOptions(false));
 
                 await assert.isRejected(promise, 'IPyKernel not installed into interpreter name:abc');
                 verify(cmdManager.executeCommand('notebook.selectKernel', anything())).never();

--- a/src/test/datascience/kernelLauncher.vscode.test.ts
+++ b/src/test/datascience/kernelLauncher.vscode.test.ts
@@ -22,6 +22,7 @@ import { PortAttributesProviders } from '../../client/common/net/portAttributePr
 import { IDisposable } from '../../client/common/types';
 import { disposeAllDisposables } from '../../client/common/helpers';
 import { CancellationTokenSource, PortAutoForwardAction } from 'vscode';
+import { DisplayOptions } from '../../client/datascience/displayOptions';
 use(chaiAsPromised);
 
 const test_Timeout = 30_000;
@@ -63,7 +64,8 @@ suite('DataScience - Kernel Launcher', () => {
             { kernelSpec, kind: 'startUsingKernelSpec', id: '1' },
             -1,
             undefined,
-            process.cwd()
+            process.cwd(),
+            new DisplayOptions(false)
         );
         kernel.exited(() => {
             if (exitExpected) {
@@ -104,7 +106,8 @@ suite('DataScience - Kernel Launcher', () => {
             { kernelSpec: spec, kind: 'startUsingKernelSpec', id: '1' },
             30_000,
             undefined,
-            process.cwd()
+            process.cwd(),
+            new DisplayOptions(false)
         );
 
         assert.isOk<IKernelConnection | undefined>(kernel.connection, 'Connection not found');
@@ -137,7 +140,8 @@ suite('DataScience - Kernel Launcher', () => {
             { kernelSpec: spec, kind: 'startUsingKernelSpec', id: '1' },
             30_000,
             undefined,
-            process.cwd()
+            process.cwd(),
+            new DisplayOptions(false)
         );
 
         // Confirm the ports used by this kernel are ignored.
@@ -188,7 +192,8 @@ suite('DataScience - Kernel Launcher', () => {
             { kernelSpec, kind: 'startUsingKernelSpec', id: '1' },
             -1,
             undefined,
-            process.cwd()
+            process.cwd(),
+            new DisplayOptions(false)
         );
 
         try {

--- a/src/test/datascience/mockJupyterManager.ts
+++ b/src/test/datascience/mockJupyterManager.ts
@@ -31,6 +31,7 @@ import { CodeSnippets, Identifiers } from '../../client/datascience/constants';
 import { KernelConnectionMetadata } from '../../client/datascience/jupyter/kernels/types';
 import {
     ICell,
+    IDisplayOptions,
     IJupyterKernel,
     IJupyterKernelSpec,
     IJupyterSession,
@@ -423,6 +424,7 @@ export class MockJupyterManager implements IJupyterSessionManager {
         _resource: Resource,
         _kernelConnection: KernelConnectionMetadata,
         _workingDirectory: string,
+        _ui: IDisplayOptions,
         cancelToken?: CancellationToken
     ): Promise<JupyterSession> {
         if (this.sessionTimeout && cancelToken) {


### PR DESCRIPTION
Part of #7849

Goal of using an object instead of a boolean flag:
* Assume we auto start a kernel & we pass boolean flag to hide the UI
* Now while auto starting, user starts running a cell
* It will use the same kernel (code) that's being auto started & since that is still in progress no UI is dispalyed

Solution:
* Change the flag to an object
* When user runs cell (kernel.start) we change the state of this object to `true` and all subsequent code will now start displaying the UI (I've added an event handler so that we can start display progress where it was skipped)
* When kernel startup fails because IPYkernel is not installed, we'll know whether it was displayed or not and we can then re-display the error message if the user runs cells just after the failure takes place