### PR TITLE
Better logging of arguments

### DIFF
--- a/src/client/api/pythonApi.ts
+++ b/src/client/api/pythonApi.ts
@@ -39,6 +39,7 @@ import { IEnvironmentActivationService } from '../interpreter/activation/types';
 import { IInterpreterQuickPickItem, IInterpreterSelector } from '../interpreter/configuration/types';
 import { IInterpreterService } from '../interpreter/contracts';
 import { IWindowsStoreInterpreter } from '../interpreter/locators/types';
+import { logValue, TraceOptions } from '../logging/trace';
 import { EnvironmentType, PythonEnvironment } from '../pythonEnvironments/info';
 import { areInterpreterPathsSame } from '../pythonEnvironments/info/interpreter';
 import { captureTelemetry, sendTelemetryEvent } from '../telemetry';
@@ -53,7 +54,6 @@ import {
     PythonApi
 } from './types';
 import { traceDecorators } from '../logging';
-import { TraceOptions } from '../logging/trace';
 
 /* eslint-disable max-classes-per-file */
 @injectable()
@@ -303,10 +303,10 @@ export class PythonInstaller implements IPythonInstaller {
 @injectable()
 export class EnvironmentActivationService implements IEnvironmentActivationService {
     constructor(@inject(IPythonApiProvider) private readonly apiProvider: IPythonApiProvider) {}
-    @traceDecorators.verbose('Getting activated env variables', TraceOptions.BeforeCall)
+    @traceDecorators.verbose('Getting activated env variables', TraceOptions.BeforeCall | TraceOptions.Arguments)
     public async getActivatedEnvironmentVariables(
         resource: Resource,
-        interpreter?: PythonEnvironment
+        @logValue<PythonEnvironment>('path') interpreter?: PythonEnvironment
     ): Promise<NodeJS.ProcessEnv | undefined> {
         const stopWatch = new StopWatch();
         const env = await this.apiProvider

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -6,7 +6,7 @@ import { IEnvironmentActivationService } from '../../interpreter/activation/type
 import { IInterpreterService } from '../../interpreter/contracts';
 import { IWindowsStoreInterpreter } from '../../interpreter/locators/types';
 import { IServiceContainer } from '../../ioc/types';
-import { TraceOptions } from '../../logging/trace';
+import { ignoreLogging, TraceOptions } from '../../logging/trace';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { IWorkspaceService } from '../application/types';
@@ -158,8 +158,9 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
             return (activatedProcPromise as unknown) as T;
         });
     }
