### PR TITLE
Wait for output before accessing it

### DIFF
--- a/src/test/datascience/interactiveWindow.vscode.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.test.ts
@@ -407,6 +407,13 @@ ${actualCode}
         );
         const lastCell = await waitForLastCellToComplete(activeInteractiveWindow, 2, true);
 
+        // Wait for the outputs to be available.
+        await waitForCondition(
+            async () => lastCell.outputs.length > 0 && lastCell.outputs[0].items.length > 0,
+            defaultNotebookTestTimeout,
+            'Outputs not avaialble'
+        );
+
         // Parse the last cell's error output
         const errorOutput = translateCellErrorOutput(lastCell.outputs[0]);
         assert.ok(errorOutput, 'No error output found');

--- a/src/test/datascience/interactiveWindow.vscode.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.test.ts
@@ -411,7 +411,7 @@ ${actualCode}
         await waitForCondition(
             async () => lastCell.outputs.length > 0 && lastCell.outputs[0].items.length > 0,
             defaultNotebookTestTimeout,
-            'Outputs not avaialble'
+            'Outputs not available'
         );
 
         // Parse the last cell's error output


### PR DESCRIPTION
Fixes flaky CI tests `Raising an exception from within a function has a stack trace:1 | Cannot read property 'items' of undefined`
https://github.com/microsoft/vscode-jupyter/runs/4861578291?check_suite_focus=true

I've run into this once before & this is also failing in our main branch .

We're trying to access the output even before its available.
I fixed this in our old tests, basically waiting for execution to complete isn't enough, each part of the notebook gets updated separately (different times).

I.e. after execution state = completed, its possible the output hasn't been added to the output yet (to my knowledge this happens because the output first needs to be sent to the UI before its updated in the extension host)

