### PR TITLE
Fix traceback formatting for IPython 8

### DIFF
--- a/news/2 Fixes/8675.md
+++ b/news/2 Fixes/8675.md
@@ -1,0 +1,1 @@
+Fix traceback parsing when using IPython 8.0 or greater.

--- a/news/2 Fixes/8697.md
+++ b/news/2 Fixes/8697.md
@@ -1,0 +1,1 @@
+Fix error tracebacks to not have background colors. Background colors from Jupyter don't match VS code themes, so they were just removed.

--- a/package.nls.json
+++ b/package.nls.json
@@ -559,5 +559,6 @@
     "DataScience.usingNonPrereleaseYes": "Yes",
     "DataScience.usingNonPrereleaseNo": "No",
     "DataScience.usingNonPrereleaseNoAndDontAskAgain": "Don't ask again",
-    "DataScience.usingNonPrerelease": "The 'prerelease' version of the Jupyter extension is recommended when running on VS code insiders. Would you like to switch?"
+    "DataScience.usingNonPrerelease": "The 'prerelease' version of the Jupyter extension is recommended when running on VS code insiders. Would you like to switch?",
+    "DataScience.cellAtFormat": "{0} Cell {1}'"
 }

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -91,6 +91,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     ['python.SelectAndInsertDebugConfiguration']: [TextDocument, Position, CancellationToken];
     ['vscode.open']: [Uri];
     ['notebook.execute']: [];
+    ['notebook.cell.edit']: [];
     ['notebook.cell.execute']:
         | []
         | [{ ranges: { start: number; end: number }[]; document?: Uri; autoReveal?: boolean }]; // TODO update this

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -1083,6 +1083,8 @@ export namespace DataScience {
         'DataScience.activatingEnvironment',
         "Activating Python Environment '{0}'"
     );
+
+    export const cellAtFormat = localize('DataScience.cellAtFormat', '{0} Cell {1}');
 }
 
 // Skip using vscode-nls and instead just compute our strings based on key values. Key values

--- a/src/client/datascience/editor-integration/cellhashprovider.ts
+++ b/src/client/datascience/editor-integration/cellhashprovider.ts
@@ -21,7 +21,7 @@ import * as localize from '../../common/utils/localize';
 import { splitMultilineString } from '../../../datascience-ui/common';
 import { uncommentMagicCommands } from '../../../datascience-ui/common/cellFactory';
 import { IDebugService, IDocumentManager } from '../../common/application/types';
-import { traceInfo } from '../../common/logger';
+import { traceInfo, traceInfoIfCI } from '../../common/logger';
 import { IFileSystem } from '../../common/platform/types';
 
 import { IConfigurationService } from '../../common/types';
@@ -475,6 +475,8 @@ export class CellHashProvider implements ICellHashProvider {
             suffix = suffix.replace(/\u001b\[3\d+m/g, '\u001b[39m');
             return `${prefix}${num}${suffix}\n`;
         });
