### PR TITLE
Remove viewBox for plot viewer

### DIFF
--- a/news/2 Fixes/7523.md
+++ b/news/2 Fixes/7523.md
@@ -1,0 +1,1 @@
+Fix plot viewer so that plots are full size when opening.

--- a/src/client/datascience/notebook/outputs/plotViewHandler.ts
+++ b/src/client/datascience/notebook/outputs/plotViewHandler.ts
@@ -62,7 +62,7 @@ function convertPngToSvg(pngOutput: NotebookCellOutputItem): string {
     // in the plot viewer works. The injected svg is sized down to 100px x 100px on the plot selection list so if
     // dims are set on the image then it scales out of bounds
     return `<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<svg height="${dims.height}" width="${dims.width}" version="1.1" viewBox="0 0 386 248" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg height="${dims.height}" width="${dims.width}" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <g>
         <image xmlns="http://www.w3.org/2000/svg" x="0" y="0" height="100%" width="100%" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="data:image/png;base64,${imageData}"/>
     </g>


### PR DESCRIPTION
Fixes #7523

Not sure why we had the viewbox there. Works much better without it.

