### PR TITLE
Fix link clicks

### DIFF
--- a/news/2 Fixes/8839.md
+++ b/news/2 Fixes/8839.md
@@ -1,0 +1,1 @@
+Fixes clicking links in error tracebacks opening two copies of a file.

--- a/src/client/datascience/editor-integration/cellhashprovider.ts
+++ b/src/client/datascience/editor-integration/cellhashprovider.ts
@@ -498,7 +498,9 @@ export class CellHashProvider implements ICellHashProvider {
                 const afterLineReplace = traceFrame.replace(LineNumberMatchRegex, (_s, prefix, num, suffix) => {
                     const n = parseInt(num, 10);
                     const newLine = matchHash!.firstNonBlankLineIndex + n - 1;
-                    return `${prefix}<a href='${matchUri?.toString()}?line=${newLine}'>${newLine + 1}</a>${suffix}`;
+                    return `${prefix}<a href='${matchUri?.toString().replace('file:', 'file_link:')}?line=${newLine}'>${
+                        newLine + 1
+                    }</a>${suffix}`;
                 });
 
                 // Then replace the input line with our uri for this cell
@@ -518,7 +520,9 @@ export class CellHashProvider implements ICellHashProvider {
                     // We have a match, replace source lines first
                     const afterLineReplace = traceFrame.replace(LineNumberMatchRegex, (_s, prefix, num, suffix) => {
                         const n = parseInt(num, 10);
-                        return `${prefix}<a href='${matchingCellUri}?line=${n - 1}'>${n}</a>${suffix}`;
+                        return `${prefix}<a href='${matchingCellUri.replace('file:', 'file_link:')}?line=${
+                            n - 1
+                        }'>${n}</a>${suffix}`;
                     });
 
                     // Then replace the input line with our uri for this cell
@@ -539,7 +543,9 @@ export class CellHashProvider implements ICellHashProvider {
             // We have a match, replace source lines with hrefs
             return traceFrame.replace(LineNumberMatchRegex, (_s, prefix, num, suffix) => {
                 const n = parseInt(num, 10);
-                return `${prefix}<a href='${fileUri?.toString()}?line=${n - 1}'>${n}</a>${suffix}`;
+                return `${prefix}<a href='${fileUri?.toString().replace('file:', 'file_link:')}?line=${
+                    n - 1
+                }'>${n}</a>${suffix}`;
             });
         }
 
@@ -567,7 +573,9 @@ export class CellHashProvider implements ICellHashProvider {
                 return traceFrame.replace(LineNumberMatchRegex, (_s, prefix, num, suffix) => {
                     const n = parseInt(num, 10);
                     const newLine = offset + n - 1;
-                    return `${prefix}<a href='${match[0]}?line=${newLine}'>${newLine + 1}</a>${suffix}`;
+                    return `${prefix}<a href='${match[0].replace('file:', 'file_link:')}?line=${newLine}'>${
+                        newLine + 1
+                    }</a>${suffix}`;
                 });
             }
         } else {
@@ -581,7 +589,9 @@ export class CellHashProvider implements ICellHashProvider {
                     return traceFrame.replace(LineNumberMatchRegex, (_s, prefix, num, suffix) => {
                         const n = parseInt(num, 10);
                         const newLine = offset + n - 1;
-                        return `${prefix}<a href='${matchingFile[0]}?line=${newLine}'>${newLine + 1}</a>${suffix}`;
+                        return `${prefix}<a href='${matchingFile[0].replace('file:', 'file_link:')}?line=${newLine}'>${
+                            newLine + 1
+                        }</a>${suffix}`;
                     });
                 }
             }

--- a/src/datascience-ui/error-renderer/index.ts
+++ b/src/datascience-ui/error-renderer/index.ts
@@ -16,7 +16,7 @@ const handleInnerClick = (event: MouseEvent, context: RendererContext<any>) => {
     for (const pathElement of event.composedPath()) {
         const node: any = pathElement;
         if (node.tagName && node.tagName.toLowerCase() === 'a' && node.href && context.postMessage) {
-            if (node.href.indexOf('file') === 0) {
+            if (node.href.indexOf('file_link:') >= 0) {
                 context.postMessage({
                     message: 'open_link',
                     payload: node.href
@@ -88,7 +88,7 @@ export const activate: ActivationFunction = (_context) => {
             // When we escape, the links would be escaped as well.
             // We need to unescape them.
             const fileLinkRegExp = new RegExp(
-                /&lt;a href=&#39;(file|vscode-notebook-cell):(.*(?=\?))\?line=(\d*)&#39;&gt;(\d*)&lt;\/a&gt;/
+                /&lt;a href=&#39;(file_link|vscode-notebook-cell):(.*(?=\?))\?line=(\d*)&#39;&gt;(\d*)&lt;\/a&gt;/
             );
             const commandRegEx = new RegExp(/&lt;a href=&#39;command:(.*)&#39;&gt;(.*)&lt;\/a&gt;/);
             const akaMsLinks = new RegExp(/&lt;a href=&#39;https:\/\/aka.ms\/(.*)&#39;&gt;(.*)&lt;\/a&gt;/);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-jupyter/issues/8839

VS code was modified to support opening file links from a webview. 

However it doesn't give focus to the same file if it's already open (which we used to do) and doesn't allow for a line number query (which we used to do).

And since we have our own link handler, it was opening twice. This opening twice breaks the IW (because you can't run a cell if the same file is open twice).

This change creates a new scheme that works around this problem - essentially going back to our link click handling.