### PR TITLE
Leverage new 1.65 `notebookKernel` contextkey to avoid impacting other extensions that implement interactive windows

### DIFF
--- a/news/2 Fixes/9037.md
+++ b/news/2 Fixes/9037.md
@@ -1,0 +1,2 @@
+Adopt new [`notebookKernel` contextkey](https://github.com/microsoft/vscode/pull/143163) (1.65) to prevent our interactive window toolbar from appearing on IWs belonging to other extensions.
+(Thanks [gjsjohnmurray](https://github.com/gjsjohnmurray))

--- a/news/2 Fixes/9038.md
+++ b/news/2 Fixes/9038.md
@@ -1,0 +1,2 @@
+Leverage new [`notebookKernel` contextkey](https://github.com/microsoft/vscode/pull/143163) and [IW placeholder text fix](https://github.com/microsoft/vscode/pull/143211) (1.65) to prevent our interactive window `Shift+Enter` keybinding from affecting IWs belonging to other extensions.
+(Thanks [gjsjohnmurray](https://github.com/gjsjohnmurray))

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
             },
             {
                 "key": "shift+enter",
-                "when": "resourceScheme == 'vscode-interactive'",
+                "when": "resourceScheme == 'vscode-interactive' && notebookKernel =~ /^ms-toolsai.jupyter\\// || resourceScheme == 'vscode-interactive' && !notebookKernel",
                 "command": "interactive.execute"
             },
             {
@@ -970,59 +970,59 @@
                 {
                     "command": "jupyter.interactive.clearAllCells",
                     "group": "navigation@0",
-                    "when": "isWorkspaceTrusted"
+                    "when": "isWorkspaceTrusted && notebookKernel =~ /^ms-toolsai.jupyter\\// || isWorkspaceTrusted && !notebookKernel"
                 },
                 {
                     "command": "jupyter.restartkernel",
                     "group": "navigation@1",
-                    "when": "isWorkspaceTrusted"
+                    "when": "isWorkspaceTrusted && notebookKernel =~ /^ms-toolsai.jupyter\\// || isWorkspaceTrusted && !notebookKernel"
                 },
                 {
                     "command": "jupyter.interruptkernel",
                     "group": "navigation@2",
-                    "when": "isWorkspaceTrusted"
+                    "when": "isWorkspaceTrusted && notebookKernel =~ /^ms-toolsai.jupyter\\// || isWorkspaceTrusted && !notebookKernel"
                 },
                 {
                     "command": "jupyter.openVariableView",
                     "group": "navigation@3",
-                    "when": "isWorkspaceTrusted"
+                    "when": "isWorkspaceTrusted && notebookKernel =~ /^ms-toolsai.jupyter\\// || isWorkspaceTrusted && !notebookKernel"
                 },
                 {
                     "command": "jupyter.interactive.exportasnotebook",
                     "group": "navigation@4",
-                    "when": "isWorkspaceTrusted"
+                    "when": "isWorkspaceTrusted && notebookKernel =~ /^ms-toolsai.jupyter\\// || isWorkspaceTrusted && !notebookKernel"
                 },
                 {
                     "command": "jupyter.interactive.exportas",
                     "group": "navigation@5",
-                    "when": "isWorkspaceTrusted"
+                    "when": "isWorkspaceTrusted && notebookKernel =~ /^ms-toolsai.jupyter\\// || isWorkspaceTrusted && !notebookKernel"
                 },
                 {
                     "command": "jupyter.expandallcells",
                     "group": "navigation@6",
-                    "when": "isWorkspaceTrusted"
+                    "when": "isWorkspaceTrusted && notebookKernel =~ /^ms-toolsai.jupyter\\// || isWorkspaceTrusted && !notebookKernel"
                 },
                 {
                     "command": "jupyter.collapseallcells",
                     "group": "navigation@7",
-                    "when": "isWorkspaceTrusted"
+                    "when": "isWorkspaceTrusted && notebookKernel =~ /^ms-toolsai.jupyter\\// || isWorkspaceTrusted && !notebookKernel"
                 }
             ],
             "interactive/cell/title": [
                 {
                     "command": "jupyter.interactive.copyCell",
                     "group": "inline@0",
-                    "when": "isWorkspaceTrusted"
+                    "when": "isWorkspaceTrusted && notebookKernel =~ /^ms-toolsai.jupyter\\// || isWorkspaceTrusted && !notebookKernel"
                 },
                 {
                     "command": "jupyter.interactive.goToCode",
                     "group": "inline@1",
-                    "when": "isWorkspaceTrusted"
+                    "when": "isWorkspaceTrusted && notebookKernel =~ /^ms-toolsai.jupyter\\// || isWorkspaceTrusted && !notebookKernel"
                 },
                 {
                     "command": "jupyter.interactive.removeCell",
                     "group": "inline@2",
-                    "when": "isWorkspaceTrusted"
+                    "when": "isWorkspaceTrusted && notebookKernel =~ /^ms-toolsai.jupyter\\// || isWorkspaceTrusted && !notebookKernel"
                 }
             ],
             "explorer/context": [


### PR DESCRIPTION
Fixes #9037 and #9038 when used with 1.65, without breaking behaviour on previous versions.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [X] Title summarizes what is changing.
-   [X] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [X] <strike>Appropriate comments and documentation strings in the code.</strike>
-   [X] <strike>Has sufficient logging.</strike>
-   [X] <strike>Has telemetry for enhancements.</strike>
-   [X] <strike>Unit tests & system/integration tests are added/updated.</strike>
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [X] <strike>[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).</strike>

Before:

![image](https://user-images.githubusercontent.com/6726799/154479382-8ea45446-0e12-44f2-afd4-93e0b29e3704.png)

After:

![image](https://user-images.githubusercontent.com/6726799/154479200-be4a8be1-f28f-4325-82bf-e775b8b1c530.png)

ping @rchiodo 

