### PR TITLE
Update completion filtering logic and make completions happen faster

### DIFF
--- a/news/2 Fixes/8536.md
+++ b/news/2 Fixes/8536.md
@@ -1,0 +1,1 @@
+Autocompletions from the jupyter kernel can sometimes not appear.

--- a/src/client/common/utils/async.ts
+++ b/src/client/common/utils/async.ts
@@ -20,12 +20,6 @@ export async function sleep(timeout: number): Promise<number> {
     });
 }
 
-// TODO: This will never reject when there's a timeout, its only used in 3 places, remove this.
-// TODO: Remove this.
-
-/**
- * @deprecated use Promise.race([..., sleep(n)])
- */
 export async function waitForPromise<T>(promise: Promise<T>, timeout: number): Promise<T | null> {
     // Set a timer that will resolve with null
     return new Promise<T | null>((resolve, reject) => {

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -565,7 +565,7 @@ export namespace Settings {
     export const JupyterServerRemoteLaunchService = JVSC_EXTENSION_ID;
     export const JupyterServerUriListMax = 10;
     // If this timeout expires, ignore the completion request sent to Jupyter.
-    export const IntellisenseTimeout = 500;
+    export const IntellisenseTimeout = 2000;
 }
 
 export namespace DataFrameLoading {

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -677,6 +677,9 @@ export class Kernel implements IKernel {
             await this.disableJedi();
             traceInfoIfCI('After Disabing jedi');
 
+            // Request completions to warm up the completion engine (first call always takes a lot longer)
+            await this.requestEmptyCompletions();
+
             // For Python notebook initialize matplotlib
             await this.initializeMatplotLib();
             traceInfoIfCI('After initializing matplotlib');
@@ -712,6 +715,13 @@ export class Kernel implements IKernel {
 
     private async disableJedi() {
         await this.executeSilently(CodeSnippets.disableJedi);
+    }
+
+    private async requestEmptyCompletions() {
+        await this.session?.requestComplete({
+            code: '__file__.',
+            cursor_pos: 9
+        });
     }
 
     /**

--- a/src/client/datascience/notebook/intellisense/pythonKernelCompletionProvider.ts
+++ b/src/client/datascience/notebook/intellisense/pythonKernelCompletionProvider.ts
@@ -277,6 +277,9 @@ export function filterCompletions(
         const wordIndex = word ? r.itemText.indexOf(word) : -1;
         let newText: string | undefined = undefined;
         let newRange: Range | { inserting: Range; replacing: Range } | undefined = undefined;
+
+        // Two cases for filtering. We're at the '.', then the word we have is the beginning of the string.
+        // Example, user typed 'df.' and r.itemText is 'df.PassengerId'. Word would be 'df.' in this case.
         if (word && wordDot && r.itemText.startsWith(word)) {
             newText = r.itemText.substring(word.length);
             newRange =
@@ -284,6 +287,8 @@ export function filterCompletions(
                     ? new Range(new Position(r.range.start.line, r.range.start.character + word.length), r.range.end)
                     : r.range;
         }
+        // We're after the '.' and the user is typing more. We are in the middle of the string then.
+        // Example, user typed 'df.Pass' and r.itemText is 'df.PassengerId'. Word would be 'Pass' in this case.
         if (!newText && wordIndex > 0) {
             newText = r.itemText.substring(wordIndex);
             newRange =

--- a/src/test/datascience/notebook/intellisense/completionProvider.unit.test.ts
+++ b/src/test/datascience/notebook/intellisense/completionProvider.unit.test.ts
@@ -28,7 +28,7 @@ suite('DataScience - Jupyter Completion Unit Tests', () => {
             label,
             sortText: generateSortString(index),
             itemText: label,
-            range,
+            range: range ?? new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0)),
             kind
         };
     }

--- a/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
@@ -4,7 +4,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 import { assert } from 'chai';
 import * as sinon from 'sinon';
-import { CancellationTokenSource, CompletionContext, CompletionTriggerKind, Position } from 'vscode';
+import { CancellationTokenSource, CompletionContext, CompletionTriggerKind, Position, window } from 'vscode';
 import { IVSCodeNotebook } from '../../../../client/common/application/types';
 import { traceInfo } from '../../../../client/common/logger';
 import { IDisposable } from '../../../../client/common/types';
@@ -95,7 +95,7 @@ suite('DataScience - VSCode Intellisense Notebook - (Code Completion via Jupyter
         const cell4 = vscodeNotebook.activeNotebookEditor!.document.cellAt(3);
 
         const token = new CancellationTokenSource().token;
-        const position = new Position(0, 3);
+        let position = new Position(0, 3);
         const context: CompletionContext = {
             triggerKind: CompletionTriggerKind.TriggerCharacter,
             triggerCharacter: '.'
@@ -106,12 +106,26 @@ suite('DataScience - VSCode Intellisense Notebook - (Code Completion via Jupyter
         // Ask a second time as Jupyter can sometimes not be ready
         traceInfo('Get completions second time in test');
         completions = await completionProvider.provideCompletionItems(cell4.document, position, token, context);
-        const items = completions.map((item) => item.label);
+        let items = completions.map((item) => item.label);
         assert.isOk(items.length);
         assert.ok(items.find((item) => (typeof item === 'string' ? item.includes('Age') : item.label.includes('Age'))));
 
         // Make sure it is skipping items that are already provided by pylance (no dupes)
         assert.notOk(
+            items.find((item) => (typeof item === 'string' ? item.includes('Name') : item.label.includes('Name')))
+        );
+
+        // Add some text after the . and make sure we still get completions
+        const editor = window.visibleTextEditors.find((e) => e.document.uri === cell4.document.uri);
+        await editor?.edit((b) => {
+            b.insert(new Position(3, 0), 'N');
+        });
+
+        position = new Position(0, 4);
+        completions = await completionProvider.provideCompletionItems(cell4.document, position, token, context);
+        items = completions.map((item) => item.label);
+        assert.isOk(items.length);
+        assert.ok(
             items.find((item) => (typeof item === 'string' ? item.includes('Name') : item.label.includes('Name')))
         );
     });


### PR DESCRIPTION
Fixes #8536

Fixing a couple of issues:
- The first completion from jupyter can take 600ms on my machine. Subsequent ones are much faster, so do a dummy request on startup.
- The sleep timeout is always firing the sleep resolver. Use waitForPromise instead which kills the sleep timer.
- Typing autocomplete on anything other than a '.' doesn't work because the sub word filtering was incorrect. Added a test for this case too.

