### PR TITLE
Add tool for replaying pylance logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,6 +278,7 @@
                 "command": "jupyter.replayPylanceLogStep",
                 "title": "Step Pylance Log",
                 "category": "Jupyter (Dev)",
+                "icon": "$(debug-start)",
                 "enablement": "jupyter.development && notebookType == jupyter-notebook && isWorkspaceTrusted && jupyter.replayLogLoaded"
             },
             {
@@ -1043,11 +1044,6 @@
                     "command": "jupyter.replayPylanceLog",
                     "title": "Replay Pylance Log",
                     "when": "jupyter.development && isWorkspaceTrusted"
-                },
-                {
-                    "command": "jupyter.debugNotebook",
-                    "title": "%jupyter.command.jupyter.debug.title%",
-                    "when": "false"
                 },
                 {
                     "command": "jupyter.debugNotebook",

--- a/package.json
+++ b/package.json
@@ -269,6 +269,18 @@
                 "enablement": "jupyter.development"
             },
             {
+                "command": "jupyter.replayPylanceLog",
+                "title": "Replay Pylance Log",
+                "category": "Jupyter (Dev)",
+                "enablement": "jupyter.development && notebookType == jupyter-notebook && isWorkspaceTrusted"
+            },
+            {
+                "command": "jupyter.replayPylanceLogStep",
+                "title": "Step Pylance Log",
+                "category": "Jupyter (Dev)",
+                "enablement": "jupyter.development && notebookType == jupyter-notebook && isWorkspaceTrusted && jupyter.replayLogLoaded"
+            },
+            {
                 "command": "jupyter.debugNotebook",
                 "title": "%jupyter.command.jupyter.debug.title%",
                 "icon": "$(bug)",
@@ -915,6 +927,11 @@
                     "command": "jupyter.notebookeditor.export",
                     "group": "Jupyter",
                     "when": "notebookType == 'jupyter-notebook' && isWorkspaceTrusted && jupyter.ispythonnotebook"
+                },
+                {
+                    "command": "jupyter.replayPylanceLogStep",
+                    "group": "navigation@1",
+                    "when": "notebookType == 'jupyter-notebook' && isWorkspaceTrusted && jupyter.replayLogLoaded"
                 }
             ],
             "notebook/cell/title": [
@@ -1022,6 +1039,16 @@
                 }
             ],
             "commandPalette": [
+                {
+                    "command": "jupyter.replayPylanceLog",
+                    "title": "Replay Pylance Log",
+                    "when": "jupyter.development && isWorkspaceTrusted"
+                },
+                {
+                    "command": "jupyter.debugNotebook",
+                    "title": "%jupyter.command.jupyter.debug.title%",
+                    "when": "false"
+                },
                 {
                     "command": "jupyter.debugNotebook",
                     "title": "%jupyter.command.jupyter.debug.title%",

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -186,4 +186,6 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [DSCommands.RunAndDebugCell]: [NotebookCell];
     [DSCommands.RunByLineNext]: [NotebookCell];
     [DSCommands.RunByLineStop]: [];
+    [DSCommands.ReplayPylanceLog]: [Uri];
+    [DSCommands.ReplayPylanceLogStep]: [];
 }

--- a/src/client/common/utils/async.ts
+++ b/src/client/common/utils/async.ts
@@ -38,6 +38,32 @@ export async function waitForPromise<T>(promise: Promise<T>, timeout: number): P
     });
 }
 
