### PR TITLE
Modify SelectJupyterURI to allow URI parameter

### DIFF
--- a/news/1 Enhancements/8918.md
+++ b/news/1 Enhancements/8918.md
@@ -1,0 +1,1 @@
+Modify command `jupyter.selectjupyteruri` to allow URI parameter

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -179,7 +179,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [DSCommands.ShowDataViewer]: [IShowDataViewerFromVariablePanel];
     [DSCommands.RefreshDataViewer]: [];
     [DSCommands.ClearSavedJupyterUris]: [];
-    [DSCommands.SelectJupyterURI]: [undefined, 'toolbar' | 'nativeNotebookStatusBar' | undefined];
+    [DSCommands.SelectJupyterURI]: [boolean | undefined, string | undefined, 'toolbar' | 'nativeNotebookStatusBar' | undefined];
     [DSCommands.SelectNativeJupyterUriFromToolBar]: [];
     [DSCommands.DebugNotebook]: [];
     [DSCommands.RunByLine]: [NotebookCell];

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -179,7 +179,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [DSCommands.ShowDataViewer]: [IShowDataViewerFromVariablePanel];
     [DSCommands.RefreshDataViewer]: [];
     [DSCommands.ClearSavedJupyterUris]: [];
-    [DSCommands.SelectJupyterURI]: [boolean | undefined, string | undefined, 'toolbar' | 'nativeNotebookStatusBar' | undefined];
+    [DSCommands.SelectJupyterURI]: [boolean | undefined, Uri | 'toolbar' | 'nativeNotebookStatusBar' | undefined];
     [DSCommands.SelectNativeJupyterUriFromToolBar]: [];
     [DSCommands.DebugNotebook]: [];
     [DSCommands.RunByLine]: [NotebookCell];

--- a/src/client/datascience/commands/serverSelector.ts
+++ b/src/client/datascience/commands/serverSelector.ts
@@ -9,6 +9,7 @@ import { IDisposable } from '../../common/types';
 import { Commands } from '../constants';
 import { JupyterServerSelector } from '../jupyter/serverSelector';
 import { traceInfo } from '../../common/logger';
