### PR TITLE
Allow to retrieve the jupyter filename programmatically (__vsc_ipynb_file__ )

### DIFF
--- a/news/1 Enhancements/8475.md
+++ b/news/1 Enhancements/8475.md
@@ -1,0 +1,2 @@
+Allow to retrieve the jupyter filename programmatically (__vsc_ipynb_file__) [fix support for ClearML]
+

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -663,7 +663,11 @@ export class Kernel implements IKernel {
 
             // Change our initial directory and path
             await this.updateWorkingDirectoryAndPath(this.resourceUri?.fsPath);
-            traceInfoIfCI('After updating working directory');
+            const file = this.resourceUri?.fsPath;
+            if (file) {
+                await this.executeSilently(`__vsc_ipynb_file__ = '${file.replace(/\\/g, '\\\\')}'`);
+            }
+            traceInfoIfCI('After updating working directory and notebook file __vsc_ipynb_file__');
             await this.disableJedi();
             traceInfoIfCI('After Disabing jedi');
 

--- a/src/test/datascience/notebook/executionService.vscode.test.ts
+++ b/src/test/datascience/notebook/executionService.vscode.test.ts
@@ -126,7 +126,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
     test('Test __vsc_ipynb_file__ defined in cell using VSCode Kernel', async () => {
         const uri = vscodeNotebook.activeNotebookEditor?.document.uri;
         if (uri && uri.scheme === 'file') {
-            await insertCodeCell('print("__vsc_ipynb_file__")', { index: 0 });
+            await insertCodeCell('print(__vsc_ipynb_file__)', { index: 0 });
             const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
             await Promise.all([runCell(cell), waitForTextOutput(cell, `${uri.path}`)]);
         }

--- a/src/test/datascience/notebook/executionService.vscode.test.ts
+++ b/src/test/datascience/notebook/executionService.vscode.test.ts
@@ -123,6 +123,14 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
 
         await Promise.all([runCell(cell), waitForTextOutput(cell, '123412341234')]);
     });
+    test('Test __vsc_ipynb_file__ defined in cell using VSCode Kernel', async () => {
+        const uri = vscodeNotebook.activeNotebookEditor?.document.uri;
+        if (uri && uri.scheme === 'file') {
+            await insertCodeCell('print("__vsc_ipynb_file__")', { index: 0 });
+            const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+            await Promise.all([runCell(cell), waitForTextOutput(cell, `${uri.path}`)]);
+        }
+    });
     test('Leading whitespace not suppressed', async () => {
         await insertCodeCell('print("\tho")\nprint("\tho")\nprint("\tho")\n', { index: 0 });
         const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;


### PR DESCRIPTION
Fix for Issue #8475 
Allowing to retrieve the jupyter filename programmatically via `__vsc_ipynb_file__` variable
This also enhancement allows to fix support for ClearML

Following the discussion on #8475 , and mostly thanks to the great guidance of @rchiodo , this PR updates `__vsc_ipynb_file__` global variable with the current jupyter filename. This enables [ClearML](https://github.com/allegroai/clearml/) to log the content of the jupyter notebook along side the outputs automagically :) 

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [ ] ~Has telemetry for enhancements.~
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] ~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [ ] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
