### PR TITLE
Fix magic in the middle of a notebook to not mess up intellisense

### DIFF
--- a/news/2 Fixes/8830.md
+++ b/news/2 Fixes/8830.md
@@ -1,0 +1,1 @@
+Fix for intellisense breaking after typing a magic into a cell other than the first.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3624,11 +3624,11 @@
             }
         },
         "@vscode/jupyter-lsp-middleware": {
-            "version": "0.2.36",
-            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.36.tgz",
-            "integrity": "sha512-oyYT8mdZolRuuen1brtjBSbjMypgmIjxpPL5M3JOAJv99LfRzjiHqVUS02mj6UJoYlnp588O88S+TzOB1TrBCw==",
+            "version": "0.2.37",
+            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.37.tgz",
+            "integrity": "sha512-o2iYtPc9YkHDNugLtMSHldavKD/5CBYRG7o2IgFhSn8Amx8vZQKPo4FXBKeZeWtZWEawDstTn2+Guo2GbKi+LA==",
             "requires": {
-                "@vscode/lsp-notebook-concat": "^0.1.5",
+                "@vscode/lsp-notebook-concat": "^0.1.6",
                 "fast-myers-diff": "^3.0.1",
                 "sha.js": "^2.4.11",
                 "vscode-languageclient": "7.0.0",
@@ -3637,9 +3637,9 @@
             }
         },
         "@vscode/lsp-notebook-concat": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/@vscode/lsp-notebook-concat/-/lsp-notebook-concat-0.1.5.tgz",
-            "integrity": "sha512-08QKLlmfPdidtIB8uzLzGjdbmOgDzpor4cde/MaSS2to8Ve3UP6J8Pd7rHNPrY04OTi7oxpYvpDxltbOliJ9dw==",
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@vscode/lsp-notebook-concat/-/lsp-notebook-concat-0.1.6.tgz",
+            "integrity": "sha512-ql/f9l5TehlYBESx+IsUh3GfT1dWhdWZQWNbpqgTSWFJDvFB66r3qaHVAkaWW04yiUkHqg6RDfVbfrfXkYRt6w==",
             "requires": {
                 "vscode-languageserver-protocol": "^3.16.0",
                 "vscode-uri": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -2098,7 +2098,7 @@
         "@jupyterlab/services": "^6.1.17",
         "@lumino/widgets": "^1.28.0",
         "@nteract/messaging": "^7.0.0",
-        "@vscode/jupyter-lsp-middleware": "^0.2.36",
+        "@vscode/jupyter-lsp-middleware": "^0.2.37",
         "ansi-to-html": "^0.6.7",
         "arch": "^2.1.0",
         "bootstrap": "^4.3.1",


### PR DESCRIPTION
Fixes #8830

There was an issue in the [concat ](https://github.com/microsoft/lsp-notebook-concat/pull/6) layer. This takes in the new change.

I'd like to take this now because otherwise this will be broken for a whole month while we wait for us to switch everybody over to using pylance for notebooks (which should have this fix in their next release)