+import { Uri } from 'vscode'
 
 @injectable()
 export class JupyterServerSelectorCommand implements IDisposable {
@@ -21,11 +22,15 @@ export class JupyterServerSelectorCommand implements IDisposable {
         this.disposables.push(
             this.commandManager.registerCommand(
                 Commands.SelectJupyterURI,
-                (local: boolean = true, userUri: string | undefined, source: 'nativeNotebookStatusBar' | 'commandPalette' | 'toolbar' = 'commandPalette') => {
+                (local: boolean = true, source: Uri | 'nativeNotebookStatusBar' | 'commandPalette' | 'toolbar' = 'commandPalette') => {
 
-                    if (!local && userUri) {
-                        traceInfo(`Setting Jupyter Server URI to remote: ${userUri}`);
-                        this.serverSelector.setJupyterURIToRemote(userUri)
+                    if (source instanceof Uri) {
+                        traceInfo(`Setting Jupyter Server URI to remote: ${source}`);
+                        console.log(`Setting Jupyter Server URI to remote: ${source}`)
+
+                        console.log(`Setting Jupyter Server URI to remote: ${source.toString(true)}`)
+
+                        this.serverSelector.setJupyterURIToRemote(source.toString(true))
                         return
                     }
 

--- a/src/client/datascience/commands/serverSelector.ts
+++ b/src/client/datascience/commands/serverSelector.ts
@@ -26,12 +26,12 @@ export class JupyterServerSelectorCommand implements IDisposable {
 
                     if (source instanceof Uri) {
                         traceInfo(`Setting Jupyter Server URI to remote: ${source}`);
-                        this.serverSelector.setJupyterURIToRemote(source.toString(true))
+                        void this.serverSelector.setJupyterURIToRemote(source.toString(true))
                         return
                     }
 
                     // Activate UI Selector
-                    this.serverSelector.selectJupyterURI(local, source)
+                    void this.serverSelector.selectJupyterURI(local, source)
                 },
                 this.serverSelector
             )

--- a/src/client/datascience/commands/serverSelector.ts
+++ b/src/client/datascience/commands/serverSelector.ts
@@ -26,10 +26,6 @@ export class JupyterServerSelectorCommand implements IDisposable {
 
                     if (source instanceof Uri) {
                         traceInfo(`Setting Jupyter Server URI to remote: ${source}`);
-                        console.log(`Setting Jupyter Server URI to remote: ${source}`)
-
-                        console.log(`Setting Jupyter Server URI to remote: ${source.toString(true)}`)
-
                         this.serverSelector.setJupyterURIToRemote(source.toString(true))
                         return
                     }

--- a/src/client/datascience/commands/serverSelector.ts
+++ b/src/client/datascience/commands/serverSelector.ts
@@ -8,6 +8,7 @@ import { ICommandManager } from '../../common/application/types';
 import { IDisposable } from '../../common/types';
 import { Commands } from '../constants';
 import { JupyterServerSelector } from '../jupyter/serverSelector';
+import { traceInfo } from '../../common/logger';
 
 @injectable()
 export class JupyterServerSelectorCommand implements IDisposable {
@@ -15,13 +16,24 @@ export class JupyterServerSelectorCommand implements IDisposable {
     constructor(
         @inject(ICommandManager) private readonly commandManager: ICommandManager,
         @inject(JupyterServerSelector) private readonly serverSelector: JupyterServerSelector
-    ) {}
+    ) { }
     public register() {
         this.disposables.push(
             this.commandManager.registerCommand(
                 Commands.SelectJupyterURI,
-                (_, source: 'nativeNotebookStatusBar' | 'commandPalette' | 'toolbar' = 'commandPalette') =>
-                    this.serverSelector.selectJupyterURI(true, source),
+                (local: boolean = true, userUri: string | undefined, source: 'nativeNotebookStatusBar' | 'commandPalette' | 'toolbar' = 'commandPalette') => {
+
+                    if (!local && userUri) {
+                        traceInfo(`Setting Jupyter Server URI to remote: ${userUri}`);
+                        this.serverSelector.setJupyterURIToRemote(userUri)
+                        return
+
+                        this.serverSelector.setJupyterURIToLocal
+                    }
+
+                    // Activate UI Selector
+                    this.serverSelector.selectJupyterURI(local, source)
+                },
                 this.serverSelector
             )
         );

--- a/src/client/datascience/commands/serverSelector.ts
+++ b/src/client/datascience/commands/serverSelector.ts
@@ -27,8 +27,6 @@ export class JupyterServerSelectorCommand implements IDisposable {
                         traceInfo(`Setting Jupyter Server URI to remote: ${userUri}`);
                         this.serverSelector.setJupyterURIToRemote(userUri)
                         return
-
-                        this.serverSelector.setJupyterURIToLocal
                     }
 
                     // Activate UI Selector

--- a/src/client/datascience/commands/serverSelector.ts
+++ b/src/client/datascience/commands/serverSelector.ts
@@ -9,7 +9,7 @@ import { IDisposable } from '../../common/types';
 import { Commands } from '../constants';
 import { JupyterServerSelector } from '../jupyter/serverSelector';
 import { traceInfo } from '../../common/logger';
-import { Uri } from 'vscode'
+import { Uri } from 'vscode';
 
 @injectable()
 export class JupyterServerSelectorCommand implements IDisposable {
@@ -17,21 +17,23 @@ export class JupyterServerSelectorCommand implements IDisposable {
     constructor(
         @inject(ICommandManager) private readonly commandManager: ICommandManager,
         @inject(JupyterServerSelector) private readonly serverSelector: JupyterServerSelector
-    ) { }
+    ) {}
     public register() {
         this.disposables.push(
             this.commandManager.registerCommand(
                 Commands.SelectJupyterURI,
-                (local: boolean = true, source: Uri | 'nativeNotebookStatusBar' | 'commandPalette' | 'toolbar' = 'commandPalette') => {
-
+                (
+                    local: boolean = true,
+                    source: Uri | 'nativeNotebookStatusBar' | 'commandPalette' | 'toolbar' = 'commandPalette'
+                ) => {
                     if (source instanceof Uri) {
                         traceInfo(`Setting Jupyter Server URI to remote: ${source}`);
-                        void this.serverSelector.setJupyterURIToRemote(source.toString(true))
-                        return
+                        void this.serverSelector.setJupyterURIToRemote(source.toString(true));
+                        return;
                     }
 
                     // Activate UI Selector
-                    void this.serverSelector.selectJupyterURI(local, source)
+                    void this.serverSelector.selectJupyterURI(local, source);
                 },
                 this.serverSelector
             )

--- a/src/test/datascience/commands/serverSelector.unit.test.ts
+++ b/src/test/datascience/commands/serverSelector.unit.test.ts
@@ -37,4 +37,16 @@ suite('DataScience - Server Selector Command', () => {
 
         verify(serverSelector.selectJupyterURI(true, 'commandPalette')).once();
     });
+
+    test(`Command Handler should set URI`, () => {
+        serverSelectorCommand.register();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const handler = (capture(commandManager.registerCommand as any).first()[1] as Function).bind(
+            serverSelectorCommand, false, "localhost"
+        );
+
+        handler();
+
+        verify(serverSelector.setJupyterURIToRemote("localhost")).once();
+    });
 });

--- a/src/test/datascience/commands/serverSelector.unit.test.ts
+++ b/src/test/datascience/commands/serverSelector.unit.test.ts
@@ -41,8 +41,8 @@ suite('DataScience - Server Selector Command', () => {
 
     test(`Command Handler should set URI`, () => {
         serverSelectorCommand.register();
-
         let uri = Uri.parse("http://localhost:1234")
+
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const handler = (capture(commandManager.registerCommand as any).first()[1] as Function).bind(
             serverSelectorCommand, false, uri

--- a/src/test/datascience/commands/serverSelector.unit.test.ts
+++ b/src/test/datascience/commands/serverSelector.unit.test.ts
@@ -41,15 +41,17 @@ suite('DataScience - Server Selector Command', () => {
 
     test(`Command Handler should set URI`, () => {
         serverSelectorCommand.register();
-        let uri = Uri.parse("http://localhost:1234")
+        let uri = Uri.parse('http://localhost:1234');
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const handler = (capture(commandManager.registerCommand as any).first()[1] as Function).bind(
-            serverSelectorCommand, false, uri
+            serverSelectorCommand,
+            false,
+            uri
         );
 
         handler();
 
-        verify(serverSelector.setJupyterURIToRemote("http://localhost:1234/")).once();
+        verify(serverSelector.setJupyterURIToRemote('http://localhost:1234/')).once();
     });
 });

--- a/src/test/datascience/commands/serverSelector.unit.test.ts
+++ b/src/test/datascience/commands/serverSelector.unit.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { anything, capture, instance, mock, verify } from 'ts-mockito';
+import { Uri } from 'vscode';
 import { CommandManager } from '../../../client/common/application/commandManager';
 import { ICommandManager } from '../../../client/common/application/types';
 import { JupyterServerSelectorCommand } from '../../../client/datascience/commands/serverSelector';
@@ -40,13 +41,15 @@ suite('DataScience - Server Selector Command', () => {
 
     test(`Command Handler should set URI`, () => {
         serverSelectorCommand.register();
+
+        let uri = Uri.parse("http://localhost:1234")
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const handler = (capture(commandManager.registerCommand as any).first()[1] as Function).bind(
-            serverSelectorCommand, false, "localhost"
+            serverSelectorCommand, false, uri
         );
 
         handler();
 
-        verify(serverSelector.setJupyterURIToRemote("localhost")).once();
+        verify(serverSelector.setJupyterURIToRemote("http://localhost:1234/")).once();
     });
 });


### PR DESCRIPTION
For #8902


Made the change to allow a bool and URI to be passed to command `jupyter.selectjupyteruri`. If source is a `Uri` it sets the serverSelector to the remote uri provided by the user.

I added the bool mostly because it seemed like that was what it was originally setup to do. But the arg was unused because `this.serverSelector.selectJupyterURI(true, source),` had `true` hardcoded. It might not be necessary but it does allow someone to call `jupyter.selectjupyteruri` and have their selector not include local options.

I also added a test for this case in the commands unit test for the serverSelector.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate. : N/A
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed). N/A
