### PR TITLE
Do not specify node versions

### DIFF
--- a/build/azure-pipeline.pre-release.yml
+++ b/build/azure-pipeline.pre-release.yml
@@ -23,10 +23,6 @@ extends:
   template: azure-pipelines/extension/pre-release.yml@templates
   parameters:
     buildSteps:
-      - task: NodeTool@0
-        inputs:
-          versionSpec: '14.16'
-
       - script: npm ci
         displayName: Install dependencies
 

--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -18,10 +18,6 @@ extends:
   template: azure-pipelines/extension/stable.yml@templates
   parameters:
     buildSteps:
-      - task: NodeTool@0
-        inputs:
-          versionSpec: '14.16'
-
       - script: npm ci
         displayName: Install dependencies
 


### PR DESCRIPTION
The azure pipelines now use the same version as we do which is the same version shipped in VS Code.