### PR TITLE
Make sure to find active interpreter even with no folder

### DIFF
--- a/news/2 Fixes/8409.md
+++ b/news/2 Fixes/8409.md
@@ -1,0 +1,1 @@
+Fix intellisense to work when no folder is opened.

--- a/src/client/datascience/notebook/intellisense/intellisenseProvider.ts
+++ b/src/client/datascience/notebook/intellisense/intellisenseProvider.ts
@@ -16,6 +16,8 @@ import { INotebookControllerManager, INotebookLanguageClientProvider } from '../
 import { VSCodeNotebookController } from '../vscodeNotebookController';
 import { LanguageServer } from './languageServer';
 
+const EmptyWorkspaceKey = 'EMPTY_WORKSPACE_KEY';
+
 /**
  * This class sets up the concatenated intellisense for every notebook as it changes its kernel.
  */
@@ -82,15 +84,16 @@ export class IntellisenseProvider implements INotebookLanguageClientProvider, IE
         const folder =
             this.workspaceService.getWorkspaceFolder(fsPath ? Uri.file(fsPath) : undefined)?.uri ||
             (this.workspaceService.rootPath ? Uri.file(this.workspaceService.rootPath) : undefined);
-        if (folder && !this.activeInterpreterCache.has(folder.fsPath)) {
+        const key = folder ? folder.fsPath : EmptyWorkspaceKey;
+        if (!this.activeInterpreterCache.has(key)) {
             this.interpreterService
                 .getActiveInterpreter(folder)
                 .then((a) => {
-                    this.activeInterpreterCache.set(folder.fsPath, a);
+                    this.activeInterpreterCache.set(key, a);
                 })
                 .ignoreErrors();
         }
-        return folder ? this.activeInterpreterCache.get(folder.fsPath) : undefined;
+        return this.activeInterpreterCache.get(key);
     }
 
     private async controllerChanged(e: { notebook: NotebookDocument; controller: VSCodeNotebookController }) {

--- a/src/client/datascience/notebook/intellisense/intellisenseProvider.ts
+++ b/src/client/datascience/notebook/intellisense/intellisenseProvider.ts
@@ -16,7 +16,7 @@ import { INotebookControllerManager, INotebookLanguageClientProvider } from '../
 import { VSCodeNotebookController } from '../vscodeNotebookController';
 import { LanguageServer } from './languageServer';
 
-const EmptyWorkspaceKey = 'EMPTY_WORKSPACE_KEY';
+const EmptyWorkspaceKey = '';
 
 /**
  * This class sets up the concatenated intellisense for every notebook as it changes its kernel.


### PR DESCRIPTION
Fixes #8409

Active interpreter is possible without a folder. Make sure to support this case.