### PR TITLE
Fix callstack walking and add 'rchiodo' as an allowed publisher

### DIFF
--- a/src/client/api/kernelApi.ts
+++ b/src/client/api/kernelApi.ts
@@ -5,7 +5,7 @@ import { injectable, inject } from 'inversify';
 import { Disposable, Event, EventEmitter, NotebookDocument } from 'vscode';
 import { disposeAllDisposables } from '../common/helpers';
 import { traceInfo } from '../common/logger';
-import { IDisposable, IDisposableRegistry } from '../common/types';
+import { IDisposable, IDisposableRegistry, IExtensions } from '../common/types';
 import { PromiseChain } from '../common/utils/async';
 import { Telemetry } from '../datascience/constants';
 import { KernelConnectionWrapper } from '../datascience/jupyter/kernels/kernelConnectionWrapper';
@@ -35,10 +35,12 @@ export class JupyterKernelServiceFactory {
         @inject(IKernelProvider) private readonly kernelProvider: IKernelProvider,
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
         @inject(INotebookControllerManager) private readonly notebookControllerManager: INotebookControllerManager,
-        @inject(ApiAccessService) private readonly apiAccess: ApiAccessService
+        @inject(ApiAccessService) private readonly apiAccess: ApiAccessService,
+        @inject(IExtensions) private readonly extensions: IExtensions
     ) {}
     public async getService() {
-        const accessInfo = await this.chainedApiAccess.chainFinally(() => this.apiAccess.getAccessInformation());
+        const info = await this.extensions.determineExtensionFromCallStack();
+        const accessInfo = await this.chainedApiAccess.chainFinally(() => this.apiAccess.getAccessInformation(info));
         if (!accessInfo.accessAllowed) {
             return;
         }


### PR DESCRIPTION
I'm working on contextual help and the callstack walking didn't work (chain promise forced stack walk across async boundary and lost original caller)

I've also added myself as an allowed publisher.