### PR TITLE
Clear separation between local and remote kernelspecs

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -527,7 +527,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         reason: 'normally' | 'onKernelDisposed' | 'onAnInterrupt' | 'onARestart' | 'withKeybinding';
 
 ## Locations Used
@@ -602,7 +602,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         status: 'installed' | 'notInstalled';
 
 ## Locations Used
@@ -1418,9 +1418,9 @@ No description provided
 
 ## Properties
 
-- 
+-
         where: 'activeInterpreter' | 'otherInterpreter' | 'path' | 'nowhere';
-- 
+-
         command: JupyterCommands;
 
 ## Locations Used
@@ -2178,7 +2178,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * The id of the extension registering with us to be displayed the dropdown list for notebook creation.
          */
@@ -2517,12 +2517,12 @@ Event can be removed. Not referenced anywhere
 
 ## Properties
 
-- 
+-
         /**
          * Extension we recommended the user to install.
          */
         extensionId: string;
-- 
+-
         /**
          * `displayed` - If prompt was displayed
          * `dismissed` - If prompt was displayed & dismissed by the user
@@ -3741,7 +3741,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         azure: boolean;
 
 ## Locations Used
@@ -4147,7 +4147,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * Whether this is the first time in the session.
          * (fetching kernels first time in the session is slower, later its cached).
@@ -4521,7 +4521,7 @@ No properties for event
 
 ## Properties
 
-- 
+-
         /**
          * Indicates whether the python extension is installed.
          * If we send telemetry fro this & this is `true`, then we have a bug.
@@ -4533,7 +4533,7 @@ No properties for event
 
 [src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts#L86](https://github.com/microsoft/vscode-jupyter/tree/main/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts#L86)
 ```typescript
-                kernelConnection.kind === 'startUsingKernelSpec'
+                kernelConnection.kind === 'startUsingLocalKernelSpec'
             ) {
                 if (!kernelConnection.interpreter) {
                     sendTelemetryEvent(Telemetry.AttemptedToLaunchRawKernelWithoutInterpreter, undefined, {
@@ -4869,38 +4869,38 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * Hash of the cell output mimetype
          *
          * @type {string}
          */
         hashedName: string;
-- 
+-
         hasText: boolean;
-- 
+-
         hasLatex: boolean;
-- 
+-
         hasHtml: boolean;
-- 
+-
         hasSvg: boolean;
-- 
+-
         hasXml: boolean;
-- 
+-
         hasJson: boolean;
-- 
+-
         hasImage: boolean;
-- 
+-
         hasGeo: boolean;
-- 
+-
         hasPlotly: boolean;
-- 
+-
         hasVega: boolean;
-- 
+-
         hasWidget: boolean;
-- 
+-
         hasJupyter: boolean;
-- 
+-
         hasVnd: boolean;
 
 ## Locations Used
@@ -4975,7 +4975,7 @@ Event can be removed. Not referenced anywhere
 
 ## Properties
 
-- 
+-
         // Result is null if user signalled cancellation or if we timed out
         isResultNull: boolean;
 
@@ -5673,7 +5673,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * Total time spent in attempting to start and connect to jupyter before giving up.
          *
@@ -5858,14 +5858,14 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * Whether this is the first time in the session.
          * (fetching kernels first time in the session is slower, later its cached).
          * This is a generic property supported for all telemetry (sent by decorators).
          */
         firstTime?: boolean;
-- 
+-
         /**
          * Whether this telemetry is for listing of all kernels or just python or just non-python.
          * (fetching kernels first time in the session is slower, later its cached).
@@ -5932,7 +5932,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         action: 'displayed';
 -  // Message displayed.
         /**
@@ -6033,7 +6033,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * Number of kernel specs.
          */
@@ -6389,7 +6389,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         action:
             | 'displayed' // Message displayed.
             | 'dismissed' // user dismissed the message.
@@ -6523,15 +6523,15 @@ No description provided
 
 ## Properties
 
-- 
+-
         moduleName: string;
-- 
+-
         /**
          * Whether the module was already (once before) installed into the python environment or
          * whether this already exists (detected via `pip list`)
          */
         isModulePresent?: 'true' | undefined;
-- 
+-
         action:
             | 'displayed' // Install prompt may have been displayed.
             | 'prompted' // Install prompt was displayed.
@@ -6546,7 +6546,7 @@ No description provided
             | 'dismissed';
 -  // User chose to dismiss the prompt.
         resourceType?: 'notebook' | 'interactive';
-- 
+-
         /**
          * Hash of the resource (notebook.uri or pythonfile.uri associated with this).
          * If we run the same notebook tomorrow, the hash will be the same.
@@ -6709,7 +6709,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         action:
             | 'displayed' // Message displayed.
             | 'dismissed' // user dismissed the message.
@@ -7229,7 +7229,7 @@ No properties for event
     @captureTelemetry(Telemetry.RawKernelStartRawSession, undefined, true)
     private async startRawSession(cancelToken?: CancellationToken, disableUI?: boolean): Promise<RawSession> {
         if (
-            this.kernelConnectionMetadata.kind !== 'startUsingKernelSpec' &&
+            this.kernelConnectionMetadata.kind !== 'startUsingLocalKernelSpec' &&
 ```
 
 </details>
@@ -7271,7 +7271,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * Number of kernel specs.
          */
@@ -7348,7 +7348,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * The result of the selection.
          * notSelected - No interpreter was selected.
