### PR TITLE
Add a language switcher that auto detects magics

### DIFF
--- a/news/1 Enhancements/4588.md
+++ b/news/1 Enhancements/4588.md
@@ -1,0 +1,1 @@
+Automatically switch cell language based on cell magics being entered.

--- a/package.json
+++ b/package.json
@@ -1880,6 +1880,12 @@
                     "default": ".%",
                     "description": "Characters which trigger auto completion on a python jupyter kernel (requires reload of VS code)",
                     "scope": "machine"
+                },
+                "jupyter.switchCellsOnMagic": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Controls whether or not cell magics auto switch the language of a cell or not",
+                    "scope": "machine"
                 }
             }
         },

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -97,6 +97,7 @@ export class JupyterSettings implements IWatchableJupyterSettings {
     public newCellOnRunLast: boolean = true;
     public pylanceHandlesNotebooks: boolean = false;
     public pythonCompletionTriggerCharacters: string = '';
+    public switchCellsOnMagic: boolean = true;
 
     public variableTooltipFields: IVariableTooltipFields = {
         python: {

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -180,6 +180,7 @@ export interface IJupyterSettings {
     readonly newCellOnRunLast: boolean;
     readonly pylanceHandlesNotebooks?: boolean;
     readonly pythonCompletionTriggerCharacters?: string;
+    readonly switchCellsOnMagic: boolean;
 }
 
 export interface IVariableTooltipFields {

--- a/src/client/datascience/notebook/languageSwitcher.ts
+++ b/src/client/datascience/notebook/languageSwitcher.ts
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+import { injectable, inject } from 'inversify';
+import { TextDocumentChangeEvent, Range, Position, languages, workspace, TextDocument } from 'vscode';
+import { IExtensionSingleActivationService } from '../../activation/types';
+import { IDocumentManager } from '../../common/application/types';
+import { IConfigurationService, IDisposableRegistry } from '../../common/types';
+import { isNotebookCell } from '../../common/utils/misc';
+import { INotebookControllerManager } from './types';
+
+// This list comes from here: https://ipython.readthedocs.io/en/stable/interactive/magics.html#cell-magics
+const LanguageMagics = [
+    ['%%sql', 'sql'],
+    ['%%bash', 'shellscript'],
+    ['%%sh', 'shellscript'],
+    ['%%kql', 'kql'],
+    ['%%javascript', 'javascript'],
+    ['%%js', 'javascript'],
+    ['%%html', 'html'],
+    ['%%ruby', 'ruby'],
+    ['%%perl', 'perl'],
+    ['%%script sql', 'sql'],
+    ['%%script bash', 'shellscript'],
+    ['%%script sh', 'shellscript'],
+    ['%%script kql', 'kql'],
+    ['%%script javascript', 'javascript'],
+    ['%%script js', 'javascript'],
+    ['%%script html', 'html'],
+    ['%%script ruby', 'ruby'],
+    ['%%script perl', 'perl'],
+    ['%%python', 'python'],
+    ['%%python2', 'python'],
+    ['%%pypy', 'python'],
+    ['%%script python', 'python'],
+    ['%%script python2', 'python'],
+    ['%%script pypy', 'python']
+];
+
+@injectable()
+export class LanguageSwitcher implements IExtensionSingleActivationService {
+    constructor(
+        @inject(IDocumentManager) private readonly documentManager: IDocumentManager,
+        @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
+        @inject(IConfigurationService) private readonly configService: IConfigurationService,
+        @inject(INotebookControllerManager) private controllerManager: INotebookControllerManager
+    ) {}
+    public async activate(): Promise<void> {
+        this.documentManager.onDidChangeTextDocument(this.onDidChangeTextDocument, this, this.disposables);
+    }
+
+    private onDidChangeTextDocument(e: TextDocumentChangeEvent) {
+        // See if this is a notebook cell or not for a python run notebook
+        if (
+            isNotebookCell(e.document.uri) &&
+            this.configService.getSettings().switchCellsOnMagic &&
+            this.hasPythonController(e.document)
+        ) {
+            this.switchOnMatch(e, LanguageMagics);
+        }
+    }
+
+    private hasPythonController(cellDocument: TextDocument): boolean {
+        const notebook = workspace.notebookDocuments.find((n) => n.getCells().find((c) => c.document === cellDocument));
+        const controller = notebook ? this.controllerManager.getSelectedNotebookController(notebook) : undefined;
+        switch (controller?.connection.kind) {
+            case 'startUsingPythonInterpreter':
+                return true;
+            case 'startUsingLocalKernelSpec':
+            case 'startUsingRemoteKernelSpec':
+                return controller.connection.kernelSpec.language === 'python';
+            case 'connectToLiveKernel':
+                return controller.connection.kernelModel.language === 'python';
+            default:
+                return false;
+        }
+    }
+
+    private switchOnMatch(e: TextDocumentChangeEvent, setToMatch: string[][]) {
+        // See if the change would add a language magic
+        const line = e.contentChanges[0].range.start.line;
+        const possibleText = e.document.getText(new Range(new Position(line, 0), new Position(line + 1, 0))).trim();
+        const match = setToMatch.find((e) => possibleText.includes(e[0]));
+        if (match) {
+            void languages.setTextDocumentLanguage(e.document, match[1]);
+        }
+    }
+}

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -165,6 +165,7 @@ import { ExportToPythonPlain } from './export/exportToPythonPlain';
 import { ErrorRendererCommunicationHandler } from './errors/errorRendererComms';
 import { KernelProgressReporter } from './progress/kernelProgressReporter';
 import { PreReleaseChecker } from './prereleaseChecker';
+import { LanguageSwitcher } from './notebook/languageSwitcher';
 
 // README: Did you make sure "dataScienceIocContainer.ts" has also been updated appropriately?
 
@@ -193,6 +194,7 @@ export function registerTypes(serviceManager: IServiceManager, inNotebookApiExpe
     serviceManager.addSingleton<INotebookEditorProvider>(INotebookEditorProvider, NotebookEditorProvider);
     serviceManager.addSingleton<CellHashProviderFactory>(CellHashProviderFactory, CellHashProviderFactory);
     serviceManager.addSingleton<IExtensionSyncActivationService>(IExtensionSyncActivationService, HoverProvider);
+    serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, LanguageSwitcher);
     serviceManager.add<ICodeWatcher>(ICodeWatcher, CodeWatcher);
     serviceManager.addSingleton<IDataScienceErrorHandler>(IDataScienceErrorHandler, DataScienceErrorHandler);
     serviceManager.add<IDataViewer>(IDataViewer, DataViewer);

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -28,6 +28,7 @@ import {
     UIKind,
     DebugSession,
     languages,
+    Range,
     Position,
     Hover,
     Diagnostic
@@ -133,6 +134,23 @@ export async function deleteAllCellsAndWait() {
     await chainWithPendingUpdates(activeEditor.document, (edit) =>
         edit.replaceNotebookCells(activeEditor.document.uri, new NotebookRange(0, activeEditor.document.cellCount), [])
     );
+}
+export async function insertIntoCell(cell: NotebookCell, pos: Position, text: string) {
+    // Find matching editor
+    const editor = window.visibleTextEditors.find((e) => e.document === cell.document);
+    assert.ok(editor, `Cannot find editor for cell ${cell.document.uri.toString()}`);
+    return editor?.edit((b) => {
+        b.insert(pos, text);
+    });
+}
+
+export async function deleteFromCell(cell: NotebookCell, range: Range) {
+    // Find matching editor
+    const editor = window.visibleTextEditors.find((e) => e.document === cell.document);
+    assert.ok(editor, `Cannot find editor for cell ${cell.document.uri.toString()}`);
+    return editor?.edit((b) => {
+        b.delete(range);
+    });
 }
 
 export async function createTemporaryFile(options: {


### PR DESCRIPTION
Fixes #4588

Added a new class 'LanguageSwitcher' that watches for cell magics that switch a cell to a different type. 

Basically if you type something like ```%%html``` the cell will auto switch to html.