+    @traceDecorators.verbose('Create activated Env', TraceOptions.BeforeCall | TraceOptions.Arguments)
     public async createActivatedEnvironment(
-        options: ExecutionFactoryCreateWithEnvironmentOptions
+        @ignoreLogging() options: ExecutionFactoryCreateWithEnvironmentOptions
     ): Promise<IPythonExecutionService> {
         // This should never happen, but if it does ensure we never run code accidentally in untrusted workspaces.
         if (!this.workspace.isTrusted) {

--- a/src/client/common/utils/decorators.ts
+++ b/src/client/common/utils/decorators.ts
@@ -215,21 +215,25 @@ export function displayProgress(title: string, location = ProgressLocation.Windo
 export type CallInfo = {
     kind: string; // "Class", etc.
     name: string;
+    methodName: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     args: any[];
+    target: Object;
 };
 
 // Return a decorator that traces the decorated function.
 export function trace(log: (c: CallInfo, t: TraceInfo) => void, logBeforeCall?: boolean) {
     // eslint-disable-next-line , @typescript-eslint/no-explicit-any
-    return function (_: Object, __: string, descriptor: TypedPropertyDescriptor<any>) {
+    return function (target: Object, methodName: string, descriptor: TypedPropertyDescriptor<any>) {
         const originalMethod = descriptor.value;
         // eslint-disable-next-line , @typescript-eslint/no-explicit-any
         descriptor.value = function (...args: any[]) {
             const call = {
                 kind: 'Class',
-                name: _ && _.constructor ? _.constructor.name : '',
-                args
+                name: target && target.constructor ? target.constructor.name : '',
+                args,
+                methodName,
+                target
             };
             // eslint-disable-next-line @typescript-eslint/no-this-alias, no-invalid-this
             const scope = this;

--- a/src/client/common/variables/environmentVariablesProvider.ts
+++ b/src/client/common/variables/environmentVariablesProvider.ts
@@ -3,9 +3,10 @@
 import { inject, injectable, optional } from 'inversify';
 import * as path from 'path';
 import { ConfigurationChangeEvent, Disposable, Event, EventEmitter, FileSystemWatcher, Uri } from 'vscode';
+import { TraceOptions } from '../../logging/trace';
 import { sendFileCreationTelemetry } from '../../telemetry/envFileTelemetry';
 import { IWorkspaceService } from '../application/types';
-import { traceVerbose } from '../logger';
+import { traceDecorators, traceVerbose } from '../logger';
 import { IDisposableRegistry } from '../types';
 import { InMemoryCache } from '../utils/cacheUtils';
 import { EnvironmentVariables, IEnvironmentVariablesProvider, IEnvironmentVariablesService } from './types';
@@ -41,6 +42,7 @@ export class EnvironmentVariablesProvider implements IEnvironmentVariablesProvid
         });
     }
 
+    @traceDecorators.verbose('Get Custom Env Variables', TraceOptions.BeforeCall | TraceOptions.Arguments)
     public async getEnvironmentVariables(resource?: Uri): Promise<EnvironmentVariables> {
         // Cache resource specific interpreter data
         const key = this.workspaceService.getWorkspaceFolderIdentifier(resource);

--- a/src/client/datascience/jupyter/kernels/helpers.ts
+++ b/src/client/datascience/jupyter/kernels/helpers.ts
@@ -450,7 +450,7 @@ export function findPreferredKernel(
     traceInfo(
         `Find preferred kernel for ${getDisplayPath(resource)} with metadata ${JSON.stringify(
             notebookMetadata || {}
-        )} & preferred interpreter ${JSON.stringify(preferredInterpreter || {})}`
+        )} & preferred interpreter ${getDisplayPath(preferredInterpreter?.path)}`
     );
     let index = -1;
 

--- a/src/client/datascience/jupyter/kernels/jupyterKernelService.ts
+++ b/src/client/datascience/jupyter/kernels/jupyterKernelService.ts
@@ -16,6 +16,7 @@ import { IFileSystem } from '../../../common/platform/types';
 import { ReadWrite, Resource } from '../../../common/types';
 import { noop } from '../../../common/utils/misc';
 import { IEnvironmentActivationService } from '../../../interpreter/activation/types';
+import { ignoreLogging, logValue } from '../../../logging/trace';
 import { PythonEnvironment } from '../../../pythonEnvironments/info';
 import { captureTelemetry, sendTelemetryEvent } from '../../../telemetry';
 import { Telemetry } from '../../constants';
@@ -51,9 +52,9 @@ export class JupyterKernelService {
     @traceDecorators.verbose('Check if a kernel is usable')
     public async ensureKernelIsUsable(
         resource: Resource,
-        kernel: KernelConnectionMetadata,
-        ui: IDisplayOptions,
-        cancelToken: CancellationToken
+        @logValue<KernelConnectionMetadata>('id') kernel: KernelConnectionMetadata,
+        @ignoreLogging() ui: IDisplayOptions,
+        @ignoreLogging() cancelToken: CancellationToken
     ): Promise<void> {
         // If we wish to wait for installation to complete, we must provide a cancel token.
         const tokenSource = new CancellationTokenSource();

--- a/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
@@ -26,7 +26,7 @@ import {
 } from '../../../common/types';
 import { Common, DataScience } from '../../../common/utils/localize';
 import { IServiceContainer } from '../../../ioc/types';
-import { TraceOptions } from '../../../logging/trace';
+import { ignoreLogging, TraceOptions } from '../../../logging/trace';
 import { EnvironmentType, PythonEnvironment } from '../../../pythonEnvironments/info';
 import { sendTelemetryEvent } from '../../../telemetry';
 import { getTelemetrySafeHashedString } from '../../../telemetry/helpers';
@@ -66,7 +66,7 @@ export class KernelDependencyService implements IKernelDependencyService {
         resource: Resource,
         interpreter: PythonEnvironment,
         ui: IDisplayOptions,
-        token: CancellationToken,
+        @ignoreLogging() token: CancellationToken,
         ignoreCache?: boolean
     ): Promise<void> {
         traceInfo(`installMissingDependencies ${getDisplayPath(interpreter.path)}`);

--- a/src/client/datascience/kernel-launcher/jupyterPaths.ts
+++ b/src/client/datascience/kernel-launcher/jupyterPaths.ts
@@ -8,6 +8,7 @@ import { CancellationToken } from 'vscode';
 import { IPlatformService } from '../../common/platform/types';
 import { IPathUtils } from '../../common/types';
 import { IEnvironmentVariablesProvider } from '../../common/variables/types';
+import { traceDecorators } from '../../logging';
 import { tryGetRealPath } from '../common';
 
 const winJupyterPath = path.join('AppData', 'Roaming', 'jupyter', 'kernels');
@@ -42,6 +43,7 @@ export class JupyterPaths {
      * This list comes from the docs here:
      * https://jupyter-client.readthedocs.io/en/stable/kernels.html#kernel-specs
      */
+    @traceDecorators.verbose('Get Kernelspec root path')
     public async getKernelSpecRootPaths(cancelToken?: CancellationToken): Promise<string[]> {
         // Paths specified in JUPYTER_PATH are supposed to come first in searching
         const paths: string[] = await this.getJupyterPathPaths(cancelToken);

--- a/src/client/datascience/kernel-launcher/kernelDaemonPool.ts
+++ b/src/client/datascience/kernel-launcher/kernelDaemonPool.ts
@@ -139,7 +139,7 @@ export class KernelDaemonPool implements IDisposable {
         });
     }
     private async preWarmKernelDaemon(resource: Resource) {
-        traceInfo(`Pre-warming kernel daemon for ${resource?.toString()}`);
+        traceInfo(`Pre-warming kernel daemon for ${getDisplayPath(resource)}`);
         const interpreter = await this.interpreterService.getActiveInterpreter(resource);
         if (!interpreter || !(await this.kernelDependencyService.areDependenciesInstalled(interpreter))) {
             return;

--- a/src/client/datascience/kernel-launcher/kernelLauncherDaemon.ts
+++ b/src/client/datascience/kernel-launcher/kernelLauncherDaemon.ts
@@ -13,6 +13,7 @@ import { IDisposable, Resource } from '../../common/types';
 import { noop } from '../../common/utils/misc';
 import { traceDecorators } from '../../logging';
 import { TraceOptions } from '../../logging/trace';
+import { logValue } from '../../logging/trace';
 import { PythonEnvironment } from '../../pythonEnvironments/info';
 import { IJupyterKernelSpec } from '../types';
 import { KernelDaemonPool } from './kernelDaemonPool';
@@ -37,8 +38,8 @@ export class PythonKernelLauncherDaemon implements IDisposable {
     public async launch(
         resource: Resource,
         workingDirectory: string,
-        kernelSpec: IJupyterKernelSpec,
-        interpreter?: PythonEnvironment
+        @logValue<IJupyterKernelSpec>('name') kernelSpec: IJupyterKernelSpec,
+        @logValue<PythonEnvironment>('path') interpreter?: PythonEnvironment
     ): Promise<{ observableOutput: ObservableExecutionResult<string>; daemon: IPythonKernelDaemon | undefined }> {
         // Check to see if we this is a python kernel that we can start using our daemon.
         const args = kernelSpec.argv.slice();

--- a/src/client/datascience/kernel-launcher/kernelProcess.ts
+++ b/src/client/datascience/kernel-launcher/kernelProcess.ts
@@ -43,7 +43,7 @@ import { KernelProcessExitedError } from '../errors/kernelProcessExitedError';
 import { PythonKernelDiedError } from '../errors/pythonKernelDiedError';
 import { KernelDiedError } from '../errors/kernelDiedError';
 import { KernelPortNotUsedTimeoutError } from '../errors/kernelPortNotUsedTimeoutError';
-import { TraceOptions } from '../../logging/trace';
+import { ignoreLogging, TraceOptions } from '../../logging/trace';
 
 // Launches and disposes a kernel process given a kernelspec and a resource or python interpreter.
 // Exposes connection information and the process itself.
@@ -385,7 +385,7 @@ export class KernelProcess implements IKernelProcess {
     }
 
     @traceDecorators.verbose('Launching kernel in kernelProcess.ts', TraceOptions.BeforeCall)
-    private async launchAsObservable(workingDirectory: string, cancelToken: CancellationToken) {
+    private async launchAsObservable(workingDirectory: string, @ignoreLogging() cancelToken: CancellationToken) {
         let exeObs: ObservableExecutionResult<string> | undefined;
 
         // Use a daemon only if the python extension is available. It requires the active interpreter

--- a/src/client/datascience/kernel-launcher/localKernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/localKernelFinder.ts
@@ -29,6 +29,7 @@ import { JupyterPaths } from './jupyterPaths';
 import { IFileSystem } from '../../common/platform/types';
 import { noop } from '../../common/utils/misc';
 import { createPromiseFromCancellation } from '../../common/cancellation';
+import { ignoreLogging, TraceOptions } from '../../logging/trace';
 
 const GlobalKernelSpecsCacheKey = 'JUPYTER_GLOBAL_KERNELSPECS';
 // This class searches for a kernel that matches the given kernel name.
@@ -48,12 +49,12 @@ export class LocalKernelFinder implements ILocalKernelFinder {
         @inject(IMemento) @named(GLOBAL_MEMENTO) private readonly globalState: Memento,
         @inject(IFileSystem) private readonly fs: IFileSystem
     ) {}
-    @traceDecorators.verbose('Find kernel spec')
+    @traceDecorators.verbose('Find kernel spec', TraceOptions.BeforeCall | TraceOptions.Arguments)
     @captureTelemetry(Telemetry.KernelFinderPerf)
     public async findKernel(
         resource: Resource,
         notebookMetadata?: nbformat.INotebookMetadata,
-        cancelToken?: CancellationToken
+        @ignoreLogging() cancelToken?: CancellationToken
     ): Promise<LocalKernelConnectionMetadata | undefined> {
         const resourceType = getResourceType(resource);
         const telemetrySafeLanguage =
@@ -117,7 +118,7 @@ export class LocalKernelFinder implements ILocalKernelFinder {
     @traceDecorators.error('List kernels failed')
     public async listKernels(
         resource: Resource,
-        cancelToken?: CancellationToken,
+        @ignoreLogging() cancelToken?: CancellationToken,
         useCache: 'useCache' | 'ignoreCache' = 'ignoreCache'
     ): Promise<LocalKernelConnectionMetadata[]> {
         const kernelsFromCachePromise =

--- a/src/client/datascience/kernel-launcher/localKernelSpecFinderBase.ts
+++ b/src/client/datascience/kernel-launcher/localKernelSpecFinderBase.ts
@@ -13,6 +13,7 @@ import { getDisplayPath } from '../../common/platform/fs-paths';
 import { IFileSystem } from '../../common/platform/types';
 import { ReadWrite } from '../../common/types';
 import { testOnlyMethod } from '../../common/utils/decorators';
+import { ignoreLogging } from '../../logging/trace';
 import { PythonEnvironment } from '../../pythonEnvironments/info';
 import { getInterpreterKernelSpecName } from '../jupyter/kernels/helpers';
 import { JupyterKernelSpec } from '../jupyter/kernels/jupyterKernelSpec';
@@ -57,7 +58,7 @@ export abstract class LocalKernelSpecFinderBase {
     protected async listKernelsWithCache(
         cacheKey: string,
         dependsOnPythonExtension: boolean,
-        finder: () => Promise<(KernelSpecConnectionMetadata | PythonKernelConnectionMetadata)[]>,
+        @ignoreLogging() finder: () => Promise<(KernelSpecConnectionMetadata | PythonKernelConnectionMetadata)[]>,
         ignoreCache?: boolean
     ): Promise<(KernelSpecConnectionMetadata | PythonKernelConnectionMetadata)[]> {
         // If we have already searched for this resource, then use that.

--- a/src/client/datascience/kernel-launcher/remoteKernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/remoteKernelFinder.ts
@@ -29,6 +29,7 @@ import { getResourceType } from '../common';
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import { getTelemetrySafeLanguage } from '../../telemetry/helpers';
 import { sendKernelListTelemetry } from '../telemetry/kernelTelemetry';
+import { ignoreLogging } from '../../logging/trace';
 
 // This class searches for a kernel that matches the given kernel name.
 // First it searches on a global persistent state, then on the installed python interpreters,
@@ -59,7 +60,7 @@ export class RemoteKernelFinder implements IRemoteKernelFinder {
         resource: Resource,
         connInfo: INotebookProviderConnection | undefined,
         notebookMetadata?: nbformat.INotebookMetadata,
-        _cancelToken?: CancellationToken
+        @ignoreLogging() _cancelToken?: CancellationToken
     ): Promise<KernelConnectionMetadata | undefined> {
         const resourceType = getResourceType(resource);
         const telemetrySafeLanguage =

--- a/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
@@ -169,9 +169,7 @@ export class HostRawNotebookProvider implements IRawNotebookProvider {
                 trackKernelResourceInformation(resource, { kernelConnection });
             }
             traceVerbose(
-                `Connecting to raw session for ${getDisplayPath(document.uri)} with connection ${JSON.stringify(
-                    kernelConnection
-                )}`
+                `Connecting to raw session for ${getDisplayPath(document.uri)} with connection ${kernelConnection.id}`
             );
             await rawSession.connect({ token: cancelToken, ui });
 

--- a/src/client/logging/_global.ts
+++ b/src/client/logging/_global.ts
@@ -119,7 +119,7 @@ export function tracing<T>(info: LogInfo, run: () => T, call?: CallInfo): T {
 }
 
 export namespace traceDecorators {
-    const DEFAULT_OPTS: TraceOptions = TraceOptions.Arguments | TraceOptions.ReturnValue;
+    const DEFAULT_OPTS: TraceOptions = TraceOptions.BeforeCall | TraceOptions.Arguments | TraceOptions.ReturnValue;
 
     export function verbose(message: string, opts: TraceOptions = DEFAULT_OPTS) {
         return createTracingDecorator([globalLogger], { message, opts, level: LogLevel.Trace });

--- a/src/client/logging/trace.ts
+++ b/src/client/logging/trace.ts
@@ -2,12 +2,14 @@
 // Licensed under the MIT License.
 'use strict';
 
+import type { Uri } from 'vscode';
 import { CallInfo, trace as traceDecorator } from '../common/utils/decorators';
 import { TraceInfo, tracing as _tracing } from '../common/utils/misc';
 import { sendTelemetryEvent } from '../telemetry';
 import { LogLevel } from './levels';
 import { ILogger, logToAll } from './logger';
 import { argsToLogString, returnValueToLogString } from './util';
+const homeAsLowerCase = (require('untildify')('~') || '').toLowerCase();
 
 // The information we want to log.
 export enum TraceOptions {
@@ -21,6 +23,63 @@ export enum TraceOptions {
     BeforeCall = 4
 }
 
+type ParameterLogInformation =
+    | {
+          parameterIndex: number;
+          propertyOfParaemterToLog: string;
+      }
+    | { parameterIndex: number; ignore: true };
+type MethodName = string | symbol;
+type ClassInstance = Object;
+const formattedParameters = new WeakMap<ClassInstance, Map<MethodName, ParameterLogInformation[]>>();
+export function logValue<T>(property: keyof T) {
+    return (
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        target: any,
+        methodName: string | symbol,
+        parameterIndex: number
+    ) => {
+        if (!formattedParameters.has(target)) {
+            formattedParameters.set(target, new Map<MethodName, ParameterLogInformation[]>());
+        }
+        let parameterInfos = formattedParameters.get(target);
+        if (!parameterInfos) {
+            formattedParameters.set(target, (parameterInfos = new Map<MethodName, ParameterLogInformation[]>()));
+        }
+        if (!parameterInfos.has(methodName)) {
+            parameterInfos.set(methodName, []);
+        }
+        const params = parameterInfos.get(methodName)!;
+        params.push({
+            parameterIndex,
+            propertyOfParaemterToLog: property as string
+        });
+    };
+}
+export function ignoreLogging() {
+    return (
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        target: any,
+        methodName: string | symbol,
+        parameterIndex: number
+    ) => {
+        if (!formattedParameters.has(target)) {
+            formattedParameters.set(target, new Map<MethodName, ParameterLogInformation[]>());
+        }
+        let parameterInfos = formattedParameters.get(target);
+        if (!parameterInfos) {
+            formattedParameters.set(target, (parameterInfos = new Map<MethodName, ParameterLogInformation[]>()));
+        }
+        if (!parameterInfos.has(methodName)) {
+            parameterInfos.set(methodName, []);
+        }
+        const params = parameterInfos.get(methodName)!;
+        params.push({
+            parameterIndex,
+            ignore: true
+        });
+    };
+}
 export function createTracingDecorator(loggers: ILogger[], logInfo: LogInfo) {
     return traceDecorator(
         (call, traced) => logResult(loggers, logInfo, traced, call),
@@ -54,19 +113,68 @@ function normalizeCall(call: CallInfo): CallInfo {
     if (!args) {
         args = [];
     }
-    return { kind, name, args };
+    return { kind, name, args, methodName: call.methodName || '', target: call.target || undefined };
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isUri(resource?: Uri | any): resource is Uri {
+    if (!resource) {
+        return false;
+    }
+    const uri = resource as Uri;
+    return typeof uri.path === 'string' && typeof uri.scheme === 'string';
+}
+
+function removeUserPaths(value: string) {
+    // Where possible strip user names from paths, then users will be more likely to provide the logs.
+    const indexOfStart = value.toLowerCase().indexOf(homeAsLowerCase);
+    return indexOfStart === -1 ? value : `~${value.substring(indexOfStart + homeAsLowerCase.length)}`;
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function formatArgument(target: Object, method: MethodName, arg: any, parameterIndex: number) {
+    if (isUri(arg)) {
+        // Where possible strip user names from paths, then users will be more likely to provide the logs.
+        return removeUserPaths(arg.fsPath);
+    }
+    const parameterInfos = formattedParameters.get(target)?.get(method);
+    const info = parameterInfos?.find((info) => info.parameterIndex === parameterIndex);
+    if (!info) {
+        return typeof arg === 'string' ? removeUserPaths(arg) : arg;
+    }
+    if ('ignore' in info && info.ignore) {
+        return '';
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let valueToLog: any = arg;
+    if ('propertyOfParaemterToLog' in info && info.propertyOfParaemterToLog) {
+        valueToLog = arg[info.propertyOfParaemterToLog];
+    }
+    return typeof valueToLog === 'string' ? removeUserPaths(valueToLog) : valueToLog;
+}
 function formatMessages(info: LogInfo, traced: TraceInfo, call?: CallInfo): string {
     call = normalizeCall(call!);
+    ``;
     const messages = [info.message];
     messages.push(`${call.kind} name = ${call.name}`.trim());
     if (traced) {
         messages.push(`completed in ${traced.elapsed}ms`);
         messages.push(`has a ${traced.returnValue ? 'truthy' : 'falsy'} return value`);
+    } else {
+        messages[messages.length - 1] = `${messages[messages.length - 1]} (started execution)`;
     }
     if ((info.opts & TraceOptions.Arguments) === TraceOptions.Arguments) {
-        messages.push(argsToLogString(call.args));
+        if (info.level === LogLevel.Trace) {
+            // This is slower, hence do this only when user enables trace logging.
+            messages.push(
+                argsToLogString(
+                    call.args.map((arg, index) =>
+                        call ? formatArgument(call.target, call.methodName, arg, index) : arg
+                    )
+                )
+            );
+        } else {
+            messages.push(argsToLogString(call.args));
+        }
     }
     if (traced && (info.opts & TraceOptions.ReturnValue) === TraceOptions.ReturnValue) {
         messages.push(returnValueToLogString(traced.returnValue));
@@ -77,7 +185,7 @@ function formatMessages(info: LogInfo, traced: TraceInfo, call?: CallInfo): stri
 function logResult(loggers: ILogger[], info: LogInfo, traced: TraceInfo, call?: CallInfo) {
     const formatted = formatMessages(info, traced, call);
     if (!traced) {
-        if (info.level) {
+        if (info.level && info.level !== LogLevel.Error) {
             logToAll(loggers, info.level, [formatted]);
         }
     } else if (traced.err === undefined) {


### PR DESCRIPTION
While working on perf related improvements & looking at some of the logs from Jims machine, it was very difficult to read the logs & get some useful information (for some cases).

**Changes:**
* Ability to define what parameters are NOT logged
* Ability to define what property of a parameter is logged (e.g. when passing PythonEnvironment as an argument, don't log the whole JSON blob, just log the path).
