### PR TITLE
Fix linter issues (eslint is being weird)

### DIFF
--- a/src/client/common/process/environmentActivationService.ts
+++ b/src/client/common/process/environmentActivationService.ts
@@ -3,7 +3,7 @@
 'use strict';
 import '../extensions';
 
-import { inject, injectable, named, optional } from 'inversify';
+import { inject, injectable, named } from 'inversify';
 
 import { IWorkspaceService } from '../application/types';
 import { IFileSystem, IPlatformService } from '../platform/types';
@@ -99,7 +99,7 @@ export class EnvironmentActivationService implements IEnvironmentActivationServi
     private readonly disposables: IDisposable[] = [];
     private readonly activatedEnvVariablesCache = new Map<string, Promise<NodeJS.ProcessEnv | undefined>>();
     private readonly envActivationCommands = new Map<string, Promise<string[] | undefined>>();
-    private static minTimeAfterWhichWeShouldCacheEnvVariables: number = MIN_TIME_AFTER_WHICH_WE_SHOULD_CACHE_ENV_VARS;
+    public static minTimeAfterWhichWeShouldCacheEnvVariables: number = MIN_TIME_AFTER_WHICH_WE_SHOULD_CACHE_ENV_VARS;
     constructor(
         @inject(IPlatformService) private readonly platform: IPlatformService,
         @inject(IProcessServiceFactory) private processServiceFactory: IProcessServiceFactory,
@@ -110,11 +110,7 @@ export class EnvironmentActivationService implements IEnvironmentActivationServi
         @inject(IPythonApiProvider) private readonly apiProvider: IPythonApiProvider,
         @inject(IMemento) @named(GLOBAL_MEMENTO) private readonly memento: Memento,
         @inject(CondaService) private readonly condaService: CondaService,
-        @inject(IFileSystem) private readonly fs: IFileSystem,
-        @optional()
-        minTimeAfterWhichWeShouldCacheEnvVariables = MIN_TIME_AFTER_WHICH_WE_SHOULD_CACHE_ENV_VARS
-    ) {
-        EnvironmentActivationService.minTimeAfterWhichWeShouldCacheEnvVariables = minTimeAfterWhichWeShouldCacheEnvVariables;
+        @inject(IFileSystem) private readonly fs: IFileSystem    ) {
         this.envVarsService.onDidEnvironmentVariablesChange(
             () => this.activatedEnvVariablesCache.clear(),
             this,

--- a/src/test/datascience/interpreters/environmentActivationService.vscode.test.ts
+++ b/src/test/datascience/interpreters/environmentActivationService.vscode.test.ts
@@ -79,6 +79,8 @@ suite('DataScience - VSCode Notebook - (Conda Execution) (slow)', function () {
         traceInfo(`Ended Test (completed) ${this.currentTest?.title}`);
     });
     function createService(serviceContainer: IServiceContainer) {
+        // Ensure everything is cached.
+        EnvironmentActivationService.minTimeAfterWhichWeShouldCacheEnvVariables = 1;
         return new EnvironmentActivationService(
             serviceContainer.get(IPlatformService),
             serviceContainer.get(IProcessServiceFactory),
@@ -89,8 +91,7 @@ suite('DataScience - VSCode Notebook - (Conda Execution) (slow)', function () {
             serviceContainer.get(IPythonApiProvider),
             serviceContainer.get(IMemento, GLOBAL_MEMENTO),
             serviceContainer.get(CondaService),
-            serviceContainer.get(IFileSystem),
-            1
+            serviceContainer.get(IFileSystem)
         );
     }
     test('Verify Conda Activation', async () => {
@@ -190,8 +191,7 @@ suite('DataScience - VSCode Notebook - (Conda Execution) (slow)', function () {
             api.serviceContainer.get(IPythonApiProvider),
             api.serviceContainer.get(IMemento, GLOBAL_MEMENTO),
             instance(mockConda),
-            api.serviceContainer.get(IFileSystem),
-            1
+            api.serviceContainer.get(IFileSystem)
         );
 
         // Get the env variables from a new instance of the class.


### PR DESCRIPTION
For some reason `@optional` is not being detected as used, even though it is used.
Not sure why but the linter marks it unused, perhaps because its used on an argument that's not a property.

Changed the way we pass arguments to the class.