### PR TITLE
Tests to ensure we do not prompt for python ext when not required

### DIFF
--- a/src/client/api/pythonApi.ts
+++ b/src/client/api/pythonApi.ts
@@ -137,6 +137,10 @@ export class PythonApiProvider implements IPythonApiProvider {
 export class PythonExtensionChecker implements IPythonExtensionChecker {
     private extensionChangeHandler: Disposable | undefined;
     private waitingOnInstallPrompt?: Promise<void>;
+    /**
+     * Used only for testsing
+     */
+    public static promptDispalyed?: boolean;
     constructor(
         @inject(IExtensions) private readonly extensions: IExtensions,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
@@ -164,6 +168,7 @@ export class PythonExtensionChecker implements IPythonExtensionChecker {
         if (this.waitingOnInstallPrompt) {
             return this.waitingOnInstallPrompt;
         }
+        PythonExtensionChecker.promptDispalyed = true;
         // Ask user if they want to install and then wait for them to actually install it.
         const yes = localize.Common.bannerLabelYes();
         const no = localize.Common.bannerLabelNo();

--- a/src/client/api/pythonApi.ts
+++ b/src/client/api/pythonApi.ts
@@ -140,7 +140,7 @@ export class PythonExtensionChecker implements IPythonExtensionChecker {
     /**
      * Used only for testsing
      */
-    public static promptDispalyed?: boolean;
+    public static promptDisplayed?: boolean;
     constructor(
         @inject(IExtensions) private readonly extensions: IExtensions,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
@@ -168,7 +168,7 @@ export class PythonExtensionChecker implements IPythonExtensionChecker {
         if (this.waitingOnInstallPrompt) {
             return this.waitingOnInstallPrompt;
         }
-        PythonExtensionChecker.promptDispalyed = true;
+        PythonExtensionChecker.promptDisplayed = true;
         // Ask user if they want to install and then wait for them to actually install it.
         const yes = localize.Common.bannerLabelYes();
         const no = localize.Common.bannerLabelNo();

--- a/src/test/datascience/notebook/nonPythonKernels.vscode.test.ts
+++ b/src/test/datascience/notebook/nonPythonKernels.vscode.test.ts
@@ -101,7 +101,7 @@ suite('DataScience - VSCode Notebook - Kernels (non-python-kernel) (slow)', () =
     });
     function verifyPromptWasNotDisplayed() {
         assert.strictEqual(
-            PythonExtensionChecker.promptDispalyed,
+            PythonExtensionChecker.promptDisplayed,
             undefined,
             'Prompt for requireing Python extension should not have been displayed'
         );

--- a/src/test/datascience/notebook/nonPythonKernels.vscode.test.ts
+++ b/src/test/datascience/notebook/nonPythonKernels.vscode.test.ts
@@ -103,7 +103,7 @@ suite('DataScience - VSCode Notebook - Kernels (non-python-kernel) (slow)', () =
         assert.strictEqual(
             PythonExtensionChecker.promptDisplayed,
             undefined,
-            'Prompt for requireing Python extension should not have been displayed'
+            'Prompt for requiring Python extension should not have been displayed'
         );
     }
     setup(async function () {

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -184,7 +184,7 @@ export async function run(): Promise<void> {
 
     /* eslint-disable no-console */
     console.time('Time taken to activate the extension');
-    console.log('Starting & waiting for Python extension to activate');
+    console.log('Starting & waiting for Jupyter extension to activate');
     await activateExtensionScript();
     console.timeEnd('Time taken to activate the extension');
 


### PR DESCRIPTION
E.g. for scenarios when user doesn't have python ext and opens a .net notebook.
Users shouldn't get prompted to isntall python extension in these cases.