### PR TITLE
Support ipywidgets when restarting remote kernels

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -668,7 +668,6 @@ module.exports = {
         'src/client/datascience/jupyter/interpreter/jupyterInterpreterOldCacheStateStore.ts',
         'src/client/datascience/jupyter/interpreter/jupyterInterpreterSelector.ts',
         'src/client/datascience/jupyter/commandLineSelector.ts',
-        'src/client/datascience/jupyter/jupyterWebSocket.ts',
         'src/client/datascience/jupyter/variableScriptLoader.ts',
         'src/client/datascience/jupyter/jupyterImporter.ts',
         'src/client/datascience/jupyter/oldJupyterVariables.ts',

--- a/src/client/datascience/baseJupyterSession.ts
+++ b/src/client/datascience/baseJupyterSession.ts
@@ -171,6 +171,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
     public async restart(): Promise<void> {
         if (this.session?.isRemoteSession && this.session.kernel) {
             await this.session.kernel.restart();
+            this.setSession(this.session, true);
             return;
         }
 
@@ -342,7 +343,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
     }
 
     // Changes the current session.
-    protected setSession(session: ISessionWithSocket | undefined) {
+    protected setSession(session: ISessionWithSocket | undefined, forceUpdateKernelSocketInfo: boolean = false) {
         const oldSession = this._session;
         if (oldSession) {
             if (this.ioPubHandler) {
@@ -367,7 +368,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
                 session.unhandledMessage.connect(this.unhandledMessageHandler);
             }
             // If we have a new session, then emit the new kernel connection information.
-            if (oldSession !== session && session.kernel) {
+            if ((forceUpdateKernelSocketInfo || oldSession !== session) && session.kernel) {
                 this._kernelSocket.next({
                     options: {
                         clientId: session.kernel.clientId,

--- a/src/client/datascience/ipywidgets/ipyWidgetMessageDispatcher.ts
+++ b/src/client/datascience/ipywidgets/ipyWidgetMessageDispatcher.ts
@@ -46,7 +46,7 @@ export class IPyWidgetMessageDispatcher implements IIPyWidgetMessageDispatcher {
     private readonly disposables: IDisposable[] = [];
     private kernelRestartHandlerAttached?: boolean;
     private kernelSocketInfo?: KernelSocketInformation;
-    private kernelWasConnectedAtleastOnce?: boolean;
+    private kernelWasConnectedAtLeastOnce?: boolean;
     private disposed = false;
     private pendingMessages: string[] = [];
     private subscribedToKernelSocket: boolean = false;
@@ -191,7 +191,7 @@ export class IPyWidgetMessageDispatcher implements IIPyWidgetMessageDispatcher {
             this.kernelSocketInfo?.socket?.removeReceiveHook(this.onKernelSocketMessage); // NOSONAR
             this.kernelSocketInfo?.socket?.removeSendHook(this.mirrorSend); // NOSONAR
 
-            if (this.kernelWasConnectedAtleastOnce) {
+            if (this.kernelWasConnectedAtLeastOnce) {
                 // this means we restarted the kernel and we now have new information.
                 // Discard all of the messages upto this point.
                 while (this.pendingMessages.length) {
@@ -210,7 +210,7 @@ export class IPyWidgetMessageDispatcher implements IIPyWidgetMessageDispatcher {
                 return;
             }
 
-            this.kernelWasConnectedAtleastOnce = true;
+            this.kernelWasConnectedAtLeastOnce = true;
             this.kernelSocketInfo = info;
             this.kernelSocketInfo.socket?.addReceiveHook(this.onKernelSocketMessage); // NOSONAR
             this.kernelSocketInfo.socket?.addSendHook(this.mirrorSend); // NOSONAR

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -311,7 +311,11 @@ export class JupyterSession extends BaseJupyterSession {
                             sessionWithSocket.resource = this.resource;
                             sessionWithSocket.kernelConnectionMetadata = this.kernelConnectionMetadata;
                             sessionWithSocket.kernelSocketInformation = {
-                                socket: JupyterWebSockets.get(session.kernel.id),
+                                get socket() {
+                                    // When we restart kernels, a new websocket is created and we need to get the new one.
+                                    // & the id in the dictionary is the kernel.id.
+                                    return JupyterWebSockets.get(session.kernel!.id);
+                                },
                                 options: {
                                     clientId: session.kernel.clientId,
                                     id: session.kernel.id,

--- a/src/client/datascience/jupyter/jupyterWebSocket.ts
+++ b/src/client/datascience/jupyter/jupyterWebSocket.ts
@@ -49,15 +49,19 @@ export function createJupyterWebSocket(cookieString?: string, allowUnauthorized?
             if (this.kernelId) {
                 JupyterWebSockets.set(this.kernelId, this);
                 this.on('close', () => {
-                    clearInterval(this.timer as any);
-                    JupyterWebSockets.delete(this.kernelId!);
+                    if (this.timer !== timer){
+                        clearInterval(timer as any);
+                    }
+                    if (JupyterWebSockets.get(this.kernelId!) === this){
+                        JupyterWebSockets.delete(this.kernelId!);
+                    }
                 });
             } else {
                 traceError('KernelId not extracted from Kernel WebSocket URL');
             }
 
             // Ping the websocket connection every 30 seconds to make sure it stays alive
-            this.timer = setInterval(() => this.ping(noop), 30_000);
+            const timer = this.timer = setInterval(() => this.ping(noop), 30_000);
         }
     }
     return JupyterWebSocket;

--- a/src/client/datascience/jupyter/jupyterWebSocket.ts
+++ b/src/client/datascience/jupyter/jupyterWebSocket.ts
@@ -40,7 +40,7 @@ export function createJupyterWebSocket(cookieString?: string, allowUnauthorized?
             }
 
             super(url, protocols, co);
-
+            let timer: NodeJS.Timeout | undefined = undefined;
             // Parse the url for the kernel id
             const parsed = /.*\/kernels\/(.*)\/.*/.exec(url);
             if (parsed && parsed.length > 1) {
@@ -49,10 +49,10 @@ export function createJupyterWebSocket(cookieString?: string, allowUnauthorized?
             if (this.kernelId) {
                 JupyterWebSockets.set(this.kernelId, this);
                 this.on('close', () => {
-                    if (this.timer !== timer){
+                    if (timer && this.timer !== timer) {
                         clearInterval(timer as any);
                     }
-                    if (JupyterWebSockets.get(this.kernelId!) === this){
+                    if (JupyterWebSockets.get(this.kernelId!) === this) {
                         JupyterWebSockets.delete(this.kernelId!);
                     }
                 });
@@ -61,7 +61,7 @@ export function createJupyterWebSocket(cookieString?: string, allowUnauthorized?
             }
 
             // Ping the websocket connection every 30 seconds to make sure it stays alive
-            const timer = this.timer = setInterval(() => this.ping(noop), 30_000);
+            timer = this.timer = setInterval(() => this.ping(noop), 30_000);
         }
     }
     return JupyterWebSocket;

--- a/src/datascience-ui/ipywidgets/common/manager.ts
+++ b/src/datascience-ui/ipywidgets/common/manager.ts
@@ -111,7 +111,7 @@ export class WidgetManager implements IIPyWidgetManager, IMessageHandler {
         }
 
         if (!data || data.version_major !== 2) {
-            console.warn('Widget data not avaialble to render an ipywidget');
+            console.warn('Widget data not available to render an ipywidget');
             return undefined;
         }
 
@@ -144,7 +144,7 @@ export class WidgetManager implements IIPyWidgetManager, IMessageHandler {
         return this.manager.display_view(data, view, { node: ele });
     }
     private initializeKernelAndWidgetManager(options: KernelSocketOptions) {
-        if (this.proxyKernel && fastDeepEqual(options, this.options)) {
+        if (this.manager && this.proxyKernel && fastDeepEqual(options, this.options)) {
             return;
         }
         this.proxyKernel?.dispose(); // NOSONAR

--- a/src/test/datascience/interactiveWindow.vscode.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.test.ts
@@ -439,6 +439,14 @@ ${actualCode}
             disposables
         );
         const lastCell = await waitForLastCellToComplete(activeInteractiveWindow, 2, true);
+
+        // Wait for the outputs to be available.
+        await waitForCondition(
+            async () => lastCell.outputs.length > 0 && lastCell.outputs[0].items.length > 0,
+            defaultNotebookTestTimeout,
+            'Outputs not available'
+        );
+
         const ipythonVersionCell = activeInteractiveWindow.notebookDocument?.cellAt(lastCell.index - 1);
         const ipythonVersion = parseInt(getTextOutputValue(ipythonVersionCell!.outputs[0]));
 
@@ -467,6 +475,13 @@ ${actualCode}
             disposables
         );
         const lastCell = await waitForLastCellToComplete(activeInteractiveWindow, 1, true);
+
+        // Wait for the outputs to be available.
+        await waitForCondition(
+            async () => lastCell.outputs.length > 0 && lastCell.outputs[0].items.length > 0,
+            defaultNotebookTestTimeout,
+            'Outputs not available'
+        );
 
         // Parse the last cell's output
         await waitForTextOutput(lastCell, '1');

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -66,6 +66,10 @@ suite('DataScience - JupyterSession', () => {
                 connect: noop,
                 disconnect: noop
             },
+            unhandledMessage: {
+                connect: noop,
+                disconnect: noop
+            },
             kernel: {
                 status: 'idle',
                 restart: () => (restartCount = restartCount + 1),
@@ -409,6 +413,14 @@ suite('DataScience - JupyterSession', () => {
 
                 const signal = mock<ISignal<ISessionWithSocket, Kernel.Status>>();
                 when(remoteSession.statusChanged).thenReturn(instance(signal));
+                when(remoteSession.unhandledMessage).thenReturn(
+                    instance(mock<ISignal<ISessionWithSocket, KernelMessage.IMessage<KernelMessage.MessageType>>>())
+                );
+                when(remoteSession.iopubMessage).thenReturn(
+                    instance(
+                        mock<ISignal<ISessionWithSocket, KernelMessage.IIOPubMessage<KernelMessage.IOPubMessageType>>>()
+                    )
+                );
 
                 await connect('connectToLiveKernel');
             });

--- a/src/test/datascience/widgets/standard.vscode.test.ts
+++ b/src/test/datascience/widgets/standard.vscode.test.ts
@@ -150,7 +150,7 @@ suite('Standard IPyWidget (Execution) (slow) (WIDGET_TEST)', function () {
 
         await testSliderWidget(comms);
     });
-    test.skip('Widget renders after restarting kernel', async () => {
+    test('Widget renders after restarting kernel', async () => {
         const comms = await initializeNotebook({ templateFile: templateNbPath });
         await testSliderWidget(comms);
 
@@ -159,15 +159,15 @@ suite('Standard IPyWidget (Execution) (slow) (WIDGET_TEST)', function () {
         await kernel.restart();
         await testSliderWidget(comms);
 
-        // Clear all cells and restart and test again.
-        await kernel.restart();
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
-        await commands.executeCommand('notebook.clearAllCellsOutputs');
-        await waitForCondition(async () => cell.outputs.length === 0, 5_000, 'Cell did not get cleared');
+        // // Clear all cells and restart and test again.
+        // await kernel.restart();
+        // const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        // await commands.executeCommand('notebook.clearAllCellsOutputs');
+        // await waitForCondition(async () => cell.outputs.length === 0, 5_000, 'Cell did not get cleared');
 
-        await testSliderWidget(comms);
+        // await testSliderWidget(comms);
     });
-    test.skip('Widget renders after interrupting kernel', async () => {
+    test('Widget renders after interrupting kernel', async () => {
         // https://github.com/microsoft/vscode-jupyter/issues/8749
         const comms = await initializeNotebook({ templateFile: templateNbPath });
         await testSliderWidget(comms);
@@ -177,12 +177,12 @@ suite('Standard IPyWidget (Execution) (slow) (WIDGET_TEST)', function () {
         await kernel.interrupt();
         await testSliderWidget(comms);
 
-        // Clear all cells and restart and test again.
-        await kernel.interrupt();
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
-        await commands.executeCommand('notebook.clearAllCellsOutputs');
-        await waitForCondition(async () => cell.outputs.length === 0, 5_000, 'Cell did not get cleared');
+        // // Clear all cells and restart and test again.
+        // await kernel.interrupt();
+        // const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        // await commands.executeCommand('notebook.clearAllCellsOutputs');
+        // await waitForCondition(async () => cell.outputs.length === 0, 5_000, 'Cell did not get cleared');
 
-        await testSliderWidget(comms);
+        // await testSliderWidget(comms);
     });
 });

--- a/src/test/datascience/widgets/standard.vscode.test.ts
+++ b/src/test/datascience/widgets/standard.vscode.test.ts
@@ -150,7 +150,7 @@ suite('Standard IPyWidget (Execution) (slow) (WIDGET_TEST)', function () {
 
         await testSliderWidget(comms);
     });
-    test('Widget renders after restarting kernel', async () => {
+    test.skip('Widget renders after restarting kernel', async () => {
         const comms = await initializeNotebook({ templateFile: templateNbPath });
         await testSliderWidget(comms);
 
@@ -159,15 +159,15 @@ suite('Standard IPyWidget (Execution) (slow) (WIDGET_TEST)', function () {
         await kernel.restart();
         await testSliderWidget(comms);
 
-        // // Clear all cells and restart and test again.
-        // await kernel.restart();
-        // const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
-        // await commands.executeCommand('notebook.clearAllCellsOutputs');
-        // await waitForCondition(async () => cell.outputs.length === 0, 5_000, 'Cell did not get cleared');
+        // Clear all cells and restart and test again.
+        await kernel.restart();
+        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        await commands.executeCommand('notebook.clearAllCellsOutputs');
+        await waitForCondition(async () => cell.outputs.length === 0, 5_000, 'Cell did not get cleared');
 
-        // await testSliderWidget(comms);
+        await testSliderWidget(comms);
     });
-    test('Widget renders after interrupting kernel', async () => {
+    test.skip('Widget renders after interrupting kernel', async () => {
         // https://github.com/microsoft/vscode-jupyter/issues/8749
         const comms = await initializeNotebook({ templateFile: templateNbPath });
         await testSliderWidget(comms);
@@ -177,12 +177,12 @@ suite('Standard IPyWidget (Execution) (slow) (WIDGET_TEST)', function () {
         await kernel.interrupt();
         await testSliderWidget(comms);
 
-        // // Clear all cells and restart and test again.
-        // await kernel.interrupt();
-        // const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
-        // await commands.executeCommand('notebook.clearAllCellsOutputs');
-        // await waitForCondition(async () => cell.outputs.length === 0, 5_000, 'Cell did not get cleared');
+        // Clear all cells and restart and test again.
+        await kernel.interrupt();
+        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        await commands.executeCommand('notebook.clearAllCellsOutputs');
+        await waitForCondition(async () => cell.outputs.length === 0, 5_000, 'Cell did not get cleared');
 
-        // await testSliderWidget(comms);
+        await testSliderWidget(comms);
     });
 });


### PR DESCRIPTION
For #8378 #8431

Looks like the previous fix never worked (i can't get it work at all without the changes in this PR).
Basically when we restart the remote kernel, wen end up with a new websocket connection and this is never used.

Hence this PR is necessary to fix this & the old fix never worked.
It was closed incorrectly (by me), user had validated a different issue. 

THis is required for this release as we have a new entry for this, either we take this PR or remove the new entry for #8378