### PR TITLE
Don't look for jupyter at startup with raw kernels

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -153,7 +153,6 @@ module.exports = {
         'src/test/datascience/data-viewing/dataViewerPDependencyService.unit.test.ts',
         'src/test/datascience/mockPythonService.ts',
         'src/test/datascience/testHelpersCore.ts',
-        'src/test/datascience/shiftEnterBanner.unit.test.ts',
         'src/test/datascience/executionServiceMock.ts',
         'src/test/datascience/mockCommandManager.ts',
         'src/test/datascience/mockInputBox.ts',

--- a/src/client/datascience/activation.ts
+++ b/src/client/datascience/activation.ts
@@ -68,6 +68,9 @@ export class Activation implements IExtensionSingleActivationService {
     @debounceAsync(500)
     @swallowExceptions('Failed to pre-warm daemon pool')
     private async PreWarmDaemonPool() {
+        // Note: we're pre-warming the daemon pool for the interpreter we're using to start jupyter.
+        // Thus if we're using raw kernels, then there's no point in pre-warming a daemon that will use
+        // the interpreter for jupyter.
         if (!this.extensionChecker.isPythonExtensionActive || this.rawSupported.isSupported) {
             // Skip prewarm if no python extension
             return;
@@ -76,6 +79,7 @@ export class Activation implements IExtensionSingleActivationService {
         if (!interpreter) {
             return;
         }
+        // Warm the daemon pool just for the interpreter used to start Jupyter.
         await this.factory.createDaemon<IPythonDaemonExecutionService>({
             daemonModule: JupyterDaemonModule,
             pythonPath: interpreter.path

--- a/src/client/datascience/activation.ts
+++ b/src/client/datascience/activation.ts
@@ -72,7 +72,7 @@ export class Activation implements IExtensionSingleActivationService {
         // Thus if we're using raw kernels, then there's no point in pre-warming a daemon that will use
         // the interpreter for jupyter.
         if (!this.extensionChecker.isPythonExtensionActive || this.rawSupported.isSupported) {
-            // Skip prewarm if no python extension
+            // Skip prewarm if no python extension or if we're using raw kernels.
             return;
         }
         const interpreter = await this.jupyterInterpreterService.getSelectedInterpreter();

--- a/src/client/datascience/notebook/notebookControllerManager.ts
+++ b/src/client/datascience/notebook/notebookControllerManager.ts
@@ -40,7 +40,6 @@ import { VSCodeNotebookController } from './vscodeNotebookController';
 import { INotebookControllerManager } from './types';
 import { InteractiveWindowView, JupyterNotebookView } from './constants';
 import { NotebookIPyWidgetCoordinator } from '../ipywidgets/notebookIPyWidgetCoordinator';
-import { InterpreterPackages } from '../telemetry/interpreterPackages';
 import { sendTelemetryEvent } from '../../telemetry';
 import { NotebookCellLanguageService } from './cellLanguageService';
 import { sendKernelListTelemetry } from '../telemetry/kernelTelemetry';
@@ -104,7 +103,6 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
         @inject(IRemoteKernelFinder) private readonly remoteKernelFinder: IRemoteKernelFinder,
         @inject(IPathUtils) private readonly pathUtils: IPathUtils,
         @inject(NotebookIPyWidgetCoordinator) private readonly widgetCoordinator: NotebookIPyWidgetCoordinator,
-        @inject(InterpreterPackages) private readonly interpreterPackages: InterpreterPackages,
         @inject(NotebookCellLanguageService) private readonly languageService: NotebookCellLanguageService,
         @inject(IWorkspaceService) private readonly workspace: IWorkspaceService,
         @inject(IPythonExtensionChecker) private readonly extensionChecker: IPythonExtensionChecker,
@@ -562,7 +560,6 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
                         this.languageService,
                         this.workspace,
                         this.isLocalLaunch ? 'local' : 'remote',
-                        this.interpreterPackages,
                         this.configuration,
                         this.widgetCoordinator,
                         this.docManager,

--- a/src/client/datascience/notebook/vscodeNotebookController.ts
+++ b/src/client/datascience/notebook/vscodeNotebookController.ts
@@ -50,11 +50,9 @@ import {
 } from '../jupyter/kernels/helpers';
 import { IKernel, IKernelProvider, KernelConnectionMetadata } from '../jupyter/kernels/types';
 import { PreferredRemoteKernelIdProvider } from '../notebookStorage/preferredRemoteKernelIdProvider';
-import { InterpreterPackages } from '../telemetry/interpreterPackages';
 import {
     initializeInteractiveOrNotebookTelemetryBasedOnUserAction,
-    sendKernelTelemetryEvent,
-    trackKernelResourceInformation
+    sendKernelTelemetryEvent
 } from '../telemetry/telemetry';
 import { KernelSocketInformation } from '../types';
 import { NotebookCellLanguageService } from './cellLanguageService';
@@ -120,7 +118,6 @@ export class VSCodeNotebookController implements Disposable {
         private readonly languageService: NotebookCellLanguageService,
         private readonly workspace: IWorkspaceService,
         private readonly localOrRemoteKernel: 'local' | 'remote',
-        private readonly interpreterPackages: InterpreterPackages,
         private readonly configuration: IConfigurationService,
         private readonly widgetCoordinator: NotebookIPyWidgetCoordinator,
         private readonly documentManager: IDocumentManager,
@@ -421,7 +418,6 @@ export class VSCodeNotebookController implements Disposable {
             default:
             // We don't know as its the default kernel on Jupyter server.
         }
-        trackKernelResourceInformation(document.uri, { kernelConnection: this.connection });
         sendKernelTelemetryEvent(document.uri, Telemetry.SwitchKernel);
         // If we have an existing kernel, then we know for a fact the user is changing the kernel.
         // Else VSC is just setting a kernel for a notebook after it has opened.
@@ -439,9 +435,6 @@ export class VSCodeNotebookController implements Disposable {
                         editor
                     )
                 );
-        }
-        if (selectedKernelConnectionMetadata.interpreter) {
-            this.interpreterPackages.trackPackages(selectedKernelConnectionMetadata.interpreter);
         }
 
         // Before we start the notebook, make sure the metadata is set to this new kernel.

--- a/src/client/datascience/preWarmVariables.ts
+++ b/src/client/datascience/preWarmVariables.ts
@@ -32,8 +32,8 @@ export class PreWarmActivatedJupyterEnvironmentVariables implements IExtensionSi
                 )
             );
             this.preWarmInterpreterVariables().ignoreErrors();
+            this.apiProvider.onDidActivatePythonExtension(this.preWarmInterpreterVariables, this, this.disposables);
         }
-        this.apiProvider.onDidActivatePythonExtension(this.preWarmInterpreterVariables, this, this.disposables);
     }
 
     private async preWarmInterpreterVariables() {

--- a/src/client/datascience/shiftEnterBanner.ts
+++ b/src/client/datascience/shiftEnterBanner.ts
@@ -11,7 +11,6 @@ import { IConfigurationService, IJupyterExtensionBanner, IPersistentStateFactory
 import * as localize from '../common/utils/localize';
 import { captureTelemetry, sendTelemetryEvent } from '../telemetry';
 import { Telemetry } from './constants';
-import { IJupyterExecution } from './types';
 
 export enum InteractiveShiftEnterStateKeys {
     ShowBanner = 'InteractiveShiftEnterBanner'
@@ -33,7 +32,6 @@ export class InteractiveShiftEnterBanner implements IJupyterExtensionBanner {
     constructor(
         @inject(IApplicationShell) private appShell: IApplicationShell,
         @inject(IPersistentStateFactory) private persistentState: IPersistentStateFactory,
-        @inject(IJupyterExecution) private jupyterExecution: IJupyterExecution,
         @inject(IConfigurationService) private configuration: IConfigurationService
     ) {
         this.initialize();
@@ -64,14 +62,6 @@ export class InteractiveShiftEnterBanner implements IJupyterExtensionBanner {
 
         const show = await this.shouldShowBanner();
         if (!show) {
-            return;
-        }
-
-        // This check is independent from shouldShowBanner, that just checks the persistent state.
-        // The Jupyter check should only happen once and should disable the banner if it fails (don't reprompt and don't recheck)
-        const jupyterFound = await this.jupyterExecution.isNotebookSupported();
-        if (!jupyterFound) {
-            await this.disableBanner();
             return;
         }
 

--- a/src/client/datascience/telemetry/interpreterPackageTracker.ts
+++ b/src/client/datascience/telemetry/interpreterPackageTracker.ts
@@ -13,6 +13,7 @@ import { isLocalLaunch } from '../jupyter/kernels/helpers';
 import { InterpreterPackages } from './interpreterPackages';
 import { INotebookControllerManager } from '../notebook/types';
 import { VSCodeNotebookController } from '../notebook/vscodeNotebookController';
+import { trackKernelResourceInformation } from './telemetry';
 
 @injectable()
 export class InterpreterPackageTracker implements IExtensionSingleActivationService {
@@ -50,6 +51,7 @@ export class InterpreterPackageTracker implements IExtensionSingleActivationServ
         if (!event.controller.connection.interpreter) {
             return;
         }
+        trackKernelResourceInformation(event.notebook.uri, { kernelConnection: event.controller.connection });
         await this.packages.trackPackages(event.controller.connection.interpreter);
     }
     private async trackUponActivation() {


### PR DESCRIPTION
Part of #7849

We pre-warm daemons (with jupyter interpreter) and look for Jupyter when we're dealing with raw kernels.
This is totally unnecessary, the only time jupyter interpreter is used is when exporting & the like (its ok for that to be fractionally slower than slowing all of extension & kernel startup). 