### PR TITLE
Fix problem with markdown being passed to pylance

### DIFF
--- a/news/2 Fixes/8769.md
+++ b/news/2 Fixes/8769.md
@@ -1,0 +1,1 @@
+Fix problem with markdown cells causing off by one errors in notebooks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3624,9 +3624,9 @@
             }
         },
         "@vscode/jupyter-lsp-middleware": {
-            "version": "0.2.34",
-            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.34.tgz",
-            "integrity": "sha512-GT7ySQ11EE3Raj2TQcods9xGtCG8paOr5z4hX1uS2vqIuBTRGA3tiBgU0B+3bkNAe/wTWhLfMx7323L0/v9SSA==",
+            "version": "0.2.36",
+            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.36.tgz",
+            "integrity": "sha512-oyYT8mdZolRuuen1brtjBSbjMypgmIjxpPL5M3JOAJv99LfRzjiHqVUS02mj6UJoYlnp588O88S+TzOB1TrBCw==",
             "requires": {
                 "@vscode/lsp-notebook-concat": "^0.1.5",
                 "fast-myers-diff": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -2012,7 +2012,7 @@
         "@jupyterlab/services": "^6.1.17",
         "@lumino/widgets": "^1.28.0",
         "@nteract/messaging": "^7.0.0",
-        "@vscode/jupyter-lsp-middleware": "^0.2.34",
+        "@vscode/jupyter-lsp-middleware": "^0.2.36",
         "ansi-to-html": "^0.6.7",
         "arch": "^2.1.0",
         "bootstrap": "^4.3.1",

--- a/src/client/datascience/notebook/intellisense/intellisenseProvider.ts
+++ b/src/client/datascience/notebook/intellisense/intellisenseProvider.ts
@@ -185,7 +185,10 @@ export class IntellisenseProvider implements INotebookLanguageClientProvider, IE
             notebookId = activeInterpreter ? this.getInterpreterIdFromCache(activeInterpreter) : undefined;
         }
 
-        return interpreterId == notebookId;
+        // Cell also have to support python
+        const cell = notebook?.getCells().find((c) => c.document.uri.toString() === uri.toString());
+
+        return interpreterId == notebookId && (!cell || cell.document.languageId === 'python');
     }
 
     private getNotebookHeader(uri: Uri) {


### PR DESCRIPTION
Fixes: #8769

With pylance handling intellisense, we were also passing non python cells along. This filters those out so pylance never sees them.

Before change:

![image](https://user-images.githubusercontent.com/19672699/150618826-f02f5533-3aaa-4feb-857c-b56b6aa6ea74.png)


Notice the off by one error on the diagnostics

After change:

![image](https://user-images.githubusercontent.com/19672699/150618689-b05fcfee-ad39-4780-b12d-df88bf962159.png)

