### PR TITLE
Manually delete temporary ipynb

### DIFF
--- a/src/client/datascience/jupyter/jupyterSessionManager.ts
+++ b/src/client/datascience/jupyter/jupyterSessionManager.ts
@@ -18,6 +18,7 @@ import { CancellationToken } from 'vscode-jsonrpc';
 import { IApplicationShell } from '../../common/application/types';
 
 import { traceError, traceInfo } from '../../common/logger';
+import { IFileSystem } from '../../common/platform/types';
 import {
     IConfigurationService,
     IOutputChannel,
@@ -76,7 +77,8 @@ export class JupyterSessionManager implements IJupyterSessionManager {
         private configService: IConfigurationService,
         private readonly appShell: IApplicationShell,
         private readonly stateFactory: IPersistentStateFactory,
-        private readonly kernelService: JupyterKernelService
+        private readonly kernelService: JupyterKernelService,
+        private readonly fs: IFileSystem
     ) {
         this.userAllowsInsecureConnections = this.stateFactory.createGlobalPersistentState<boolean>(
             GlobalStateUserAllowsInsecureConnections,
@@ -201,7 +203,8 @@ export class JupyterSessionManager implements IJupyterSessionManager {
             workingDirectory,
             this.configService.getSettings(resource).jupyterLaunchTimeout,
             this.kernelService,
-            this.configService.getSettings(resource).jupyterInterruptTimeout
+            this.configService.getSettings(resource).jupyterInterruptTimeout,
+            this.fs
         );
         try {
             await session.connect({ token: cancelToken, ui });

--- a/src/client/datascience/jupyter/jupyterSessionManagerFactory.ts
+++ b/src/client/datascience/jupyter/jupyterSessionManagerFactory.ts
@@ -21,6 +21,7 @@ import {
 } from '../types';
 import { JupyterSessionManager } from './jupyterSessionManager';
 import { JupyterKernelService } from './kernels/jupyterKernelService';
+import { IFileSystem } from '../../common/platform/types';
 
 @injectable()
 export class JupyterSessionManagerFactory implements IJupyterSessionManagerFactory {
@@ -33,7 +34,8 @@ export class JupyterSessionManagerFactory implements IJupyterSessionManagerFacto
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(IPersistentStateFactory) private readonly stateFactory: IPersistentStateFactory,
         @inject(IDisposableRegistry) private readonly disposableRegistry: IDisposableRegistry,
-        @inject(JupyterKernelService) private readonly kernelService: JupyterKernelService
+        @inject(JupyterKernelService) private readonly kernelService: JupyterKernelService,
+        @inject(IFileSystem) private readonly fs: IFileSystem
     ) {}
 
     /**
@@ -50,7 +52,8 @@ export class JupyterSessionManagerFactory implements IJupyterSessionManagerFacto
             this.config,
             this.appShell,
             this.stateFactory,
-            this.kernelService
+            this.kernelService,
+            this.fs
         );
         await result.initialize(connInfo);
         this.disposableRegistry.push(

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -18,6 +18,7 @@ import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { CancellationTokenSource, Uri } from 'vscode';
 
 import { traceInfo } from '../../../client/common/logger';
+import { IFileSystem } from '../../../client/common/platform/types';
 import { ReadWrite, Resource } from '../../../client/common/types';
 import { createDeferred, Deferred } from '../../../client/common/utils/async';
 import { DataScience } from '../../../client/common/utils/localize';
@@ -139,7 +140,8 @@ suite('DataScience - JupyterSession', () => {
             '',
             1,
             instance(kernelService),
-            1
+            1,
+            instance(mock<IFileSystem>())
         );
     }
     setup(() => createJupyterSession());


### PR DESCRIPTION
We've seen users with systems where the temporary ipynb files do not get deleted.
This PR just removes them using node.js
Why don't we do this always instead of using the Jupyter lab API
