### PR TITLE
Add 'jupyter.runStartupCommands' to top of the pylance concat file

### DIFF
--- a/news/2 Fixes/7993.md
+++ b/news/2 Fixes/7993.md
@@ -1,1 +1,3 @@
-Let code in 'jupyter.runStartupCommands' work with intellisense.
+Let code in 'jupyter.runStartupCommands' work with intellisense. 
+
+For example, if your startup commands were 'import pandas as pd', auto completion would now work automatically for 'pd.' without having to type the import first.

--- a/news/2 Fixes/7993.md
+++ b/news/2 Fixes/7993.md
@@ -1,0 +1,1 @@
+Let code in 'jupyter.runStartupCommands' work with intellisense.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3624,9 +3624,9 @@
             }
         },
         "@vscode/jupyter-lsp-middleware": {
-            "version": "0.2.24",
-            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.24.tgz",
-            "integrity": "sha512-S9RfLczr3SaGqAFqkL6ggSh4d3SRIw6LG2l/A1g1HvYFQ0i8lnXr1YxWWYWVwOPATjhb9yYuxX2xE9YWjPyeYg==",
+            "version": "0.2.25",
+            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.25.tgz",
+            "integrity": "sha512-dllNG0pu92KTTjxPgsqQEaZBPTwUWSoDG8lY/PDpLKnILAdajURaUFnNVbUAPJ6VKAHj3VoYkaqTlRajihUlHw==",
             "requires": {
                 "fast-myers-diff": "^3.0.1",
                 "sha.js": "^2.4.11",

--- a/package.json
+++ b/package.json
@@ -1986,7 +1986,7 @@
         "@jupyterlab/services": "^6.1.17",
         "@lumino/widgets": "^1.28.0",
         "@nteract/messaging": "^7.0.0",
-        "@vscode/jupyter-lsp-middleware": "^0.2.24",
+        "@vscode/jupyter-lsp-middleware": "^0.2.25",
         "ansi-to-html": "^0.6.7",
         "arch": "^2.1.0",
         "bootstrap": "^4.3.1",

--- a/src/client/datascience/notebook/intellisense/intellisenseProvider.ts
+++ b/src/client/datascience/notebook/intellisense/intellisenseProvider.ts
@@ -182,7 +182,7 @@ export class IntellisenseProvider implements INotebookLanguageClientProvider, IE
 
         if (setting) {
             // Cleanup the line feeds. User may have typed them into the settings UI so they will have an extra \\ on the front.
-            return setting.replace(/\\n/g, '\n');
+            return setting.replace(/\\n/g, '\n').replace(/\\r/g, '\r');
         }
         return '';
     }

--- a/src/client/datascience/notebook/intellisense/languageServer.ts
+++ b/src/client/datascience/notebook/intellisense/languageServer.ts
@@ -128,7 +128,8 @@ export class LanguageServer implements Disposable {
     public static async createLanguageServer(
         middlewareType: 'pylance' | 'jupyter',
         interpreter: PythonEnvironment,
-        shouldAllowIntellisense: (uri: Uri, interpreterId: string, interpreterPath: string) => boolean
+        shouldAllowIntellisense: (uri: Uri, interpreterId: string, interpreterPath: string) => boolean,
+        getNotebookHeader: (uri: Uri) => string
     ): Promise<LanguageServer | undefined> {
         const cancellationStrategy = new FileBasedCancellationStrategy();
         const serverOptions = await LanguageServer.createServerOptions(interpreter, cancellationStrategy);
@@ -143,13 +144,15 @@ export class LanguageServer implements Disposable {
                           () => noop, // Don't trace output. Slows things down too much
                           NOTEBOOK_SELECTOR,
                           interpreter.path,
-                          (uri) => shouldAllowIntellisense(uri, interpreterId, interpreter.path)
+                          (uri) => shouldAllowIntellisense(uri, interpreterId, interpreter.path),
+                          getNotebookHeader
                       )
                     : createPylanceMiddleware(
                           () => languageClient,
                           NOTEBOOK_SELECTOR,
                           interpreter.path,
-                          (uri) => shouldAllowIntellisense(uri, interpreterId, interpreter.path)
+                          (uri) => shouldAllowIntellisense(uri, interpreterId, interpreter.path),
+                          getNotebookHeader
                       );
 
             // Client options should be the same for all servers we support.


### PR DESCRIPTION
Fixes #7993 

Import the new concat doc I just fixed in https://github.com/microsoft/vscode-jupyter-lsp-middleware/pull/26. This imports the 'runstartupcommands' onto the top of the concat document sent to pylance.