+
+        traceInfoIfCI(`Trace frame to match: ${traceFrame}`);
 
         const inputMatch = /^Input.*?\[.*32mIn\s+\[(\d+).*?0;36m(.*?)\n.*/.exec(traceFrame);
         if (inputMatch && inputMatch.length > 1) {

--- a/src/client/datascience/editor-integration/cellhashprovider.ts
+++ b/src/client/datascience/editor-integration/cellhashprovider.ts
@@ -533,7 +533,7 @@ export class CellHashProvider implements ICellHashProvider {
             }
         }
 
-        const fileMatch = /^File.*?\[1;32m(.*):\d+.*\u001b.*\n/.exec(traceFrame);
+        const fileMatch = /^File.*?\[\d;32m(.*):\d+.*\u001b.*\n/.exec(traceFrame);
         if (fileMatch && fileMatch.length > 1) {
             const fileUri = Uri.file(fileMatch[1]);
             // We have a match, replace source lines with hrefs

--- a/src/datascience-ui/error-renderer/index.ts
+++ b/src/datascience-ui/error-renderer/index.ts
@@ -23,6 +23,14 @@ const handleInnerClick = (event: MouseEvent, context: RendererContext<any>) => {
                 });
                 event.preventDefault();
                 return;
+            }
+            if (node.href.indexOf('vscode-notebook-cell') === 0) {
+                context.postMessage({
+                    message: 'open_link',
+                    payload: node.href
+                });
+                event.preventDefault();
+                return;
             } else if (node.href.indexOf('command') === 0) {
                 context.postMessage({
                     message: 'open_link',
@@ -79,16 +87,18 @@ export const activate: ActivationFunction = (_context) => {
             // RegEx `<a href='<file path>?line=<linenumber>'>line number</a>`
             // When we escape, the links would be escaped as well.
             // We need to unescape them.
-            const fileLinkRegExp = new RegExp(/&lt;a href=&#39;file:(.*(?=\?))\?line=(\d*)&#39;&gt;(\d*)&lt;\/a&gt;/);
+            const fileLinkRegExp = new RegExp(
+                /&lt;a href=&#39;(file|vscode-notebook-cell):(.*(?=\?))\?line=(\d*)&#39;&gt;(\d*)&lt;\/a&gt;/
+            );
             const commandRegEx = new RegExp(/&lt;a href=&#39;command:(.*)&#39;&gt;(.*)&lt;\/a&gt;/);
             const akaMsLinks = new RegExp(/&lt;a href=&#39;https:\/\/aka.ms\/(.*)&#39;&gt;(.*)&lt;\/a&gt;/);
             traceback = traceback.map((line) => {
                 let matches: RegExpExecArray | undefined | null;
                 while ((matches = fileLinkRegExp.exec(line)) !== null) {
-                    if (matches.length === 4) {
+                    if (matches.length === 5) {
                         line = line.replace(
                             matches[0],
-                            `<a href='file:${matches[1]}?line=${matches[2]}'>${matches[3]}<a>`
+                            `<a href='${matches[1]}:${matches[2]}?line=${matches[3]}'>${matches[4]}<a>`
                         );
                     }
                 }

--- a/src/test/constants.ts
+++ b/src/test/constants.ts
@@ -43,3 +43,5 @@ export const SMOKE_TEST_EXTENSIONS_DIR = path.join(
     'ext',
     'smokeTestExtensionsFolder'
 );
+
+export const IPYTHON_VERSION_CODE = 'import IPython\nprint(int(IPython.__version__[0]))\n';

--- a/src/test/datascience/interactiveWindow.vscode.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.test.ts
@@ -11,11 +11,11 @@ import { traceInfo, traceInfoIfCI } from '../../client/common/logger';
 import { getDisplayPath } from '../../client/common/platform/fs-paths';
 import { IDisposable } from '../../client/common/types';
 import { InteractiveWindowProvider } from '../../client/datascience/interactive-window/interactiveWindowProvider';
-import { translateCellErrorOutput } from '../../client/datascience/notebook/helpers/helpers';
+import { getTextOutputValue, translateCellErrorOutput } from '../../client/datascience/notebook/helpers/helpers';
 import { INotebookControllerManager } from '../../client/datascience/notebook/types';
 import { IDataScienceCodeLensProvider, IInteractiveWindowProvider } from '../../client/datascience/types';
 import { captureScreenShot, IExtensionTestApi, sleep, waitForCondition } from '../common';
-import { initialize, IS_REMOTE_NATIVE_TEST } from '../initialize';
+import { initialize, IPYTHON_VERSION_CODE, IS_REMOTE_NATIVE_TEST } from '../initialize';
 import {
     createStandaloneInteractiveWindow,
     insertIntoInputEditor,
@@ -428,10 +428,12 @@ ${actualCode}
     test('Raising an exception from system code has a stack trace', async function () {
         const { activeInteractiveWindow } = await runCurrentFile(
             interactiveWindowProvider,
-            '# %%\nimport pathlib as pathlib\nx = pathlib.Path()\ny = None\nx.joinpath(y, "Foo")',
+            `# %%\n${IPYTHON_VERSION_CODE}# %%\nimport pathlib as pathlib\nx = pathlib.Path()\ny = None\nx.joinpath(y, "Foo")`,
             disposables
         );
-        const lastCell = await waitForLastCellToComplete(activeInteractiveWindow, 1, true);
+        const lastCell = await waitForLastCellToComplete(activeInteractiveWindow, 2, true);
+        const ipythonVersionCell = activeInteractiveWindow.notebookDocument?.cellAt(lastCell.index - 1);
+        const ipythonVersion = parseInt(getTextOutputValue(ipythonVersionCell!.outputs[0]));
 
         // Parse the last cell's error output
         const errorOutput = translateCellErrorOutput(lastCell.outputs[0]);
@@ -442,9 +444,13 @@ ${actualCode}
         const converter = new ansiToHtml();
         const html = converter.toHtml(errorOutput.traceback.join('\n'));
 
-        // Should be more than 3 hrefs
+        // Should be more than 3 hrefs if ipython 8 or not
         const hrefs = html.match(/<a\s+href='.*\?line=(\d+)'/gm);
-        assert.ok(hrefs?.length > 3, '3 hrefs not found in traceback');
+        if (ipythonVersion >= 8) {
+            assert.ok(hrefs?.length > 3, 'Wrong number of hrefs found in traceback');
+        } else {
+            assert.ok(hrefs?.length >= 1, 'Wrong number of hrefs found in traceback');
+        }
     });
 
     test('Running a cell with markdown and code runs two cells', async () => {

--- a/src/test/datascience/interactiveWindow.vscode.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.test.ts
@@ -447,9 +447,9 @@ ${actualCode}
         // Should be more than 3 hrefs if ipython 8 or not
         const hrefs = html.match(/<a\s+href='.*\?line=(\d+)'/gm);
         if (ipythonVersion >= 8) {
-            assert.ok(hrefs?.length > 3, 'Wrong number of hrefs found in traceback');
+            assert.isAtLeast(hrefs?.length, 4, 'Wrong number of hrefs found in traceback for IPython 8');
         } else {
-            assert.ok(hrefs?.length >= 1, 'Wrong number of hrefs found in traceback');
+            assert.isAtLeast(hrefs?.length, 1, 'Wrong number of hrefs found in traceback for IPython 7 or earlier');
         }
     });
 

--- a/src/test/datascience/notebook/executionService.vscode.test.ts
+++ b/src/test/datascience/notebook/executionService.vscode.test.ts
@@ -132,6 +132,27 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
             await Promise.all([runCell(cell), waitForTextOutput(cell, `${uri.fsPath}`)]);
         }
     });
+    test('Test exceptions have hrefs', async () => {
+        const uri = vscodeNotebook.activeNotebookEditor?.document.uri;
+        if (uri && uri.scheme === 'file') {
+            const codeCell = await insertCodeCell('raise Exception("FOO")', { index: 0 });
+            await runCell(codeCell);
+            await waitForExecutionCompletedWithErrors(codeCell);
+
+            // Parse the last cell's error output
+            const errorOutput = translateCellErrorOutput(codeCell.outputs[0]);
+            assert.ok(errorOutput, 'No error output found');
+
+            // Convert to html for easier parsing
+            const ansiToHtml = require('ansi-to-html') as typeof import('ansi-to-html');
+            const converter = new ansiToHtml();
+            const html = converter.toHtml(errorOutput.traceback.join('\n'));
+
+            // Should be more than 3 hrefs
+            const hrefs = html.match(/<a\s+href='.*\?line=(\d+)'/gm);
+            assert.ok(hrefs?.length >= 1, 'Hrefs not found in traceback');
+        }
+    });
     test('Leading whitespace not suppressed', async () => {
         await insertCodeCell('print("\tho")\nprint("\tho")\nprint("\tho")\n', { index: 0 });
         const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;


### PR DESCRIPTION
Fixes #8675 
Fixes #8697 

Implement support for traceback error parsing in IPython 8

Expand this parsing to work in notebooks now too.

This is how the IW will look after this change: 

![image](https://user-images.githubusercontent.com/19672699/149594309-e29efdef-68d9-4376-ba60-8234f6d0a1e0.png)

And notebooks look similar:

![image](https://user-images.githubusercontent.com/19672699/149594337-a580a5b1-7b43-44bb-95e8-83b44a8ca4ea.png)


