### PR TITLE
Remove redundant API method

### DIFF
--- a/src/client/datascience/kernel-launcher/localKernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/localKernelFinder.ts
@@ -125,10 +125,6 @@ export class LocalKernelFinder implements ILocalKernelFinder {
         }
     }
 
-    public async listNonPythonKernels(cancelToken?: CancellationToken): Promise<LocalKernelConnectionMetadata[]> {
-        return this.filterKernels(await this.nonPythonKernelFinder.listKernelSpecs(false, cancelToken));
-    }
-
     /**
      * Search all our local file system locations for installed kernel specs and return them
      */

--- a/src/client/datascience/kernel-launcher/types.ts
+++ b/src/client/datascience/kernel-launcher/types.ts
@@ -70,13 +70,6 @@ export interface ILocalKernelFinder {
         notebookMetadata?: nbformat.INotebookMetadata
     ): LocalKernelConnectionMetadata | undefined;
     /**
-     * Finds all kernel specs excluding Python.
-     */
-    listNonPythonKernels(
-        cancelToken?: CancellationToken,
-        useCache?: 'useCache' | 'ignoreCache'
-    ): Promise<LocalKernelConnectionMetadata[]>;
-    /**
      * Finds all kernel specs including Python.
      */
     listKernels(

--- a/src/client/datascience/notebook/notebookControllerManager.ts
+++ b/src/client/datascience/notebook/notebookControllerManager.ts
@@ -346,7 +346,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
         this.createNotebookControllers(connections);
 
         // If we're listing Python kernels & there aren't any, then add a placeholder for `Python` which will prompt users to install python
-        if (!('listRemoteKernels' in options)) {
+        if ('useCache' in options) {
             if (connections.some((item) => isPythonKernelConnection(item))) {
                 this.removeNoPythonControllers();
             } else {

--- a/src/test/datascience/debugger.vscode.test.ts
+++ b/src/test/datascience/debugger.vscode.test.ts
@@ -196,7 +196,8 @@ suite('VSCode Notebook - Run By Line', function () {
         );
     });
 
-    test('Run a second time after interrupt', async function () {
+    test.skip('Run a second time after interrupt', async function () {
+        // https://github.com/microsoft/vscode-jupyter/issues/8753
         await insertCodeCell(
             'import time\nfor i in range(0,50):\n  time.sleep(.1)\n  print("sleepy")\nprint("final output")',
             {


### PR DESCRIPTION
While attempting to document the code, found an API call that was unnecessary.
* `listNonPythonKernels` is not required
* We list non-python kernels when fetching all kernels (including Python) in the `listKernels` method

I think we used this code path in the old code and is now redundant.

As Peng mentioned, writing the documentation helps identify issues & I think its already proved beneficial here (I think).