### PR TITLE
Disable insiders until the new year

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -87,11 +87,11 @@ jobs:
           echo "vsix_name=ms-toolsai-jupyter-insiders.vsix" >> $GITHUB_ENV
           echo "test_matrix_os=[\"ubuntu-latest\", \"windows-latest\"]" >> $GITHUB_ENV
 
-      - name: pre-release channel
-        # Scheduled builds will publish pre-release builds.
-        if: github.event_name == 'schedule' && github.ref == 'refs/heads/main'
-        run: |
-          echo "release_channel=pre-release" >> $GITHUB_ENV
+    #   - name: pre-release channel
+    #     # Scheduled builds will publish pre-release builds.
+    #     if: github.event_name == 'schedule' && github.ref == 'refs/heads/main'
+    #     run: |
+    #       echo "release_channel=pre-release" >> $GITHUB_ENV
 
       - name: release
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && contains(github.ref, 'refs/heads/release')


### PR DESCRIPTION
No point pushing releases every day when there are 0 commits (changes to the code).