### PR TITLE
Ignore checking injectable for base classes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -299,7 +299,6 @@ module.exports = {
         'src/client/interpreter/display/progressDisplay.ts',
         'src/client/interpreter/display/interpreterSelectionTip.ts',
         'src/client/constants.ts',
-        'src/client/extensionInit.ts',
         'src/client/sourceMapSupport.ts',
         'src/client/startupTelemetry.ts',
         'src/client/typeFormatters/blockFormatProvider.ts',

--- a/src/client/extensionInit.ts
+++ b/src/client/extensionInit.ts
@@ -19,7 +19,7 @@ import { IServiceContainer, IServiceManager } from './ioc/types';
 // that it is inherently synchronous.
 
 export function initializeGlobals(context: IExtensionContext): [IServiceManager, IServiceContainer] {
-    const cont = new Container();
+    const cont = new Container({ skipBaseClassChecks: true });
     const serviceManager = new ServiceManager(cont);
     const serviceContainer = new ServiceContainer(cont);
 


### PR DESCRIPTION
Basically gets rid of this error on CI and on user machines

```
7665 Warn 22:12:54: Failed to decorate EventEmitter for DI (possibly already decorated by another Extension) Error: Cannot apply @injectable decorator multiple times.
2021-12-08T22:12:54.9432943Z     at /home/runner/work/vscode-jupyter/vscode-jupyter/node_modules/inversify/lib/annotation/injectable.js:8:19
2021-12-08T22:12:54.9441681Z     at DecorateConstructor (/home/runner/work/vscode-jupyter/vscode-jupyter/node_modules/reflect-metadata/Reflect.js:541:33)
2021-12-08T22:12:54.9451256Z     at Reflect.decorate (/home/runner/work/vscode-jupyter/vscode-jupyter/node_modules/reflect-metadata/Reflect.js:130:24)
2021-12-08T22:12:54.9453649Z     at _decorate (/home/runner/work/vscode-jupyter/vscode-jupyter/node_modules/inversify/lib/annotation/decorator_utils.js:42:13)
2021-12-08T22:12:54.9456012Z     at decorate (/home/runner/work/vscode-jupyter/vscode-jupyter/node_modules/inversify/lib/annotation/decorator_utils.js:55:9)
2021-12-08T22:12:54.9458081Z     at Object.<anonymous> (/home/runner/work/vscode-jupyter/vscode-jupyter/out/client/ioc/container.js:964:28)
2021-12-08T22:12:54.9459950Z     at Module._compile (internal/modules/cjs/loader.js:1125:30)
2021-12-08T22:12:54.9462390Z     at Module.replacementCompile (/home/runner/work/vscode-jupyter/vscode-jupyter/node_modules/append-transform/index.js:60:13)
2021-12-08T22:12:54.9463968Z     at Module._extensions..js (internal/modules/cjs/loader.js:1155:10)
2021-12-08T22:12:54.9465548Z     at /home/runner/work/vscode-jupyter/vscode-jupyter/node_modules/append-transform/index.js:64:4
2021-12-08T22:12:54.9467530Z     at require.extensions..js (/home/runner/work/vscode-jupyter/vscode-jupyter/src/test/datascience/reactHelpers.ts:418:17)
2021-12-08T22:12:54.9469573Z     at Object.<anonymous> (/home/runner/work/vscode-jupyter/vscode-jupyter/node_modules/append-transform/index.js:64:4)
2021-12-08T22:12:54.9470871Z     at Module.load (internal/modules/cjs/loader.js:982:32)
```