### PR TITLE
Monkey patch the kernel to allow debugging and tracebacks to coexist

### DIFF
--- a/news/2 Fixes/8568.md
+++ b/news/2 Fixes/8568.md
@@ -1,0 +1,1 @@
+Fix problem where error stack traces would show random code that hadn't actually been run.

--- a/pythonFiles/vscode_datascience_helpers/kernel/addRunCellHook.py
+++ b/pythonFiles/vscode_datascience_helpers/kernel/addRunCellHook.py
@@ -10,28 +10,31 @@ __VSCODE_wrapped_run_cell = False
 # https://github.com/microsoft/vscode-jupyter/blob/312511f3cbd8b2bb5bc70fa9b771429e22d0c258/src/client/datascience/editor-integration/cellhashprovider.ts#L181
 def __VSCODE_compute_hash(code, number=0):
     hash_digest = _VSCODE_hashlib.sha1(code.encode("utf-8")).hexdigest()
-    return '<ipython-input-{0}-{1}>'.format(number, hash_digest[:12])
+    return "<ipython-input-{0}-{1}>".format(number, hash_digest[:12])
+
 
 # This function will wrap InteractiveShell.run-cell and force its IPYKERNEL_CELL_NAME to match the
-# predicted value used by the Jupyter Extension 
+# predicted value used by the Jupyter Extension
 def __VSCODE_wrap_run_cell(wrapped_func):
-        old_func = wrapped_func.__func__
-        __VSCODE_wrapped_run_cell = True
-        def wrapper(*args, **kwargs):
-            try:
-                store_history = args[2] if len(args) > 2 else kwargs['store_history']
-                if store_history:
-                    predicted_name = __VSCODE_compute_hash(args[1], args[0].execution_count)
-                    os.environ["IPYKERNEL_CELL_NAME"] = predicted_name
-                result = old_func(*args, **kwargs)
-                if store_history:
-                    del os.environ["IPYKERNEL_CELL_NAME"]
-                return result
-            except:
-                return old_func(*args, **kwargs)
-        return _VSCODE_types.MethodType(wrapper, wrapped_func.__self__)
+    old_func = wrapped_func.__func__
+    __VSCODE_wrapped_run_cell = True
+
+    def wrapper(*args, **kwargs):
+        try:
+            store_history = args[2] if len(args) > 2 else kwargs["store_history"]
+            if store_history:
+                predicted_name = __VSCODE_compute_hash(args[1], args[0].execution_count)
+                os.environ["IPYKERNEL_CELL_NAME"] = predicted_name
+            result = old_func(*args, **kwargs)
+            if store_history:
+                del os.environ["IPYKERNEL_CELL_NAME"]
+            return result
+        except:
+            return old_func(*args, **kwargs)
+
+    return _VSCODE_types.MethodType(wrapper, wrapped_func.__self__)
+
 
 # Double check this still exists on IPython
-if (get_ipython() and get_ipython().run_cell and not __VSCODE_wrapped_run_cell):
+if get_ipython() and get_ipython().run_cell and not __VSCODE_wrapped_run_cell:
     get_ipython().run_cell = __VSCODE_wrap_run_cell(get_ipython().run_cell)
-

