### PR TITLE
Unified progress messages for kernels

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -655,7 +655,6 @@ module.exports = {
         'src/client/application/misc/joinMailingListPrompt.ts',
         'src/client/datascience/data-viewing/dataViewerMessageListener.ts',
         'src/client/datascience/progress/progressReporter.ts',
-        'src/client/datascience/progress/types.ts',
         'src/client/datascience/progress/decorator.ts',
         'src/client/datascience/ipywidgets/rceProvider.ts',
         'src/client/datascience/ipywidgets/remoteWidgetScriptSourceProvider.ts',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -655,7 +655,6 @@ module.exports = {
         'src/client/application/misc/joinMailingListPrompt.ts',
         'src/client/datascience/data-viewing/dataViewerMessageListener.ts',
         'src/client/datascience/progress/progressReporter.ts',
-        'src/client/datascience/progress/messages.ts',
         'src/client/datascience/progress/types.ts',
         'src/client/datascience/progress/decorator.ts',
         'src/client/datascience/ipywidgets/rceProvider.ts',

--- a/package.nls.json
+++ b/package.nls.json
@@ -243,7 +243,7 @@
     "DataScienceSurveyBanner.bannerLabelYes": "Yes, take survey now",
     "DataScienceSurveyBanner.bannerLabelNo": "No, thanks",
     "InteractiveShiftEnterBanner.bannerMessage": "Would you like to run code in the 'Interactive' window (an IPython console) for 'shift-enter'? Select 'No' to continue to run code in the Python Terminal. This can be changed later in settings.",
-    "DataScience.restartingKernelStatus": "Restarting Jupyter Kernel",
+    "DataScience.restartingKernelStatus": "Restarting Kernel {0}",
     "DataScience.executingCode": "Executing Cell",
     "DataScience.collapseAll": "Collapse all cell inputs",
     "DataScience.expandAll": "Expand all cell inputs",

--- a/package.nls.nl.json
+++ b/package.nls.nl.json
@@ -46,7 +46,7 @@
     "DataScienceSurveyBanner.bannerMessage": "Zou je alsjeblieft 2 minuten kunnen nemen om ons te vertellen hoe de Python-data-science-functionaliteiten voor jou werkt?",
     "DataScienceSurveyBanner.bannerLabelYes": "Ja, neem nu deel aan het onderzoek",
     "DataScienceSurveyBanner.bannerLabelNo": "Nee, bedankt",
-    "DataScience.restartingKernelStatus": "IPython-Kernel herstarten",
+    "DataScience.restartingKernelStatus": "IPython-Kernel herstarten {0}",
     "DataScience.executingCode": "Cel aan het uitvoeren",
     "DataScience.collapseAll": "Alle cel-invoeren sluiten",
     "DataScience.expandAll": "Alle cel-invoeren openen",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -219,7 +219,7 @@
     "DataScienceSurveyBanner.bannerLabelYes": "是，现在就接受调查",
     "DataScienceSurveyBanner.bannerLabelNo": "不，谢谢",
     "InteractiveShiftEnterBanner.bannerMessage": "是否在按下 'shift-enter' 时在'交互式'窗口（IPython 控制台）中运行代码？选择 'No' 继续在 Python 终端中运行代码。这可以之后在设置中更改。",
-    "DataScience.restartingKernelStatus": "正在重新启动 Jupyter 内核",
+    "DataScience.restartingKernelStatus": "正在重新启动 内核 {0}",
     "DataScience.executingCode": "正在执行单元",
     "DataScience.collapseAll": "折叠所有单元输入",
     "DataScience.expandAll": "展开所有单元输入",

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -21,7 +21,7 @@
     "Common.gotIt": "懂了！",
     "downloading.file": "正在下載 {0}...",
     "downloading.file.progress": "目前 {0}{1}，總共 {2} KB ({3}%)",
-    "DataScience.restartingKernelStatus": "正在重新啟動 Jupyter 核心",
+    "DataScience.restartingKernelStatus": "正在重新啟動 核心 {0}",
     "DataScience.collapseVariableExplorerLabel": "變數",
     "DataScience.notebookExport": "匯出",
     "DataScience.notebookExportAs.shorttitle": "匯出",

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -371,7 +371,7 @@ export namespace DataScience {
         "Don't Ask Again"
     );
     export const restartKernelMessageNo = localize('DataScience.restartKernelMessageNo', 'Cancel');
-    export const restartingKernelStatus = localize('DataScience.restartingKernelStatus', 'Restarting Jupyter Kernel');
+    export const restartingKernelStatus = localize('DataScience.restartingKernelStatus', 'Restarting Kernel {0}');
     export const restartingKernelFailed = localize(
         'DataScience.restartingKernelFailed',
         'Kernel restart failed. Jupyter server is hung. Please reload VS code.'

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -10,7 +10,7 @@ import { IWorkspaceService } from '../../common/application/types';
 import { Cancellation } from '../../common/cancellation';
 import { WrappedError } from '../../common/errors/types';
 import { traceInfo } from '../../common/logger';
-import { IConfigurationService, IDisposableRegistry } from '../../common/types';
+import { IConfigurationService, IDisposableRegistry, Resource } from '../../common/types';
 import * as localize from '../../common/utils/localize';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
@@ -218,6 +218,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
             );
 
             const connection = await this.startNotebookServer(
+                options.resource,
                 useDefaultConfig,
                 this.configuration.getSettings(undefined).jupyterCommandLineArguments,
                 workingDirectory,
@@ -244,12 +245,13 @@ export class JupyterExecutionBase implements IJupyterExecution {
     // eslint-disable-next-line
     @captureTelemetry(Telemetry.StartJupyter)
     private async startNotebookServer(
+        resource: Resource,
         useDefaultConfig: boolean,
         customCommandLine: string[],
         workingDirectory: string,
         cancelToken: CancellationToken
     ): Promise<IJupyterConnection> {
-        return this.notebookStarter.start(useDefaultConfig, customCommandLine, workingDirectory, cancelToken);
+        return this.notebookStarter.start(resource, useDefaultConfig, customCommandLine, workingDirectory, cancelToken);
     }
     private onSettingsChanged() {
         // Clear our usableJupyterInterpreter so that we recompute our values

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -21,8 +21,6 @@ import { DataScience } from '../../common/utils/localize';
 import { captureTelemetry } from '../../telemetry';
 import { BaseJupyterSession, JupyterSessionStartError } from '../baseJupyterSession';
 import { Telemetry } from '../constants';
-import { reportAction } from '../progress/decorator';
-import { ReportableAction } from '../progress/types';
 import { IDisplayOptions, IJupyterConnection, ISessionWithSocket } from '../types';
 import { JupyterInvalidKernelError } from '../errors/jupyterInvalidKernelError';
 import { JupyterWebSockets } from './jupyterWebSocket';
@@ -77,7 +75,6 @@ export class JupyterSession extends BaseJupyterSession {
         super(resource, kernelConnectionMetadata, restartSessionUsed, workingDirectory, interruptTimeout);
     }
 
-    @reportAction(ReportableAction.JupyterSessionWaitForIdleSession)
     @captureTelemetry(Telemetry.WaitForIdleJupyter, undefined, true)
     public waitForIdle(timeout: number): Promise<void> {
         // Wait for idle on this session

--- a/src/client/datascience/jupyter/kernels/jupyterKernelService.ts
+++ b/src/client/datascience/jupyter/kernels/jupyterKernelService.ts
@@ -21,8 +21,6 @@ import { PythonEnvironment } from '../../../pythonEnvironments/info';
 import { captureTelemetry, sendTelemetryEvent } from '../../../telemetry';
 import { Telemetry } from '../../constants';
 import { ILocalKernelFinder } from '../../kernel-launcher/types';
-import { reportAction } from '../../progress/decorator';
-import { ReportableAction } from '../../progress/types';
 import { IDisplayOptions, IJupyterKernelSpec, IKernelDependencyService } from '../../types';
 import { cleanEnvironment } from './helpers';
 import { JupyterKernelSpec } from './jupyterKernelSpec';
@@ -116,7 +114,6 @@ export class JupyterKernelService {
     // eslint-disable-next-line complexity
     @captureTelemetry(Telemetry.RegisterInterpreterAsKernel, undefined, true)
     @traceDecorators.error('Failed to register an interpreter as a kernel')
-    @reportAction(ReportableAction.KernelsRegisterKernel)
     // eslint-disable-next-line
     private async registerKernel(
         kernel: LocalKernelConnectionMetadata,

--- a/src/client/datascience/progress/kernelProgressReporter.ts
+++ b/src/client/datascience/progress/kernelProgressReporter.ts
@@ -129,9 +129,8 @@ export class KernelProgressReporter implements IExtensionSyncActivationService {
                         progressInfo.reporter.report({
                             message: progressInfo.progressList[progressInfo.progressList.length - 1]
                         });
-                    }
-                    // If we have no more messages, then remove the reporter.
-                    if (progressInfo.progressList.length === 0) {
+                    } else {
+                        // If we have no more messages, then remove the reporter.
                         KernelProgressReporter.instance!.kernelResourceProgressReporter.delete(key);
                         progressInfo.dispose();
                     }

--- a/src/client/datascience/progress/kernelProgressReporter.ts
+++ b/src/client/datascience/progress/kernelProgressReporter.ts
@@ -1,0 +1,182 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { inject, injectable } from 'inversify';
+import { Disposable, Progress, ProgressLocation, window } from 'vscode';
+import { IExtensionSyncActivationService } from '../../activation/types';
+import { disposeAllDisposables } from '../../common/helpers';
+import { IDisposable, IDisposableRegistry, Resource } from '../../common/types';
+import { createDeferred } from '../../common/utils/async';
+import { noop } from '../../common/utils/misc';
+import { getUserMessageForAction } from './messages';
+import { ReportableAction } from './types';
+
+/**
+ * Used to report any progress related to Kernels, such as start, restart, interrupt, install, etc.
+ */
+@injectable()
+export class KernelProgressReporter implements IExtensionSyncActivationService {
+    private static disposables = new Set<IDisposable>();
+    private static instance?: KernelProgressReporter;
+    private kernelResourceProgressReporter = new Map<
+        string,
+        {
+            pendingProgress: string[];
+            /**
+             * List of messages displayed in the progress UI.
+             */
+            progressList: string[];
+            reporter?: Progress<{ message?: string; increment?: number }>;
+        } & IDisposable
+    >();
+    constructor(@inject(IDisposableRegistry) disposables: IDisposableRegistry) {
+        disposables.push(this);
+        KernelProgressReporter.instance = this;
+    }
+    activate(): void {
+        //
+    }
+    public dispose() {
+        disposeAllDisposables(Array.from(KernelProgressReporter.disposables));
+    }
+
+    /**
+     * Creates the progress reporter, however if one exists for the same resource, then it will use the existing one.
+     */
+    public static createProgressReporter(resource: Resource, title: string): IDisposable {
+        if (!KernelProgressReporter.instance) {
+            return new Disposable(noop);
+        }
+
+        // If we have a progress reporter, then use it.
+        const key = resource ? resource.fsPath : '';
+        if (KernelProgressReporter.instance.kernelResourceProgressReporter.has(key)) {
+            return KernelProgressReporter.reportProgress(resource, title);
+        } else {
+            return KernelProgressReporter.createProgressReporterInternal(key, title);
+        }
+    }
+
+    /**
+     * Creates the progress reporter for the duration of a method.
+     * However if one exists for the same resource, then it will use the existing one.
+     */
+    public static wrapWithProgressReporter<T>(resource: Resource, title: string, cb: () => Promise<T>): Promise<T> {
+        const key = resource ? resource.fsPath : '';
+        if (!KernelProgressReporter.instance) {
+            return cb();
+        }
+        // If we have a progress reporter, then use it.
+        let progress: IDisposable;
+        if (KernelProgressReporter.instance.kernelResourceProgressReporter.has(key)) {
+            progress = KernelProgressReporter.reportProgressInternal(key, title);
+        } else {
+            progress = KernelProgressReporter.createProgressReporterInternal(key, title);
+        }
+        return cb().finally(() => progress.dispose());
+    }
+
+    /**
+     * Will not create a progress reporter, but only update the progress message.
+     * If the progress reporter is not already created, then the progress messages will be tracked so they
+     * can be displayed if a progress reporter is available before this progress completes.
+     */
+    public static reportProgress(resource: Resource, action: ReportableAction): IDisposable;
+    public static reportProgress(resource: Resource, title: string): IDisposable;
+    public static reportProgress(resource: Resource, option: string | ReportableAction): IDisposable {
+        const progressMessage = typeof option === 'string' ? option : getUserMessageForAction(option);
+        const key = resource ? resource.fsPath : '';
+        if (!progressMessage) {
+            return new Disposable(() => noop);
+        }
+
+        return KernelProgressReporter.reportProgressInternal(key, progressMessage || '');
+    }
+    private static reportProgressInternal(key: string, title: string): IDisposable {
+        if (!KernelProgressReporter.instance) {
+            return new Disposable(noop);
+        }
+        let progressInfo = KernelProgressReporter.instance.kernelResourceProgressReporter.get(key);
+        if (!progressInfo) {
+            progressInfo = {
+                pendingProgress: [],
+                progressList: [],
+                dispose: noop
+            };
+            KernelProgressReporter.instance!.kernelResourceProgressReporter.set(key, progressInfo);
+        }
+
+        if (progressInfo.reporter) {
+            progressInfo.progressList.push(title);
+            progressInfo.reporter.report({ message: title });
+        } else {
+            progressInfo.pendingProgress.push(title);
+        }
+        // Unwind the progress messages.
+        return {
+            dispose: () => {
+                try {
+                    if (!progressInfo?.reporter) {
+                        return;
+                    }
+                    // Find the list of progress messages just before this one.
+                    const index = progressInfo.progressList.findIndex((value) => value === title);
+                    if (index >= 0) {
+                        progressInfo.progressList.splice(index);
+                    }
+                    // If we have previous messages, display the last item.
+                    if (progressInfo.progressList.length > 0) {
+                        progressInfo.reporter.report({
+                            message: progressInfo.progressList[progressInfo.progressList.length - 1]
+                        });
+                    }
+                    // If we have no more messages, then remove the reporter.
+                    if (progressInfo.progressList.length === 0) {
+                        KernelProgressReporter.instance!.kernelResourceProgressReporter.delete(key);
+                        progressInfo.dispose();
+                    }
+                } catch (ex) {
+                    console.error(`Failed to dispose Progress reporter for ${key}`, ex);
+                }
+            }
+        };
+    }
+
+    private static createProgressReporterInternal(key: string, title: string) {
+        const deferred = createDeferred();
+        const disposable = new Disposable(() => deferred.resolve());
+        const existingInfo = KernelProgressReporter.instance!.kernelResourceProgressReporter.get(key) || {
+            pendingProgress: [] as string[],
+            progressList: [] as string[],
+            dispose: () => disposable.dispose()
+        };
+
+        KernelProgressReporter.instance!.kernelResourceProgressReporter.set(key, {
+            ...existingInfo,
+            dispose: () => disposable.dispose()
+        });
+        void window.withProgress({ location: ProgressLocation.Notification, title }, async (progress) => {
+            const info = KernelProgressReporter.instance!.kernelResourceProgressReporter.get(key);
+            if (!info) {
+                return;
+            }
+            info.reporter = progress;
+            // If we have any messages, then report them.
+            while (info.pendingProgress.length > 0) {
+                const message = info.pendingProgress.shift();
+                if (message) {
+                    info.progressList.push(message);
+                    progress.report({ message });
+                }
+            }
+            await deferred.promise;
+            if (KernelProgressReporter.instance!.kernelResourceProgressReporter.get(key) === info) {
+                KernelProgressReporter.instance!.kernelResourceProgressReporter.delete(key);
+            }
+            KernelProgressReporter.disposables.delete(disposable);
+        });
+        KernelProgressReporter.disposables.add(disposable);
+
+        return disposable;
+    }
+}

--- a/src/client/datascience/progress/messages.ts
+++ b/src/client/datascience/progress/messages.ts
@@ -8,18 +8,14 @@ import { ReportableAction } from './types';
 
 const progressMessages = {
     [ReportableAction.JupyterSessionWaitForIdleSession]: DataScience.waitingForJupyterSessionToBeIdle(),
-    [ReportableAction.KernelsGetKernelForLocalConnection]: DataScience.gettingListOfKernelsForLocalConnection(),
     [ReportableAction.KernelsGetKernelForRemoteConnection]: DataScience.gettingListOfKernelsForRemoteConnection(),
     [ReportableAction.KernelsGetKernelSpecs]: DataScience.gettingListOfKernelSpecs(),
     [ReportableAction.KernelsRegisterKernel]: DataScience.registeringKernel(),
     [ReportableAction.NotebookConnect]: DataScience.connectingToJupyter(),
     [ReportableAction.NotebookStart]: DataScience.startingJupyterNotebook(),
-    [ReportableAction.RawKernelConnecting]: DataScience.rawKernelConnectingSession(),
-    [ReportableAction.CheckingIfImportIsSupported]: DataScience.checkingIfImportIsSupported(), // Localize these later
     [ReportableAction.InstallingMissingDependencies]: DataScience.installingMissingDependencies(),
     [ReportableAction.ExportNotebookToPython]: DataScience.exportNotebookToPython(),
-    [ReportableAction.PerformingExport]: DataScience.performingExport(),
-    [ReportableAction.ConvertingToPDF]: DataScience.convertingToPDF()
+    [ReportableAction.PerformingExport]: DataScience.performingExport()
 };
 
 /**

--- a/src/client/datascience/progress/types.ts
+++ b/src/client/datascience/progress/types.ts
@@ -42,5 +42,5 @@ export enum ReportableAction {
     JupyterSessionWaitForIdleSession = 'JupyterSessionWaitForIdleSession',
     InstallingMissingDependencies = 'InstallingMissingDependencies',
     ExportNotebookToPython = 'ExportNotebookToPython',
-    PerformingExport = 'PerformingExport',
+    PerformingExport = 'PerformingExport'
 }

--- a/src/client/datascience/progress/types.ts
+++ b/src/client/datascience/progress/types.ts
@@ -16,11 +16,6 @@ export interface IProgressReporter {
  */
 export enum ReportableAction {
     /**
-     * Getting kernels for a local connection.
-     * If not found, user may have to select or we might register a kernel.
-     */
-    KernelsGetKernelForLocalConnection = 'KernelsStartGetKernelForLocalConnection',
-    /**
      * Getting kernels for a remote connection.
      * If not found, user may have to select.
      */
@@ -45,13 +40,7 @@ export enum ReportableAction {
      * Wait for session to go idle.
      */
     JupyterSessionWaitForIdleSession = 'JupyterSessionWaitForIdleSession',
-    /**
-     * Connecting a raw kernel session
-     */
-    RawKernelConnecting = 'RawKernelConnecting',
-    CheckingIfImportIsSupported = 'CheckingIfImportIsSupported',
     InstallingMissingDependencies = 'InstallingMissingDependencies',
     ExportNotebookToPython = 'ExportNotebookToPython',
     PerformingExport = 'PerformingExport',
-    ConvertingToPDF = 'ConvertingToPDF'
 }

--- a/src/client/datascience/raw-kernel/rawJupyterSession.ts
+++ b/src/client/datascience/raw-kernel/rawJupyterSession.ts
@@ -20,8 +20,6 @@ import { IpyKernelNotInstalledError } from '../errors/ipyKernelNotInstalledError
 import { getDisplayNameOrNameOfKernelConnection } from '../jupyter/kernels/helpers';
 import { KernelConnectionMetadata } from '../jupyter/kernels/types';
 import { IKernelLauncher } from '../kernel-launcher/types';
-import { reportAction } from '../progress/decorator';
-import { ReportableAction } from '../progress/types';
 import { RawSession } from '../raw-kernel/rawSession';
 import { sendKernelTelemetryEvent, trackKernelResourceInformation } from '../telemetry/telemetry';
 import { IDisplayOptions, ISessionWithSocket } from '../types';
@@ -61,7 +59,6 @@ export class RawJupyterSession extends BaseJupyterSession {
         super(resource, kernelConnection, restartSessionUsed, workingDirectory, interruptTimeout);
     }
 
-    @reportAction(ReportableAction.JupyterSessionWaitForIdleSession)
     public async waitForIdle(timeout: number): Promise<void> {
         // Wait until status says idle.
         if (this.session) {

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -165,6 +165,7 @@ import { KernelCommandListener } from './jupyter/kernels/kernelCommandListener';
 import { CellHashProviderFactory } from './editor-integration/cellHashProviderFactory';
 import { ExportToPythonPlain } from './export/exportToPythonPlain';
 import { ErrorRendererCommunicationHandler } from './errors/errorRendererComms';
+import { KernelProgressReporter } from './progress/kernelProgressReporter';
 
 // README: Did you make sure "dataScienceIocContainer.ts" has also been updated appropriately?
 
@@ -294,6 +295,7 @@ export function registerTypes(serviceManager: IServiceManager, inNotebookApiExpe
     serviceManager.addSingleton<INotebookWatcher>(INotebookWatcher, NotebookWatcher);
     serviceManager.addSingleton<IExtensionSyncActivationService>(IExtensionSyncActivationService, ExtensionRecommendationService);
     serviceManager.addSingleton<IExtensionSyncActivationService>(IExtensionSyncActivationService, ErrorRendererCommunicationHandler);
+    serviceManager.addSingleton<IExtensionSyncActivationService>(IExtensionSyncActivationService, KernelProgressReporter);
     serviceManager.addSingleton<IDebuggingManager>(IDebuggingManager, DebuggingManager, undefined, [IExtensionSingleActivationService]);
 
     registerNotebookTypes(serviceManager);

--- a/src/test/datascience/interactive-common/notebookServerProvider.unit.test.ts
+++ b/src/test/datascience/interactive-common/notebookServerProvider.unit.test.ts
@@ -11,7 +11,6 @@ import { DisplayOptions } from '../../../client/datascience/displayOptions';
 import { NotebookServerProvider } from '../../../client/datascience/interactive-common/notebookServerProvider';
 import { JupyterServerSelector } from '../../../client/datascience/jupyter/serverSelector';
 import { JupyterServerUriStorage } from '../../../client/datascience/jupyter/serverUriStorage';
-import { ProgressReporter } from '../../../client/datascience/progress/progressReporter';
 import { IJupyterExecution, INotebookServer } from '../../../client/datascience/types';
 import { IInterpreterService } from '../../../client/interpreter/contracts';
 import { PythonEnvironment } from '../../../client/pythonEnvironments/info';
@@ -29,7 +28,6 @@ function createTypeMoq<T>(tag: string): typemoq.IMock<T> {
 /* eslint-disable  */
 suite('DataScience - NotebookServerProvider', () => {
     let serverProvider: NotebookServerProvider;
-    let progressReporter: ProgressReporter;
     let configurationService: IConfigurationService;
     let jupyterExecution: IJupyterExecution;
     let interpreterService: IInterpreterService;
@@ -43,7 +41,6 @@ suite('DataScience - NotebookServerProvider', () => {
     const disposables: Disposable[] = [];
     let source: CancellationTokenSource;
     setup(() => {
-        progressReporter = mock(ProgressReporter);
         configurationService = mock<IConfigurationService>();
         jupyterExecution = mock<IJupyterExecution>();
         interpreterService = mock<IInterpreterService>();
@@ -61,7 +58,6 @@ suite('DataScience - NotebookServerProvider', () => {
 
         // Create the server provider
         serverProvider = new NotebookServerProvider(
-            instance(progressReporter),
             instance(configurationService),
             instance(jupyterExecution),
             instance(interpreterService),


### PR DESCRIPTION
Debt item, something that came up in a Code review.
@rchiodo /cc
Also fixes https://github.com/microsoft/vscode-jupyter/issues/8452

**Solution**
* We have a progress reporter specifically for kernels
* the flow is:
	* Create a progress reporter
	* Report progress anywhere in the code for a give resource (resource is unique per kernel)
* If we report progress and progress reporter is not avaialble, we keep track of the messages to be dispalyed
	* E.g. if auto start is enabled, and we start the kernel, but no progress is displayed
	* Then subsequently users hits the run button,   	
	* Now the progress reporter is created and we display the right progress messsage as we have a list of latest progress messages to be displayed
 

Now:
* If you start multiple notebooks, yo'ull get seperate progress indicators
* Also, this fixes (https://github.com/microsoft/vscode-jupyter/issues/8452) a bug with old approach, if you use Julia and run a cell, progress indicator will appear for a fraction of a few sconds, but after that nothing. The problem is we spend a few seconds waiting for idle, but no progress bar, and no spinner in cells either. hence its as though nothing is happening, now we have a progress bar until we get the spinner.