### PR TITLE
Try to activate conda environments using conda activation scripts 

### DIFF
--- a/build/ci/performance/perf-results.json
+++ b/build/ci/performance/perf-results.json
@@ -1,1 +1,1 @@
-{ "run_number": 69, "head_ref": "rchiodo/perf_test_step_1", "results": {} }
+{ "run_number": 87, "head_ref": "useCondaActivate", "results": {} }

--- a/src/client/api/serviceRegistry.ts
+++ b/src/client/api/serviceRegistry.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { IExtensionSingleActivationService } from '../activation/types';
-import { EnvironmentActivationService } from '../common/process/interpreterActivation';
+import { EnvironmentActivationService } from '../common/process/environmentActivationService';
 import { IEnvironmentActivationService } from '../interpreter/activation/types';
 import { IInterpreterSelector } from '../interpreter/configuration/types';
 import { IInterpreterService } from '../interpreter/contracts';

--- a/src/client/common/process/environmentActivationService.ts
+++ b/src/client/common/process/environmentActivationService.ts
@@ -1,18 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
-import '../../common/extensions';
+import '../extensions';
 
 import { inject, injectable, named } from 'inversify';
 
-import { IWorkspaceService } from '../../common/application/types';
-import { IFileSystem, IPlatformService } from '../../common/platform/types';
-import * as internalScripts from '../../common/process/internal/scripts';
-import { ExecutionResult, IProcessServiceFactory } from '../../common/process/types';
-import { GLOBAL_MEMENTO, IDisposable, IMemento, Resource } from '../../common/types';
-import { createDeferredFromPromise, sleep } from '../../common/utils/async';
-import { OSType } from '../../common/utils/platform';
-import { EnvironmentVariables, IEnvironmentVariablesProvider } from '../../common/variables/types';
+import { IWorkspaceService } from '../application/types';
+import { IFileSystem, IPlatformService } from '../platform/types';
+import * as internalScripts from './internal/scripts';
+import { ExecutionResult, IProcessServiceFactory } from './types';
+import { GLOBAL_MEMENTO, IDisposable, IMemento, Resource } from '../types';
+import { createDeferredFromPromise, sleep } from '../utils/async';
+import { OSType } from '../utils/platform';
+import { EnvironmentVariables, IEnvironmentVariablesProvider } from '../variables/types';
 import { EnvironmentType, PythonEnvironment } from '../../pythonEnvironments/info';
 import { sendTelemetryEvent } from '../../telemetry';
 import { logValue, TraceOptions } from '../../logging/trace';
@@ -29,7 +29,7 @@ import { traceDecorators, traceError, traceInfo, traceVerbose, traceWarning } fr
 import { getTelemetrySafeHashedString } from '../../telemetry/helpers';
 import { CondaService } from './condaService';
 import { condaVersionSupportsLiveStreaming, createCondaEnv } from './pythonEnvironment';
-import { printEnvVariablesToFile } from '../../common/process/internal/scripts';
+import { printEnvVariablesToFile } from './internal/scripts';
 import { ProcessService } from './proc';
 import { BufferDecoder } from './decoder';
 import { testOnlyMethod } from '../utils/decorators';

--- a/src/test/datascience/interpreters/interpreterActivation.vscode.test.ts
+++ b/src/test/datascience/interpreters/interpreterActivation.vscode.test.ts
@@ -110,15 +110,18 @@ suite('DataScience - VSCode Notebook - (Conda Execution) (slow)', function () {
         stub.restore();
 
         envActivationService = createService(api.serviceContainer);
-        const activatedCommandEnvVars = await envActivationService.getActivatedEnvVarsUsingActivationCommands(
+        const activatedCommandEnvVarsPromise = envActivationService.getActivatedEnvVarsUsingActivationCommands(
             undefined,
             activeCondaInterpreter
         );
 
+        const activatedCommandEnvVars = await activatedCommandEnvVarsPromise;
+
         envActivationService = createService(api.serviceContainer);
         const activatedCondaRunEnvVars = await envActivationService.getCondaEnvVariables(
             undefined,
-            activeCondaInterpreter
+            activeCondaInterpreter,
+            activatedCommandEnvVarsPromise
         );
 
         verifyVariables(activatedEnvVars1!, '(main)');

--- a/src/test/datascience/interpreters/interpreterActivation.vscode.test.ts
+++ b/src/test/datascience/interpreters/interpreterActivation.vscode.test.ts
@@ -11,7 +11,7 @@ import { captureScreenShot, IExtensionTestApi } from '../../common';
 import { initialize } from '../../initialize';
 import { PythonEnvironment } from '../../../client/pythonEnvironments/info';
 import { IInterpreterService } from '../../../client/interpreter/contracts';
-import { EnvironmentActivationService } from '../../../client/common/process/interpreterActivation';
+import { EnvironmentActivationService } from '../../../client/common/process/environmentActivationService';
 import * as path from 'path';
 import { IS_WINDOWS } from '../../../client/common/platform/constants';
 import { IProcessServiceFactory } from '../../../client/common/process/types';


### PR DESCRIPTION
For #8580

The assumption is that conda activation scripts are faster, and conda run is slower.
We'll attempt to get activated env variables using both mechanisms and get env variables from which ever is faster.

Please note comments in https://github.com/microsoft/vscode-jupyter/issues/8580
This could slow things even more.
Perhaps we should try conda activate first and then fallback to conda run?

Either way, this PR has been created to start the conversation and @greazer  can try the VSIX at his end to see if there's any noticeable perf.