### PR TITLE
Fix tabbing through all levels for completions in a path

### DIFF
--- a/news/2 Fixes/7816.md
+++ b/news/2 Fixes/7816.md
@@ -1,0 +1,1 @@
+Fix completions for paths for notebooks so that you can keep tabbing through all entries. This used to stop after the first level.

--- a/src/client/datascience/notebook/intellisense/pythonKernelCompletionProvider.ts
+++ b/src/client/datascience/notebook/intellisense/pythonKernelCompletionProvider.ts
@@ -311,6 +311,20 @@ export function filterCompletions(
     // If not inside of a string, filter out file names (things with a '.' in them or end with '/')
     if (!insideString) {
         result = result.filter((r) => !r.itemText.includes('.') && !r.itemText.endsWith('/'));
+    } else {
+        // If inside a string and ending with '/', then add a command to force a suggestion right after
+        result = result.map((r) => {
+            if (r.itemText.endsWith('/')) {
+                return {
+                    ...r,
+                    command: {
+                        command: 'editor.action.triggerSuggest',
+                        title: ''
+                    }
+                };
+            }
+            return r;
+        });
     }
 
     // Remove any duplicates (picking pylance over jupyter)


### PR DESCRIPTION
Fixes #7816 

Thanks @misolori. I used the html extension and figured out what it was returning differently. Its completion items include a command to run when they are completed.

