### PR TITLE
Faster activation of Python environments such as Conda

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -296,7 +296,6 @@ module.exports = {
         'src/client/interpreter/interpreterVersion.ts',
         'src/client/interpreter/activation/wrapperEnvironmentActivationService.ts',
         'src/client/interpreter/activation/terminalEnvironmentActivationService.ts',
-        'src/client/interpreter/activation/types.ts',
         'src/client/interpreter/activation/service.ts',
         'src/client/interpreter/display/shebangCodeLensProvider.ts',
         'src/client/interpreter/display/index.ts',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -563,7 +563,6 @@ module.exports = {
         'src/client/common/installer/pipEnvInstaller.ts',
         'src/client/common/installer/productService.ts',
         'src/client/common/installer/pipInstaller.ts',
-        'src/client/common/process/currentProcess.ts',
         'src/client/common/process/pythonToolService.ts',
         'src/client/common/process/internal/scripts/testing_tools.ts',
         'src/client/common/process/logger.ts',

--- a/src/client/api/pythonApi.ts
+++ b/src/client/api/pythonApi.ts
@@ -18,7 +18,7 @@ import { isCI } from '../common/constants';
 import { trackPackageInstalledIntoInterpreter } from '../common/installer/productInstaller';
 import { ProductNames } from '../common/installer/productNames';
 import { InterpreterUri } from '../common/installer/types';
-import { traceInfo, traceInfoIfCI } from '../common/logger';
+import { traceDecorators, traceInfo, traceInfoIfCI } from '../common/logger';
 import { getDisplayPath } from '../common/platform/fs-paths';
 import {
     GLOBAL_MEMENTO,
@@ -36,6 +36,7 @@ import { PythonExtension, Telemetry } from '../datascience/constants';
 import { InterpreterPackages } from '../datascience/telemetry/interpreterPackages';
 import { IInterpreterQuickPickItem, IInterpreterSelector } from '../interpreter/configuration/types';
 import { IInterpreterService } from '../interpreter/contracts';
+import { TraceOptions } from '../logging/trace';
 import { PythonEnvironment } from '../pythonEnvironments/info';
 import { areInterpreterPathsSame } from '../pythonEnvironments/info/interpreter';
 import { captureTelemetry, sendTelemetryEvent } from '../telemetry';
@@ -235,6 +236,7 @@ export class PythonInstaller implements IPythonInstaller {
         @inject(IMemento) @named(GLOBAL_MEMENTO) private readonly memento: Memento
     ) {}
 
+    @traceDecorators.verbose('Installing Product', TraceOptions.Arguments | TraceOptions.BeforeCall)
     public async install(
         product: Product,
         resource?: InterpreterUri,
@@ -333,6 +335,7 @@ export class InterpreterService implements IInterpreterService {
     }
 
     @captureTelemetry(Telemetry.InterpreterListingPerf)
+    @traceDecorators.verbose('Get Interpreters', TraceOptions.Arguments | TraceOptions.BeforeCall)
     public getInterpreters(resource?: Uri): Promise<PythonEnvironment[]> {
         this.hookupOnDidChangeInterpreterEvent();
         // Cache result as it only changes when the interpreter list changes or we add more workspace folders
@@ -344,6 +347,7 @@ export class InterpreterService implements IInterpreterService {
 
     private workspaceCachedActiveInterpreter = new Map<string, Promise<PythonEnvironment | undefined>>();
     @captureTelemetry(Telemetry.ActiveInterpreterListingPerf)
+    @traceDecorators.verbose('Get Active Interpreter', TraceOptions.Arguments | TraceOptions.BeforeCall)
     public getActiveInterpreter(resource?: Uri): Promise<PythonEnvironment | undefined> {
         this.hookupOnDidChangeInterpreterEvent();
         const workspaceId = this.workspace.getWorkspaceFolderIdentifier(resource);
@@ -375,6 +379,7 @@ export class InterpreterService implements IInterpreterService {
         return promise;
     }
 
+    @traceDecorators.verbose('Get Interpreter details', TraceOptions.Arguments | TraceOptions.BeforeCall)
     public async getInterpreterDetails(pythonPath: string, resource?: Uri): Promise<undefined | PythonEnvironment> {
         this.hookupOnDidChangeInterpreterEvent();
         try {

--- a/src/client/api/serviceRegistry.ts
+++ b/src/client/api/serviceRegistry.ts
@@ -4,13 +4,13 @@
 'use strict';
 
 import { IExtensionSingleActivationService } from '../activation/types';
+import { EnvironmentActivationService } from '../common/process/interpreterActivation';
 import { IEnvironmentActivationService } from '../interpreter/activation/types';
 import { IInterpreterSelector } from '../interpreter/configuration/types';
 import { IInterpreterService } from '../interpreter/contracts';
 import { InterpreterStatusBarVisibility } from '../interpreter/display/visibilityFilter';
 import { IServiceManager } from '../ioc/types';
 import {
-    EnvironmentActivationService,
     InterpreterSelector,
     InterpreterService,
     LanguageServerProvider,

--- a/src/client/api/types.ts
+++ b/src/client/api/types.ts
@@ -78,7 +78,7 @@ export type PythonApi = {
      */
     getActivatedEnvironmentVariables(
         resource: Resource,
-        interpreter?: PythonEnvironment,
+        interpreter: PythonEnvironment,
         allowExceptions?: boolean
     ): Promise<NodeJS.ProcessEnv | undefined>;
     /**

--- a/src/client/common/installer/productInstaller.ts
+++ b/src/client/common/installer/productInstaller.ts
@@ -92,14 +92,14 @@ export abstract class BaseInstaller {
 
     public async install(
         product: Product,
-        resource?: InterpreterUri,
+        interpreter: PythonEnvironment,
         cancel?: CancellationToken,
         reInstallAndUpdate?: boolean,
         installPipIfRequired?: boolean
     ): Promise<InstallerResponse> {
         return this.serviceContainer
             .get<IPythonInstaller>(IPythonInstaller)
-            .install(product, resource, cancel, reInstallAndUpdate, installPipIfRequired);
+            .install(product, interpreter, cancel, reInstallAndUpdate, installPipIfRequired);
     }
     @traceDecorators.verbose('Checking if product is installed')
     public async isInstalled(
@@ -158,19 +158,12 @@ export class DataScienceInstaller extends BaseInstaller {
     // Override base installer to support a more DS-friendly streamlined installation.
     public async install(
         product: Product,
-        interpreterUri?: InterpreterUri,
+        interpreter: PythonEnvironment,
         cancel?: CancellationToken,
         reInstallAndUpdate?: boolean,
         installPipIfRequired?: boolean
     ): Promise<InstallerResponse> {
-        // Precondition
-        if (isResource(interpreterUri)) {
-            throw new Error('All data science packages require an interpreter be passed in');
-        }
         const installer = this.serviceContainer.get<IPythonInstaller>(IPythonInstaller);
-
-        // At this point we know that `interpreterUri` is of type PythonInterpreter
-        const interpreter = interpreterUri as PythonEnvironment;
 
         // If we're on windows and user is using a shell other than cmd or powershell, then Python installer will fail to install
         // the packages in the terminal (gitbash, wsh are not supported by Python extension).
@@ -271,12 +264,12 @@ export class ProductInstaller implements IInstaller {
     public dispose() {}
     public async install(
         product: Product,
-        resource: InterpreterUri,
+        interpreter: PythonEnvironment,
         cancel?: CancellationToken,
         reInstallAndUpdate?: boolean,
         installPipIfRequired?: boolean
     ): Promise<InstallerResponse> {
-        return this.createInstaller().install(product, resource, cancel, reInstallAndUpdate, installPipIfRequired);
+        return this.createInstaller().install(product, interpreter, cancel, reInstallAndUpdate, installPipIfRequired);
     }
     public async isInstalled(product: Product, interpreter: PythonEnvironment): Promise<boolean | undefined> {
         return this.createInstaller().isInstalled(product, interpreter);

--- a/src/client/common/process/currentProcess.ts
+++ b/src/client/common/process/currentProcess.ts
@@ -8,6 +8,6 @@ import { EnvironmentVariables } from '../variables/types';
 @injectable()
 export class CurrentProcess {
     public get env(): EnvironmentVariables {
-        return (process.env as any) as EnvironmentVariables;
+        return (process.env as unknown) as EnvironmentVariables;
     }
 }

--- a/src/client/common/process/currentProcess.ts
+++ b/src/client/common/process/currentProcess.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+
+import { injectable } from 'inversify';
+import { EnvironmentVariables } from '../variables/types';
+
+@injectable()
+export class CurrentProcess {
+    public get env(): EnvironmentVariables {
+        return (process.env as any) as EnvironmentVariables;
+    }
+}

--- a/src/client/common/process/interpreterActivation.ts
+++ b/src/client/common/process/interpreterActivation.ts
@@ -1,0 +1,326 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+import '../../common/extensions';
+
+import { inject, injectable, named } from 'inversify';
+
+import { IWorkspaceService } from '../../common/application/types';
+import { IPlatformService } from '../../common/platform/types';
+import * as internalScripts from '../../common/process/internal/scripts';
+import { ExecutionResult, IProcessServiceFactory } from '../../common/process/types';
+import { GLOBAL_MEMENTO, IDisposable, IMemento, Resource } from '../../common/types';
+import { createDeferredFromPromise, sleep } from '../../common/utils/async';
+import { OSType } from '../../common/utils/platform';
+import { IEnvironmentVariablesProvider } from '../../common/variables/types';
+import { EnvironmentType, PythonEnvironment } from '../../pythonEnvironments/info';
+import { sendTelemetryEvent } from '../../telemetry';
+import { logValue, TraceOptions } from '../../logging/trace';
+import { getInterpreterHash } from '../../pythonEnvironments/info/interpreter';
+import { IPythonApiProvider } from '../../api/types';
+import { StopWatch } from '../utils/stopWatch';
+import { Telemetry } from '../../datascience/constants';
+import { Memento } from 'vscode';
+import { getDisplayPath } from '../platform/fs-paths';
+import { IEnvironmentActivationService } from '../../interpreter/activation/types';
+import { IInterpreterService } from '../../interpreter/contracts';
+import { CurrentProcess } from './currentProcess';
+import { traceDecorators, traceError, traceInfo, traceVerbose, traceWarning } from '../logger';
+
+const ENVIRONMENT_PREFIX = 'e8b39361-0157-4923-80e1-22d70d46dee6';
+const ENVIRONMENT_TIMEOUT = 30000;
+const CONDA_ENVIRONMENT_TIMEOUT = 60_000;
+
+export enum TerminalShellType {
+    commandPrompt = 'commandPrompt',
+    bash = 'bash'
+}
+
+// The shell under which we'll execute activation scripts.
+export const defaultShells = {
+    [OSType.Windows]: { shell: 'cmd', shellType: TerminalShellType.commandPrompt },
+    [OSType.OSX]: { shell: 'bash', shellType: TerminalShellType.bash },
+    [OSType.Linux]: { shell: 'bash', shellType: TerminalShellType.bash },
+    [OSType.Unknown]: undefined
+};
+export const PYTHON_WARNINGS = 'PYTHONWARNINGS';
+
+const condaRetryMessages = [
+    'The process cannot access the file because it is being used by another process',
+    'The directory is not empty'
+];
+
+const ENVIRONMENT_ACTIVATION_COMMAND_CACHE_KEY_PREFIX = 'ENVIRONMENT_ACTIVATION_COMMAND_CACHE_KEY_PREFIX_{0}';
+
+@injectable()
+export class EnvironmentActivationService implements IEnvironmentActivationService {
+    private readonly disposables: IDisposable[] = [];
+    private readonly activatedEnvVariablesCache = new Map<string, Promise<NodeJS.ProcessEnv | undefined>>();
+    private readonly envActivationCommands = new Map<string, Promise<string[] | undefined>>();
+    constructor(
+        @inject(IPlatformService) private readonly platform: IPlatformService,
+        @inject(IProcessServiceFactory) private processServiceFactory: IProcessServiceFactory,
+        @inject(CurrentProcess) private currentProcess: CurrentProcess,
+        @inject(IWorkspaceService) private workspace: IWorkspaceService,
+        @inject(IInterpreterService) private interpreterService: IInterpreterService,
+        @inject(IEnvironmentVariablesProvider) private readonly envVarsService: IEnvironmentVariablesProvider,
+        @inject(IPythonApiProvider) private readonly apiProvider: IPythonApiProvider,
+        @inject(IMemento) @named(GLOBAL_MEMENTO) private readonly memento: Memento
+    ) {
+        this.envVarsService.onDidEnvironmentVariablesChange(
+            () => this.activatedEnvVariablesCache.clear(),
+            this,
+            this.disposables
+        );
+
+        this.interpreterService.onDidChangeInterpreter(
+            () => this.activatedEnvVariablesCache.clear(),
+            this,
+            this.disposables
+        );
+    }
+
+    public dispose(): void {
+        this.disposables.forEach((d) => d.dispose());
+    }
+    @traceDecorators.verbose('Getting activated env variables', TraceOptions.BeforeCall | TraceOptions.Arguments)
+    public async getActivatedEnvironmentVariables(
+        resource: Resource,
+        @logValue<PythonEnvironment>('path') interpreter?: PythonEnvironment
+    ): Promise<NodeJS.ProcessEnv | undefined> {
+        const stopWatch = new StopWatch();
+        const envVariablesOurSelves = createDeferredFromPromise(
+            this.getActivatedEnvironmentVariablesOurselves(resource, interpreter)
+        );
+        const envVariablesFromPython = createDeferredFromPromise(
+            this.getActivatedEnvironmentVariablesFromPython(resource, interpreter)
+        );
+
+        await Promise.race([envVariablesOurSelves.promise, envVariablesFromPython.promise]);
+        void envVariablesFromPython.promise.then(() =>
+            traceVerbose(`Got env vars with python ${getDisplayPath(interpreter?.path)} in ${stopWatch.elapsedTime}ms`)
+        );
+        void envVariablesOurSelves.promise.then(() =>
+            traceVerbose(`Got env vars ourselves ${getDisplayPath(interpreter?.path)} in ${stopWatch.elapsedTime}ms`)
+        );
+        // If we got this using our way, and we have env variables use it.
+        if (envVariablesOurSelves.resolved) {
+            if (envVariablesOurSelves.value) {
+                traceVerbose(`Got env vars ourselves faster ${getDisplayPath(interpreter?.path)}`);
+                return envVariablesOurSelves.value;
+            } else {
+                traceVerbose(`Got env vars ourselves faster, but empty ${getDisplayPath(interpreter?.path)}`);
+            }
+        }
+        if (!envVariablesOurSelves.resolved) {
+            traceVerbose(`Got env vars with python ext faster ${getDisplayPath(interpreter?.path)}`);
+        }
+        return envVariablesFromPython.promise;
+    }
+    @traceDecorators.verbose(
+        'Getting activated env variables from Python',
+        TraceOptions.BeforeCall | TraceOptions.Arguments
+    )
+    private async getActivatedEnvironmentVariablesFromPython(
+        resource: Resource,
+        @logValue<PythonEnvironment>('path') interpreter?: PythonEnvironment
+    ): Promise<NodeJS.ProcessEnv | undefined> {
+        const stopWatch = new StopWatch();
+        const env = await this.apiProvider
+            .getApi()
+            .then((api) => api.getActivatedEnvironmentVariables(resource, interpreter, false));
+
+        const envType = interpreter?.envType;
+        sendTelemetryEvent(Telemetry.GetActivatedEnvironmentVariables, stopWatch.elapsedTime, {
+            envType,
+            failed: Object.keys(env || {}).length === 0
+        });
+        // We must get actiavted env variables for Conda env, if not running stuff against conda will not work.
+        // Hence we must log these as errors (so we can see them in jupyter logs).
+        if (!env && envType === EnvironmentType.Conda) {
+            traceError(`Failed to get activated conda env variables for ${getDisplayPath(interpreter?.path)}`);
+        }
+        return env;
+    }
+    @traceDecorators.verbose(
+        'Getting activated env variables ourselves',
+        TraceOptions.BeforeCall | TraceOptions.Arguments
+    )
+    private async getActivatedEnvironmentVariablesOurselves(
+        resource: Resource,
+        @logValue<PythonEnvironment>('path') interpreter?: PythonEnvironment
+    ): Promise<NodeJS.ProcessEnv | undefined> {
+        const workspaceKey = this.workspace.getWorkspaceFolderIdentifier(resource);
+        const key = `${workspaceKey}_${interpreter && getInterpreterHash(interpreter)}`;
+        const shellInfo = defaultShells[this.platform.osType];
+        if (!shellInfo) {
+            return;
+        }
+
+        if (this.activatedEnvVariablesCache.has(key)) {
+            return this.activatedEnvVariablesCache.get(key);
+        }
+
+        const promise = (async () => {
+            try {
+                let isPossiblyCondaEnv = false;
+                const [activationCommands, processService] = await Promise.all([
+                    this.getActivationCommands(resource, interpreter),
+                    this.processServiceFactory.create(resource)
+                ]);
+                if (!activationCommands || activationCommands.length === 0) {
+                    return;
+                }
+                traceVerbose(`Activation Commands received ${activationCommands} for shell ${shellInfo.shell}`);
+                isPossiblyCondaEnv = activationCommands.join(' ').toLowerCase().includes('conda');
+                // Run the activate command collect the environment from it.
+                const activationCommand = this.fixActivationCommands(activationCommands).join(' && ');
+                const customEnvVars = await this.envVarsService.getEnvironmentVariables(resource);
+                const hasCustomEnvVars = Object.keys(customEnvVars).length;
+                const env = hasCustomEnvVars ? customEnvVars : { ...this.currentProcess.env };
+
+                // Make sure python warnings don't interfere with getting the environment. However
+                // respect the warning in the returned values
+                const oldWarnings = env[PYTHON_WARNINGS];
+                env[PYTHON_WARNINGS] = 'ignore';
+
+                traceVerbose(`${hasCustomEnvVars ? 'Has' : 'No'} Custom Env Vars`);
+
+                // In order to make sure we know where the environment output is,
+                // put in a dummy echo we can look for
+                const [args, parse] = internalScripts.printEnvVariables();
+                args.forEach((arg, i) => {
+                    args[i] = arg.toCommandArgument();
+                });
+                const command = `${activationCommand} && echo '${ENVIRONMENT_PREFIX}' && python ${args.join(' ')}`;
+                traceVerbose(`Activating Environment to capture Environment variables, ${command}`);
+
+                // Do some wrapping of the call. For two reasons:
+                // 1) Conda activate can hang on certain systems. Fail after 30 seconds.
+                // See the discussion from hidesoon in this issue: https://github.com/Microsoft/vscode-python/issues/4424
+                // His issue is conda never finishing during activate. This is a conda issue, but we
+                // should at least tell the user.
+                // 2) Retry because of this issue here: https://github.com/microsoft/vscode-python/issues/9244
+                // This happens on AzDo machines a bunch when using Conda (and we can't dictate the conda version in order to get the fix)
+                let result: ExecutionResult<string> | undefined;
+                let tryCount = 1;
+                let returnedEnv: NodeJS.ProcessEnv | undefined;
+                while (!result) {
+                    try {
+                        result = await processService.shellExec(command, {
+                            env,
+                            shell: shellInfo.shell,
+                            timeout: isPossiblyCondaEnv ? CONDA_ENVIRONMENT_TIMEOUT : ENVIRONMENT_TIMEOUT,
+                            maxBuffer: 1000 * 1000,
+                            throwOnStdErr: false
+                        });
+
+                        try {
+                            // Try to parse the output, even if we have errors in stderr, its possible they are false positives.
+                            // If variables are available, then ignore errors (but log them).
+                            returnedEnv = this.parseEnvironmentOutput(result.stdout, parse);
+                        } catch (ex) {
+                            if (!result.stderr) {
+                                throw ex;
+                            }
+                        }
+                        if (result.stderr) {
+                            if (returnedEnv) {
+                                traceWarning('Got env variables but with errors', result.stderr);
+                            } else {
+                                throw new Error(`StdErr from ShellExec, ${result.stderr} for ${command}`);
+                            }
+                        }
+                    } catch (exc) {
+                        // Special case. Conda for some versions will state a file is in use. If
+                        // that's the case, wait and try again. This happens especially on AzDo
+                        const excString = exc.toString();
+                        if (condaRetryMessages.find((m) => excString.includes(m)) && tryCount < 10) {
+                            traceInfo(`Conda is busy, attempting to retry ...`);
+                            result = undefined;
+                            tryCount += 1;
+                            await sleep(500);
+                        } else {
+                            throw exc;
+                        }
+                    }
+                }
+
+                // Put back the PYTHONWARNINGS value
+                if (oldWarnings && returnedEnv) {
+                    returnedEnv[PYTHON_WARNINGS] = oldWarnings;
+                } else if (returnedEnv) {
+                    delete returnedEnv[PYTHON_WARNINGS];
+                }
+                return returnedEnv;
+            } catch (e) {
+                traceError('Failed to get activated enviornment variables ourselves', e);
+                return;
+            }
+        })();
+
+        promise.catch(() => {
+            if (this.activatedEnvVariablesCache.get(key) === promise) {
+                this.activatedEnvVariablesCache.delete(key);
+            }
+        });
+        this.activatedEnvVariablesCache.set(key, promise);
+
+        return promise;
+    }
+    @traceDecorators.verbose('Getting env activation commands', TraceOptions.BeforeCall | TraceOptions.Arguments)
+    private async getActivationCommands(
+        resource: Resource,
+        @logValue<PythonEnvironment>('path') interpreter?: PythonEnvironment
+    ): Promise<string[] | undefined> {
+        if (!interpreter?.path) {
+            return;
+        }
+        const key = ENVIRONMENT_ACTIVATION_COMMAND_CACHE_KEY_PREFIX.format(interpreter.path);
+        const cachedData = this.memento.get<string[]>(key, []);
+        if (cachedData && cachedData.length > 0) {
+            return cachedData;
+        }
+        if (this.envActivationCommands.has(key)) {
+            return this.envActivationCommands.get(key);
+        }
+        const shellInfo = defaultShells[this.platform.osType];
+        if (!shellInfo) {
+            return;
+        }
+        const promise = (async () => {
+            try {
+                const activationCommands = await this.apiProvider
+                    .getApi()
+                    .then(
+                        (api) =>
+                            api.getEnvironmentActivationShellCommands &&
+                            api.getEnvironmentActivationShellCommands(resource, interpreter)
+                    );
+
+                if (!activationCommands || activationCommands.length === 0) {
+                    return;
+                }
+                traceVerbose(`Activation Commands received ${activationCommands} for shell ${shellInfo.shell}`);
+                void this.memento.update(key, activationCommands);
+                return activationCommands;
+            } catch (ex) {
+                traceError(`Failed to get env activation commands for ${getDisplayPath(interpreter.path)}`, ex);
+                return;
+            }
+        })();
+        this.envActivationCommands.set(key, promise);
+        return promise;
+    }
+    protected fixActivationCommands(commands: string[]): string[] {
+        // Replace 'source ' with '. ' as that works in shell exec
+        return commands.map((cmd) => cmd.replace(/^source\s+/, '. '));
+    }
+    @traceDecorators.error('Failed to parse Environment variables')
+    @traceDecorators.verbose('parseEnvironmentOutput', TraceOptions.None)
+    protected parseEnvironmentOutput(output: string, parse: (out: string) => NodeJS.ProcessEnv | undefined) {
+        output = output.substring(output.indexOf(ENVIRONMENT_PREFIX) + ENVIRONMENT_PREFIX.length);
+        const js = output.substring(output.indexOf('{')).trim();
+        return parse(js);
+    }
+}

--- a/src/client/common/process/proc.ts
+++ b/src/client/common/process/proc.ts
@@ -3,7 +3,7 @@
 import { exec, execSync, spawn } from 'child_process';
 import { EventEmitter } from 'events';
 import { Observable } from 'rxjs/Observable';
-import { traceInfo } from '../logger';
+import { traceVerbose } from '../logger';
 
 import { IDisposable } from '../types';
 import { createDeferred } from '../utils/async';
@@ -194,7 +194,7 @@ export class ProcessService extends EventEmitter implements IProcessService {
     public shellExec(command: string, options: ShellOptions = {}): Promise<ExecutionResult<string>> {
         const shellOptions = this.getDefaultOptions(options);
         return new Promise((resolve, reject) => {
-            traceInfo(`Execing command ${command} with options ${JSON.stringify(shellOptions)}`);
+            traceVerbose(`Execing command ${command} with options ${JSON.stringify(shellOptions)}`);
             const proc = exec(command, shellOptions, (e, stdout, stderr) => {
                 if (e && e !== null) {
                     reject(e);

--- a/src/client/common/process/processFactory.ts
+++ b/src/client/common/process/processFactory.ts
@@ -5,6 +5,7 @@
 
 import { inject, injectable } from 'inversify';
 import { Uri } from 'vscode';
+import { TraceOptions } from '../../logging/trace';
 import { IWorkspaceService } from '../application/types';
 import { traceDecorators } from '../logger';
 import { IDisposableRegistry } from '../types';
@@ -21,7 +22,7 @@ export class ProcessServiceFactory implements IProcessServiceFactory {
         @inject(IDisposableRegistry) private readonly disposableRegistry: IDisposableRegistry,
         @inject(IWorkspaceService) private readonly workspace: IWorkspaceService
     ) {}
-    @traceDecorators.verbose('Create ProcessService')
+    @traceDecorators.verbose('Create ProcessService', TraceOptions.BeforeCall | TraceOptions.Arguments)
     public async create(resource?: Uri): Promise<IProcessService> {
         // This should never happen, but if it does ensure we never run code accidentally in untrusted workspaces.
         if (!this.workspace.isTrusted) {

--- a/src/client/common/process/serviceRegistry.ts
+++ b/src/client/common/process/serviceRegistry.ts
@@ -3,6 +3,7 @@
 
 import { IServiceManager } from '../../ioc/types';
 import { CondaService } from './condaService';
+import { CurrentProcess } from './currentProcess';
 import { BufferDecoder } from './decoder';
 import { ProcessServiceFactory } from './processFactory';
 import { PythonExecutionFactory } from './pythonExecutionFactory';
@@ -13,4 +14,5 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IProcessServiceFactory>(IProcessServiceFactory, ProcessServiceFactory);
     serviceManager.addSingleton<IPythonExecutionFactory>(IPythonExecutionFactory, PythonExecutionFactory);
     serviceManager.addSingleton<CondaService>(CondaService, CondaService);
+    serviceManager.addSingleton<CurrentProcess>(CurrentProcess, CurrentProcess);
 }

--- a/src/client/interpreter/activation/types.ts
+++ b/src/client/interpreter/activation/types.ts
@@ -10,7 +10,7 @@ export const IEnvironmentActivationService = Symbol('IEnvironmentActivationServi
 export interface IEnvironmentActivationService {
     getActivatedEnvironmentVariables(
         resource: Resource,
-        interpreter?: PythonEnvironment,
+        interpreter: PythonEnvironment,
         allowExceptions?: boolean
     ): Promise<NodeJS.ProcessEnv | undefined>;
 }

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -570,9 +570,25 @@ export interface IEventNamePropertyMapping {
          */
         envType?: EnvironmentType;
         /**
+         * Duplicate of `envType`, the property `envType` doesn't seem to be coming through.
+         * If we can get `envType`, then we'll deprecate this new property.
+         * Else we just deprecate & remote the old property.
+         */
+        pythonEnvType?: EnvironmentType;
+        /**
          * Whether the env variables were fetched successfully or not.
          */
         failed: boolean;
+        /**
+         * Source where the env variables were fetched from.
+         * If `python`, then env variables were fetched from Python extension.
+         * If `jupyter`, then env variables were fetched from Jupyter extension.
+         */
+        source: 'python' | 'jupyter';
+        /**
+         * Reason for not being able to get the env variables.
+         */
+         reason?: 'noActivationCommands' | 'unknownOS' | 'emptyVariables' | 'unhandledError';
     };
     [EventName.HASHED_PACKAGE_PERF]: never | undefined;
     /**

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -588,7 +588,7 @@ export interface IEventNamePropertyMapping {
         /**
          * Reason for not being able to get the env variables.
          */
-         reason?: 'noActivationCommands' | 'unknownOS' | 'emptyVariables' | 'unhandledError';
+        reason?: 'noActivationCommands' | 'unknownOS' | 'emptyVariables' | 'unhandledError';
     };
     [EventName.HASHED_PACKAGE_PERF]: never | undefined;
     /**

--- a/src/test/datascience/jupyter/kernels/jupyterKernelService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/jupyterKernelService.unit.test.ts
@@ -14,7 +14,6 @@ import { LocalKernelFinder } from '../../../../client/datascience/kernel-launche
 import { ILocalKernelFinder } from '../../../../client/datascience/kernel-launcher/types';
 import { IEnvironmentActivationService } from '../../../../client/interpreter/activation/types';
 import { IKernelDependencyService } from '../../../../client/datascience/types';
-import { EnvironmentActivationService } from '../../../../client/api/pythonApi';
 import { EnvironmentType } from '../../../../client/pythonEnvironments/info';
 import { EXTENSION_ROOT_DIR } from '../../../../client/constants';
 import * as path from 'path';
@@ -289,7 +288,7 @@ suite('DataScience - JupyterKernelService', () => {
         });
         when(fs.areLocalPathsSame(anything(), anything())).thenCall((a, b) => arePathsSame(a, b));
         when(fs.searchLocal(anything(), anything())).thenResolve([]);
-        appEnv = mock(EnvironmentActivationService);
+        appEnv = mock<IEnvironmentActivationService>();
         when(appEnv.getActivatedEnvironmentVariables(anything(), anything(), anything())).thenResolve({});
         kernelFinder = mock(LocalKernelFinder);
         testWorkspaceFolder = path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'datascience');


### PR DESCRIPTION
For #7849
* Get activated environment variable activation ourselves (& not using Python extension)
* Note: We still rely on python extension to generate the commands used to activate an environment

Here are some stats:
* Non-Conda - Our code takes 300-400ms and Python extension takes 1300-1500ms
* Conda - Our code takes 5s with conda and Python extension takes 10s 

So we're definitely saving a few seconds