@@ -7762,7 +7762,7 @@ export function sendNotebookOrKernelLanguageTelemetry(
 [src/client/datascience/notebook/vscodeNotebookController.ts#L379](https://github.com/microsoft/vscode-jupyter/tree/main/src/client/datascience/notebook/vscodeNotebookController.ts#L379)
 ```typescript
                 break;
-            case 'startUsingKernelSpec':
+            case 'startUsingLocalKernelSpec':
                 sendNotebookOrKernelLanguageTelemetry(
                     Telemetry.SwitchToExistingKernel,
                     this.connection.kernelSpec.language
@@ -7931,7 +7931,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         isErrorOutput: boolean;
 
 ## Locations Used
@@ -8524,28 +8524,28 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * Carries `true` if environment variables are present, `false` otherwise
          *
          * @type {boolean}
          */
         hasEnvVars?: boolean;
-- 
+-
         /**
          * Carries `true` if fetching environment variables failed, `false` otherwise
          *
          * @type {boolean}
          */
         failed?: boolean;
-- 
+-
         /**
          * Whether the environment was activated within a terminal or not.
          *
          * @type {boolean}
          */
         activatedInTerminal?: boolean;
-- 
+-
         /**
          * Whether the environment was activated by the wrapper class.
          * If `true`, this telemetry is sent by the class that wraps the two activation providers   .

--- a/src/client/datascience/extensionRecommendation.ts
+++ b/src/client/datascience/extensionRecommendation.ts
@@ -83,7 +83,10 @@ export class ExtensionRecommendationService implements IExtensionSyncActivationS
     }
 
     private onNotebookControllerSelected({ controller }: { controller: VSCodeNotebookController }) {
-        if (controller.connection.kind !== 'startUsingKernelSpec') {
+        if (
+            controller.connection.kind !== 'startUsingLocalKernelSpec' &&
+            controller.connection.kind !== 'startUsingRemoteKernelSpec'
+        ) {
             return;
         }
         if (isPythonKernelConnection(controller.connection)) {

--- a/src/client/datascience/jupyter/kernels/helpers.ts
+++ b/src/client/datascience/jupyter/kernels/helpers.ts
@@ -790,8 +790,8 @@ export function findPreferredKernel(
                 subScore === 5 && // This is a bit flakey. Number isn't consistent. Should probably just make the order of kernelspecs have the preferred one first
                 score === 5 &&
                 (metadata.kind === 'startUsingPythonInterpreter' ||
-                    metadata.kind === 'startUsingRemoteKernelSpec' ||
-                    (metadata.kind === 'startUsingLocalKernelSpec' &&
+                    ((metadata.kind === 'startUsingLocalKernelSpec' ||
+                        metadata.kind === 'startUsingRemoteKernelSpec') &&
                         metadata.kernelSpec.language === PYTHON_LANGUAGE)) &&
                 preferredInterpreterKernelSpecIndex >= 0 &&
                 bestScore <= 2

--- a/src/client/datascience/jupyter/kernels/types.ts
+++ b/src/client/datascience/jupyter/kernels/types.ts
@@ -44,7 +44,7 @@ export type LiveKernelConnectionMetadata = Readonly<{
  * This could be a raw kernel (spec might have path to executable for .NET or the like).
  * If the executable is not defined in kernelspec json, & it is a Python kernel, then we'll use the provided python interpreter.
  */
-export type KernelSpecConnectionMetadata = Readonly<{
+export type LocalKernelSpecConnectionMetadata = Readonly<{
     kernelModel?: undefined;
     kernelSpec: IJupyterKernelSpec;
     /**
@@ -53,7 +53,19 @@ export type KernelSpecConnectionMetadata = Readonly<{
      * This interpreter could also be the interpreter associated with the kernel spec that we are supposed to start.
      */
     interpreter?: PythonEnvironment;
-    kind: 'startUsingKernelSpec';
+    kind: 'startUsingLocalKernelSpec';
+    id: string;
+}>;
+/**
+ * Connection metadata for Remote Kernels started using kernelspec (JSON).
+ * This could be a raw kernel (spec might have path to executable for .NET or the like).
+ * If the executable is not defined in kernelspec json, & it is a Python kernel, then we'll use the provided python interpreter.
+ */
+export type RemoteKernelSpecConnectionMetadata = Readonly<{
+    kernelModel?: undefined;
+    interpreter?: undefined;
+    kernelSpec: IJupyterKernelSpec;
+    kind: 'startUsingRemoteKernelSpec';
     id: string;
 }>;
 /**
@@ -75,14 +87,15 @@ export type PythonKernelConnectionMetadata = Readonly<{
  */
 export type KernelConnectionMetadata =
     | Readonly<LiveKernelConnectionMetadata>
-    | Readonly<KernelSpecConnectionMetadata>
+    | Readonly<LocalKernelSpecConnectionMetadata>
+    | Readonly<RemoteKernelSpecConnectionMetadata>
     | Readonly<PythonKernelConnectionMetadata>;
 
 /**
  * Connection metadata for local kernels. Makes it easier to not have to check for the live connection type.
  */
 export type LocalKernelConnectionMetadata =
-    | Readonly<KernelSpecConnectionMetadata>
+    | Readonly<LocalKernelSpecConnectionMetadata>
     | Readonly<PythonKernelConnectionMetadata>;
 
 export interface IKernelSpecQuickPickItem<T extends KernelConnectionMetadata = KernelConnectionMetadata>

--- a/src/client/datascience/kernel-launcher/kernelLauncher.ts
+++ b/src/client/datascience/kernel-launcher/kernelLauncher.ts
@@ -17,7 +17,7 @@ import { IFileSystem } from '../../common/platform/types';
 import { IProcessServiceFactory, IPythonExecutionFactory } from '../../common/process/types';
 import { IDisposableRegistry, Resource } from '../../common/types';
 import { Telemetry } from '../constants';
-import { KernelSpecConnectionMetadata, PythonKernelConnectionMetadata } from '../jupyter/kernels/types';
+import { LocalKernelSpecConnectionMetadata, PythonKernelConnectionMetadata } from '../jupyter/kernels/types';
 import { IDisplayOptions, IKernelDependencyService } from '../types';
 import { KernelDaemonPool } from './kernelDaemonPool';
 import { KernelEnvironmentVariablesService } from './kernelEnvVarsService';
@@ -94,7 +94,7 @@ export class KernelLauncher implements IKernelLauncher {
     }
 
     public async launch(
-        kernelConnectionMetadata: KernelSpecConnectionMetadata | PythonKernelConnectionMetadata,
+        kernelConnectionMetadata: LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata,
         timeout: number,
         resource: Resource,
         workingDirectory: string,
@@ -123,7 +123,7 @@ export class KernelLauncher implements IKernelLauncher {
     }
 
     private async launchProcess(
-        kernelConnectionMetadata: KernelSpecConnectionMetadata | PythonKernelConnectionMetadata,
+        kernelConnectionMetadata: LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata,
         resource: Resource,
         workingDirectory: string,
         timeout: number,
@@ -217,7 +217,7 @@ export class KernelLauncher implements IKernelLauncher {
     }
 
     private async getKernelConnection(
-        kernelConnectionMetadata: KernelSpecConnectionMetadata | PythonKernelConnectionMetadata
+        kernelConnectionMetadata: LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata
     ): Promise<IKernelConnection> {
         const ports = await this.chainGetConnectionPorts();
         return {

--- a/src/client/datascience/kernel-launcher/kernelProcess.ts
+++ b/src/client/datascience/kernel-launcher/kernelProcess.ts
@@ -32,7 +32,7 @@ import {
     findIndexOfConnectionFile,
     isPythonKernelConnection
 } from '../jupyter/kernels/helpers';
-import { KernelSpecConnectionMetadata, PythonKernelConnectionMetadata } from '../jupyter/kernels/types';
+import { LocalKernelSpecConnectionMetadata, PythonKernelConnectionMetadata } from '../jupyter/kernels/types';
 import { IJupyterKernelSpec } from '../types';
 import { KernelDaemonPool } from './kernelDaemonPool';
 import { KernelEnvironmentVariablesService } from './kernelEnvVarsService';
@@ -51,7 +51,7 @@ export class KernelProcess implements IKernelProcess {
     public get exited(): Event<{ exitCode?: number; reason?: string }> {
         return this.exitEvent.event;
     }
-    public get kernelConnectionMetadata(): Readonly<KernelSpecConnectionMetadata | PythonKernelConnectionMetadata> {
+    public get kernelConnectionMetadata(): Readonly<LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata> {
         return this._kernelConnectionMetadata;
     }
     public get connection(): Readonly<IKernelConnection> {
@@ -77,12 +77,12 @@ export class KernelProcess implements IKernelProcess {
     private pythonDaemon?: IPythonKernelDaemon;
     private connectionFile?: string;
     private _launchKernelSpec?: IJupyterKernelSpec;
-    private readonly _kernelConnectionMetadata: Readonly<KernelSpecConnectionMetadata | PythonKernelConnectionMetadata>;
+    private readonly _kernelConnectionMetadata: Readonly<LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata>;
     constructor(
         private readonly processExecutionFactory: IProcessServiceFactory,
         private readonly daemonPool: KernelDaemonPool,
         private readonly _connection: IKernelConnection,
-        kernelConnectionMetadata: KernelSpecConnectionMetadata | PythonKernelConnectionMetadata,
+        kernelConnectionMetadata: LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata,
         private readonly fileSystem: IFileSystem,
         private readonly resource: Resource,
         private readonly extensionChecker: IPythonExtensionChecker,

--- a/src/client/datascience/kernel-launcher/kernelProcess.ts
+++ b/src/client/datascience/kernel-launcher/kernelProcess.ts
@@ -51,7 +51,9 @@ export class KernelProcess implements IKernelProcess {
     public get exited(): Event<{ exitCode?: number; reason?: string }> {
         return this.exitEvent.event;
     }
-    public get kernelConnectionMetadata(): Readonly<LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata> {
+    public get kernelConnectionMetadata(): Readonly<
+        LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata
+    > {
         return this._kernelConnectionMetadata;
     }
     public get connection(): Readonly<IKernelConnection> {
@@ -77,7 +79,9 @@ export class KernelProcess implements IKernelProcess {
     private pythonDaemon?: IPythonKernelDaemon;
     private connectionFile?: string;
     private _launchKernelSpec?: IJupyterKernelSpec;
-    private readonly _kernelConnectionMetadata: Readonly<LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata>;
+    private readonly _kernelConnectionMetadata: Readonly<
+        LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata
+    >;
     constructor(
         private readonly processExecutionFactory: IProcessServiceFactory,
         private readonly daemonPool: KernelDaemonPool,

--- a/src/client/datascience/kernel-launcher/localKernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/localKernelFinder.ts
@@ -15,7 +15,7 @@ import { Telemetry } from '../constants';
 import {
     findPreferredKernel,
     getDisplayNameOrNameOfKernelConnection,
-    getInterpreterHashInMetdata,
+    getInterpreterHashInMetadata,
     getLanguageInNotebookMetadata
 } from '../jupyter/kernels/helpers';
 import { LocalKernelConnectionMetadata } from '../jupyter/kernels/types';
@@ -182,7 +182,7 @@ export class LocalKernelFinder implements ILocalKernelFinder {
         if (!notebookMetadata) {
             return;
         }
-        const interpreterHash = getInterpreterHashInMetdata(notebookMetadata);
+        const interpreterHash = getInterpreterHashInMetadata(notebookMetadata);
         if (!interpreterHash) {
             return;
         }
@@ -238,7 +238,7 @@ export class LocalKernelFinder implements ILocalKernelFinder {
                             .catch(noop)
                     );
                 }
-                if (item.kind === 'startUsingKernelSpec' && item.kernelSpec?.specFile) {
+                if (item.kind === 'startUsingLocalKernelSpec' && item.kernelSpec?.specFile) {
                     // Possible the kernelspec file no longer exists, in such cases, exclude this cached kernel from the list.
                     promises.push(
                         this.fs

--- a/src/client/datascience/kernel-launcher/localKernelSpecFinderBase.ts
+++ b/src/client/datascience/kernel-launcher/localKernelSpecFinderBase.ts
@@ -17,7 +17,7 @@ import { ignoreLogging } from '../../logging/trace';
 import { PythonEnvironment } from '../../pythonEnvironments/info';
 import { getInterpreterKernelSpecName } from '../jupyter/kernels/helpers';
 import { JupyterKernelSpec } from '../jupyter/kernels/jupyterKernelSpec';
-import { KernelSpecConnectionMetadata, PythonKernelConnectionMetadata } from '../jupyter/kernels/types';
+import { LocalKernelSpecConnectionMetadata, PythonKernelConnectionMetadata } from '../jupyter/kernels/types';
 import { IJupyterKernelSpec } from '../types';
 
 type KernelSpecFileWithContainingInterpreter = { interpreter?: PythonEnvironment; kernelSpecFile: string };
@@ -33,7 +33,7 @@ export abstract class LocalKernelSpecFinderBase {
         {
             usesPython: boolean;
             wasPythonExtInstalled: boolean;
-            promise: Promise<(KernelSpecConnectionMetadata | PythonKernelConnectionMetadata)[]>;
+            promise: Promise<(LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata)[]>;
         }
     >();
 
@@ -58,9 +58,9 @@ export abstract class LocalKernelSpecFinderBase {
     protected async listKernelsWithCache(
         cacheKey: string,
         dependsOnPythonExtension: boolean,
-        @ignoreLogging() finder: () => Promise<(KernelSpecConnectionMetadata | PythonKernelConnectionMetadata)[]>,
+        @ignoreLogging() finder: () => Promise<(LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata)[]>,
         ignoreCache?: boolean
-    ): Promise<(KernelSpecConnectionMetadata | PythonKernelConnectionMetadata)[]> {
+    ): Promise<(LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata)[]> {
         // If we have already searched for this resource, then use that.
         const result = this.kernelSpecCache.get(cacheKey);
         if (result && !ignoreCache) {
@@ -77,7 +77,7 @@ export abstract class LocalKernelSpecFinderBase {
         const promise = finder().then((items) => {
             const distinctKernelMetadata = new Map<
                 string,
-                KernelSpecConnectionMetadata | PythonKernelConnectionMetadata
+                LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata
             >();
             traceInfoIfCI(
                 `Kernel specs for ${cacheKey?.toString() || 'undefined'} are \n ${JSON.stringify(items, undefined, 4)}`

--- a/src/client/datascience/kernel-launcher/localKnownPathKernelSpecFinder.ts
+++ b/src/client/datascience/kernel-launcher/localKnownPathKernelSpecFinder.ts
@@ -9,7 +9,7 @@ import { IFileSystem } from '../../common/platform/types';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { getKernelId, isKernelRegisteredByUs } from '../jupyter/kernels/helpers';
-import { KernelSpecConnectionMetadata, PythonKernelConnectionMetadata } from '../jupyter/kernels/types';
+import { LocalKernelSpecConnectionMetadata, PythonKernelConnectionMetadata } from '../jupyter/kernels/types';
 import { IJupyterKernelSpec } from '../types';
 import { LocalKernelSpecFinderBase, oldKernelsSpecFolderName } from './localKernelSpecFinderBase';
 import { JupyterPaths } from './jupyterPaths';
@@ -65,7 +65,7 @@ export class LocalKnownPathKernelSpecFinder extends LocalKernelSpecFinderBase {
     public async listKernelSpecs(
         includePythonKernels: boolean,
         cancelToken?: CancellationToken
-    ): Promise<(KernelSpecConnectionMetadata | PythonKernelConnectionMetadata)[]> {
+    ): Promise<(LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata)[]> {
         return this.listKernelsWithCache(includePythonKernels ? 'IncludePython' : 'ExcludePython', false, async () => {
             // First find the on disk kernel specs and interpreters
             const kernelSpecs = await this.findKernelSpecs(cancelToken);
@@ -79,8 +79,8 @@ export class LocalKnownPathKernelSpecFinder extends LocalKernelSpecFinderBase {
                 })
                 .map(
                     (k) =>
-                        <KernelSpecConnectionMetadata>{
-                            kind: 'startUsingKernelSpec',
+                        <LocalKernelSpecConnectionMetadata>{
+                            kind: 'startUsingLocalKernelSpec',
                             kernelSpec: k,
                             interpreter: undefined,
                             id: getKernelId(k)

--- a/src/client/datascience/kernel-launcher/remoteKernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/remoteKernelFinder.ts
@@ -14,7 +14,7 @@ import { findPreferredKernel, getKernelId, getLanguageInNotebookMetadata } from 
 import {
     KernelConnectionMetadata,
     LiveKernelConnectionMetadata,
-    KernelSpecConnectionMetadata
+    RemoteKernelSpecConnectionMetadata
 } from '../jupyter/kernels/types';
 import { PreferredRemoteKernelIdProvider } from '../notebookStorage/preferredRemoteKernelIdProvider';
 import {
@@ -121,8 +121,8 @@ export class RemoteKernelFinder implements IRemoteKernelFinder {
 
                 // Turn them both into a combined list
                 const mappedSpecs = specs.map((s) => {
-                    const kernel: KernelSpecConnectionMetadata = {
-                        kind: 'startUsingKernelSpec',
+                    const kernel: RemoteKernelSpecConnectionMetadata = {
+                        kind: 'startUsingRemoteKernelSpec',
                         kernelSpec: s,
                         id: getKernelId(s, undefined)
                     };

--- a/src/client/datascience/kernel-launcher/types.ts
+++ b/src/client/datascience/kernel-launcher/types.ts
@@ -9,7 +9,7 @@ import { ObservableExecutionResult } from '../../common/process/types';
 import { IAsyncDisposable, IDisposable, Resource } from '../../common/types';
 import {
     KernelConnectionMetadata,
-    KernelSpecConnectionMetadata,
+    LocalKernelSpecConnectionMetadata,
     LocalKernelConnectionMetadata,
     PythonKernelConnectionMetadata
 } from '../jupyter/kernels/types';
@@ -18,7 +18,7 @@ import { IDisplayOptions, INotebookProviderConnection } from '../types';
 export const IKernelLauncher = Symbol('IKernelLauncher');
 export interface IKernelLauncher {
     launch(
-        kernelConnectionMetadata: KernelSpecConnectionMetadata | PythonKernelConnectionMetadata,
+        kernelConnectionMetadata: LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata,
         timeout: number,
         resource: Resource,
         workingDirectory: string,
@@ -42,7 +42,7 @@ export interface IKernelConnection {
 
 export interface IKernelProcess extends IAsyncDisposable {
     readonly connection: Readonly<IKernelConnection>;
-    readonly kernelConnectionMetadata: Readonly<KernelSpecConnectionMetadata | PythonKernelConnectionMetadata>;
+    readonly kernelConnectionMetadata: Readonly<LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata>;
     /**
      * This event is triggered if the process is exited
      */

--- a/src/client/datascience/notebook/emptyNotebookCellLanguageService.ts
+++ b/src/client/datascience/notebook/emptyNotebookCellLanguageService.ts
@@ -67,7 +67,8 @@ export class EmptyNotebookCellLanguageService implements IExtensionSingleActivat
                 language = connection.kernelModel.language;
                 break;
             }
-            case 'startUsingKernelSpec': {
+            case 'startUsingRemoteKernelSpec':
+            case 'startUsingLocalKernelSpec': {
                 language = connection.kernelSpec.language;
                 break;
             }

--- a/src/client/datascience/notebook/kernelFilter/kernelFilterService.ts
+++ b/src/client/datascience/notebook/kernelFilter/kernelFilterService.ts
@@ -29,12 +29,12 @@ export class KernelFilterService implements IDisposable {
     }
     public isKernelHidden(kernelConnection: KernelConnectionMetadata): boolean {
         const hiddenList = this.getFilters();
-        if (kernelConnection.kind === 'connectToLiveKernel') {
+        if (kernelConnection.kind === 'connectToLiveKernel' || kernelConnection.kind === 'startUsingRemoteKernelSpec') {
             return false;
         }
         return hiddenList.some((item) => {
             if (
-                kernelConnection.kind === 'startUsingKernelSpec' &&
+                kernelConnection.kind === 'startUsingLocalKernelSpec' &&
                 item.type === 'jupyterKernelspec' &&
                 kernelConnection.kernelSpec.specFile
             ) {
@@ -97,7 +97,7 @@ export class KernelFilterService implements IDisposable {
             traceVerbose('Hiding default or live kernels via filter is not supported');
             return;
         }
-        if (connection.kind === 'startUsingKernelSpec' && connection.kernelSpec.specFile) {
+        if (connection.kind === 'startUsingLocalKernelSpec' && connection.kernelSpec.specFile) {
             return <KernelSpecFiter>{
                 path: this.pathUtils.getDisplayName(connection.kernelSpec.specFile),
                 type: 'jupyterKernelspec'

--- a/src/client/datascience/notebook/notebookControllerManager.ts
+++ b/src/client/datascience/notebook/notebookControllerManager.ts
@@ -278,15 +278,21 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
         let defaultPythonKernel: VSCodeNotebookController | undefined;
         let defaultPythonLanguageKernel: VSCodeNotebookController | undefined;
         controllers.forEach((item) => {
-            if (item.connection.kind === 'startUsingKernelSpec' && item.connection.kernelSpec.name === 'python') {
+            if (
+                (item.connection.kind === 'startUsingLocalKernelSpec' ||
+                    item.connection.kind === 'startUsingRemoteKernelSpec') &&
+                item.connection.kernelSpec.name === 'python'
+            ) {
                 defaultPythonKernel = item;
             } else if (
-                item.connection.kind === 'startUsingKernelSpec' &&
+                (item.connection.kind === 'startUsingLocalKernelSpec' ||
+                    item.connection.kind === 'startUsingRemoteKernelSpec') &&
                 item.connection.kernelSpec.name === 'python3'
             ) {
                 defaultPython3Kernel = item;
             } else if (
-                item.connection.kind === 'startUsingKernelSpec' &&
+                (item.connection.kind === 'startUsingLocalKernelSpec' ||
+                    item.connection.kind === 'startUsingRemoteKernelSpec') &&
                 item.connection.kernelSpec.language === PYTHON_LANGUAGE
             ) {
                 defaultPythonLanguageKernel = item;
@@ -705,7 +711,8 @@ export function getControllerDisplayName(kernelConnection: KernelConnectionMetad
         case 'connectToLiveKernel': {
             return currentDisplayName;
         }
-        case 'startUsingKernelSpec': {
+        case 'startUsingRemoteKernelSpec':
+        case 'startUsingLocalKernelSpec': {
             if (
                 kernelConnection.interpreter?.envType &&
                 kernelConnection.interpreter.envType !== EnvironmentType.Global

--- a/src/client/datascience/notebook/vscodeNotebookController.ts
+++ b/src/client/datascience/notebook/vscodeNotebookController.ts
@@ -201,7 +201,7 @@ export class VSCodeNotebookController implements Disposable {
         if (
             !pyVersion ||
             pyVersion.major >= 4 ||
-            (this.kernelConnection.kind !== 'startUsingKernelSpec' &&
+            (this.kernelConnection.kind !== 'startUsingLocalKernelSpec' &&
                 this.kernelConnection.kind !== 'startUsingPythonInterpreter')
         ) {
             return;
@@ -376,7 +376,10 @@ export class VSCodeNotebookController implements Disposable {
                 kernel.kernelConnectionMetadata,
                 kernel.info
             );
-            if (this.kernelConnection.kind === 'startUsingKernelSpec') {
+            if (
+                this.kernelConnection.kind === 'startUsingLocalKernelSpec' ||
+                this.kernelConnection.kind === 'startUsingRemoteKernelSpec'
+            ) {
                 if (kernel.info.status === 'ok') {
                     saveKernelInfo();
                 } else {
@@ -411,7 +414,8 @@ export class VSCodeNotebookController implements Disposable {
                     this.connection.kernelModel.language
                 );
                 break;
-            case 'startUsingKernelSpec':
+            case 'startUsingLocalKernelSpec':
+            case 'startUsingRemoteKernelSpec':
                 sendNotebookOrKernelLanguageTelemetry(
                     Telemetry.SwitchToExistingKernel,
                     this.connection.kernelSpec.language
@@ -476,7 +480,7 @@ function getKernelConnectionCategory(kernelConnection: KernelConnectionMetadata)
     switch (kernelConnection.kind) {
         case 'connectToLiveKernel':
             return DataScience.kernelCategoryForJupyterSession();
-        case 'startUsingKernelSpec':
+        case 'startUsingLocalKernelSpec':
             return DataScience.kernelCategoryForJupyterKernel();
         case 'startUsingPythonInterpreter': {
             switch (kernelConnection.interpreter.envType) {

--- a/src/client/datascience/notebook/vscodeNotebookController.ts
+++ b/src/client/datascience/notebook/vscodeNotebookController.ts
@@ -480,6 +480,7 @@ function getKernelConnectionCategory(kernelConnection: KernelConnectionMetadata)
     switch (kernelConnection.kind) {
         case 'connectToLiveKernel':
             return DataScience.kernelCategoryForJupyterSession();
+        case 'startUsingRemoteKernelSpec':
         case 'startUsingLocalKernelSpec':
             return DataScience.kernelCategoryForJupyterKernel();
         case 'startUsingPythonInterpreter': {

--- a/src/client/datascience/notebookStorage/baseModel.ts
+++ b/src/client/datascience/notebookStorage/baseModel.ts
@@ -38,7 +38,8 @@ export function updateNotebookMetadata(
         case 'connectToLiveKernel':
             language = kernelConnection.kernelModel.language;
             break;
-        case 'startUsingKernelSpec':
+        case 'startUsingRemoteKernelSpec':
+        case 'startUsingLocalKernelSpec':
             language = kernelConnection.kernelSpec.language;
             break;
         case 'startUsingPythonInterpreter':

--- a/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
@@ -116,7 +116,7 @@ export class HostRawNotebookProvider implements IRawNotebookProvider {
             if (
                 kernelConnection &&
                 isPythonKernelConnection(kernelConnection) &&
-                kernelConnection.kind === 'startUsingKernelSpec'
+                kernelConnection.kind === 'startUsingLocalKernelSpec'
             ) {
                 if (!kernelConnection.interpreter) {
                     sendTelemetryEvent(Telemetry.AttemptedToLaunchRawKernelWithoutInterpreter, undefined, {

--- a/src/client/datascience/raw-kernel/rawJupyterSession.ts
+++ b/src/client/datascience/raw-kernel/rawJupyterSession.ts
@@ -246,7 +246,7 @@ export class RawJupyterSession extends BaseJupyterSession {
     @captureTelemetry(Telemetry.RawKernelStartRawSession, undefined, true)
     private async startRawSession(options: { token: CancellationToken; ui: IDisplayOptions }): Promise<RawSession> {
         if (
-            this.kernelConnectionMetadata.kind !== 'startUsingKernelSpec' &&
+            this.kernelConnectionMetadata.kind !== 'startUsingLocalKernelSpec' &&
             this.kernelConnectionMetadata.kind !== 'startUsingPythonInterpreter'
         ) {
             throw new Error(

--- a/src/client/datascience/raw-kernel/rawKernel.ts
+++ b/src/client/datascience/raw-kernel/rawKernel.ts
@@ -126,7 +126,7 @@ export class RawKernel implements Kernel.IKernelConnection {
         this.socket.dispose();
     }
     public get spec(): Promise<KernelSpec.ISpecModel | undefined> {
-        if (this.kernelProcess.kernelConnectionMetadata.kind === 'startUsingKernelSpec') {
+        if (this.kernelProcess.kernelConnectionMetadata.kind === 'startUsingLocalKernelSpec') {
             const kernelSpec = cloneDeep(this.kernelProcess.kernelConnectionMetadata.kernelSpec) as any;
             const resources = 'resources' in kernelSpec ? kernelSpec.resources : {};
             return {

--- a/src/client/datascience/telemetry/kernelTelemetry.ts
+++ b/src/client/datascience/telemetry/kernelTelemetry.ts
@@ -25,7 +25,8 @@ export function sendKernelListTelemetry(
             case 'connectToLiveKernel':
                 counters.kernelLiveCount += 1;
                 break;
-            case 'startUsingKernelSpec':
+            case 'startUsingRemoteKernelSpec':
+            case 'startUsingLocalKernelSpec':
                 counters.kernelSpecCount += 1;
                 break;
             case 'startUsingPythonInterpreter': {

--- a/src/client/datascience/telemetry/telemetry.ts
+++ b/src/client/datascience/telemetry/telemetry.ts
@@ -214,7 +214,8 @@ export function trackKernelResourceInformation(resource: Resource, information: 
             case 'connectToLiveKernel':
                 language = kernelConnection.kernelModel.language;
                 break;
-            case 'startUsingKernelSpec':
+            case 'startUsingRemoteKernelSpec':
+            case 'startUsingLocalKernelSpec':
                 language = kernelConnection.kernelSpec.language;
                 break;
             case 'startUsingPythonInterpreter':

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -487,7 +487,10 @@ export interface IEventNamePropertyMapping {
      */
     [Telemetry.PythonKerneExecutableMatches]: {
         match: 'true' | 'false';
-        kernelConnectionType: 'startUsingKernelSpec' | 'startUsingPythonInterpreter';
+        kernelConnectionType:
+            | 'startUsingLocalKernelSpec'
+            | 'startUsingPythonInterpreter'
+            | 'startUsingRemoteKernelSpec';
     };
     /**
      * Sent when a jupyter session fails to start and we ask the user for a new kernel
@@ -1453,7 +1456,8 @@ export interface IEventNamePropertyMapping {
         kind:
             | 'startUsingPythonInterpreter'
             | 'startUsingDefaultKernel'
-            | 'startUsingKernelSpec'
+            | 'startUsingLocalKernelSpec'
+            | 'startUsingRemoteKernelSpec'
             | 'connectToLiveKernel';
     } & Partial<TelemetryErrorProperties>;
     /*

--- a/src/test/datascience/execution.unit.test.ts
+++ b/src/test/datascience/execution.unit.test.ts
@@ -986,7 +986,7 @@ suite('Jupyter Execution', async () => {
             display_name: 'somename'
         };
         const kernelMetadata: LocalKernelConnectionMetadata = {
-            kind: 'startUsingKernelSpec',
+            kind: 'startUsingLocalKernelSpec',
             kernelSpec,
             id: getKernelId(kernelSpec)
         };

--- a/src/test/datascience/extensionRecommendation.unit.test.ts
+++ b/src/test/datascience/extensionRecommendation.unit.test.ts
@@ -92,7 +92,7 @@ suite('DataScience Extension Recommendation', () => {
                     const kernelSpec: IJupyterKernelSpec = {
                         language
                     } as any;
-                    when(controller.connection).thenReturn({ kind: 'startUsingKernelSpec', kernelSpec, id: '' });
+                    when(controller.connection).thenReturn({ kind: 'startUsingLocalKernelSpec', kernelSpec, id: '' });
                     return instance(controller);
                 }
                 test('No recommendations for python Notebooks', async () => {

--- a/src/test/datascience/ipywidgets/localWidgetScriptSourceProvider.unit.test.ts
+++ b/src/test/datascience/ipywidgets/localWidgetScriptSourceProvider.unit.test.ts
@@ -56,7 +56,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
                 metadata: { interpreter: { sysPrefix: 'sysPrefix', path: 'pythonPath' } }
             },
             id: '',
-            kind: 'startUsingKernelSpec'
+            kind: 'startUsingLocalKernelSpec'
         });
         when(fs.searchLocal(anything(), anything())).thenResolve([]);
 
@@ -80,7 +80,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
                 metadata: { interpreter: { sysPrefix, path: 'pythonPath' } }
             },
             id: '',
-            kind: 'startUsingKernelSpec'
+            kind: 'startUsingLocalKernelSpec'
         });
         when(fs.searchLocal(anything(), anything())).thenResolve([]);
 
@@ -100,7 +100,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
         when(kernel.kernelConnectionMetadata).thenReturn({
             kernelSpec: { name: '', display_name: '', argv: [], path: kernelPath, language: PYTHON_LANGUAGE },
             id: '',
-            kind: 'startUsingKernelSpec'
+            kind: 'startUsingLocalKernelSpec'
         });
         when(fs.searchLocal(anything(), anything())).thenResolve([]);
 
@@ -121,7 +121,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
                 metadata: { interpreter: { sysPrefix: 'sysPrefix', path: 'pythonPath' } }
             },
             id: '',
-            kind: 'startUsingKernelSpec'
+            kind: 'startUsingLocalKernelSpec'
         });
         when(fs.searchLocal(anything(), anything())).thenResolve([]);
 
@@ -147,7 +147,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
                 metadata: { interpreter: { sysPrefix, path: 'pythonPath' } }
             },
             id: '',
-            kind: 'startUsingKernelSpec'
+            kind: 'startUsingLocalKernelSpec'
         });
         when(fs.searchLocal(anything(), anything())).thenResolve([
             // In order to match the real behavior, don't use join here
@@ -182,7 +182,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
                 metadata: { interpreter: { sysPrefix, path: 'pythonPath' } }
             },
             id: '',
-            kind: 'startUsingKernelSpec'
+            kind: 'startUsingLocalKernelSpec'
         });
         when(fs.searchLocal(anything(), anything())).thenResolve([
             // In order to match the real behavior, don't use join here
@@ -215,7 +215,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
                 metadata: { interpreter: { sysPrefix, path: 'pythonPath' } }
             },
             id: '',
-            kind: 'startUsingKernelSpec'
+            kind: 'startUsingLocalKernelSpec'
         });
         when(fs.searchLocal(anything(), anything())).thenResolve([
             // In order to match the real behavior, don't use join here

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -83,7 +83,7 @@ suite('DataScience - JupyterSession', () => {
         connection = mock<IJupyterConnection>();
         mockKernelSpec = {
             id: 'xyz',
-            kind: 'startUsingKernelSpec',
+            kind: 'startUsingLocalKernelSpec',
             kernelSpec: {
                 argv: [],
                 display_name: '',
@@ -139,7 +139,7 @@ suite('DataScience - JupyterSession', () => {
         );
     }
     setup(() => createJupyterSession());
-    async function connect(kind: 'startUsingKernelSpec' | 'connectToLiveKernel' = 'startUsingKernelSpec') {
+    async function connect(kind: 'startUsingLocalKernelSpec' | 'connectToLiveKernel' = 'startUsingLocalKernelSpec') {
         const nbFile = 'file path';
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         when(contentsManager.newUntitled(anything())).thenResolve({ path: nbFile } as any);
@@ -189,7 +189,7 @@ suite('DataScience - JupyterSession', () => {
                 when(session.isRemoteSession).thenReturn(true);
                 when(session.kernelConnectionMetadata).thenReturn({
                     id: '',
-                    kind: 'startUsingKernelSpec',
+                    kind: 'startUsingLocalKernelSpec',
                     kernelSpec: {} as any
                 });
                 when(session.shutdown()).thenResolve();
@@ -237,7 +237,7 @@ suite('DataScience - JupyterSession', () => {
                 when(session.isRemoteSession).thenReturn(true);
                 when(session.kernelConnectionMetadata).thenReturn({
                     id: '',
-                    kind: 'startUsingKernelSpec',
+                    kind: 'startUsingLocalKernelSpec',
                     kernelSpec: {} as any
                 });
                 when(session.shutdown()).thenResolve();

--- a/src/test/datascience/jupyter/kernels/jupyterKernelService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/jupyterKernelService.unit.test.ts
@@ -98,7 +98,7 @@ suite('DataScience - JupyterKernelService', () => {
             id: '2'
         },
         {
-            kind: 'startUsingKernelSpec',
+            kind: 'startUsingLocalKernelSpec',
             kernelSpec: {
                 specFile: '\\usr\\share\\jupyter\\kernels\\julia.json',
                 name: 'julia',
@@ -154,7 +154,7 @@ suite('DataScience - JupyterKernelService', () => {
             id: '5'
         },
         {
-            kind: 'startUsingKernelSpec',
+            kind: 'startUsingLocalKernelSpec',
             kernelSpec: {
                 specFile: '\\usr\\local\\share\\jupyter\\kernels\\julia.json',
                 name: 'julia',
@@ -210,7 +210,7 @@ suite('DataScience - JupyterKernelService', () => {
             id: '8'
         },
         {
-            kind: 'startUsingKernelSpec',
+            kind: 'startUsingLocalKernelSpec',
             kernelSpec: {
                 specFile: 'C:\\Users\\Rich\\.local\\share\\jupyter\\kernels\\julia.json',
                 name: 'julia',

--- a/src/test/datascience/kernelLauncher.vscode.test.ts
+++ b/src/test/datascience/kernelLauncher.vscode.test.ts
@@ -64,7 +64,7 @@ suite('DataScience - Kernel Launcher', () => {
         let exitExpected = false;
         const deferred = createDeferred<boolean>();
         const kernel = await kernelLauncher.launch(
-            { kernelSpec, kind: 'startUsingKernelSpec', id: '1' },
+            { kernelSpec, kind: 'startUsingLocalKernelSpec', id: '1' },
             -1,
             undefined,
             process.cwd(),
@@ -107,7 +107,7 @@ suite('DataScience - Kernel Launcher', () => {
         };
 
         const kernel = await kernelLauncher.launch(
-            { kernelSpec: spec, kind: 'startUsingKernelSpec', id: '1' },
+            { kernelSpec: spec, kind: 'startUsingLocalKernelSpec', id: '1' },
             30_000,
             undefined,
             process.cwd(),
@@ -142,7 +142,7 @@ suite('DataScience - Kernel Launcher', () => {
         };
 
         const kernel = await kernelLauncher.launch(
-            { kernelSpec: spec, kind: 'startUsingKernelSpec', id: '1' },
+            { kernelSpec: spec, kind: 'startUsingLocalKernelSpec', id: '1' },
             30_000,
             undefined,
             process.cwd(),
@@ -195,7 +195,7 @@ suite('DataScience - Kernel Launcher', () => {
 
     test('Bind with ZMQ', async function () {
         const kernel = await kernelLauncher.launch(
-            { kernelSpec, kind: 'startUsingKernelSpec', id: '1' },
+            { kernelSpec, kind: 'startUsingLocalKernelSpec', id: '1' },
             -1,
             undefined,
             process.cwd(),

--- a/src/test/datascience/kernelProcess.vscode.test.ts
+++ b/src/test/datascience/kernelProcess.vscode.test.ts
@@ -17,7 +17,7 @@ import {
 } from '../../client/common/process/types';
 import { anything, capture, instance, mock, when } from 'ts-mockito';
 import { KernelDaemonPool } from '../../client/datascience/kernel-launcher/kernelDaemonPool';
-import { KernelSpecConnectionMetadata } from '../../client/datascience/jupyter/kernels/types';
+import { LocalKernelSpecConnectionMetadata } from '../../client/datascience/jupyter/kernels/types';
 import { IFileSystem } from '../../client/common/platform/types';
 import { KernelEnvironmentVariablesService } from '../../client/datascience/kernel-launcher/kernelEnvVarsService';
 import { KernelProcess } from '../../client/datascience/kernel-launcher/kernelProcess';
@@ -61,7 +61,7 @@ suite('DataScience - Kernel Process', () => {
         disposeAllDisposables(disposables);
     });
 
-    function launchKernel(metadata: KernelSpecConnectionMetadata, connectionFile: string) {
+    function launchKernel(metadata: LocalKernelSpecConnectionMetadata, connectionFile: string) {
         const processExecutionFactory = mock<IProcessServiceFactory>();
         const daemonPool = mock<KernelDaemonPool>();
         const connection = mock<IKernelConnection>();
@@ -103,7 +103,7 @@ suite('DataScience - Kernel Process', () => {
         );
     }
     test('Launch from kernelspec (linux)', async function () {
-        const metadata: KernelSpecConnectionMetadata = {
+        const metadata: LocalKernelSpecConnectionMetadata = {
             id: '1',
             kernelSpec: {
                 argv: [
@@ -124,7 +124,7 @@ suite('DataScience - Kernel Process', () => {
                 name: '',
                 path: ''
             },
-            kind: 'startUsingKernelSpec'
+            kind: 'startUsingLocalKernelSpec'
         };
         const kernelProcess = launchKernel(metadata, 'wow/connection_config.json');
         await kernelProcess.launch('', 10_000, token.token);
@@ -140,7 +140,7 @@ suite('DataScience - Kernel Process', () => {
         await kernelProcess.dispose();
     });
     test('Launch from kernelspec (linux with space in file name)', async function () {
-        const metadata: KernelSpecConnectionMetadata = {
+        const metadata: LocalKernelSpecConnectionMetadata = {
             id: '1',
             kernelSpec: {
                 argv: [
@@ -161,7 +161,7 @@ suite('DataScience - Kernel Process', () => {
                 name: '',
                 path: ''
             },
-            kind: 'startUsingKernelSpec'
+            kind: 'startUsingLocalKernelSpec'
         };
         const kernelProcess = launchKernel(metadata, 'wow/connection config.json');
         await kernelProcess.launch('', 10_000, token.token);
@@ -177,7 +177,7 @@ suite('DataScience - Kernel Process', () => {
         await kernelProcess.dispose();
     });
     test('Launch from kernelspec (windows)', async function () {
-        const metadata: KernelSpecConnectionMetadata = {
+        const metadata: LocalKernelSpecConnectionMetadata = {
             id: '1',
             kernelSpec: {
                 argv: [
@@ -196,7 +196,7 @@ suite('DataScience - Kernel Process', () => {
                 name: '',
                 path: ''
             },
-            kind: 'startUsingKernelSpec'
+            kind: 'startUsingLocalKernelSpec'
         };
         const kernelProcess = launchKernel(metadata, 'connection_config.json');
         await kernelProcess.launch('', 10_000, token.token);
@@ -212,7 +212,7 @@ suite('DataScience - Kernel Process', () => {
         await kernelProcess.dispose();
     });
     test('Launch from kernelspec (windows with space in file name)', async function () {
-        const metadata: KernelSpecConnectionMetadata = {
+        const metadata: LocalKernelSpecConnectionMetadata = {
             id: '1',
             kernelSpec: {
                 argv: [
@@ -231,7 +231,7 @@ suite('DataScience - Kernel Process', () => {
                 name: '',
                 path: ''
             },
-            kind: 'startUsingKernelSpec'
+            kind: 'startUsingLocalKernelSpec'
         };
         const kernelProcess = launchKernel(metadata, 'D:\\hello\\connection config.json');
         await kernelProcess.launch('', 10_000, token.token);

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -407,7 +407,7 @@ suite('Dummy8', () => {
 //                             env: undefined
 //                         };
 //                         const invalidMetadata: KernelSpecConnectionMetadata = {
-//                             kind: 'startUsingKernelSpec',
+//                             kind: 'startUsingLocalKernelSpec',
 //                             kernelSpec: invalidKernel,
 //                             id: '1'
 //                         };
@@ -429,7 +429,7 @@ suite('Dummy8', () => {
 //                         const editor = (ne.editor as any) as NativeEditorWebView;
 //                         await editor.updateNotebookOptions({
 //                             kernelSpec: invalidKernel,
-//                             kind: 'startUsingKernelSpec',
+//                             kind: 'startUsingLocalKernelSpec',
 //                             id: '1'
 //                         });
 

--- a/src/test/datascience/notebook/notebookControllerManager.unit.test.ts
+++ b/src/test/datascience/notebook/notebookControllerManager.unit.test.ts
@@ -27,7 +27,7 @@ suite('Notebook Controller Manager', () => {
         test('Display the name if language is not specified', () => {
             const name = getDisplayNameOrNameOfKernelConnection({
                 id: '',
-                kind: 'startUsingKernelSpec',
+                kind: 'startUsingLocalKernelSpec',
                 kernelSpec: {
                     argv: [],
                     display_name: 'kspecname',
@@ -41,7 +41,7 @@ suite('Notebook Controller Manager', () => {
         test('Display the name if language is not python', () => {
             const name = getDisplayNameOrNameOfKernelConnection({
                 id: '',
-                kind: 'startUsingKernelSpec',
+                kind: 'startUsingLocalKernelSpec',
                 kernelSpec: {
                     argv: [],
                     display_name: 'kspecname',
@@ -56,7 +56,7 @@ suite('Notebook Controller Manager', () => {
         test('Display the name even if kernel is inside an unknown Python environment', () => {
             const name = getDisplayNameOrNameOfKernelConnection({
                 id: '',
-                kind: 'startUsingKernelSpec',
+                kind: 'startUsingLocalKernelSpec',
                 kernelSpec: {
                     argv: [],
                     display_name: 'kspecname',
@@ -73,7 +73,7 @@ suite('Notebook Controller Manager', () => {
         test('Display name even if kernel is inside a global Python environment', () => {
             const name = getDisplayNameOrNameOfKernelConnection({
                 id: '',
-                kind: 'startUsingKernelSpec',
+                kind: 'startUsingLocalKernelSpec',
                 kernelSpec: {
                     argv: [],
                     display_name: 'kspecname',
@@ -91,7 +91,7 @@ suite('Notebook Controller Manager', () => {
         test('Display name if kernel is inside a non-global Python environment', () => {
             const name = getDisplayNameOrNameOfKernelConnection({
                 id: '',
-                kind: 'startUsingKernelSpec',
+                kind: 'startUsingLocalKernelSpec',
                 kernelSpec: {
                     argv: [],
                     display_name: 'kspecname',
@@ -111,7 +111,7 @@ suite('Notebook Controller Manager', () => {
         test('Display name if kernel is inside a non-global 64bit Python environment', () => {
             const name = getDisplayNameOrNameOfKernelConnection({
                 id: '',
-                kind: 'startUsingKernelSpec',
+                kind: 'startUsingLocalKernelSpec',
                 kernelSpec: {
                     argv: [],
                     display_name: 'kspecname',
@@ -131,7 +131,7 @@ suite('Notebook Controller Manager', () => {
         test('Prefixed with `<env name>` kernel is inside a non-global Python environment', () => {
             const name = getDisplayNameOrNameOfKernelConnection({
                 id: '',
-                kind: 'startUsingKernelSpec',
+                kind: 'startUsingLocalKernelSpec',
                 kernelSpec: {
                     argv: [],
                     display_name: 'kspecname',
@@ -151,7 +151,7 @@ suite('Notebook Controller Manager', () => {
         test('Prefixed with `<env name>` kernel is inside a non-global 64-bit Python environment', () => {
             const name = getDisplayNameOrNameOfKernelConnection({
                 id: '',
-                kind: 'startUsingKernelSpec',
+                kind: 'startUsingLocalKernelSpec',
                 kernelSpec: {
                     argv: [],
                     display_name: 'kspecname',
@@ -173,7 +173,7 @@ suite('Notebook Controller Manager', () => {
         test('Display name if language is python', () => {
             const name = getDisplayNameOrNameOfKernelConnection({
                 id: '',
-                kind: 'startUsingKernelSpec',
+                kind: 'startUsingLocalKernelSpec',
                 kernelSpec: {
                     argv: [],
                     display_name: 'kspecname',
@@ -188,7 +188,7 @@ suite('Notebook Controller Manager', () => {
         test('Display name even if kernel is associated an unknown Python environment', () => {
             const name = getDisplayNameOrNameOfKernelConnection({
                 id: '',
-                kind: 'startUsingKernelSpec',
+                kind: 'startUsingLocalKernelSpec',
                 kernelSpec: {
                     argv: [],
                     display_name: 'kspecname',
@@ -208,7 +208,7 @@ suite('Notebook Controller Manager', () => {
         test('Display name even if kernel is associated with a global Python environment', () => {
             const name = getDisplayNameOrNameOfKernelConnection({
                 id: '',
-                kind: 'startUsingKernelSpec',
+                kind: 'startUsingLocalKernelSpec',
                 kernelSpec: {
                     argv: [],
                     display_name: 'kspecname',
@@ -229,7 +229,7 @@ suite('Notebook Controller Manager', () => {
         test('Display name if kernel is associated with a non-global Python environment', () => {
             const name = getDisplayNameOrNameOfKernelConnection({
                 id: '',
-                kind: 'startUsingKernelSpec',
+                kind: 'startUsingLocalKernelSpec',
                 kernelSpec: {
                     argv: [],
                     display_name: 'kspecname',
@@ -251,7 +251,7 @@ suite('Notebook Controller Manager', () => {
         test('Display name if kernel is associated with a non-global 64bit Python environment', () => {
             const name = getDisplayNameOrNameOfKernelConnection({
                 id: '',
-                kind: 'startUsingKernelSpec',
+                kind: 'startUsingLocalKernelSpec',
                 kernelSpec: {
                     argv: [],
                     display_name: 'kspecname',
@@ -272,7 +272,7 @@ suite('Notebook Controller Manager', () => {
         test('Display name if kernel is associated with a non-global 64bit Python environment and includes version', () => {
             const name = getDisplayNameOrNameOfKernelConnection({
                 id: '',
-                kind: 'startUsingKernelSpec',
+                kind: 'startUsingLocalKernelSpec',
                 kernelSpec: {
                     argv: [],
                     display_name: 'kspecname',
@@ -301,7 +301,7 @@ suite('Notebook Controller Manager', () => {
         test('Prefixed with `<env name>` kernel is associated with a non-global Python environment', () => {
             const name = getDisplayNameOrNameOfKernelConnection({
                 id: '',
-                kind: 'startUsingKernelSpec',
+                kind: 'startUsingLocalKernelSpec',
                 kernelSpec: {
                     argv: [],
                     display_name: 'kspecname',
@@ -330,7 +330,7 @@ suite('Notebook Controller Manager', () => {
         test('Prefixed with `<env name>` kernel is associated with a non-global 64-bit Python environment', () => {
             const name = getDisplayNameOrNameOfKernelConnection({
                 id: '',
-                kind: 'startUsingKernelSpec',
+                kind: 'startUsingLocalKernelSpec',
                 kernelSpec: {
                     argv: [],
                     display_name: 'kspecname',

--- a/src/test/datascience/raw-kernel/rawKernel.functional.test.ts
+++ b/src/test/datascience/raw-kernel/rawKernel.functional.test.ts
@@ -87,7 +87,7 @@ suite('Dummy13', () => {
 //             ioc.get<IProcessServiceFactory>(IProcessServiceFactory),
 //             ioc.get<KernelDaemonPool>(KernelDaemonPool),
 //             connectionInfo as any,
-//             { kernelSpec, interpreter, kind: 'startUsingKernelSpec', id: '1' },
+//             { kernelSpec, interpreter, kind: 'startUsingLocalKernelSpec', id: '1' },
 //             ioc.get<IFileSystem>(IFileSystem),
 //             undefined,
 //             ioc.get<IPythonExtensionChecker>(IPythonExtensionChecker),


### PR DESCRIPTION
Debt
We have LocalKernelSpecs vs Remote kernel specs.
In the code we don't make a distinction, however we do in places by determing whehter we're using a local or remote connection & then change accordingly.

The plan is to disconnect the notion of having local & remote seprately. The kernel connection metadata will tell us whether its local vs remote.

This is a first stage towards not having to reload vS Code when chaning remote kernel Url.

Either way, IMHO is a good change to clearly distinguish between local vs remote.
E.g. if you look at the kernel Launcher, and raw kernel stuff we only deal with `LocalKernelSpecConnection` and not the type `RemoteKernelConnection`
Better typing as well.