### PR TITLE
Remove unused property `bypassCondaExecution`

### DIFF
--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -78,7 +78,6 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
             allowEnvironmentFetchExceptions: true,
             interpreter: options.interpreter,
             resource: options.resource,
-            bypassCondaExecution: true
         });
         // No daemon support in Python 2.7 or during shutdown
         if ((interpreter?.version && interpreter.version.major < 3) || this.config.getSettings().disablePythonDaemon) {

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -77,7 +77,7 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
         const activatedProcPromise = this.createActivatedEnvironment({
             allowEnvironmentFetchExceptions: true,
             interpreter: options.interpreter,
-            resource: options.resource,
+            resource: options.resource
         });
         // No daemon support in Python 2.7 or during shutdown
         if ((interpreter?.version && interpreter.version.major < 3) || this.config.getSettings().disablePythonDaemon) {

--- a/src/client/common/process/types.ts
+++ b/src/client/common/process/types.ts
@@ -132,13 +132,6 @@ export type ExecutionFactoryCreateWithEnvironmentOptions = {
     resource?: Uri;
     interpreter: PythonEnvironment;
     allowEnvironmentFetchExceptions?: boolean;
-    /**
-     * Ignore running `conda run` when running code.
-     * It is known to fail in certain scenarios. Where necessary we might want to bypass this.
-     *
-     * @type {boolean}
-     */
-    bypassCondaExecution?: boolean;
 };
 export interface IPythonExecutionFactory {
     create(options: ExecutionFactoryCreationOptions): Promise<IPythonExecutionService>;

--- a/src/client/datascience/data-viewing/dataViewerDependencyService.ts
+++ b/src/client/datascience/data-viewing/dataViewerDependencyService.ts
@@ -118,7 +118,7 @@ export class DataViewerDependencyService {
         const launcher = await this.pythonFactory.createActivatedEnvironment({
             resource: undefined,
             interpreter,
-            allowEnvironmentFetchExceptions: true,
+            allowEnvironmentFetchExceptions: true
         });
         try {
             const result = await launcher.exec(['-c', 'import pandas;print(pandas.__version__)'], {

--- a/src/client/datascience/data-viewing/dataViewerDependencyService.ts
+++ b/src/client/datascience/data-viewing/dataViewerDependencyService.ts
@@ -119,7 +119,6 @@ export class DataViewerDependencyService {
             resource: undefined,
             interpreter,
             allowEnvironmentFetchExceptions: true,
-            bypassCondaExecution: true
         });
         try {
             const result = await launcher.exec(['-c', 'import pandas;print(pandas.__version__)'], {

--- a/src/client/datascience/export/exportBase.ts
+++ b/src/client/datascience/export/exportBase.ts
@@ -91,7 +91,6 @@ export class ExportBase implements INbConvertExport {
             resource: source,
             interpreter,
             allowEnvironmentFetchExceptions: false,
-            bypassCondaExecution: true
         });
     }
 }

--- a/src/client/datascience/export/exportBase.ts
+++ b/src/client/datascience/export/exportBase.ts
@@ -90,7 +90,7 @@ export class ExportBase implements INbConvertExport {
         return this.pythonExecutionFactory.createActivatedEnvironment({
             resource: source,
             interpreter,
-            allowEnvironmentFetchExceptions: false,
+            allowEnvironmentFetchExceptions: false
         });
     }
 }

--- a/src/client/datascience/jupyter/interpreter/jupyterCommand.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommand.ts
@@ -65,7 +65,6 @@ class InterpreterJupyterCommand implements IJupyterCommand {
             }
             return pythonExecutionFactory.createActivatedEnvironment({
                 interpreter: this._interpreter,
-                bypassCondaExecution: true
             });
         });
     }
@@ -198,7 +197,6 @@ export class InterpreterJupyterKernelSpecCommand extends InterpreterJupyterComma
         // Try getting kernels using python script, if that fails (even if there's output in stderr) rethrow original exception.
         const activatedEnv = await this.pythonExecutionFactory.createActivatedEnvironment({
             interpreter,
-            bypassCondaExecution: true
         });
         return activatedEnv.exec(
             [path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'vscode_datascience_helpers', 'getJupyterKernels.py')],
@@ -209,7 +207,6 @@ export class InterpreterJupyterKernelSpecCommand extends InterpreterJupyterComma
         // Try getting kernels using python script, if that fails (even if there's output in stderr) rethrow original exception.
         const activatedEnv = await this.pythonExecutionFactory.createActivatedEnvironment({
             interpreter,
-            bypassCondaExecution: true
         });
         return activatedEnv.exec(
             [

--- a/src/client/datascience/jupyter/interpreter/jupyterCommand.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommand.ts
@@ -64,7 +64,7 @@ class InterpreterJupyterCommand implements IJupyterCommand {
                 }
             }
             return pythonExecutionFactory.createActivatedEnvironment({
-                interpreter: this._interpreter,
+                interpreter: this._interpreter
             });
         });
     }
