### PR TITLE
Disable failing test caused by pylance change

### DIFF
--- a/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
@@ -111,9 +111,10 @@ suite('DataScience - VSCode Intellisense Notebook - (Code Completion via Jupyter
         assert.ok(items.find((item) => (typeof item === 'string' ? item.includes('Age') : item.label.includes('Age'))));
 
         // Make sure it is skipping items that are already provided by pylance (no dupes)
-        assert.notOk(
-            items.find((item) => (typeof item === 'string' ? item.includes('Name') : item.label.includes('Name')))
-        );
+        // Pylance isn't returning them right now: https://github.com/microsoft/vscode-jupyter/issues/8842
+        // assert.notOk(
+        //     items.find((item) => (typeof item === 'string' ? item.includes('Name') : item.label.includes('Name')))
+        // );
 
         // Add some text after the . and make sure we still get completions
         const editor = window.visibleTextEditors.find((e) => e.document.uri === cell4.document.uri);


### PR DESCRIPTION
For https://github.com/microsoft/vscode-jupyter/issues/8842

Pylance seems to have changed what they return for ```pandas.read_csv```. It causes this test to fail. 

Disabling the line that checks this.