### PR TITLE
Add output channel for kernel exclusive output

### DIFF
--- a/news/2 Fixes/4954.md
+++ b/news/2 Fixes/4954.md
@@ -1,0 +1,1 @@
+Add `jupyter.logKernelOutputSeparately` to expose the console logs of a kernel and or jupyter server (when we don't start a kernel directly ourselves). This option should make it easier to diagnose kernel only problems.

--- a/package.json
+++ b/package.json
@@ -1960,6 +1960,12 @@
                     "default": ".%",
                     "description": "Characters which trigger auto completion on a python jupyter kernel (requires reload of VS code)",
                     "scope": "machine"
+                },
+                "jupyter.logKernelOutputSeparately": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Creates separate output panels for kernels/jupyter server console output",
+                    "scope": "machine"
                 }
             }
         },

--- a/package.nls.json
+++ b/package.nls.json
@@ -560,5 +560,7 @@
     "DataScience.usingNonPrereleaseNo": "No",
     "DataScience.usingNonPrereleaseNoAndDontAskAgain": "Don't ask again",
     "DataScience.usingNonPrerelease": "The 'prerelease' version of the Jupyter extension is recommended when running on VS code insiders. Would you like to switch?",
-    "DataScience.cellAtFormat": "{0} Cell {1}'"
+    "DataScience.cellAtFormat": "{0} Cell {1}'",
+    "DataScience.jupyterServerConsoleOutputChannel": "Jupyter Server Console",
+    "DataScience.kernelConsoleOutputChannel": "{0} Kernel Console Output"
 }

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -97,6 +97,7 @@ export class JupyterSettings implements IWatchableJupyterSettings {
     public newCellOnRunLast: boolean = true;
     public pylanceHandlesNotebooks: boolean = false;
     public pythonCompletionTriggerCharacters: string = '';
+    public logKernelOutputSeparately: boolean = false;
 
     public variableTooltipFields: IVariableTooltipFields = {
         python: {

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -180,6 +180,7 @@ export interface IJupyterSettings {
     readonly newCellOnRunLast: boolean;
     readonly pylanceHandlesNotebooks?: boolean;
     readonly pythonCompletionTriggerCharacters?: string;
+    readonly logKernelOutputSeparately: boolean;
 }
 
 export interface IVariableTooltipFields {

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -1096,6 +1096,16 @@ export namespace DataScience {
         'DataScience.usingNonPrerelease',
         `The 'prerelease' version of the Jupyter extension is recommended when running on VS code insiders. Would you like to switch?`
     );
+
+    export const jupyterServerConsoleOutputChannel = localize(
+        'DataScience.jupyterServerConsoleOutputChannel',
+        `Jupyter Server Console`
+    );
+
+    export const kernelConsoleOutputChannel = localize(
+        'DataScience.kernelConsoleOutputChannel',
+        `{0} Kernel Console Output`
+    );
 }
 
 // Skip using vscode-nls and instead just compute our strings based on key values. Key values

--- a/src/client/datascience/devTools/jupyterOutputChannel.ts
+++ b/src/client/datascience/devTools/jupyterOutputChannel.ts
@@ -1,18 +1,26 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { window } from 'vscode';
-import { IOutputChannel } from '../../common/types';
+import { window, workspace } from 'vscode';
+import { IDisposableRegistry, IOutputChannel } from '../../common/types';
+import * as localize from '../../common/utils/localize';
 
 /**
  * Returns the output panel for output related to Jupyter Server.
  */
-export function getJupyterOutputChannel(isDevMode: boolean, defaultOutputChannel: IOutputChannel): IOutputChannel {
-    if (!isDevMode) {
+export function getJupyterOutputChannel(
+    isDevMode: boolean,
+    disposables: IDisposableRegistry,
+    defaultOutputChannel: IOutputChannel
+): IOutputChannel {
+    const forceLog = workspace.getConfiguration('jupyter').get('logKernelOutputSeparately', false);
+    if (!isDevMode && !forceLog) {
         return defaultOutputChannel;
     }
-    // This isn't added to list of disposables, that should be fine (only used in dev mode).
-    const jupyterServerOutputChannel = window.createOutputChannel('Dev: Jupyter Server');
+    const jupyterServerOutputChannel = window.createOutputChannel(
+        localize.DataScience.jupyterServerConsoleOutputChannel()
+    );
+    disposables.push(jupyterServerOutputChannel);
     const handler: ProxyHandler<IOutputChannel> = {
         get(target: IOutputChannel, propKey: keyof IOutputChannel) {
             const method = target[propKey];

--- a/src/client/datascience/kernel-launcher/kernelProcess.ts
+++ b/src/client/datascience/kernel-launcher/kernelProcess.ts
@@ -270,7 +270,7 @@ export class KernelProcess implements IKernelProcess {
 
     private sendToOutput(data: string) {
         if (this.outputChannel) {
-            this.outputChannel.appendLine(data);
+            this.outputChannel.append(data);
         }
     }
 

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -89,7 +89,7 @@ async function activateLegacy(
     serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, standardOutputChannel, STANDARD_OUTPUT_CHANNEL);
     serviceManager.addSingletonInstance<OutputChannel>(
         IOutputChannel,
-        getJupyterOutputChannel(isDevMode, standardOutputChannel),
+        getJupyterOutputChannel(isDevMode, context.subscriptions, standardOutputChannel),
         JUPYTER_OUTPUT_CHANNEL
     );
     serviceManager.addSingletonInstance<boolean>(IsCodeSpace, env.uiKind == UIKind.Web);

--- a/src/test/datascience/kernelProcess.vscode.test.ts
+++ b/src/test/datascience/kernelProcess.vscode.test.ts
@@ -94,7 +94,8 @@ suite('DataScience - Kernel Process', () => {
             undefined,
             instance(extensionChecker),
             instance(kernelEnvVarsService),
-            instance(pythonExecFactory)
+            instance(pythonExecFactory),
+            undefined
         );
     }
     test('Launch from kernelspec (linux)', async function () {


### PR DESCRIPTION
Fixes #4954

Add a new output channel for raw kernels that maps to the per notebook kernel output. 

For non raw, use a setting to expose the already used 'Dev: Jupyter Server' channel (and rename it).