### PR TITLE
Simpler Kernel API

### DIFF
--- a/build/ci/performance/perf-results.json
+++ b/build/ci/performance/perf-results.json
@@ -1,1 +1,1 @@
-{ "run_number": 69, "head_ref": "rchiodo/perf_test_step_1", "results": {} }
+{ "run_number": 73, "head_ref": "insiderApiChanges", "results": {} }

--- a/src/client/api/extension.d.ts
+++ b/src/client/api/extension.d.ts
@@ -5,8 +5,11 @@
 import { CancellationToken, Event, NotebookDocument } from 'vscode';
 import type { Kernel } from '@jupyterlab/services/lib/kernel';
 import type { Session } from '@jupyterlab/services';
-import { Observable } from 'rxjs/Observable';
-import type { Data as WebSocketData } from 'ws';
+
+/**
+ * Data represents the message payload received over the WebSocket.
+ */
+export type WebSocketData = string | Buffer | ArrayBuffer | Buffer[];
 
 export interface JupyterAPI {
     /**
@@ -173,26 +176,35 @@ export type LiveRemoteKernelConnectionMetadata = LiveKernelConnectionMetadata;
 export type ActiveKernel = LiveKernelConnectionMetadata;
 
 export interface IKernelSocket {
+    /**
+     * Whether the kernel socket is read & available for use.
+     */
+    ready: boolean;
+    /**
+     * Event fired when the underlying socket state changes.
+     * E.g. when the socket is connected/available or changes to another socket.
+     */
+    onDidChange: Event<void>;
+    /**
+     * Sends data to the underlying Jupyter kernel over the socket connection.
+     * This bypasses all of the jupyter kernel comms infrastructure.
+     */
     sendToRealKernel(data: any, cb?: (err?: Error) => void): void;
     /**
      * Adds a listener to a socket that will be called before the socket's onMessage is called. This
      * allows waiting for a callback before processing messages
-     * @param listener
      */
     addReceiveHook(hook: (data: WebSocketData) => Promise<void>): void;
     /**
      * Removes a listener for the socket. When no listeners are present, the socket no longer blocks
-     * @param listener
      */
     removeReceiveHook(hook: (data: WebSocketData) => Promise<void>): void;
     /**
      * Adds a hook to the sending of data from a websocket. Hooks can block sending so be careful.
-     * @param patch
      */
     addSendHook(hook: (data: any, cb?: (err?: Error) => void) => Promise<void>): void;
     /**
      * Removes a send hook from the socket.
-     * @param hook
      */
     removeSendHook(hook: (data: any, cb?: (err?: Error) => void) => Promise<void>): void;
 }
@@ -206,7 +218,7 @@ export type IKernelConnectionInfo = {
      * Underlying socket used by jupyterlab/services to communicate with kernel.
      * See jupyterlab/services/kernel/default.ts
      */
-    kernelSocket: Observable<IKernelSocket | undefined>;
+    kernelSocket: IKernelSocket;
 };
 
 export interface IExportedKernelService {

--- a/src/client/datascience/jupyter/kernels/kernelConnectionWrapper.ts
+++ b/src/client/datascience/jupyter/kernels/kernelConnectionWrapper.ts
@@ -33,11 +33,8 @@ import type {
 import { ISpecModel } from '@jupyterlab/services/lib/kernelspec/restapi';
 import { JSONObject } from '@lumino/coreutils';
 import { Signal } from '@lumino/signaling';
-import { Observable } from 'rxjs/Observable';
-import { ReplaySubject } from 'rxjs/ReplaySubject';
 import { Disposable } from 'vscode';
 import { IDisposable } from '../../../common/types';
-import { IKernelSocket } from '../../types';
 import { IKernel } from './types';
 
 export class KernelConnectionWrapper implements Kernel.IKernelConnection {
@@ -49,11 +46,6 @@ export class KernelConnectionWrapper implements Kernel.IKernelConnection {
     public get serverSettings() {
         return this.kernelConnection.serverSettings;
     }
-    private _kernelSocket = new ReplaySubject<IKernelSocket | undefined>();
-    public get kernelSocket(): Observable<IKernelSocket | undefined> {
-        return this._kernelSocket;
-    }
-
     public readonly disposed = new Signal<this, void>(this);
 
     constructor(
@@ -64,9 +56,6 @@ export class KernelConnectionWrapper implements Kernel.IKernelConnection {
         kernel.onDisposed(() => this.disposed.emit(), this, disposables);
         kernel.onStatusChanged(() => this.statusChanged.emit(kernel.status), this, disposables);
         this.startHandleKernelMessages(this.kernelConnection);
-        kernel.kernelSocket.subscribe((socket) => {
-            this._kernelSocket.next(socket?.socket);
-        });
         disposables.push(new Disposable(() => this.stopHandlingKernelMessages(this.kernelConnection)));
     }
     public get id(): string {


### PR DESCRIPTION
Reduces the npm packages required by extension authors.
ws & rxjs packages are no longer required to use the kernel API
Also makes it easier to consume the Socket events (users won't have to bind/unbind/bind again, it will be handled internally when kernels restarts)