### PR TITLE
marking 'change directory on import/export' as deprecated

### DIFF
--- a/news/2 Fixes/4419.md
+++ b/news/2 Fixes/4419.md
@@ -1,0 +1,1 @@
+Deprecate "Change Directory on Import Export Setting"

--- a/package.json
+++ b/package.json
@@ -1555,6 +1555,7 @@
                 "jupyter.changeDirOnImportExport": {
                     "type": "boolean",
                     "default": false,
+                    "deprecationMessage": "This setting is deprecated and will be removed in the next release.",
                     "description": "When importing or exporting a Jupyter Notebook add a directory change command to allow relative path loading to work.",
                     "scope": "resource"
                 },


### PR DESCRIPTION
For #4419

This feature has a few issues: the path format is broken for Windows, the path is incorrect for importing/exporting notebooks, and it's not implemented in non-nbconvert code-paths. Looking at telemetry, this is a fairly low-use feature, so we can probably just remove it.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