@@ -196,7 +196,7 @@ export class InterpreterJupyterKernelSpecCommand extends InterpreterJupyterComma
     private async getKernelSpecList(interpreter: PythonEnvironment, options: SpawnOptions) {
         // Try getting kernels using python script, if that fails (even if there's output in stderr) rethrow original exception.
         const activatedEnv = await this.pythonExecutionFactory.createActivatedEnvironment({
-            interpreter,
+            interpreter
         });
         return activatedEnv.exec(
             [path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'vscode_datascience_helpers', 'getJupyterKernels.py')],
@@ -206,7 +206,7 @@ export class InterpreterJupyterKernelSpecCommand extends InterpreterJupyterComma
     private async getKernelSpecVersion(interpreter: PythonEnvironment, options: SpawnOptions) {
         // Try getting kernels using python script, if that fails (even if there's output in stderr) rethrow original exception.
         const activatedEnv = await this.pythonExecutionFactory.createActivatedEnvironment({
-            interpreter,
+            interpreter
         });
         return activatedEnv.exec(
             [

--- a/src/client/datascience/jupyter/kernels/helpers.ts
+++ b/src/client/datascience/jupyter/kernels/helpers.ts
@@ -875,7 +875,7 @@ export async function sendTelemetryForPythonKernelExecutable(
         executionService
             .createActivatedEnvironment({
                 interpreter: kernelConnection.interpreter,
-                allowEnvironmentFetchExceptions: true,
+                allowEnvironmentFetchExceptions: true
             })
             .then(async (execService) => {
                 const execOutput = await execService.exec(['-c', 'import sys;print(sys.executable)'], {

--- a/src/client/datascience/jupyter/kernels/helpers.ts
+++ b/src/client/datascience/jupyter/kernels/helpers.ts
@@ -876,7 +876,6 @@ export async function sendTelemetryForPythonKernelExecutable(
             .createActivatedEnvironment({
                 interpreter: kernelConnection.interpreter,
                 allowEnvironmentFetchExceptions: true,
-                bypassCondaExecution: true
             })
             .then(async (execService) => {
                 const execOutput = await execService.exec(['-c', 'import sys;print(sys.executable)'], {

--- a/src/client/datascience/kernel-launcher/kernelLauncherDaemon.ts
+++ b/src/client/datascience/kernel-launcher/kernelLauncherDaemon.ts
@@ -57,7 +57,7 @@ export class PythonKernelLauncherDaemon implements IDisposable {
             // Possible we're running regular code such as `python xyz.py` or `python -m abc` (ansible, or other kernels)
             const executionServicePromise = this.pythonExecFactory.createActivatedEnvironment({
                 resource,
-                interpreter,
+                interpreter
             });
 
             traceInfo(`Launching kernel daemon for ${kernelSpec.display_name} # ${getDisplayPath(interpreter?.path)}`);

--- a/src/client/datascience/kernel-launcher/kernelLauncherDaemon.ts
+++ b/src/client/datascience/kernel-launcher/kernelLauncherDaemon.ts
@@ -58,7 +58,6 @@ export class PythonKernelLauncherDaemon implements IDisposable {
             const executionServicePromise = this.pythonExecFactory.createActivatedEnvironment({
                 resource,
                 interpreter,
-                bypassCondaExecution: true
             });
 
             traceInfo(`Launching kernel daemon for ${kernelSpec.display_name} # ${getDisplayPath(interpreter?.path)}`);

--- a/src/client/datascience/telemetry/interpreterPackages.ts
+++ b/src/client/datascience/telemetry/interpreterPackages.ts
@@ -122,7 +122,6 @@ export class InterpreterPackages {
     private async getPackageInformation(interpreter: PythonEnvironment) {
         const service = await this.executionFactory.createActivatedEnvironment({
             allowEnvironmentFetchExceptions: true,
-            bypassCondaExecution: true,
             interpreter
         });
 

--- a/src/test/datascience/remoteTestHelpers.ts
+++ b/src/test/datascience/remoteTestHelpers.ts
@@ -17,8 +17,7 @@ export async function createPythonService(
             return pythonFactory.createActivatedEnvironment({
                 resource: undefined,
                 interpreter: python,
-                allowEnvironmentFetchExceptions: true,
-                bypassCondaExecution: true
+                allowEnvironmentFetchExceptions: true
             });
         }
     }


### PR DESCRIPTION
This is not used anywhere in our code, nor do we pass this onto the Python extension.

This is a remnant of when Jupyter was part of Python extension and some changes were made in Python extension to conda activation and it was broken (& for the Jupyter code we decided to avoid calling into the new approach for conda activate by using this property) 