+export async function waitForCondition(
+    condition: () => Promise<boolean>,
+    timeout: number,
+    interval: number
+): Promise<boolean> {
+    // Set a timer that will resolve with null
+    return new Promise<boolean>((resolve) => {
+        let finish: (result: boolean) => void;
+        const timer = setTimeout(() => finish(false), timeout);
+        const intervalId = setInterval(() => {
+            condition()
+                .then((r) => {
+                    if (r) {
+                        finish(true);
+                    }
+                })
+                .catch((_e) => finish(false));
+        }, interval);
+        finish = (result: boolean) => {
+            clearTimeout(timer);
+            clearInterval(intervalId);
+            resolve(result);
+        };
+    });
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isThenable<T>(v: any): v is Thenable<T> {
     return typeof v?.then === 'function';

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -162,6 +162,8 @@ export namespace Commands {
     export const RunAndDebugCell = 'jupyter.runAndDebugCell';
     export const RunByLineNext = 'jupyter.runByLineNext';
     export const RunByLineStop = 'jupyter.runByLineStop';
+    export const ReplayPylanceLog = 'jupyter.replayPylanceLog';
+    export const ReplayPylanceLogStep = 'jupyter.replayPylanceLogStep';
 }
 
 export namespace CodeLensCommands {
@@ -199,6 +201,7 @@ export namespace EditorContexts {
     export const IsDataViewerActive = 'jupyter.dataViewerActive';
     export const HasNativeNotebookOrInteractiveWindowOpen = 'jupyter.hasNativeNotebookOrInteractiveWindowOpen';
     export const ZmqAvailable = 'jupyter.zmqavailable';
+    export const ReplayLogLoaded = 'jupyter.replayLogLoaded';
 }
 
 export namespace RegExpValues {

--- a/src/client/datascience/notebook/intellisense/logReplayService.ts
+++ b/src/client/datascience/notebook/intellisense/logReplayService.ts
@@ -18,7 +18,11 @@ import { ContextKey } from '../../../common/contextKey';
 import { sleep, waitForCondition } from '../../../common/utils/async';
 
 /**
- * Class used to replay pylance log output to regenerate a series of edits. SHIFT+F10 will play the steps one at a time
+ * Class used to replay pylance log output to regenerate a series of edits.
+ *
+ * To use this
+ * - Run "Jupyter (dev): Replay pylance log"
+ * - Click on the 'Step Pylance Log' button that appears
  */
 @injectable()
 export class LogReplayService implements IExtensionSingleActivationService {

--- a/src/client/datascience/notebook/intellisense/logReplayService.ts
+++ b/src/client/datascience/notebook/intellisense/logReplayService.ts
@@ -21,8 +21,17 @@ import { sleep, waitForCondition } from '../../../common/utils/async';
  * Class used to replay pylance log output to regenerate a series of edits.
  *
  * To use this
- * - Run "Jupyter (dev): Replay pylance log"
+ * - Have customer do a bunch of edits with these settings active:
+ *   "notebook-intellisense.logLevel": "Trace"
+ *   "notebook-intellisense.trace.server.verbosity": "Verbose",
+ * - Save output of the 'language server' trace (should have the same name as the kernel)
+ * - Run "Jupyter (dev): Replay pylance log" and pick the output file
  * - Click on the 'Step Pylance Log' button that appears
+ *
+ * Note:
+ * There may be bugs with
+ * - Creating new cells
+ * - Deleting tabs (seems to only delete a single space)
  */
 @injectable()
 export class LogReplayService implements IExtensionSingleActivationService {

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -165,11 +165,12 @@ import { ExportToPythonPlain } from './export/exportToPythonPlain';
 import { ErrorRendererCommunicationHandler } from './errors/errorRendererComms';
 import { KernelProgressReporter } from './progress/kernelProgressReporter';
 import { PreReleaseChecker } from './prereleaseChecker';
+import { LogReplayService } from './notebook/intellisense/logReplayService';
 
 // README: Did you make sure "dataScienceIocContainer.ts" has also been updated appropriately?
 
 // eslint-disable-next-line
-export function registerTypes(serviceManager: IServiceManager, inNotebookApiExperiment: boolean) {
+export function registerTypes(serviceManager: IServiceManager, inNotebookApiExperiment: boolean, isDevMode: boolean) {
     const isVSCInsiders = serviceManager.get<IApplicationEnvironment>(IApplicationEnvironment).channel === 'insiders';
     const useVSCodeNotebookAPI = inNotebookApiExperiment;
     serviceManager.addSingletonInstance<number>(DataScienceStartupTime, Date.now());
@@ -231,6 +232,9 @@ export function registerTypes(serviceManager: IServiceManager, inNotebookApiExpe
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, NotebookUsageTracker);
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, MigrateJupyterInterpreterStateService);
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, VariableViewActivationService);
+    if (isDevMode) {
+        serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, LogReplayService);
+    }
     serviceManager.addSingleton<IInteractiveWindowProvider>(IInteractiveWindowProvider, InteractiveWindowProvider);
     serviceManager.addSingleton<IDataScienceCommandListener>(IDataScienceCommandListener, NativeInteractiveWindowCommandListener);
     serviceManager.addSingleton<IDataScienceCommandListener>(IDataScienceCommandListener, KernelCommandListener);

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -144,7 +144,7 @@ async function activateLegacy(
 
     // Register datascience types after experiments have loaded.
     // To ensure we can register types based on experiments.
-    dataScienceRegisterTypes(serviceManager, useVSCodeNotebookAPI);
+    dataScienceRegisterTypes(serviceManager, useVSCodeNotebookAPI, isDevMode);
 
     // Language feature registrations.
     activationRegisterTypes(serviceManager);


### PR DESCRIPTION
For #8678

The LogReplayService (only available in dev mode) allows you to playback the debug output of pylance intellisense and have it generate the same edits to a notebook.

I used this to investigate #8678.

