### PR TITLE
fix #8455

### DIFF
--- a/news/2 Fixes/8455.md
+++ b/news/2 Fixes/8455.md
@@ -1,0 +1,1 @@
+Context key not updated when interactive window is created from command palatte.

--- a/src/client/datascience/interactive-window/interactiveWindow.ts
+++ b/src/client/datascience/interactive-window/interactiveWindow.ts
@@ -222,6 +222,11 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
                 }
             })
         );
+
+        if (window.activeNotebookEditor === this._notebookEditor) {
+            this._onDidChangeViewState.fire();
+        }
+
         this.listenForControllerSelection(notebookEditor.document);
         return notebookEditor;
     }


### PR DESCRIPTION
For #8455. Emit active iw event on iw creation to ensure the context keys are updated.
