### PR TITLE
Fix pylance timing out

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -590,13 +590,12 @@ jobs:
           VSC_JUPYTER_CI_RUN_JAVA_NB_TEST: ${{ matrix.python == 'conda' }}
           VSC_JUPYTER_CI_IS_CONDA: ${{ matrix.python == 'conda' }}
           VSC_JUPYTER_CI_TEST_VSC_CHANNEL: 'insiders'
-        id: test_notebook_vscode
+        id: test_notebook_vscode_ubuntu
         if: matrix.python != 'noPython' && matrix.os == 'ubuntu-latest'
 
       - name: Run Native Notebook with VSCode & Jupyter (windows)
-        uses: GabrielBB/xvfb-action@v1.4
-        with:
-          run: ${{ env.xvfbCommand }} npm run testNativeNotebooksInVSCodeWithoutTestSuffix
+        run: |
+          npm run testNativeNotebooksInVSCodeWithoutTestSuffix
         env:
           VSC_FORCE_REAL_JUPYTER: 1
           VSC_JUPYTER_FORCE_LOGGING: 1
@@ -608,7 +607,7 @@ jobs:
           VSC_JUPYTER_CI_IS_CONDA: ${{ matrix.python == 'conda' }}
           VSC_JUPYTER_CI_TEST_VSC_CHANNEL: 'insiders'
           TEST_FILES_SUFFIX: '+(interrupt|execut)*.vscode.test'
-        id: test_notebook_vscode
+        id: test_notebook_vscode_windows
         if: matrix.python != 'noPython' && matrix.os == 'windows-latest'
 
       - name: Publish Notebook Test Report

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -584,8 +584,13 @@ jobs:
       - name: Set test script (windows)
         if: matrix.os == 'windows-latest'
         run: |
-          echo "TEST_FILES_SUFFIX=+(interrupt|execut)*.vscode.test" >> $GITHUB_ENV
           echo "TEST_SCRIPT=testNativeNotebooksInVSCodeWithoutTestSuffix" >> $GITHUB_ENV