--- a/pythonFiles/vscode_datascience_helpers/kernel/addRunCellHook.py
+++ b/pythonFiles/vscode_datascience_helpers/kernel/addRunCellHook.py
@@ -1,0 +1,37 @@
+import types as _VSCODE_types
+import os
+import hashlib as _VSCODE_hashlib
+from IPython import get_ipython
+
+# Variable that prevent wrapping from happing more than_once
+__VSCODE_wrapped_run_cell = False
+
+# This function computes the hash for the code. It must follow the same algorithm as in use here:
+# https://github.com/microsoft/vscode-jupyter/blob/312511f3cbd8b2bb5bc70fa9b771429e22d0c258/src/client/datascience/editor-integration/cellhashprovider.ts#L181
+def __VSCODE_compute_hash(code, number=0):
+    hash_digest = _VSCODE_hashlib.sha1(code.encode("utf-8")).hexdigest()
+    return '<ipython-input-{0}-{1}>'.format(number, hash_digest[:12])
+
+# This function will wrap InteractiveShell.run-cell and force its IPYKERNEL_CELL_NAME to match the
+# predicted value used by the Jupyter Extension 
+def __VSCODE_wrap_run_cell(wrapped_func):
+        old_func = wrapped_func.__func__
+        __VSCODE_wrapped_run_cell = True
+        def wrapper(*args, **kwargs):
+            try:
+                store_history = args[2] if len(args) > 2 else kwargs['store_history']
+                if store_history:
+                    predicted_name = __VSCODE_compute_hash(args[1], args[0].execution_count)
+                    os.environ["IPYKERNEL_CELL_NAME"] = predicted_name
+                result = old_func(*args, **kwargs)
+                if store_history:
+                    del os.environ["IPYKERNEL_CELL_NAME"]
+                return result
+            except:
+                return old_func(*args, **kwargs)
+        return _VSCODE_types.MethodType(wrapper, wrapped_func.__self__)
+
+# Double check this still exists on IPython
+if (get_ipython() and get_ipython().run_cell and not __VSCODE_wrapped_run_cell):
+    get_ipython().run_cell = __VSCODE_wrap_run_cell(get_ipython().run_cell)
+

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -602,6 +602,11 @@ export namespace GetVariableInfo {
     export const VariableInfoImportFunc = `${VariableInfoImportName}._VSCODE_getVariableInfo`;
 }
 
