### PR TITLE
Cache the result of ipykernel dependency check

### DIFF
--- a/src/client/common/errors/errorUtils.ts
+++ b/src/client/common/errors/errorUtils.ts
@@ -380,6 +380,24 @@ export function analyzeKernelErrors(
             };
         }
     }
+    // This happens when ipykernel is not installed and we attempt to run without checking for ipykernel.
+    // '/home/don/samples/pySamples/crap/.venv/bin/python: No module named ipykernel_launcher\n'
+    const noModule = 'No module named'.toLowerCase();
+    if (stdErr.includes(noModule)) {
+        const line = stdErrOrStackTrace
+            .splitLines()
+            .map((line) => line.trim())
+            .filter((line) => line.length)
+            .find((line) => line.toLowerCase().includes(noModule));
+        const moduleName = line ? line.substring(line.toLowerCase().indexOf(noModule) + noModule.length).trim() : '';
+        if (line) {
+            return {
+                reason: KernelFailureReason.moduleNotFoundFailure,
+                moduleName,
+                telemetrySafeTags: ['module.notfound.error']
+            };
+        }
+    }
 }
 
 function extractModuleAndFileFromImportError(errorLine: string) {

--- a/src/client/common/installer/productInstaller.ts
+++ b/src/client/common/installer/productInstaller.ts
@@ -50,10 +50,11 @@ export async function clearInstalledIntoInterpreterMemento(
     const key = `${getInterpreterHash({ path: interpreterPath })}#${ProductNames.get(product)}`;
     await memento.update(key, undefined);
 }
-export async function isModulePresentInEnvironment(memento: Memento, product: Product, interpreter?: InterpreterUri) {
-    if (isResource(interpreter)) {
-        return;
-    }
+export function isModulePresentInEnvironmentCache(memento: Memento, product: Product, interpreter: PythonEnvironment) {
+    const key = `${getInterpreterHash(interpreter)}#${ProductNames.get(product)}`;
+    return memento.get<boolean>(key, false);
+}
+export async function isModulePresentInEnvironment(memento: Memento, product: Product, interpreter: PythonEnvironment) {
     const key = `${getInterpreterHash(interpreter)}#${ProductNames.get(product)}`;
     if (memento.get(key, false)) {
         return true;

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -962,13 +962,24 @@ export enum KernelInterpreterDependencyResponse {
 
 export const IKernelDependencyService = Symbol('IKernelDependencyService');
 export interface IKernelDependencyService {
+    /**
+     * @param {boolean} [ignoreCache] We cache the results of this call so we don't have to do it again (users rarely uninstall ipykernel).
+     */
     installMissingDependencies(
         resource: Resource,
         interpreter: PythonEnvironment,
         ui: IDisplayOptions,
-        token: CancellationToken
+        token: CancellationToken,
+        ignoreCache?: boolean
     ): Promise<void>;
-    areDependenciesInstalled(interpreter: PythonEnvironment, _token?: CancellationToken): Promise<boolean>;
+    /**
+     * @param {boolean} [ignoreCache] We cache the results of this call so we don't have to do it again (users rarely uninstall ipykernel).
+     */
+    areDependenciesInstalled(
+        interpreter: PythonEnvironment,
+        token?: CancellationToken,
+        ignoreCache?: boolean
+    ): Promise<boolean>;
 }
 
 export const IKernelVariableRequester = Symbol('IKernelVariableRequester');


### PR DESCRIPTION
Part of #7849

* If we've check if `IPyKernel` is installed, then cache that
* If `IPyKernel` isn't installed & kernel startup fails, ensure we double check if `IPyKernel` is installed & prompt the user to install that