+
+      # For some reason we cant set two environment variables at the same time on dinwos
+      - name: Set test files suffix (windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          echo "TEST_FILES_SUFFIX=+(interrupt|execut)*.vscode.test" >> $GITHUB_ENV
 
       - name: Echo variables
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -576,31 +576,10 @@ jobs:
           check_name: VSCode Test Report
         if: (steps.test_vscode.outcome == 'failure' || steps.test_vscode.outcome == 'failure') && failure()
 
-      - name: Set test script (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          echo "TEST_SCRIPT=testNativeNotebooksInVSCode" >> $GITHUB_ENV
-
-      - name: Set test script (windows)
-        if: matrix.os == 'windows-latest'
-        run: |
-          echo "TEST_SCRIPT=testNativeNotebooksInVSCodeWithoutTestSuffix" >> $GITHUB_ENV
-
-      # For some reason we cant set two environment variables at the same time on dinwos
-      - name: Set test files suffix (windows)
-        if: matrix.os == 'windows-latest'
-        run: |
-          echo "TEST_FILES_SUFFIX=+(interrupt|execut)*.vscode.test" >> $GITHUB_ENV
-
-      - name: Echo variables
-        run: |
-          echo "TEST_FILES_SUFFIX = ${{ env.TEST_FILES_SUFFIX }}"
-          echo "TEST_SCRIPT = ${{ env.TEST_SCRIPT }}"
-
-      - name: Run Native Notebook with VSCode & Jupyter
+      - name: Run Native Notebook with VSCode & Jupyter (ubuntu)
         uses: GabrielBB/xvfb-action@v1.4
         with:
-          run: ${{ env.xvfbCommand }} npm run ${{ env.TEST_SCRIPT }}
+          run: ${{ env.xvfbCommand }} npm run testNativeNotebooksInVSCode
         env:
           VSC_FORCE_REAL_JUPYTER: 1
           VSC_JUPYTER_FORCE_LOGGING: 1
@@ -612,7 +591,25 @@ jobs:
           VSC_JUPYTER_CI_IS_CONDA: ${{ matrix.python == 'conda' }}
           VSC_JUPYTER_CI_TEST_VSC_CHANNEL: 'insiders'
         id: test_notebook_vscode
-        if: matrix.python != 'noPython'
+        if: matrix.python != 'noPython' && matrix.os == 'ubuntu-latest'
+
+      - name: Run Native Notebook with VSCode & Jupyter (windows)
+        uses: GabrielBB/xvfb-action@v1.4
+        with:
+          run: ${{ env.xvfbCommand }} npm run testNativeNotebooksInVSCodeWithoutTestSuffix
+        env:
+          VSC_FORCE_REAL_JUPYTER: 1
+          VSC_JUPYTER_FORCE_LOGGING: 1
+          VSC_PYTHON_FORCE_LOGGING: 1
+          VSC_JUPYTER_CI_RUN_NON_PYTHON_NB_TEST: 1
+          VSC_JUPYTER_REMOTE_NATIVE_TEST: ${{ matrix.jupyter == 'remote' }}
+          VSC_JUPYTER_NON_RAW_NATIVE_TEST: ${{ matrix.jupyter == 'local' }}
+          VSC_JUPYTER_CI_RUN_JAVA_NB_TEST: ${{ matrix.python == 'conda' }}
+          VSC_JUPYTER_CI_IS_CONDA: ${{ matrix.python == 'conda' }}
+          VSC_JUPYTER_CI_TEST_VSC_CHANNEL: 'insiders'
+          TEST_FILES_SUFFIX: '+(interrupt|execut)*.vscode.test'
+        id: test_notebook_vscode
+        if: matrix.python != 'noPython' && matrix.os == 'windows-latest'
 
       - name: Publish Notebook Test Report
         uses: scacap/action-surefire-report@v1

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -616,7 +616,7 @@ jobs:
           github_token: ${{ secrets.TOKEN_TO_CREATE_RELEASE }}
           report_paths: ${{ env.TEST_RESULTS_GLOB }}
           check_name: Notebook Test Report ${{matrix.os}} ${{matrix.pythonVersion}} ${{matrix.python}} ${{matrix.jupyter}}
-        if: steps.test_notebook_vscode.outcome == 'failure' && failure()
+        if: (steps.test_notebook_vscode_windows.outcome == 'failure' || steps.test_notebook_vscode_ubuntu.outcome == 'failure') && failure()
 
       - name: Run Native Notebook with VSCode & Jupyter (without Python)
         uses: GabrielBB/xvfb-action@v1.4

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -587,6 +587,11 @@ jobs:
           echo "TEST_FILES_SUFFIX=+(interrupt|execut)*.vscode.test" >> $GITHUB_ENV
           echo "TEST_SCRIPT=testNativeNotebooksInVSCodeWithoutTestSuffix" >> $GITHUB_ENV
 
+      - name: Echo variables
+        run: |
+          echo "TEST_FILES_SUFFIX = ${{ env.TEST_FILES_SUFFIX }}"
+          echo "TEST_SCRIPT = ${{ env.TEST_SCRIPT }}"
+
       - name: Run Native Notebook with VSCode & Jupyter
         uses: GabrielBB/xvfb-action@v1.4
         with:

--- a/news/2 Fixes/8906.md
+++ b/news/2 Fixes/8906.md
@@ -1,0 +1,1 @@
+Make autocomplete return faster regardless of how long pylance takes to return.

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -752,7 +752,7 @@ export class Kernel implements IKernel {
             // Set the ipynb file
             const file = this.resourceUri?.fsPath;
             if (file) {
-                result.push(`__vsc_ipynb_file__ = '${file.replace(/\\/g, '\\\\')}'`);
+                result.push(`__vsc_ipynb_file__ = "${file.replace(/\\/g, '\\\\')}"`);
             }
             result.push(CodeSnippets.disableJedi);
 

--- a/src/client/datascience/notebook/intellisense/pythonKernelCompletionProvider.ts
+++ b/src/client/datascience/notebook/intellisense/pythonKernelCompletionProvider.ts
@@ -91,14 +91,13 @@ export class PythonKernelCompletionProvider implements CompletionItemProvider {
         // Allow slower timeouts for CI (testing).
         const timeout =
             parseInt(process.env.VSC_JUPYTER_IntellisenseTimeout || '0', 10) || Settings.IntellisenseTimeout;
-        const pylanceTimeout = Math.min(1000, timeout);
         traceInfoIfCI(`Notebook completion request for ${document.getText()}, ${document.offsetAt(position)}`);
         const [result, pylanceResults] = await Promise.all([
             waitForPromise(
                 this.getJupyterCompletion(kernel.session, document.getText(), document.offsetAt(position), token),
                 timeout
             ),
-            waitForPromise(this.getPylanceCompletions(document, position, context, token), pylanceTimeout)
+            waitForPromise(this.getPylanceCompletions(document, position, context, token), timeout)
         ]);
         if (!result) {
             traceInfoIfCI(`Notebook completions not found.`);

--- a/src/client/datascience/notebook/intellisense/pythonKernelCompletionProvider.ts
+++ b/src/client/datascience/notebook/intellisense/pythonKernelCompletionProvider.ts
@@ -91,13 +91,14 @@ export class PythonKernelCompletionProvider implements CompletionItemProvider {
         // Allow slower timeouts for CI (testing).
         const timeout =
             parseInt(process.env.VSC_JUPYTER_IntellisenseTimeout || '0', 10) || Settings.IntellisenseTimeout;
+        const pylanceTimeout = Math.min(1000, timeout);
         traceInfoIfCI(`Notebook completion request for ${document.getText()}, ${document.offsetAt(position)}`);
         const [result, pylanceResults] = await Promise.all([
             waitForPromise(
                 this.getJupyterCompletion(kernel.session, document.getText(), document.offsetAt(position), token),
                 timeout
             ),
-            this.getPylanceCompletions(document, position, context, token)
+            waitForPromise(this.getPylanceCompletions(document, position, context, token), pylanceTimeout)
         ]);
         if (!result) {
             traceInfoIfCI(`Notebook completions not found.`);

--- a/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
@@ -172,7 +172,6 @@ suite('DataScience - VSCode Intellisense Notebook - (Code Completion via Jupyter
                 )
             );
         }
-
         // Make sure it is skipping items that are already provided by pylance (no dupes)
         // Pylance isn't returning them right now: https://github.com/microsoft/vscode-jupyter/issues/8842
         // assert.notOk(

--- a/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
@@ -172,11 +172,6 @@ suite('DataScience - VSCode Intellisense Notebook - (Code Completion via Jupyter
                 )
             );
         }
-        // Make sure it is skipping items that are already provided by pylance (no dupes)
-        // Pylance isn't returning them right now: https://github.com/microsoft/vscode-jupyter/issues/8842
-        // assert.notOk(
-        //     items.find((item) => (typeof item === 'string' ? item.includes('Name') : item.label.includes('Name')))
-        // );
 
         if (!textToFilterCompletions || !itemToExistInCompletionAfterFilter) {
             return;

--- a/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
@@ -173,6 +173,12 @@ suite('DataScience - VSCode Intellisense Notebook - (Code Completion via Jupyter
             );
         }
 
+        // Make sure it is skipping items that are already provided by pylance (no dupes)
+        // Pylance isn't returning them right now: https://github.com/microsoft/vscode-jupyter/issues/8842
+        // assert.notOk(
+        //     items.find((item) => (typeof item === 'string' ? item.includes('Name') : item.label.includes('Name')))
+        // );
+
         if (!textToFilterCompletions || !itemToExistInCompletionAfterFilter) {
             return;
         }

--- a/src/test/standardTest.ts
+++ b/src/test/standardTest.ts
@@ -20,7 +20,7 @@ const extensionDevelopmentPath = process.env.CODE_EXTENSIONS_PATH
     ? process.env.CODE_EXTENSIONS_PATH
     : EXTENSION_ROOT_DIR_FOR_TESTS;
 const isRunningSmokeTests = process.env.TEST_FILES_SUFFIX === 'smoke.test';
-const isRunningVSCodeTests = process.env.TEST_FILES_SUFFIX === 'vscode.test';
+const isRunningVSCodeTests = process.env.TEST_FILES_SUFFIX?.includes('vscode.test');
 
 function requiresPythonExtensionToBeInstalled() {
     if (process.env.VSC_JUPYTER_CI_TEST_DO_NOT_INSTALL_PYTHON_EXT) {


### PR DESCRIPTION
Fixes #8906 

Pylance can be slow and our jupyter completions were waiting for it to finish before returning any of the data the kernel might have.

This change maximizes that to 1 second.

