### PR TITLE
Interactive widget should work with remote Jupyter

### DIFF
--- a/news/2 Fixes/8378.md
+++ b/news/2 Fixes/8378.md
@@ -1,0 +1,1 @@
+Ensure interactive widgets work when connecting to remote Jupyter (or when falling back to starting Jupyter locally).

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -20,7 +20,7 @@ import * as localize from '../../common/utils/localize';
 import { DataScience } from '../../common/utils/localize';
 import { captureTelemetry } from '../../telemetry';
 import { BaseJupyterSession, JupyterSessionStartError } from '../baseJupyterSession';
-import { Telemetry } from '../constants';
+import { Identifiers, Telemetry } from '../constants';
 import { reportAction } from '../progress/decorator';
 import { ReportableAction } from '../progress/types';
 import { IDisplayOptions, IJupyterConnection, ISessionWithSocket } from '../types';
@@ -32,6 +32,7 @@ import { KernelConnectionMetadata } from './kernels/types';
 import { SessionDisposedError } from '../errors/sessionDisposedError';
 import { DisplayOptions } from '../displayOptions';
 import { CancellationTokenSource } from 'vscode';
+import { noop } from '../../common/utils/misc';
 
 const jvscIdentifier = '-jvsc-';
 function getRemoteIPynbSuffix(): string {
@@ -133,6 +134,9 @@ export class JupyterSession extends BaseJupyterSession {
 
             // Make sure it is idle before we return
             await this.waitForIdleOnSession(newSession, this.idleTimeout);
+
+            // So that we don't have problems with ipywidgets, always register the default ipywidgets comm target.
+            newSession.kernel?.registerCommTarget(Identifiers.DefaultCommTarget, noop);
         } catch (exc) {
             // Don't swallow known exceptions.
             if (exc instanceof BaseError) {


### PR DESCRIPTION
For #8378

Basically interactive widgets has never worked with non-raw kernels.
@rchiodo (try the simple sample here https://github.com/microsoft/vscode-jupyter/issues/8378 and you'll see the `print` output doesn't update when using non-raw or remote).