### PR TITLE
re-use the same codeWatcher when providing code lenses

### DIFF
--- a/news/3 Code Health/8919.md
+++ b/news/3 Code Health/8919.md
@@ -1,0 +1,1 @@
+Re-use the same codeWatchers per document when providing code lenses.

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -502,7 +502,6 @@ export interface ICodeWatcher extends IDisposable {
     setDocument(document: TextDocument): void;
     getVersion(): number;
     getCodeLenses(): CodeLens[];
-    getCachedSettings(): IJupyterSettings | undefined;
     runAllCells(): Promise<void>;
     runCell(range: Range): Promise<void>;
     debugCell(range: Range): Promise<void>;

--- a/src/test/datascience/editor-integration/codelensprovider.unit.test.ts
+++ b/src/test/datascience/editor-integration/codelensprovider.unit.test.ts
@@ -152,12 +152,8 @@ suite('DataScienceCodeLensProvider Unit Tests', () => {
         targetCodeWatcher2.setup((tc) => tc.uri).returns(() => uri2);
         targetCodeWatcher2.setup((tc) => tc.getVersion()).returns(() => 1);
 
-        serviceContainer
-            .setup((c) => c.get(TypeMoq.It.isValue(ICodeWatcher)))
-            .returns(() => targetCodeWatcher1.object);
-        serviceContainer
-            .setup((c) => c.get(TypeMoq.It.isValue(ICodeWatcher)))
-            .returns(() => targetCodeWatcher2.object);
+        serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(ICodeWatcher))).returns(() => targetCodeWatcher1.object);
+        serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(ICodeWatcher))).returns(() => targetCodeWatcher2.object);
 
         documentManager.setup((d) => d.textDocuments).returns(() => [document1.object, document2.object]);
 


### PR DESCRIPTION
Fixes #8919

We can just update the code lenses for the new version of the document.
The codeWatcher doesn't use the settings that it was holding, so we can stop deserializing that every time.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