+export namespace AddRunCellHook {
+    export const SysPath = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'vscode_datascience_helpers', 'kernel');
+    export const ScriptPath = path.join(SysPath, 'addRunCellHook.py');
+}
+
 export namespace Identifiers {
     export const GeneratedThemeName = 'ipython-theme'; // This needs to be all lower class and a valid class name.
     export const RawPurpose = 'raw';

--- a/src/client/datascience/jupyter/kernels/cellExecution.ts
+++ b/src/client/datascience/jupyter/kernels/cellExecution.ts
@@ -46,7 +46,7 @@ import {
     translateErrorOutput
 } from '../../notebook/helpers/helpers';
 import { ICellHash, ICellHashProvider, IDataScienceErrorHandler, IJupyterSession } from '../../types';
-import { executeSilently, isPythonKernelConnection } from './helpers';
+import { isPythonKernelConnection } from './helpers';
 import { IKernel, KernelConnectionMetadata, NotebookCellRunState } from './types';
 import { Kernel } from '@jupyterlab/services';
 import { CellOutputDisplayIdTracker } from './cellDisplayIdTracker';
@@ -481,11 +481,6 @@ export class CellExecution implements IDisposable {
             let hash: ICellHash | undefined = undefined;
             if (this.cell.notebook.notebookType === InteractiveWindowView) {
                 hash = await this.cellHashProvider.addCellHash(this.cell);
-
-                // If using ipykernel 6, we need to set the IPYKERNEL_CELL_NAME so that
-                // debugging can work. However this code is harmless for IPYKERNEL 5 so just always do it
-                // We need to wait for the result so we don't accidently hang the kernel (QT5 event loop doesn't handle concurrent requests)
-                await executeSilently(session, `import os;os.environ["IPYKERNEL_CELL_NAME"] = '${hash?.runtimeFile}'`);
             }
 
             // At this point we're about to ACTUALLY execute some code. Fire an event to indicate that

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -25,7 +25,7 @@ import { IConfigurationService, IDisposable, IDisposableRegistry, Resource } fro
 import { noop } from '../../../common/utils/misc';
 import { StopWatch } from '../../../common/utils/stopWatch';
 import { sendTelemetryEvent } from '../../../telemetry';
-import { CodeSnippets, Commands, Identifiers, Telemetry } from '../../constants';
+import { AddRunCellHook, CodeSnippets, Commands, Identifiers, Telemetry } from '../../constants';
 import {
     initializeInteractiveOrNotebookTelemetryBasedOnUserAction,
     sendKernelTelemetryEvent,
@@ -690,6 +690,10 @@ export class Kernel implements IKernel {
             await this.initializeMatplotLib();
             traceInfoIfCI('After initializing matplotlib');
 
+            // Initialize debug cell support.
+            // (IPYKERNEL_CELL_NAME has to be set on every cell execution, but we can't execute a cell to change it)
+            await this.initializeDebugCellHook();
+
             if (isLocalConnection(this.kernelConnectionMetadata)) {
                 await sendTelemetryForPythonKernelExecutable(
                     this,
@@ -844,6 +848,17 @@ export class Kernel implements IKernel {
             await this.executeSilently(configInit);
         }
     }
+
+    private async initializeDebugCellHook() {
+        // If using ipykernel 6, we need to set the IPYKERNEL_CELL_NAME so that
+        // debugging can work. However this code is harmless for IPYKERNEL 5 so just always do it
+        if (await this.fs.localFileExists(AddRunCellHook.ScriptPath)) {
+            const fileContents = await this.fs.readLocalFile(AddRunCellHook.ScriptPath);
+            await this.executeSilently(fileContents);
+        }
+        traceError(`Cannot run non-existant script file: ${AddRunCellHook.ScriptPath}`);
+    }
+
     private async runStartupCommands() {
         const settings = this.configService.getSettings(this.resourceUri);
         // Run any startup commands that we specified. Support the old form too

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -709,7 +709,7 @@ export interface ICellHash {
     executionCount: number;
     id: string; // Cell id as sent to jupyter
     timestamp: number;
-    code: string; // Code that was actually hashed (might include breakpoint)
+    code: string; // Code that was actually hashed (might include breakpoint and other code)
     debuggerStartLine: number; // 1 based line in source .py that we start our file mapping from
 }
 

--- a/src/test/datascience/helpers.ts
+++ b/src/test/datascience/helpers.ts
@@ -171,7 +171,7 @@ export async function waitForLastCellToComplete(
             return codeCell && (numberOfCells === -1 || numberOfCells === codeCells!.length) ? true : false;
         },
         defaultNotebookTestTimeout,
-        `No code cell found in interactive window notebook documen`
+        `No code cell found in interactive window notebook document`
     );
     if (errorsOkay) {
         await waitForCellExecutionToComplete(codeCell!);

--- a/src/test/datascience/helpers.ts
+++ b/src/test/datascience/helpers.ts
@@ -11,8 +11,10 @@ import { Commands } from '../../client/datascience/constants';
 import { InteractiveWindow } from '../../client/datascience/interactive-window/interactiveWindow';
 import { InteractiveWindowProvider } from '../../client/datascience/interactive-window/interactiveWindowProvider';
 import { IDataScienceCodeLensProvider, IInteractiveWindowProvider } from '../../client/datascience/types';
+import { waitForCondition } from '../common';
 import {
     createTemporaryFile,
+    defaultNotebookTestTimeout,
     waitForCellExecutionToComplete,
     waitForExecutionCompletedSuccessfully
 } from './notebook/helper';
@@ -151,20 +153,26 @@ export async function runCurrentFile(
     return { activeInteractiveWindow, untitledPythonFile };
 }
 
-export async function waitForLastCellToComplete(interactiveWindow: InteractiveWindow, errorsOkay?: boolean) {
+export async function waitForLastCellToComplete(
+    interactiveWindow: InteractiveWindow,
+    numberOfCells: number = -1,
+    errorsOkay?: boolean
+) {
     const notebookDocument = vscode.workspace.notebookDocuments.find(
         (doc) => doc.uri.toString() === interactiveWindow?.notebookUri?.toString()
     );
-    const cells = notebookDocument?.getCells();
     assert.ok(notebookDocument !== undefined, 'Interactive window notebook document not found');
+
     let codeCell: vscode.NotebookCell | undefined;
-    for (let i = cells!.length - 1; i >= 0; i -= 1) {
-        if (cells![i].kind === vscode.NotebookCellKind.Code) {
-            codeCell = cells![i];
-            break;
-        }
-    }
-    assert.ok(codeCell !== undefined, 'No code cell found in interactive window notebook document');
+    await waitForCondition(
+        async () => {
+            const codeCells = notebookDocument?.getCells().filter((c) => c.kind === vscode.NotebookCellKind.Code);
+            codeCell = codeCells && codeCells.length ? codeCells[codeCells.length - 1] : undefined;
+            return codeCell && (numberOfCells === -1 || numberOfCells === codeCells!.length) ? true : false;
+        },
+        defaultNotebookTestTimeout,
+        `No code cell found in interactive window notebook documen`
+    );
     if (errorsOkay) {
         await waitForCellExecutionToComplete(codeCell!);
     } else {

--- a/src/test/datascience/interactiveDebugging.vscode.test.ts
+++ b/src/test/datascience/interactiveDebugging.vscode.test.ts
@@ -597,7 +597,7 @@ def foo():
     });
 
     test('Step into a previous cell', async () => {
-        // Need a function and a call to i
+        // Need a function and a call to the function
         const source = `
 # %%
 def foo():

--- a/src/test/datascience/interactiveDebugging.vscode.test.ts
+++ b/src/test/datascience/interactiveDebugging.vscode.test.ts
@@ -10,11 +10,11 @@ import { traceInfo } from '../../client/common/logger';
 import { IDisposable } from '../../client/common/types';
 import { Commands } from '../../client/datascience/constants';
 import { InteractiveWindowProvider } from '../../client/datascience/interactive-window/interactiveWindowProvider';
-import { IInteractiveWindowProvider } from '../../client/datascience/types';
+import { IDataScienceCodeLensProvider, IInteractiveWindowProvider } from '../../client/datascience/types';
 import { IVariableViewProvider } from '../../client/datascience/variablesView/types';
 import { captureScreenShot, IExtensionTestApi, waitForCondition } from '../common';
 import { initialize, IS_REMOTE_NATIVE_TEST } from '../initialize';
-import { submitFromPythonFile, waitForLastCellToComplete } from './helpers';
+import { submitFromPythonFile, submitFromPythonFileUsingCodeWatcher, waitForLastCellToComplete } from './helpers';
 import { closeNotebooksAndCleanUpAfterTests, defaultNotebookTestTimeout, getCellOutputs } from './notebook/helper';
 import { ITestWebviewHost } from './testInterfaces';
 import { waitForVariablesToMatch } from './variableView/variableViewHelpers';
@@ -26,6 +26,7 @@ suite('Interactive window debugging', async function () {
     const disposables: IDisposable[] = [];
     let interactiveWindowProvider: InteractiveWindowProvider;
     let variableViewProvider: ITestVariableViewProvider;
+    let codeWatcherProvider: IDataScienceCodeLensProvider;
     let debugAdapterTracker: vscode.DebugAdapterTracker | undefined;
     const tracker: vscode.DebugAdapterTrackerFactory = {
         createDebugAdapterTracker: function (
@@ -47,6 +48,7 @@ suite('Interactive window debugging', async function () {
         const coreVariableViewProvider = api.serviceContainer.get<IVariableViewProvider>(IVariableViewProvider);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         variableViewProvider = (coreVariableViewProvider as any) as ITestVariableViewProvider; // Cast to expose the test interfaces
+        codeWatcherProvider = api.serviceManager.get(IDataScienceCodeLensProvider);
     });
     teardown(async function () {
         traceInfo(`Ended Test ${this.currentTest?.title}`);
@@ -415,7 +417,7 @@ suite('Interactive window debugging', async function () {
             defaultNotebookTestTimeout,
             `Couldn't find stop command`
         );
-        const lastCell = await waitForLastCellToComplete(activeInteractiveWindow, true);
+        const lastCell = await waitForLastCellToComplete(activeInteractiveWindow, -1, true);
         const outputs = getCellOutputs(lastCell);
         assert.isFalse(outputs.includes('finished'), 'Cell finished during a stop');
     });
@@ -604,12 +606,13 @@ def foo():
 # %%
 foo()
 `;
-        const { activeInteractiveWindow, untitledPythonFile } = await submitFromPythonFile(
+        const { activeInteractiveWindow, untitledPythonFile } = await submitFromPythonFileUsingCodeWatcher(
             interactiveWindowProvider,
+            codeWatcherProvider,
             source,
             disposables
         );
-        await waitForLastCellToComplete(activeInteractiveWindow);
+        await waitForLastCellToComplete(activeInteractiveWindow, 2);
 
         let codeLenses: vscode.CodeLens[] = [];
         // Wait for the debug cell code lens to appear
@@ -619,7 +622,7 @@ foo()
                     'vscode.executeCodeLensProvider',
                     untitledPythonFile.uri
                 )) as vscode.CodeLens[];
-                return codeLenses && codeLenses.length == 8;
+                return codeLenses && codeLenses.length == 7;
             },
             defaultNotebookTestTimeout,
             `Invalid number of code lenses returned`
@@ -627,7 +630,7 @@ foo()
 
         let stopped = false;
         let stoppedOnLine = false;
-        let targetLine = 9;
+        let targetLine = 7;
         debugAdapterTracker = {
             onDidSendMessage: (message) => {
                 if (message.event == 'stopped') {
@@ -639,10 +642,10 @@ foo()
             }
         };
 
-        assert.ok(codeLenses, `No code lenses found`);
-        assert.equal(codeLenses.length, 8, `Wrong number of code lenses found`);
-        let args = codeLenses[6].command!.arguments || [];
-        void vscode.commands.executeCommand(codeLenses[2].command!.command, ...args);
+        const debugCellCodeLenses = codeLenses.filter((c) => c.command?.command === Commands.DebugCell);
+        const debugCellCodeLens = debugCellCodeLenses[1];
+        let args = debugCellCodeLens.command!.arguments || [];
+        void vscode.commands.executeCommand(debugCellCodeLens.command!.command, ...args);
 
         // Wait for breakpoint to be hit
         await waitForCondition(
@@ -665,7 +668,7 @@ foo()
         // Perform a step into
         stopped = false;
         stoppedOnLine = false;
-        targetLine = 7;
+        targetLine = 4;
 
         void vscode.commands.executeCommand('workbench.action.debug.stepInto');
         await waitForCondition(

--- a/src/test/datascience/interactiveWindow.vscode.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.test.ts
@@ -11,6 +11,7 @@ import { traceInfo, traceInfoIfCI } from '../../client/common/logger';
 import { getDisplayPath } from '../../client/common/platform/fs-paths';
 import { IDisposable } from '../../client/common/types';
 import { InteractiveWindowProvider } from '../../client/datascience/interactive-window/interactiveWindowProvider';
+import { translateCellErrorOutput } from '../../client/datascience/notebook/helpers/helpers';
 import { INotebookControllerManager } from '../../client/datascience/notebook/types';
 import { IDataScienceCodeLensProvider, IInteractiveWindowProvider } from '../../client/datascience/types';
 import { captureScreenShot, IExtensionTestApi, sleep, waitForCondition } from '../common';
@@ -404,16 +405,24 @@ ${actualCode}
             '# %%\ndef raiser():\n  raise Exception("error")\n# %%\nraiser()',
             disposables
         );
-        await waitForLastCellToComplete(activeInteractiveWindow);
+        const lastCell = await waitForLastCellToComplete(activeInteractiveWindow, 2, true);
 
-        const notebookDocument = vscode.workspace.notebookDocuments.find(
-            (doc) => doc.uri.toString() === activeInteractiveWindow?.notebookUri?.toString()
-        );
+        // Parse the last cell's error output
+        const errorOutput = translateCellErrorOutput(lastCell.outputs[0]);
+        assert.ok(errorOutput, 'No error output found');
+        assert.equal(errorOutput.traceback.length, 5, 'Traceback wrong size');
 
-        await waitForExecutionCompletedWithErrors(notebookDocument!.cellAt(notebookDocument!.cellCount - 1));
+        // Convert to html for easier parsing
+        const ansiToHtml = require('ansi-to-html') as typeof import('ansi-to-html');
+        const converter = new ansiToHtml();
+        const html = converter.toHtml(errorOutput.traceback.join('\n'));
 
-        // Wait for error to appear
-        await waitForExecutionCompletedWithErrors(notebookDocument!.cellAt(1));
+        // Should be threee hrefs for the two lines in the call stack
+        const hrefs = html.match(/<a\s+href='.*\?line=(\d+)'/gm);
+        assert.equal(hrefs?.length, 3, '3 hrefs not found in traceback');
+        assert.ok(hrefs[0].endsWith("line=4'"), 'Wrong first ref line');
+        assert.ok(hrefs[1].endsWith("line=1'"), 'Wrong second ref line');
+        assert.ok(hrefs[2].endsWith("line=2'"), 'Wrong third ref line');
     });
 
     // todo@joyceerhl

--- a/src/test/datascience/interactiveWindow.vscode.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.test.ts
@@ -398,6 +398,24 @@ ${actualCode}
         await waitForTextOutput(notebookDocument!.cellAt(1), '1\n2');
     });
 
+    test('Raising an exception from within a function has a stack trace', async () => {
+        const { activeInteractiveWindow } = await runCurrentFile(
+            interactiveWindowProvider,
+            '# %%\ndef raiser():\n  raise Exception("error")\n# %%\nraiser()',
+            disposables
+        );
+        await waitForLastCellToComplete(activeInteractiveWindow);
+
+        const notebookDocument = vscode.workspace.notebookDocuments.find(
+            (doc) => doc.uri.toString() === activeInteractiveWindow?.notebookUri?.toString()
+        );
+
+        await waitForExecutionCompletedWithErrors(notebookDocument!.cellAt(notebookDocument!.cellCount - 1));
+
+        // Wait for error to appear
+        await waitForExecutionCompletedWithErrors(notebookDocument!.cellAt(1));
+    });
+
     // todo@joyceerhl
     // test('Verify CWD', () => { });
     // test('Multiple executes go to last active window', async () => { });


### PR DESCRIPTION
Fixes #8568

The root cause was explained in #8568 but I'll reiterate here.

We have code that does this:

```
import os;os.environ["IPYKERNEL_CELL_NAME"] = '${hash?.runtimeFile}'
```

This environment variable is used by the kernel to 'name' a cell execution so that when we get a stackframe in the debugger, it can be uniquely identified.

The problem was it was never being 'unset'. 

So when an error occurs and jupyter tries to parse all of the cells that lead to an exception, it can't determine which cell ```<ipython-2-hashyvalue>``` is actually referring to.

Example:

1. User executes ```def foo():\n  raise Exception("FOO")\n```
2. We execute ```import os;os.environ["IPYKERNEL_CELL_NAME"] = '<ipython-1-hashy.py>'``` as a silent cell
3. We execute ```def foo():\n  raise Exception("FOO")\n``` 
4. Jupyter associates ```def foo():\n  raise Exception("FOO")\n``` with ```<ipython-1-hashy.py>```
5. User executes ```foo()```
6. We execute ```import os;os.environ["IPYKERNEL_CELL_NAME"] = '<ipython-2-hashy2.py>'``` as a silent cell
7. Jupyter associates ```import os;os.environ["IPYKERNEL_CELL_NAME"] = '<ipython-2-hashy2.py>'``` with ```<ipython-1-hashy.py>``` because IPYKERNEL_CELL_NAME was set
8. We execute ```foo()```
9. Jupyter associates ```foo()``` with ```<ipython-2-hashy2.py>```
5. Exception is raised
6. Traceback is generated that has the following in it
- <ipython-1-hashy.py>
- <ipython-2-hashy.py>
7. ```<ipython-1-hashy.py>``` is mapped to the ```import os;os.environ["IPYKERNEL_CELL_NAME"] = '<ipython-2-hashy2.py>``` from step 7 instead of ```def foo():\n  raise Exception("FOO")\n``` from step 3
8. Traceback is invalid.

The crux of the problem is that we need an environment variable set during a cell executing but then unset for everything that comes after it (or set to something different).

What if we could execute the code we use to generate the hash inside the kernel somehow?

I had 3 ideas on how to solve this (picked the last one)
1. Use the debugger to eval the code prior to running each cell
2. Use the [pre_run_code_hook](https://github.com/ipython/ipython/blob/996c53ed74e204063c12adf4cab6896657c36e60/IPython/core/hooks.py#L55) from IPython to run code before
3. Monkey patch the run_cell in the kernel

I picked the last one because:
1. These entries need to be set regardless of whether or not we're debugging. It's too late if we have to wait for debugging because previous cells wouldn't have been mapped. (Makes stepping into predefined functions impossible)
2. ```pre_run_code_hook``` is deprecated and doesn't seem to actually get the code. The code is necessary in order to compute the hash. Plus we'd have to write an entire kernel extension.

