### PR TITLE
Improved handling of missing dependencies and support scenarios where…

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "recommendations": [
         "ms-vscode.vscode-typescript-tslint-plugin",
         "editorconfig.editorconfig",
-        "esbenp.prettier-vscode"
+        "esbenp.prettier-vscode",
+        "hbenl.vscode-mocha-test-adapter"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,5 +56,9 @@
         // Match what black does.
         "--max-line-length=88"
     ],
-    "typescript.preferences.importModuleSpecifier": "relative"
+    "typescript.preferences.importModuleSpecifier": "relative",
+    "mochaExplorer.files": "./out/test/**/*.unit.test.js",
+    "mochaExplorer.require": ["ts-node/register", "./out/test/unittests.js"],
+    "mochaExplorer.ui": "tdd",
+    "mochaExplorer.nodeArgv": ["--enable-source-maps"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2022.2.103 (5 March 2022)
+
+### Fixes
+
+1. Update display names of Python Environments in kernel picker if the Python version has changed.
+   ([#9104](https://github.com/Microsoft/vscode-jupyter/issues/9104))
+1. Support for detection of missing dependencies in scenarios where users re-create the Python Environments (virtual env or Conda env) or for some reason manually uninstall some of the dependencies.
+   ([#9135](https://github.com/Microsoft/vscode-jupyter/issues/9135))
+
 ## 2022.2.102 (4 March 2022)
 
 ### Fixes

--- a/news/2 Fixes/9104.md
+++ b/news/2 Fixes/9104.md
@@ -1,0 +1,1 @@
+Update display names of Python Environments in kernel picker if the Python version has changed.

--- a/news/2 Fixes/9104.md
+++ b/news/2 Fixes/9104.md
@@ -1,1 +1,0 @@
-Update display names of Python Environments in kernel picker if the Python version has changed.

--- a/news/2 Fixes/9135.md
+++ b/news/2 Fixes/9135.md
@@ -1,0 +1,1 @@
+Support for detection of missing dependencies in scenarios where users re-create the Python Environments (virtual env or Conda env) or for some reason manually uninstall some of the dependencies.

--- a/news/2 Fixes/9135.md
+++ b/news/2 Fixes/9135.md
@@ -1,1 +1,0 @@
-Support for detection of missing dependencies in scenarios where users re-create the Python Environments (virtual env or Conda env) or for some reason manually uninstall some of the dependencies.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter",
-  "version": "2022.2.102",
+  "version": "2022.2.103",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "jupyter",
     "displayName": "Jupyter",
-    "version": "2022.2.102",
+    "version": "2022.2.103",
     "description": "Jupyter notebook support, interactive programming and computing that supports Intellisense, debugging and more.",
     "publisher": "ms-toolsai",
     "author": {

--- a/src/client/datascience/errors/errorHandler.ts
+++ b/src/client/datascience/errors/errorHandler.ts
@@ -1,19 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import type * as nbformat from '@jupyterlab/nbformat';
-import { inject, injectable } from 'inversify';
-import { IApplicationShell, IWorkspaceService } from '../../common/application/types';
+import { inject, injectable, named } from 'inversify';
+import { IApplicationShell, ICommandManager, IVSCodeNotebook, IWorkspaceService } from '../../common/application/types';
 import { BaseError, WrappedError } from '../../common/errors/types';
-import { traceWarning } from '../../common/logger';
+import { traceError, traceWarning } from '../../common/logger';
 import { Common, DataScience } from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
 import { IpyKernelNotInstalledError } from './ipyKernelNotInstalledError';
 import { JupyterInstallError } from './jupyterInstallError';
 import { JupyterSelfCertsError } from './jupyterSelfCertsError';
-import { getLanguageInNotebookMetadata } from '../jupyter/kernels/helpers';
+import { getLanguageInNotebookMetadata, isPythonKernelConnection } from '../jupyter/kernels/helpers';
 import { isPythonNotebook } from '../notebook/helpers/helpers';
 import {
     IDataScienceErrorHandler,
+    IInteractiveWindowProvider,
     IJupyterInterpreterDependencyManager,
     IKernelDependencyService,
     KernelInterpreterDependencyResponse
@@ -22,6 +23,8 @@ import {
     CancellationError as VscCancellationError,
     CancellationTokenSource,
     ConfigurationTarget,
+    EventEmitter,
+    Memento,
     NotebookCell,
     NotebookCellOutput,
     NotebookCellOutputItem
@@ -34,13 +37,20 @@ import { KernelProcessExitedError } from './kernelProcessExitedError';
 import { PythonKernelDiedError } from './pythonKernelDiedError';
 import {
     analyzeKernelErrors,
-    getErrorMessageFromPythonTraceback,
+    getErrorMessageFromPythonTraceback as getErrorMessageFromPythonTraceBack,
     KernelFailure,
     KernelFailureReason
 } from '../../common/errors/errorUtils';
 import { IKernelProvider, KernelConnectionMetadata } from '../jupyter/kernels/types';
 import { getDisplayPath } from '../../common/platform/fs-paths';
-import { IBrowserService, IConfigurationService, Product, Resource } from '../../common/types';
+import {
+    GLOBAL_MEMENTO,
+    IBrowserService,
+    IConfigurationService,
+    IMemento,
+    Product,
+    Resource
+} from '../../common/types';
 import { Commands, Telemetry } from '../constants';
 import { sendTelemetryEvent } from '../../telemetry';
 import { DisplayOptions } from '../displayOptions';
@@ -53,10 +63,20 @@ import { JupyterInterpreterService } from '../jupyter/interpreter/jupyterInterpr
 import { ProductNames } from '../../common/installer/productNames';
 import { EnvironmentType } from '../../pythonEnvironments/info';
 import { JupyterInterpreterDependencyResponse } from '../jupyter/interpreter/jupyterInterpreterDependencyService';
-import { translateProductToModule } from '../../common/installer/productInstaller';
+import {
+    clearInstalledIntoInterpreterMemento,
+    translateProductToModule
+} from '../../common/installer/productInstaller';
+import { JupyterInvalidKernelError } from './jupyterInvalidKernelError';
+import { selectKernel } from '../jupyter/kernels/kernelSelector';
 
+function getFirstCell(cells?: NotebookCell[]) {
+    return cells?.length ? cells[0] : undefined;
+}
 @injectable()
 export class DataScienceErrorHandler implements IDataScienceErrorHandler {
+    private readonly _onShouldRunCells = new EventEmitter<NotebookCell[]>();
+    public readonly onShouldRunCells = this._onShouldRunCells.event;
     constructor(
         @inject(IApplicationShell) private readonly applicationShell: IApplicationShell,
         @inject(IJupyterInterpreterDependencyManager)
@@ -66,7 +86,8 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
         @inject(IConfigurationService) private readonly configuration: IConfigurationService,
         @inject(IKernelDependencyService) private readonly kernelDependency: IKernelDependencyService,
         @inject(JupyterInterpreterService) private readonly jupyterInterpreter: JupyterInterpreterService,
-        @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer
+        @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer,
+        @inject(IMemento) @named(GLOBAL_MEMENTO) private readonly memento: Memento
     ) {}
     public async handleError(err: Error): Promise<void> {
         traceWarning('DataScience Error', err);
@@ -78,13 +99,21 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
         purpose: 'start' | 'restart' | 'interrupt' | 'execution',
         kernelConnection: KernelConnectionMetadata,
         resource: Resource,
-        cellToDisplayErrors?: NotebookCell
+        pendingCells?: NotebookCell[]
     ): Promise<void> {
         traceWarning('Kernel Error', err);
-        await this.handleErrorImplementation(
+        if (kernelConnection.interpreter && purpose === 'start') {
+            // If we failed to start the kernel, then clear cache used to track
+            // whether we have dependencies installed or not.
+            // Possible something is missing.
+            void clearInstalledIntoInterpreterMemento(this.memento, undefined, kernelConnection.interpreter.path);
+        }
+        return this.handleErrorImplementation(
             err,
             purpose,
-            cellToDisplayErrors,
+            kernelConnection,
+            resource,
+            pendingCells,
             async (error: BaseError, defaultErrorMessage?: string) => {
                 const failureInfo = analyzeKernelErrors(
                     error.stdErr || '',
@@ -92,41 +121,21 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
                     kernelConnection.interpreter?.sysPrefix,
                     err instanceof JupyterConnectError
                 );
-                if (
-                    err instanceof IpyKernelNotInstalledError &&
-                    err.reason === KernelInterpreterDependencyResponse.uiHidden &&
-                    (purpose === 'start' || purpose === 'restart') &&
-                    kernelConnection.interpreter &&
-                    kernelConnection.kind !== 'connectToLiveKernel' &&
-                    kernelConnection.kind !== 'startUsingRemoteKernelSpec'
-                ) {
-                    // Its possible auto start ran and UI was disabled, but subsequently
-                    // user attempted to run a cell, & the prompt wasn't displayed to the user.
-                    const token = new CancellationTokenSource();
-                    await this.kernelDependency
-                        .installMissingDependencies(
-                            resource,
-                            kernelConnection,
-                            new DisplayOptions(false),
-                            token.token,
-                            true
-                        )
-                        .finally(() => token.dispose());
-                    return;
-                } else if (
-                    err instanceof IpyKernelNotInstalledError &&
-                    (purpose === 'start' || purpose === 'restart')
-                ) {
-                    cellToDisplayErrors = err.firstQueuedCell || cellToDisplayErrors;
-                    if (!err.anotherKernelSelected) {
-                        void this.displayIPyKernelMissingErrorInCell(kernelConnection, cellToDisplayErrors);
-                    }
+                if (err instanceof IpyKernelNotInstalledError && (purpose === 'start' || purpose === 'restart')) {
+                    this.handleIPyKernelNotInstalledError(err, purpose, kernelConnection, resource, pendingCells).catch(
+                        noop
+                    );
                     return;
                 } else if (err instanceof JupyterInstallError && (purpose === 'start' || purpose === 'restart')) {
-                    void this.displayJupyterMissingErrorInCell(err, kernelConnection, cellToDisplayErrors);
+                    void this.displayJupyterMissingErrorInCell(err, kernelConnection, getFirstCell(pendingCells));
                     return;
                 } else if (err instanceof JupyterConnectError) {
-                    void this.handleJupyterStartupError(failureInfo, err, kernelConnection, cellToDisplayErrors);
+                    this.handleJupyterStartupError(
+                        failureInfo,
+                        err,
+                        kernelConnection,
+                        getFirstCell(pendingCells)
+                    ).catch(noop);
                     return;
                 }
 
@@ -137,7 +146,7 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
                                 getDisplayPath(failureInfo.fileName, this.workspace.workspaceFolders || [])
                             ),
                             'https://aka.ms/kernelFailuresOverridingBuiltInModules',
-                            cellToDisplayErrors
+                            getFirstCell(pendingCells)
                         );
                         break;
                     }
@@ -163,9 +172,18 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
                             } catch (ex) {
                                 // Handle instances where installation failed or or cancelled it.
                                 if (ex instanceof IpyKernelNotInstalledError) {
+                                    if (ex.selectAnotherKernel) {
+                                        this.displayKernelPickerAndReRunCells(
+                                            kernelConnection,
+                                            resource,
+                                            pendingCells
+                                        ).catch(noop);
+                                        return;
+                                    }
+
                                     await this.displayIPyKernelMissingErrorInCell(
                                         kernelConnection,
-                                        cellToDisplayErrors
+                                        getFirstCell(pendingCells)
                                     );
                                 } else {
                                     throw ex;
@@ -175,7 +193,7 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
                             await this.showMessageWithMoreInfo(
                                 DataScience.failedToStartKernelDueToMissingModule().format(failureInfo.moduleName),
                                 'https://aka.ms/kernelFailuresMissingModule',
-                                cellToDisplayErrors
+                                getFirstCell(pendingCells)
                             );
                         }
                         break;
@@ -191,13 +209,13 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
                                     fileName
                                 ),
                                 'https://aka.ms/kernelFailuresModuleImportErrFromFile',
-                                cellToDisplayErrors
+                                getFirstCell(pendingCells)
                             );
                         } else {
                             await this.showMessageWithMoreInfo(
                                 DataScience.failedToStartKernelDueToImportFailure().format(failureInfo.moduleName),
                                 'https://aka.ms/kernelFailuresModuleImportErr',
-                                cellToDisplayErrors
+                                getFirstCell(pendingCells)
                             );
                         }
                         break;
@@ -209,7 +227,7 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
                         await this.showMessageWithMoreInfo(
                             message,
                             'https://aka.ms/kernelFailuresDllLoad',
-                            cellToDisplayErrors
+                            getFirstCell(pendingCells)
                         );
                         break;
                     }
@@ -217,7 +235,7 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
                         await this.showMessageWithMoreInfo(
                             DataScience.failedToStartKernelDueToWin32APIFailure(),
                             'https://aka.ms/kernelFailuresWin32Api',
-                            cellToDisplayErrors
+                            getFirstCell(pendingCells)
                         );
                         break;
                     }
@@ -225,7 +243,7 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
                         await this.showMessageWithMoreInfo(
                             DataScience.failedToStartKernelDueToPyZmqFailure(),
                             'https://aka.ms/kernelFailuresPyzmq',
-                            cellToDisplayErrors
+                            getFirstCell(pendingCells)
                         );
                         break;
                     }
@@ -233,7 +251,7 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
                         await this.showMessageWithMoreInfo(
                             DataScience.failedToStartKernelDueToOldIPython(),
                             'https://aka.ms/kernelFailuresOldIPython',
-                            cellToDisplayErrors
+                            getFirstCell(pendingCells)
                         );
                         break;
                     }
@@ -241,18 +259,163 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
                         await this.showMessageWithMoreInfo(
                             DataScience.failedToStartKernelDueToOldIPyKernel(),
                             'https://aka.ms/kernelFailuresOldIPyKernel',
-                            cellToDisplayErrors
+                            getFirstCell(pendingCells)
                         );
                         break;
                     }
                     default:
                         if (defaultErrorMessage) {
-                            void this.displayErrorsInCell(defaultErrorMessage, cellToDisplayErrors);
+                            this.displayErrorsInCell(defaultErrorMessage, getFirstCell(pendingCells)).catch(noop);
                             await this.applicationShell.showErrorMessage(defaultErrorMessage);
                         }
                 }
             }
         );
+    }
+    private async handleIPyKernelNotInstalledError(
+        err: Error,
+        purpose?: 'start' | 'restart' | 'interrupt' | 'execution',
+        kernelConnection?: KernelConnectionMetadata,
+        resource?: Resource,
+        pendingCells?: NotebookCell[]
+    ) {
+        if (!kernelConnection || !(err instanceof IpyKernelNotInstalledError)) {
+            return;
+        }
+        if (purpose !== 'start' && purpose !== 'restart') {
+            return;
+        }
+        if (err.reason === KernelInterpreterDependencyResponse.uiHidden && kernelConnection.interpreter) {
+            if (err.selectAnotherKernel) {
+                return this.displayKernelPickerAndReRunCells(kernelConnection, resource, pendingCells);
+            }
+            // Its possible auto start ran and UI was disabled, but subsequently
+            // user attempted to run a cell, & the prompt wasn't displayed to the user.
+            const token = new CancellationTokenSource();
+            try {
+                await this.kernelDependency
+                    .installMissingDependencies(
+                        resource,
+                        kernelConnection,
+                        new DisplayOptions(false),
+                        token.token,
+                        true
+                    )
+                    .finally(() => token.dispose());
+            } catch (ex) {
+                if (ex instanceof IpyKernelNotInstalledError) {
+                    if (ex.selectAnotherKernel) {
+                        return this.displayKernelPickerAndReRunCells(kernelConnection, resource, pendingCells);
+                    } else {
+                        return this.displayIPyKernelMissingErrorInCell(
+                            kernelConnection,
+                            pendingCells ? pendingCells[0] : undefined
+                        );
+                    }
+                }
+                traceError(`IPyKernel not installed`, ex);
+            }
+            return;
+        } else if (purpose === 'start' || purpose === 'restart') {
+            if (err.selectAnotherKernel) {
+                return this.displayKernelPickerAndReRunCells(kernelConnection, resource, pendingCells);
+            } else {
+                return this.displayIPyKernelMissingErrorInCell(
+                    kernelConnection,
+                    pendingCells ? pendingCells[0] : undefined
+                );
+            }
+        }
+    }
+    private async displayKernelPickerAndReRunCells(
+        _kernelConnection: KernelConnectionMetadata,
+        resource: Resource,
+        pendingCells?: NotebookCell[]
+    ) {
+        if (
+            await selectKernel(
+                resource,
+                this.serviceContainer.get<IVSCodeNotebook>(IVSCodeNotebook),
+                this.serviceContainer.get<IInteractiveWindowProvider>(IInteractiveWindowProvider),
+                this.serviceContainer.get<ICommandManager>(ICommandManager)
+            )
+        ) {
+            if (!pendingCells || pendingCells.length === 0) {
+                return;
+            }
+            // Display kernel picker & then trigger an execution of the cells.
+            this._onShouldRunCells.fire(Array.from(pendingCells || []));
+        }
+    }
+    /**
+     * Sometimes kernel execution fails as ipykernel or similar dependencies are not installed.
+     * This could happen when we assume its installed (based on some previous cache) & then attempt to start.
+     * E.g. user re-creates the virtual env, or re-installs python, in that case ipykernel is no longer available.
+     *
+     * In these cases, check if the dependencies are available or not, & if not, then prompt to install.
+     * If packages are found, then return an lets process the errors as usual.
+     */
+    private async handlePossibleDependencyError(
+        err: Error,
+        defaultErrorMessage: string,
+        kernelConnectionMetadata?: KernelConnectionMetadata,
+        resource?: Resource,
+        pendingCells?: NotebookCell[]
+    ): Promise<undefined | 'ErrorsHandledAndAddressed'> {
+        if (
+            !(err instanceof JupyterInvalidKernelError) &&
+            !(err instanceof KernelDiedError) &&
+            !(err instanceof KernelProcessExitedError)
+        ) {
+            return;
+        }
+        if (!kernelConnectionMetadata || !isPythonKernelConnection(kernelConnectionMetadata)) {
+            return;
+        }
+        if (err instanceof KernelDiedError && !err.message.includes('No module named ipykernel_launcher')) {
+            return;
+        }
+        // Possible ipykernel or other such dependencies is no longer installed in the environment.
+        // Look for the dependencies once again.
+        const installed = await this.kernelDependency.areDependenciesInstalled(
+            kernelConnectionMetadata,
+            undefined,
+            true
+        );
+        if (installed) {
+            return;
+        }
+        const startupUi = new DisplayOptions(false);
+        const token = new CancellationTokenSource();
+        try {
+            const response = await this.kernelDependency.installMissingDependencies(
+                resource,
+                kernelConnectionMetadata,
+                startupUi,
+                token.token,
+                true
+            );
+            // If we have successfully installed, then re-run the cells.
+            if (response === 'dependenciesInstalled' && pendingCells?.length) {
+                // Re-run the cells as dependencies were installed.
+                this._onShouldRunCells.fire(pendingCells);
+            }
+        } catch (ex) {
+            traceError(`Missing dependencies not installed`, ex);
+            const cellToDisplayErrors =
+                Array.isArray(pendingCells) && pendingCells.length ? pendingCells[0] : undefined;
+            if (ex instanceof IpyKernelNotInstalledError) {
+                if (ex.selectAnotherKernel) {
+                    this.displayKernelPickerAndReRunCells(kernelConnectionMetadata, resource, pendingCells).catch(noop);
+                    return;
+                }
+                this.displayIPyKernelMissingErrorInCell(kernelConnectionMetadata, cellToDisplayErrors).catch(noop);
+            } else {
+                this.displayErrorsInCell(defaultErrorMessage, cellToDisplayErrors).catch(noop);
+                this.applicationShell.showErrorMessage(defaultErrorMessage).then(noop, noop);
+            }
+        }
+        return 'ErrorsHandledAndAddressed';
     }
     private async showMessageWithMoreInfo(
         message: string,
@@ -262,7 +425,7 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
         if (!message.includes(Commands.ViewJupyterOutput)) {
             message = `${message} \n${DataScience.viewJupyterLogForFurtherInfo()}`;
         }
-        void this.displayErrorsInCell(message, cellToDisplayErrors, moreInfoLink);
+        this.displayErrorsInCell(message, cellToDisplayErrors, moreInfoLink).catch(noop);
         const buttons = moreInfoLink ? [Common.learnMore()] : [];
         await this.applicationShell.showErrorMessage(message, ...buttons).then((selection) => {
             if (selection === Common.learnMore() && moreInfoLink) {
@@ -329,7 +492,9 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
     private async handleErrorImplementation(
         err: Error,
         purpose?: 'start' | 'restart' | 'interrupt' | 'execution',
-        cellToDisplayErrors?: NotebookCell,
+        kernelConnectionMetadata?: KernelConnectionMetadata,
+        resource?: Resource,
+        pendingCells?: NotebookCell[],
         handler?: (error: BaseError, defaultErrorMessage?: string) => Promise<void>
     ): Promise<void> {
         const errorPrefix = getErrorMessagePrefix(purpose);
@@ -364,15 +529,14 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
                     }
                 });
         } else if (err instanceof IpyKernelNotInstalledError) {
-            if ((purpose === 'start' || purpose === 'restart') && handler) {
-                await handler(err);
-            }
-            noop();
+            this.handleIPyKernelNotInstalledError(err, purpose, kernelConnectionMetadata, resource, pendingCells).catch(
+                noop
+            );
         } else if (err instanceof VscCancellationError || err instanceof CancellationError) {
             // Don't show the message for cancellation errors
             traceWarning(`Cancelled by user`, err);
         } else if (err instanceof KernelConnectionTimeoutError || err instanceof KernelPortNotUsedTimeoutError) {
-            void this.displayErrorsInCell(err.message, cellToDisplayErrors);
+            void this.displayErrorsInCell(err.message, getFirstCell(pendingCells));
             this.applicationShell.showErrorMessage(err.message).then(noop, noop);
         } else if (
             err instanceof KernelDiedError ||
@@ -383,18 +547,38 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
             const defaultErrorMessage = getCombinedErrorMessage(
                 errorPrefix,
                 // PythonKernelDiedError has an `errorMessage` property, use that over `err.stdErr` for user facing error messages.
-                'errorMessage' in err ? err.errorMessage : getErrorMessageFromPythonTraceback(err.stdErr) || err.stdErr
+                'errorMessage' in err ? err.errorMessage : getErrorMessageFromPythonTraceBack(err.stdErr) || err.stdErr
             );
+            const result = await this.handlePossibleDependencyError(
+                err,
+                defaultErrorMessage,
+                kernelConnectionMetadata,
+                resource,
+                pendingCells
+            );
+            if (result === 'ErrorsHandledAndAddressed') {
+                return;
+            }
             if ((purpose === 'restart' || purpose === 'start') && handler) {
                 await handler(err, defaultErrorMessage);
             } else {
-                void this.displayErrorsInCell(defaultErrorMessage, cellToDisplayErrors);
+                void this.displayErrorsInCell(defaultErrorMessage, getFirstCell(pendingCells));
                 this.applicationShell.showErrorMessage(defaultErrorMessage).then(noop, noop);
             }
         } else {
             // Some errors have localized and/or formatted error messages.
             const message = getCombinedErrorMessage(errorPrefix, err.message || err.toString());
-            void this.displayErrorsInCell(message, cellToDisplayErrors);
+            const result = await this.handlePossibleDependencyError(
+                err,
+                message,
+                kernelConnectionMetadata,
+                resource,
+                pendingCells
+            );
+            if (result === 'ErrorsHandledAndAddressed') {
+                return;
+            }
+            void this.displayErrorsInCell(message, getFirstCell(pendingCells));
             this.applicationShell.showErrorMessage(message).then(noop, noop);
         }
     }

--- a/src/client/datascience/errors/ipyKernelNotInstalledError.ts
+++ b/src/client/datascience/errors/ipyKernelNotInstalledError.ts
@@ -1,17 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { NotebookCell } from 'vscode';
 import { BaseError } from '../../common/errors/types';
 import { traceError } from '../../common/logger';
 import { KernelInterpreterDependencyResponse } from '../types';
 
 export class IpyKernelNotInstalledError extends BaseError {
+    /**
+     * @param {boolean} selectAnotherKernel Whether the user chose to use another kernel.
+     */
     constructor(
         message: string,
         public reason: KernelInterpreterDependencyResponse,
-        public readonly anotherKernelSelected: boolean,
-        public readonly firstQueuedCell?: NotebookCell
+        public readonly selectAnotherKernel: boolean
     ) {
         super('noipykernel', message);
         traceError(`IPykernel not detected`);

--- a/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
@@ -5,7 +5,7 @@
 
 import { inject, injectable, named } from 'inversify';
 import { CancellationToken, Memento } from 'vscode';
-import { IApplicationShell, ICommandManager, IVSCodeNotebook } from '../../../common/application/types';
+import { IApplicationShell } from '../../../common/application/types';
 import { createPromiseFromCancellation, wrapCancellationTokens } from '../../../common/cancellation';
 import {
     isModulePresentInEnvironment,
@@ -26,28 +26,21 @@ import {
 } from '../../../common/types';
 import { Common, DataScience } from '../../../common/utils/localize';
 import { IServiceContainer } from '../../../ioc/types';
-import { ignoreLogging, TraceOptions } from '../../../logging/trace';
+import { ignoreLogging, logValue, TraceOptions } from '../../../logging/trace';
 import { EnvironmentType, PythonEnvironment } from '../../../pythonEnvironments/info';
 import { sendTelemetryEvent } from '../../../telemetry';
 import { getTelemetrySafeHashedString } from '../../../telemetry/helpers';
 import { getResourceType } from '../../common';
 import { Telemetry } from '../../constants';
 import { IpyKernelNotInstalledError } from '../../errors/ipyKernelNotInstalledError';
-import { VSCodeNotebookController } from '../../notebook/vscodeNotebookController';
 import { KernelProgressReporter } from '../../progress/kernelProgressReporter';
 import {
     IDisplayOptions,
-    IInteractiveWindowProvider,
     IKernelDependencyService,
+    IRawNotebookSupportedService,
     KernelInterpreterDependencyResponse
 } from '../../types';
-import { selectKernel } from './kernelSelector';
-import {
-    IKernelProvider,
-    KernelConnectionMetadata,
-    LocalKernelSpecConnectionMetadata,
-    PythonKernelConnectionMetadata
-} from './types';
+import { KernelConnectionMetadata } from './types';
 
 /**
  * Responsible for managing dependencies of a Python interpreter required to run as a Jupyter Kernel.
@@ -61,9 +54,7 @@ export class KernelDependencyService implements IKernelDependencyService {
         @inject(IInstaller) private readonly installer: IInstaller,
         @inject(IMemento) @named(GLOBAL_MEMENTO) private readonly memento: Memento,
         @inject(IsCodeSpace) private readonly isCodeSpace: boolean,
-        @inject(ICommandManager) private readonly commandManager: ICommandManager,
-        @inject(IVSCodeNotebook) private readonly notebooks: IVSCodeNotebook,
-        @inject(IVSCodeNotebook) private readonly vscNotebook: IVSCodeNotebook,
+        @inject(IRawNotebookSupportedService) private readonly rawSupport: IRawNotebookSupportedService,
         @inject(IServiceContainer) protected serviceContainer: IServiceContainer // @inject(IInteractiveWindowProvider) private readonly interactiveWindowProvider: IInteractiveWindowProvider
     ) {}
     /**
@@ -77,7 +68,7 @@ export class KernelDependencyService implements IKernelDependencyService {
         ui: IDisplayOptions,
         @ignoreLogging() token: CancellationToken,
         ignoreCache?: boolean
-    ): Promise<void> {
+    ): Promise<void | 'dependenciesInstalled'> {
         traceInfo(`installMissingDependencies ${getDisplayPath(kernelConnection.interpreter?.path)}`);
         if (
             kernelConnection.kind === 'connectToLiveKernel' ||
@@ -115,14 +106,28 @@ export class KernelDependencyService implements IKernelDependencyService {
             if (token?.isCancellationRequested) {
                 return;
             }
-            await this.handleKernelDependencyResponse(result, kernelConnection, resource);
+            if (result === KernelInterpreterDependencyResponse.ok) {
+                return 'dependenciesInstalled';
+            }
+            const shouldSelectAnotherKernel = result === KernelInterpreterDependencyResponse.selectDifferentKernel;
+
+            // Throw an error so,to ensure it gets handled & displayed.
+            const message = kernelConnection.interpreter?.displayName
+                ? `${kernelConnection.interpreter?.displayName}:${getDisplayPath(kernelConnection.interpreter?.path)}`
+                : getDisplayPath(kernelConnection.interpreter?.path);
+            throw new IpyKernelNotInstalledError(
+                DataScience.ipykernelNotInstalled().format(message),
+                result,
+                shouldSelectAnotherKernel
+            );
         } finally {
             // Don't need to cache anymore
             this.installPromises.delete(kernelConnection.interpreter.path);
         }
     }
+    @traceDecorators.verbose('Are Dependencies Installed')
     public async areDependenciesInstalled(
-        kernelConnection: KernelConnectionMetadata,
+        @logValue<KernelConnectionMetadata>('id') kernelConnection: KernelConnectionMetadata,
         token?: CancellationToken,
         ignoreCache?: boolean
     ): Promise<boolean> {
@@ -137,10 +142,14 @@ export class KernelDependencyService implements IKernelDependencyService {
         // Makes a big difference with conda on windows.
         if (
             !ignoreCache &&
+            // When dealing with Jupyter (non-raw), don't cache, always check.
+            // The reason is even if ipykernel isn't available, the kernel will still be started (i.e. the process is started),
+            // However Jupyter doesn't notify a failure to start.
+            this.rawSupport.isSupported &&
             isModulePresentInEnvironmentCache(this.memento, Product.ipykernel, kernelConnection.interpreter)
         ) {
             traceInfo(
-                `IPykernel found previously in this environment ${getDisplayPath(kernelConnection.interpreter.path)}`
+                `IPyKernel found previously in this environment ${getDisplayPath(kernelConnection.interpreter.path)}`
             );
             return true;
         }
@@ -160,57 +169,6 @@ export class KernelDependencyService implements IKernelDependencyService {
             installedPromise,
             createPromiseFromCancellation({ token, defaultValue: false, cancelAction: 'resolve' })
         ]);
-    }
-
-    private async handleKernelDependencyResponse(
-        response: KernelInterpreterDependencyResponse,
-        kernelConnection: PythonKernelConnectionMetadata | LocalKernelSpecConnectionMetadata,
-        resource: Resource
-    ) {
-        if (response === KernelInterpreterDependencyResponse.ok) {
-            return;
-        }
-        const kernelProvider = this.serviceContainer.get<IKernelProvider>(IKernelProvider);
-        const kernel = kernelProvider.kernels.find(
-            (item) =>
-                item.kernelConnectionMetadata === kernelConnection &&
-                this.vscNotebook.activeNotebookEditor?.document &&
-                this.vscNotebook.activeNotebookEditor?.document === item.notebookDocument &&
-                (item.resourceUri || '')?.toString() === (resource || '').toString()
-        );
-        const firstQueuedCell = kernel && kernel.pendingCells.length > 0 ? kernel.pendingCells[0] : undefined;
-        let anotherKernelSelected = false;
-        if (response === KernelInterpreterDependencyResponse.selectDifferentKernel) {
-            if (kernel) {
-                // If user changes the kernel, then the next kernel must run the pending cells.
-                // Store it for the other kernel to pick them up.
-                VSCodeNotebookController.pendingCells.set(kernel.notebookDocument, kernel.pendingCells);
-            }
-            await selectKernel(
-                resource,
-                this.notebooks,
-                this.serviceContainer.get(IInteractiveWindowProvider),
-                this.commandManager
-            );
-            if (kernel) {
-                VSCodeNotebookController.pendingCells.delete(kernel.notebookDocument);
-                // If the previous kernel has been disposed (or disposing),
-                // then this means the user selected a new kernel.
-                anotherKernelSelected = kernel.disposed || kernel.disposing;
-            }
-        }
-        // If selecting a new kernel, the current code paths don't allow us to just change a kernel on the fly.
-        // We pass kernel connection information around, hence if there's a change we need to start all over again.
-        // Throwing this exception will get the user to start again.
-        const message = kernelConnection.interpreter?.displayName
-            ? `${kernelConnection.interpreter?.displayName}:${getDisplayPath(kernelConnection.interpreter?.path)}`
-            : getDisplayPath(kernelConnection.interpreter?.path);
-        throw new IpyKernelNotInstalledError(
-            DataScience.ipykernelNotInstalled().format(message),
-            response,
-            anotherKernelSelected,
-            firstQueuedCell
-        );
     }
     private async runInstaller(
         resource: Resource,
@@ -285,7 +243,6 @@ export class KernelDependencyService implements IKernelDependencyService {
                 });
                 return KernelInterpreterDependencyResponse.cancel;
             }
-
             if (selection === selectKernel) {
                 sendTelemetryEvent(Telemetry.PythonModuleInstall, undefined, {
                     action: 'differentKernel',

--- a/src/client/datascience/jupyter/kernels/kernelExecution.ts
+++ b/src/client/datascience/jupyter/kernels/kernelExecution.ts
@@ -78,6 +78,12 @@ export class KernelExecution implements IDisposable {
         const result = await executionQueue.waitForCompletion([cell]);
         return result[0];
     }
+    public async cancel() {
+        const executionQueue = this.documentExecutions.get(this.kernel.notebookDocument);
+        if (executionQueue) {
+            await executionQueue.cancel(true);
+        }
+    }
 
     /**
      * Interrupts the execution of cells.
@@ -144,10 +150,14 @@ export class KernelExecution implements IDisposable {
         }
 
         // Restart the active execution
-        await (this._restartPromise ? this._restartPromise : (this._restartPromise = this.restartExecution(session)));
-
-        // Done restarting, clear restart promise
-        this._restartPromise = undefined;
+        if (!this._restartPromise) {
+            this._restartPromise = this.restartExecution(session);
+            this._restartPromise.finally(() => {
+                // Done restarting, clear restart promise
+                this._restartPromise = undefined;
+            });
+        }
+        await this._restartPromise;
     }
     public dispose() {
         this.disposables.forEach((d) => d.dispose());

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -10,19 +10,23 @@ import { traceError } from '../../../common/logger';
 import { KernelConnectionMetadata } from './types';
 import { JVSC_EXTENSION_ID } from '../../../common/constants';
 
+/**
+ * Return `true` if a new kernel has been selected.
+ */
 export async function selectKernel(
     resource: Resource,
     notebooks: IVSCodeNotebook,
     interactiveWindowProvider: IInteractiveWindowProvider | undefined,
     commandManager: ICommandManager
-) {
+): Promise<boolean> {
     const notebookEditor = findNotebookEditor(resource, notebooks, interactiveWindowProvider);
     if (notebookEditor) {
         return commandManager.executeCommand('notebook.selectKernel', {
             notebookEditor
-        });
+        }) as Promise<boolean>;
     }
     traceError(`Unable to select kernel as the Notebook document could not be identified`);
+    return false;
 }
 
 export async function switchKernel(

--- a/src/client/datascience/notebook/notebookControllerManager.ts
+++ b/src/client/datascience/notebook/notebookControllerManager.ts
@@ -40,7 +40,7 @@ import {
 } from '../jupyter/kernels/types';
 import { ILocalKernelFinder, IRemoteKernelFinder } from '../kernel-launcher/types';
 import { PreferredRemoteKernelIdProvider } from '../notebookStorage/preferredRemoteKernelIdProvider';
-import { IJupyterServerUriStorage, INotebookProvider } from '../types';
+import { IDataScienceErrorHandler, IJupyterServerUriStorage, INotebookProvider } from '../types';
 import { getNotebookMetadata, isPythonNotebook } from './helpers/helpers';
 import { VSCodeNotebookController } from './vscodeNotebookController';
 import { INotebookControllerManager } from './types';
@@ -139,7 +139,8 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
         @inject(IBrowserService) private readonly browser: IBrowserService,
         @inject(CondaService) private readonly condaService: CondaService,
         @inject(JupyterServerSelector) private readonly jupyterServerSelector: JupyterServerSelector,
-        @inject(IJupyterServerUriStorage) private readonly serverUriStorage: IJupyterServerUriStorage
+        @inject(IJupyterServerUriStorage) private readonly serverUriStorage: IJupyterServerUriStorage,
+        @inject(IDataScienceErrorHandler) private readonly errorHandler: IDataScienceErrorHandler
     ) {
         this._onNotebookControllerSelected = new EventEmitter<{
             notebook: NotebookDocument;
@@ -205,7 +206,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
 
             // Fetch the list of kernels ignoring the cache.
             this.loadLocalNotebookControllersImpl('ignoreCache')
-                .catch((ex) => console.error('Failed to fetch controllers without cache', ex))
+                .catch((ex) => traceError('Failed to fetch controllers without cache', ex))
                 .finally(() => {
                     this._controllersLoaded = true;
                     let timer: NodeJS.Timeout | number | undefined;
@@ -218,7 +219,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
                             timer = setTimeout(
                                 () =>
                                     this.loadLocalNotebookControllersImpl('ignoreCache').catch((ex) =>
-                                        console.error(
+                                        traceError(
                                             'Failed to re-query python kernels after changes to list of interpreters',
                                             ex
                                         )
@@ -710,7 +711,26 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
                 [kernelConnection.id, JupyterNotebookView],
                 [`${kernelConnection.id}${this.interactiveControllerIdSuffix}`, InteractiveWindowView]
             ]
-                .filter(([id]) => !this.registeredControllers.has(id))
+                .filter(([id]) => {
+                    const controller = this.registeredControllers.get(id);
+                    if (controller) {
+                        // If we already have this controller, its possible the Python version information has changed.
+                        // E.g. we had a cached kernlespec, and since then the user updated their version of python,
+                        // Now we need to update the display name of the kernelspec.
+                        // Assume user created a venv with name `.venv` and points to Python 3.8
+                        // Tomorrow they delete this folder and re-create it with version Python 3.9.
+                        // Similarly they could re-create conda environments or just install a new version of Global Python env.
+                        if (
+                            isPythonKernelConnection(kernelConnection) &&
+                            (kernelConnection.kind === 'startUsingLocalKernelSpec' ||
+                                kernelConnection.kind === 'startUsingPythonInterpreter')
+                        ) {
+                            controller.updateInterpreterDetails(kernelConnection);
+                        }
+                        return false;
+                    }
+                    return true;
+                })
                 .forEach(([id, viewType]) => {
                     let hideController = false;
                     if (kernelConnection.kind === 'connectToLiveKernel') {
@@ -743,7 +763,8 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
                         this.docManager,
                         this.appShell,
                         this.browser,
-                        this.extensionChecker
+                        this.extensionChecker,
+                        this.errorHandler
                     );
                     // Hook up to if this NotebookController is selected or de-selected
                     controller.onNotebookControllerSelected(

--- a/src/client/datascience/notebook/vscodeNotebookController.ts
+++ b/src/client/datascience/notebook/vscodeNotebookController.ts
@@ -26,7 +26,7 @@ import {
 } from '../../common/application/types';
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import { disposeAllDisposables } from '../../common/helpers';
-import { traceInfo, traceInfoIfCI } from '../../common/logger';
+import { traceInfo, traceInfoIfCI, traceVerbose } from '../../common/logger';
 import { getDisplayPath } from '../../common/platform/fs-paths';
 import {
     IBrowserService,
@@ -36,6 +36,7 @@ import {
     IExtensionContext,
     IPathUtils
 } from '../../common/types';
+import { createDeferred } from '../../common/utils/async';
 import { Common, DataScience } from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
 import { TraceOptions } from '../../logging/trace';
@@ -50,21 +51,24 @@ import {
     getRemoteKernelSessionInformation,
     isPythonKernelConnection,
     getKernelConnectionPath,
-    getKernelRegistrationInfo
+    getKernelRegistrationInfo,
+    getDisplayNameOrNameOfKernelConnection
 } from '../jupyter/kernels/helpers';
 import {
     IKernel,
     IKernelProvider,
     isLocalConnection,
     KernelConnectionMetadata,
-    LiveKernelConnectionMetadata
+    LiveKernelConnectionMetadata,
+    LocalKernelSpecConnectionMetadata,
+    PythonKernelConnectionMetadata
 } from '../jupyter/kernels/types';
 import { PreferredRemoteKernelIdProvider } from '../notebookStorage/preferredRemoteKernelIdProvider';
 import {
     initializeInteractiveOrNotebookTelemetryBasedOnUserAction,
     sendKernelTelemetryEvent
 } from '../telemetry/telemetry';
-import { KernelSocketInformation } from '../types';
+import { IDataScienceErrorHandler, KernelSocketInformation } from '../types';
 import { NotebookCellLanguageService } from './cellLanguageService';
 import { InteractiveWindowView } from './constants';
 import { isJupyterNotebook, traceCellMessage, updateNotebookDocumentMetadata } from './helpers/helpers';
@@ -78,7 +82,6 @@ export class VSCodeNotebookController implements Disposable {
     private readonly _onDidDispose = new EventEmitter<void>();
     private readonly disposables: IDisposable[] = [];
     private notebookKernels = new WeakMap<NotebookDocument, IKernel>();
-    public static pendingCells = new WeakMap<NotebookDocument, readonly NotebookCell[]>();
     public readonly controller: NotebookController;
     /**
      * Used purely for testing purposes.
@@ -113,7 +116,7 @@ export class VSCodeNotebookController implements Disposable {
         return this.associatedDocuments.has(doc);
     }
 
-    private readonly associatedDocuments = new WeakSet<NotebookDocument>();
+    private readonly associatedDocuments = new WeakMap<NotebookDocument, Promise<void>>();
     constructor(
         private kernelConnection: KernelConnectionMetadata,
         id: string,
@@ -133,7 +136,8 @@ export class VSCodeNotebookController implements Disposable {
         private readonly documentManager: IDocumentManager,
         private readonly appShell: IApplicationShell,
         private readonly browser: IBrowserService,
-        private readonly extensionChecker: IPythonExtensionChecker
+        private readonly extensionChecker: IPythonExtensionChecker,
+        private readonly errorHandler: IDataScienceErrorHandler
     ) {
         disposableRegistry.push(this);
         this._onNotebookControllerSelected = new EventEmitter<{
@@ -159,9 +163,15 @@ export class VSCodeNotebookController implements Disposable {
         this.controller.supportedLanguages = this.languageService.getSupportedLanguages(kernelConnection);
         // Hook up to see when this NotebookController is selected by the UI
         this.controller.onDidChangeSelectedNotebooks(this.onDidChangeSelectedNotebooks, this, this.disposables);
+        this.errorHandler.onShouldRunCells(this.onShouldRunCells, this, this.disposables);
     }
     public updateRemoteKernelDetails(kernelConnection: LiveKernelConnectionMetadata) {
         this.controller.detail = getRemoteKernelSessionInformation(kernelConnection);
+    }
+    public updateInterpreterDetails(
+        kernelConnection: LocalKernelSpecConnectionMetadata | PythonKernelConnectionMetadata
+    ) {
+        this.controller.label = getDisplayNameOrNameOfKernelConnection(kernelConnection);
     }
     public asWebviewUri(localResource: Uri): Uri {
         return this.controller.asWebviewUri(localResource);
@@ -253,9 +263,6 @@ export class VSCodeNotebookController implements Disposable {
             // Possible it gets called again in our tests (due to hacks for testing purposes).
             return;
         }
-        // Capture list of pending cells to execute.
-        // As we're in an async method these can be deleted by the time we got to the bottom of this method.
-        const pendingCells = VSCodeNotebookController.pendingCells.get(event.notebook);
 
         if (!event.selected) {
             // If user has selected another controller, then kill the current kernel.
@@ -281,9 +288,8 @@ export class VSCodeNotebookController implements Disposable {
             return;
         }
         this.warnWhenUsingOutdatedPython();
-        traceInfoIfCI(`Notebook Controller set ${getDisplayPath(event.notebook.uri)}, ${this.id}`);
-        this.associatedDocuments.add(event.notebook);
-
+        const deferred = createDeferred<void>();
+        this.associatedDocuments.set(event.notebook, deferred.promise);
         // Now actually handle the change
         this.widgetCoordinator.setActiveController(event.notebook, this);
         await this.onDidSelectController(event.notebook);
@@ -292,21 +298,32 @@ export class VSCodeNotebookController implements Disposable {
         // If this NotebookController was selected, fire off the event
         this._onNotebookControllerSelected.fire({ notebook: event.notebook, controller: this });
         this._onNotebookControllerSelectionChanged.fire();
-
-        if (pendingCells?.length) {
-            await this.handleExecution([...pendingCells], event.notebook);
+        traceVerbose(`Controller selection change completed`);
+        deferred.resolve();
+    }
+    private async onShouldRunCells(cells: NotebookCell[]) {
+        if (cells.length === 0) {
+            return;
         }
+        const promise = this.associatedDocuments.get(cells[0].notebook);
+        if (!promise) {
+            return;
+        }
+        // Run the cells after we've completed switching to this controller.
+        await promise;
+        traceInfoIfCI(`Re-Run pending cells for controller ${this.id} using ${this.connection.id}`);
+        await this.handleExecution(cells, cells[0].notebook);
     }
     /**
      * Scenario 1:
      * Assume user opens a notebook and language is C++ or .NET Interactive, they start writing python code.
-     * Next users hits the run button, next user will be promtped to select a kernel.
+     * Next users hits the run button, next user will be prompted to select a kernel.
      * User now selects a Python kernel.
      * Nothing happens, that's right nothing happens.
-     * This is because C++ is not a lanaugage supported by the python kernel.
+     * This is because C++ is not a languages supported by the python kernel.
      * Hence VS Code will not send the execution call to the extension.
      *
-     * Solution, go through the cells and change the languges to something that's supported.
+     * Solution, go through the cells and change the language to something that's supported.
      *
      * Scenario 2:
      * User has .NET extension installed.
@@ -511,7 +528,8 @@ export class VSCodeNotebookController implements Disposable {
             !this.configuration.getSettings(undefined).disableJupyterAutoStart &&
             isLocalConnection(this.kernelConnection)
         ) {
-            await newKernel.start({ disableUI: true }).catch(noop);
+            // Startup could fail due to missing dependencies or the like.
+            void newKernel.start({ disableUI: true });
         }
     }
 }

--- a/src/client/datascience/progress/kernelProgressReporter.ts
+++ b/src/client/datascience/progress/kernelProgressReporter.ts
@@ -5,6 +5,7 @@ import { inject, injectable } from 'inversify';
 import { Disposable, Progress, ProgressLocation, window } from 'vscode';
 import { IExtensionSyncActivationService } from '../../activation/types';
 import { disposeAllDisposables } from '../../common/helpers';
+import { traceError } from '../../common/logger';
 import { IDisposable, IDisposableRegistry, Resource } from '../../common/types';
 import { createDeferred } from '../../common/utils/async';
 import { noop } from '../../common/utils/misc';
@@ -160,7 +161,7 @@ export class KernelProgressReporter implements IExtensionSyncActivationService {
                         progressInfo.dispose();
                     }
                 } catch (ex) {
-                    console.error(`Failed to dispose Progress reporter for ${key}`, ex);
+                    traceError(`Failed to dispose Progress reporter for ${key}`, ex);
                 }
             }
         };

--- a/src/client/datascience/raw-kernel/rawJupyterSession.ts
+++ b/src/client/datascience/raw-kernel/rawJupyterSession.ts
@@ -8,6 +8,7 @@ import { CancellationToken } from 'vscode-jsonrpc';
 import { CancellationError, createPromiseFromCancellation } from '../../common/cancellation';
 import { getTelemetrySafeErrorMessageFromPythonTraceback } from '../../common/errors/errorUtils';
 import { traceError, traceInfo, traceVerbose, traceWarning } from '../../common/logger';
+import { getDisplayPath } from '../../common/platform/fs-paths';
 import { IDisposable, IOutputChannel, Resource } from '../../common/types';
 import { createDeferred, sleep, TimedOutError } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
@@ -254,7 +255,11 @@ export class RawJupyterSession extends BaseJupyterSession {
             );
         }
 
-        traceInfo(`Starting raw kernel ${getDisplayNameOrNameOfKernelConnection(this.kernelConnectionMetadata)}`);
+        traceInfo(
+            `Starting raw kernel ${getDisplayNameOrNameOfKernelConnection(
+                this.kernelConnectionMetadata
+            )} for interpreter ${getDisplayPath(this.kernelConnectionMetadata.interpreter?.path)}`
+        );
 
         this.terminatingStatus = undefined;
         const process = await this.kernelLauncher.launch(

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -407,6 +407,11 @@ export interface IInteractiveWindowProvider {
 export const IDataScienceErrorHandler = Symbol('IDataScienceErrorHandler');
 export interface IDataScienceErrorHandler {
     /**
+     * Event raised when an error has been handled and the cells need to be
+     * executed with the currently active kernel (kernel associated with cells)
+     */
+    onShouldRunCells: Event<NotebookCell[]>;
+    /**
      * Handles the errors and if necessary displays an error message.
      * The value of `context` is used to determine the context of the error message, whether it applies to starting or interrupting kernels or the like.
      * Thus based on the context the error message would be different.
@@ -420,7 +425,7 @@ export interface IDataScienceErrorHandler {
         context: 'start' | 'restart' | 'interrupt' | 'execution',
         kernelConnection: KernelConnectionMetadata,
         resource: Resource,
-        cellToDisplayErrors?: NotebookCell
+        pendingCells?: readonly NotebookCell[]
     ): Promise<void>;
 }
 
@@ -1006,7 +1011,7 @@ export interface IKernelDependencyService {
         ui: IDisplayOptions,
         token: CancellationToken,
         ignoreCache?: boolean
-    ): Promise<void>;
+    ): Promise<void | 'dependenciesInstalled' | 'differentKernelSelected'>;
     /**
      * @param {boolean} [ignoreCache] We cache the results of this call so we don't have to do it again (users rarely uninstall ipykernel).
      */

--- a/src/test/datascience/errorHandler.unit.test.ts
+++ b/src/test/datascience/errorHandler.unit.test.ts
@@ -4,7 +4,7 @@
 'use strict';
 import * as dedent from 'dedent';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
-import { Uri, WorkspaceFolder } from 'vscode';
+import { Memento, Uri, WorkspaceFolder } from 'vscode';
 import { IApplicationShell, IWorkspaceService } from '../../client/common/application/types';
 import { getDisplayPath } from '../../client/common/platform/fs-paths';
 import { Common, DataScience } from '../../client/common/utils/localize';
@@ -56,7 +56,8 @@ suite('DataScience Error Handler Unit Tests', () => {
             instance(configuration),
             instance(kernelDependencyInstaller),
             instance(jupyterInterpreterService),
-            instance(svcContainer)
+            instance(svcContainer),
+            instance(mock<Memento>())
         );
         when(applicationShell.showErrorMessage(anything())).thenResolve();
         when(applicationShell.showErrorMessage(anything(), anything())).thenResolve();
@@ -213,7 +214,7 @@ suite('DataScience Error Handler Unit Tests', () => {
         };
         test('Unable to import <name> from user overriding module (windows)', async () => {
             await dataScienceErrorHandler.handleKernelError(
-                new KernelDiedError('Hello', stdErrorMessages.userOrverridingRandomPyFile_Windows),
+                new KernelDiedError('Hello', stdErrorMessages.userOrverridingRandomPyFile_Windows, undefined),
                 'start',
                 kernelConnection,
                 undefined
@@ -236,7 +237,7 @@ suite('DataScience Error Handler Unit Tests', () => {
             ];
             when(workspaceService.workspaceFolders).thenReturn(workspaceFolders);
             await dataScienceErrorHandler.handleKernelError(
-                new KernelDiedError('Hello', stdErrorMessages.userOrverridingRandomPyFile_Windows),
+                new KernelDiedError('Hello', stdErrorMessages.userOrverridingRandomPyFile_Windows, undefined),
                 'start',
                 kernelConnection,
                 undefined
@@ -253,7 +254,7 @@ suite('DataScience Error Handler Unit Tests', () => {
         });
         test('Unable to import <name> from user overriding module (linux)', async () => {
             await dataScienceErrorHandler.handleKernelError(
-                new KernelDiedError('Hello', stdErrorMessages.userOrverridingRandomPyFile_Unix),
+                new KernelDiedError('Hello', stdErrorMessages.userOrverridingRandomPyFile_Unix, undefined),
                 'start',
                 kernelConnection,
                 undefined
@@ -280,7 +281,7 @@ suite('DataScience Error Handler Unit Tests', () => {
             ];
             when(workspaceService.workspaceFolders).thenReturn(workspaceFolders);
             await dataScienceErrorHandler.handleKernelError(
-                new KernelDiedError('Hello', stdErrorMessages.userOrverridingRandomPyFile_Unix),
+                new KernelDiedError('Hello', stdErrorMessages.userOrverridingRandomPyFile_Unix, undefined),
                 'start',
                 kernelConnection,
                 undefined
@@ -299,7 +300,8 @@ suite('DataScience Error Handler Unit Tests', () => {
                     `
 import win32api
 ImportError: No module named 'win32api'
-`
+`,
+                    undefined
                 ),
                 'start',
                 kernelConnection,
@@ -318,7 +320,8 @@ ImportError: No module named 'win32api'
                     `
 import xyz
 ImportError: No module named 'xyz'
-`
+`,
+                    undefined
                 ),
                 'start',
                 kernelConnection,
@@ -333,7 +336,8 @@ ImportError: No module named 'xyz'
             await dataScienceErrorHandler.handleKernelError(
                 new KernelDiedError(
                     'Hello',
-                    `ImportError: cannot import name 'constants' from partially initialized module 'zmq.backend.cython' (most likely due to a circular import) (C:\\Users\\<user>\\AppData\\Roaming\\Python\\Python38\\site-packages\\zmq\\backend\\cython\\__init__.py)`
+                    `ImportError: cannot import name 'constants' from partially initialized module 'zmq.backend.cython' (most likely due to a circular import) (C:\\Users\\<user>\\AppData\\Roaming\\Python\\Python38\\site-packages\\zmq\\backend\\cython\\__init__.py)`,
+                    undefined
                 ),
                 'start',
                 kernelConnection,
@@ -346,7 +350,7 @@ ImportError: No module named 'xyz'
         });
         test('Unknown Dll load failure', async () => {
             await dataScienceErrorHandler.handleKernelError(
-                new KernelDiedError('Hello', `ImportError: DLL load failed`),
+                new KernelDiedError('Hello', `ImportError: DLL load failed`, undefined),
                 'start',
                 kernelConnection,
                 undefined
@@ -358,7 +362,7 @@ ImportError: No module named 'xyz'
         });
         test('Dll load failure', async () => {
             await dataScienceErrorHandler.handleKernelError(
-                new KernelDiedError('Hello', `import XYZ\nImportError: DLL load failed`),
+                new KernelDiedError('Hello', `import XYZ\nImportError: DLL load failed`, undefined),
                 'start',
                 kernelConnection,
                 undefined

--- a/src/test/datascience/execution.unit.test.ts
+++ b/src/test/datascience/execution.unit.test.ts
@@ -11,7 +11,7 @@ import { anything, instance, match, mock, reset, when } from 'ts-mockito';
 import { Matcher } from 'ts-mockito/lib/matcher/type/Matcher';
 import * as TypeMoq from 'typemoq';
 import * as uuid from 'uuid/v4';
-import { CancellationTokenSource, ConfigurationChangeEvent, Disposable, EventEmitter } from 'vscode';
+import { CancellationTokenSource, ConfigurationChangeEvent, Disposable, EventEmitter, ExtensionMode } from 'vscode';
 import { ApplicationShell } from '../../client/common/application/applicationShell';
 import { IApplicationShell, IWorkspaceService } from '../../client/common/application/types';
 import { WorkspaceService } from '../../client/common/application/workspace';
@@ -34,6 +34,7 @@ import {
 import {
     IAsyncDisposableRegistry,
     IConfigurationService,
+    IExtensionContext,
     IOutputChannel,
     IPathUtils,
     Product
@@ -971,10 +972,13 @@ suite('Jupyter Execution', async () => {
         when(serviceContainer.get<IJupyterSubCommandExecutionService>(IJupyterSubCommandExecutionService)).thenReturn(
             jupyterCmdExecutionService
         );
+        const context = mock<IExtensionContext>();
+        when(context.extensionMode).thenReturn(ExtensionMode.Production);
         notebookStarter = new NotebookStarter(
             jupyterCmdExecutionService,
             instance(fileSystem),
             instance(serviceContainer),
+            instance(context),
             instance(jupyterOutputChannel)
         );
         const kernelFinder = mock(LocalKernelFinder);

--- a/src/test/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.unit.test.ts
+++ b/src/test/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.unit.test.ts
@@ -36,7 +36,7 @@ use(chaiPromise);
 
 suite('DataScience - Jupyter InterpreterSubCommandExecutionService', () => {
     let jupyterInterpreter: JupyterInterpreterService;
-    let interperterService: IInterpreterService;
+    let interpreterService: IInterpreterService;
     let jupyterDependencyService: JupyterInterpreterDependencyService;
     let execService: IPythonDaemonExecutionService;
     let jupyterInterpreterExecutionService: JupyterInterpreterSubCommandExecutionService;
@@ -44,7 +44,7 @@ suite('DataScience - Jupyter InterpreterSubCommandExecutionService', () => {
     const activePythonInterpreter = createPythonInterpreter({ displayName: 'activePythonInterpreter' });
     let notebookStartResult: ObservableExecutionResult<string>;
     setup(() => {
-        interperterService = mock<IInterpreterService>();
+        interpreterService = mock<IInterpreterService>();
         jupyterInterpreter = mock(JupyterInterpreterService);
         jupyterDependencyService = mock(JupyterInterpreterDependencyService);
         const getRealPathStub = sinon.stub(fsExtra, 'realpath');
@@ -68,7 +68,7 @@ suite('DataScience - Jupyter InterpreterSubCommandExecutionService', () => {
         };
         jupyterInterpreterExecutionService = new JupyterInterpreterSubCommandExecutionService(
             instance(jupyterInterpreter),
-            instance(interperterService),
+            instance(interpreterService),
             instance(jupyterDependencyService),
             instance(execFactory),
             output,
@@ -79,8 +79,8 @@ suite('DataScience - Jupyter InterpreterSubCommandExecutionService', () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             notebookStartResult as any
         );
-        when(interperterService.getActiveInterpreter()).thenResolve(activePythonInterpreter);
-        when(interperterService.getActiveInterpreter(undefined)).thenResolve(activePythonInterpreter);
+        when(interpreterService.getActiveInterpreter()).thenResolve(activePythonInterpreter);
+        when(interpreterService.getActiveInterpreter(undefined)).thenResolve(activePythonInterpreter);
     });
     teardown(() => {
         sinon.restore();
@@ -100,7 +100,7 @@ suite('DataScience - Jupyter InterpreterSubCommandExecutionService', () => {
             assert.isFalse(isSupported);
         });
         test('Jupyter cannot be started because no interpreter has been selected', async () => {
-            when(interperterService.getActiveInterpreter(undefined)).thenResolve(undefined);
+            when(interpreterService.getActiveInterpreter(undefined)).thenResolve(undefined);
             const reason = await jupyterInterpreterExecutionService.getReasonForJupyterNotebookNotBeingSupported(
                 undefined
             );

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -5,10 +5,12 @@ import { assert } from 'chai';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import { commands, Memento } from 'vscode';
-import { IVSCodeNotebook } from '../../../../client/common/application/types';
+import { commands, Memento, window, workspace } from 'vscode';
+import { ICommandManager, IVSCodeNotebook } from '../../../../client/common/application/types';
+import { WrappedError } from '../../../../client/common/errors/types';
 import { clearInstalledIntoInterpreterMemento } from '../../../../client/common/installer/productInstaller';
 import { ProductNames } from '../../../../client/common/installer/productNames';
+import { getDisplayPath } from '../../../../client/common/platform/fs-paths';
 import { BufferDecoder } from '../../../../client/common/process/decoder';
 import { ProcessService } from '../../../../client/common/process/proc';
 import {
@@ -24,11 +26,18 @@ import {
 } from '../../../../client/common/types';
 import { createDeferred } from '../../../../client/common/utils/async';
 import { Common, DataScience } from '../../../../client/common/utils/localize';
+import { IpyKernelNotInstalledError } from '../../../../client/datascience/errors/ipyKernelNotInstalledError';
+import { Kernel } from '../../../../client/datascience/jupyter/kernels/kernel';
+import { IKernelProvider } from '../../../../client/datascience/jupyter/kernels/types';
+import { JupyterNotebookView } from '../../../../client/datascience/notebook/constants';
 import { hasErrorOutput } from '../../../../client/datascience/notebook/helpers/helpers';
+import { INotebookControllerManager } from '../../../../client/datascience/notebook/types';
+import { KernelInterpreterDependencyResponse } from '../../../../client/datascience/types';
 import { IInterpreterService } from '../../../../client/interpreter/contracts';
-import { getInterpreterHash } from '../../../../client/pythonEnvironments/info/interpreter';
-import { getOSType, IExtensionTestApi, OSType, waitForCondition } from '../../../common';
-import { EXTENSION_ROOT_DIR_FOR_TESTS, IS_REMOTE_NATIVE_TEST } from '../../../constants';
+import { areInterpreterPathsSame, getInterpreterHash } from '../../../../client/pythonEnvironments/info/interpreter';
+import { captureScreenShot, getOSType, IExtensionTestApi, OSType, waitForCondition } from '../../../common';
+import { EXTENSION_ROOT_DIR_FOR_TESTS, IS_REMOTE_NATIVE_TEST, JVSC_EXTENSION_ID_FOR_TESTS } from '../../../constants';
+import { noop } from '../../../core';
 import { closeActiveWindows, initialize } from '../../../initialize';
 import { openNotebook } from '../../helpers';
 import {
@@ -40,7 +49,8 @@ import {
     waitForKernelToChange,
     waitForKernelToGetAutoSelected,
     defaultNotebookTestTimeout,
-    assertVSCCellIsNotRunning
+    assertVSCCellIsNotRunning,
+    getCellOutputs
 } from '../../notebook/helper';
 
 /* eslint-disable no-invalid-this, , , @typescript-eslint/no-explicit-any */
@@ -54,11 +64,14 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
     const executable = getOSType() === OSType.Windows ? 'Scripts/python.exe' : 'bin/python'; // If running locally on Windows box.
     let venvPythonPath = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src/test/datascience/.venvnokernel', executable);
     let venvNoRegPath = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src/test/datascience/.venvnoreg', executable);
-    const expectedPromptMessageSuffix = `requires ${ProductNames.get(Product.ipykernel)!} package.`;
+    const expectedPromptMessageSuffix = `requires ${ProductNames.get(Product.ipykernel)!} package`;
 
     let api: IExtensionTestApi;
     let installer: IInstaller;
     let memento: Memento;
+    let installerSpy: sinon.SinonSpy;
+    let kernelProvider: IKernelProvider;
+    let commandManager: ICommandManager;
     let vscodeNotebook: IVSCodeNotebook;
     const delayForUITest = 30_000;
     this.timeout(120_000); // Slow test, we need to uninstall/install ipykernel.
@@ -79,6 +92,8 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         }
         this.timeout(120_000);
         api = await initialize();
+        kernelProvider = api.serviceContainer.get<IKernelProvider>(IKernelProvider);
+        commandManager = api.serviceContainer.get<ICommandManager>(ICommandManager);
         installer = api.serviceContainer.get<IInstaller>(IInstaller);
         memento = api.serviceContainer.get<Memento>(IMemento, GLOBAL_MEMENTO);
         vscodeNotebook = api.serviceContainer.get<IVSCodeNotebook>(IVSCodeNotebook);
@@ -97,9 +112,12 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         venvPythonPath = interpreter1.path;
         venvNoRegPath = interpreter2.path;
     });
-
     setup(async function () {
         console.log(`Start test ${this.currentTest?.title}`);
+        const configService = api.serviceContainer.get<IConfigurationService>(IConfigurationService);
+        configSettings = configService.getSettings(undefined) as any;
+        configSettings.disableJupyterAutoStart = true;
+
         // Don't use same file (due to dirty handling, we might save in dirty.)
         // Coz we won't save to file, hence extension will backup in dirty file and when u re-open it will open from dirty.
         nbFile = await createTemporaryNotebook(templateIPynbFile, disposables);
@@ -111,9 +129,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
                 .toString('utf8')
                 .replace('<hash>', getInterpreterHash({ path: venvPythonPath }))
         );
-        // Uninstall ipykernel from the virtual env.
-        const proc = new ProcessService(new BufferDecoder());
-        await proc.exec(venvPythonPath, ['-m', 'pip', 'uninstall', 'ipykernel', '--yes']);
+        await uninstallIPyKernel(venvPythonPath);
         await closeActiveWindows();
         await Promise.all([
             clearInstalledIntoInterpreterMemento(memento, Product.ipykernel, venvPythonPath),
@@ -124,8 +140,12 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
     });
     teardown(async function () {
         console.log(`End test ${this.currentTest?.title}`);
+        if (this.currentTest?.isFailed()) {
+            await captureScreenShot(this.currentTest?.title);
+        }
         configSettings.disableJupyterAutoStart = previousDisableJupyterAutoStartValue;
         await closeNotebooksAndCleanUpAfterTests(disposables);
+        sinon.restore();
     });
 
     test('Test Install IPyKernel prompt message', async () => {
@@ -133,72 +153,17 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         assert.ok(
             DataScience.libraryRequiredToLaunchJupyterKernelNotInstalledInterpreter()
                 .format('', ProductNames.get(Product.ipykernel)!)
-                .endsWith(expectedPromptMessageSuffix),
+                .endsWith(`${expectedPromptMessageSuffix}.`),
             'Message has changed, please update this test'
         );
     });
 
-    [true, false].forEach((which) => {
-        const interpreterPath = which ? venvPythonPath : venvNoRegPath;
-        test.skip(`Ensure prompt is displayed when ipykernel module is not found and it gets installed '${path.basename(
-            interpreterPath
-        )}'`, async function () {
-            // Confirm message is displayed & we click 'Install` button.
-            const prompt = await hijackPrompt(
-                'showInformationMessage',
-                { endsWith: expectedPromptMessageSuffix },
-                { text: Common.install(), clickImmediately: true },
-                disposables
-            );
-            const installed = createDeferred();
-            console.log(`Running ensure prompt and looking for kernel ${interpreterPath}`);
-
-            // Confirm it is installed.
-            const showInformationMessage = sinon
-                .stub(installer, 'install')
-                .callsFake(async function (product: Product) {
-                    // Call original method
-                    const result: InstallerResponse = await ((installer.install as any).wrappedMethod.apply(
-                        installer,
-                        arguments
-                    ) as Promise<InstallerResponse>);
-                    if (product === Product.ipykernel && result === InstallerResponse.Installed) {
-                        installed.resolve();
-                    }
-                    return result;
-                });
-
-            try {
-                await openNotebook(nbFile);
-                await waitForKernelToChange({ interpreterPath });
-
-                // Run all cells
-                void commands.executeCommand('notebook.execute');
-
-                // The prompt should be displayed.
-                await waitForCondition(
-                    async () => prompt.displayed.then(() => true),
-                    delayForUITest,
-                    'Prompt not displayed'
-                );
-
-                // ipykernel should get installed.
-                await waitForCondition(
-                    async () => installed.promise.then(() => true),
-                    delayForUITest,
-                    'Prompt not displayed or not installed successfully'
-                );
-
-                // If this is a native notebook, then wait for cell to get executed completely (else VSC can hang).
-                // This is because extension will attempt to update cells, while tests may have deleted/closed notebooks.
-                const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
-                await waitForExecutionCompletedSuccessfully(cell);
-            } finally {
-                prompt.dispose();
-                showInformationMessage.restore();
-            }
-        });
-    });
+    test(`Ensure prompt is displayed when ipykernel module is not found and it gets installed for '${path.basename(
+        venvPythonPath
+    )}'`, async () => openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath));
+    test(`Ensure prompt is displayed when ipykernel module is not found and it gets installed for '${path.basename(
+        venvNoRegPath
+    )}'`, async () => openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath));
     test('Ensure ipykernel install prompt is displayed every time you try to run a cell (VSCode Notebook)', async function () {
         if (IS_REMOTE_NATIVE_TEST) {
             return this.skip();
@@ -207,7 +172,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         // Confirm message is displayed & then dismiss the message (so that execution stops due to missing dependency).
         const prompt = await hijackPrompt(
             'showInformationMessage',
-            { endsWith: expectedPromptMessageSuffix },
+            { contains: expectedPromptMessageSuffix },
             { dismissPrompt: true },
             disposables
         );
@@ -260,4 +225,341 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
             'No errors in cell'
         );
     });
+    test('Ensure ipykernel install prompt is displayed even after uninstalling ipykernel (VSCode Notebook)', async function () {
+        if (IS_REMOTE_NATIVE_TEST) {
+            return this.skip();
+        }
+
+        // Verify we can open a notebook, run a cell and ipykernel prompt should be displayed.
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath);
+        await closeNotebooksAndCleanUpAfterTests();
+
+        // Un-install IpyKernel
+        await uninstallIPyKernel(venvPythonPath);
+
+        nbFile = await createTemporaryNotebook(templateIPynbFile, disposables);
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath);
+    });
+    test('Ensure ipykernel install prompt is displayed even selecting another kernel which too does not have IPyKernel installed (VSCode Notebook)', async function () {
+        if (IS_REMOTE_NATIVE_TEST) {
+            return this.skip();
+        }
+
+        // Verify we can open a notebook, run a cell and ipykernel prompt should be displayed.
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath);
+        await closeNotebooksAndCleanUpAfterTests();
+
+        // Un-install IpyKernel
+        await uninstallIPyKernel(venvPythonPath);
+        await uninstallIPyKernel(venvNoRegPath);
+
+        nbFile = await createTemporaryNotebook(templateIPynbFile, disposables);
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath, venvNoRegPath);
+    });
+    test('Ensure ipykernel install prompt is not displayed after selecting another kernel which has IPyKernel installed (VSCode Notebook)', async function () {
+        if (IS_REMOTE_NATIVE_TEST) {
+            return this.skip();
+        }
+
+        // Verify we can open a notebook, run a cell and ipykernel prompt should be displayed.
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath);
+        await closeNotebooksAndCleanUpAfterTests();
+
+        // Un-install IpyKernel
+        await uninstallIPyKernel(venvPythonPath);
+        await installIPyKernel(venvNoRegPath);
+
+        nbFile = await createTemporaryNotebook(templateIPynbFile, disposables);
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath, venvNoRegPath, 'DoNotInstallIPyKernel');
+    });
+    test.only('Should be prompted to re-install ipykernel when restarting a kernel from which ipykernel was uninstalled (VSCode Notebook)', async function () {
+        if (IS_REMOTE_NATIVE_TEST) {
+            return this.skip();
+        }
+
+        // Verify we can open a notebook, run a cell and ipykernel prompt should be displayed.
+        console.log('Step1');
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath);
+
+        // Un-install IpyKernel
+        console.log('Step2');
+        await uninstallIPyKernel(venvPythonPath);
+
+        // Now that IPyKernel is missing, if we attempt to restart a kernel, we should get a prompt.
+        // Previously things just hang at weird spots, its not a likely scenario, but this test ensures the code works as expected.
+        const notebook = workspace.notebookDocuments.find(
+            (item) => item.uri.fsPath.toLowerCase() === nbFile.toLowerCase()
+        )!;
+        const kernel = kernelProvider.get(notebook)!;
+
+        // Confirm message is displayed.
+        installerSpy = sinon.spy(installer, 'install');
+        console.log('Step3');
+        const promptToInstall = await clickInstallFromIPyKernelPrompt();
+
+        kernel.restart().catch(noop);
+        console.log('Step4');
+        await Promise.all([
+            waitForCondition(
+                async () => promptToInstall.displayed.then(() => true),
+                delayForUITest,
+                'Prompt not displayed'
+            ),
+            waitForIPyKernelToGetInstalled()
+        ]);
+    });
+    test('Ensure ipykernel install prompt is displayed and we can select another kernel after uninstalling IPyKernel from a live notebook and then restarting the kernel (VSCode Notebook)', async function () {
+        if (IS_REMOTE_NATIVE_TEST) {
+            return this.skip();
+        }
+
+        // Verify we can open a notebook, run a cell and ipykernel prompt should be displayed.
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath);
+
+        // Un-install IpyKernel
+        await uninstallIPyKernel(venvPythonPath);
+
+        // Now that IPyKernel is missing, if we attempt to restart a kernel, we should get a prompt.
+        // Previously things just hang at weird spots, its not a likely scenario, but this test ensures the code works as expected.
+        const notebook = workspace.notebookDocuments.find(
+            (item) => item.uri.fsPath.toLowerCase() === nbFile.toLowerCase()
+        )!;
+        const kernel = kernelProvider.get(notebook)!;
+
+        // Confirm message is displayed.
+        const promptToInstall = await selectKernelFromIPyKernelPrompt();
+        const { kernelSelected } = hookupKernelSelected(promptToInstall, venvNoRegPath);
+
+        await Promise.all([
+            kernel.restart().catch(noop),
+            waitForCondition(
+                async () => promptToInstall.displayed.then(() => true),
+                delayForUITest,
+                'Prompt not displayed'
+            ),
+            waitForCondition(async () => kernelSelected, delayForUITest, 'New kernel not selected'),
+            // Verify the new kernel associated with this notebook is different.
+            waitForCondition(
+                async () => {
+                    assert.ok(kernelProvider.get(notebook));
+                    assert.notEqual(kernel, kernelProvider.get(notebook));
+                    return true;
+                },
+                delayForUITest,
+                'Underlying IKernel should have changed as well'
+            )
+        ]);
+    });
+    test('Ensure ipykernel install prompt is NOT displayed when auto start is enabled & ipykernel is missing (VSCode Notebook)', async function () {
+        // Ensure we have auto start enabled, and verify kernel startup fails silently without any notifications.
+        // When running a cell we should get an install prompt.
+        configSettings.disableJupyterAutoStart = false;
+        const promptToInstall = await clickInstallFromIPyKernelPrompt();
+        const kernelStartSpy = sinon.spy(Kernel.prototype, 'start');
+
+        await uninstallIPyKernel(venvPythonPath);
+        await openNotebook(nbFile);
+        await waitForKernelToGetAutoSelected();
+
+        await Promise.all([
+            waitForCondition(
+                async () => kernelStartSpy.callCount > 0,
+                delayForUITest,
+                'Did not attempt to auto start the kernel'
+            )
+        ]);
+
+        // Wait for kernel startup to fail & verify the error.
+        try {
+            await kernelStartSpy.getCall(0).returnValue;
+            assert.fail('Did not fail as expected');
+        } catch (ex) {
+            const err = WrappedError.unwrap(ex) as IpyKernelNotInstalledError;
+            assert.ok(err instanceof IpyKernelNotInstalledError, 'Expected IpyKernelNotInstalledError');
+            assert.strictEqual(err.reason, KernelInterpreterDependencyResponse.uiHidden);
+        }
+
+        assert.strictEqual(promptToInstall.getDisplayCount(), 0, 'Prompt should not have been displayed');
+        promptToInstall.dispose();
+
+        assert.strictEqual(
+            window.activeNotebookEditor?.document.cellAt(0).outputs.length,
+            0,
+            'Should not have any outputs with ipykernel missing error'
+        );
+
+        // If we try to run a cell, verify a prompt is displayed.
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath);
+    });
+    async function uninstallIPyKernel(pythonExecPath: string) {
+        // Uninstall ipykernel from the virtual env.
+        const proc = new ProcessService(new BufferDecoder());
+        await proc.exec(pythonExecPath, ['-m', 'pip', 'uninstall', 'ipykernel', '--yes']);
+    }
+    async function installIPyKernel(pythonExecPath: string) {
+        // Uninstall ipykernel from the virtual env.
+        const proc = new ProcessService(new BufferDecoder());
+        await proc.exec(pythonExecPath, ['-m', 'pip', 'install', 'ipykernel']);
+    }
+    async function selectKernelFromIPyKernelPrompt() {
+        return hijackPrompt(
+            'showInformationMessage',
+            { contains: expectedPromptMessageSuffix },
+            { text: DataScience.selectKernel(), clickImmediately: true },
+            disposables
+        );
+    }
+    async function clickInstallFromIPyKernelPrompt() {
+        return hijackPrompt(
+            'showInformationMessage',
+            { contains: expectedPromptMessageSuffix },
+            { text: Common.install(), clickImmediately: true },
+            disposables
+        );
+    }
+    /**
+     * Performs a few assertions in this function:
+     *
+     * 1. Verify IPYKernel installation prompt is displayed.
+     * 2. Verify IPYKernel is installed (based on value for the argument for `ipykernelInstallRequirement`)
+     * 3. Verify the Kernel points to the right interpreter
+     */
+    async function openNotebookAndInstallIpyKernelWhenRunningCell(
+        interpreterPath: string,
+        interpreterOfNewKernelToSelect?: string,
+        ipykernelInstallRequirement: 'DoNotInstallIPyKernel' | 'ShouldInstallIPYKernel' = 'ShouldInstallIPYKernel'
+    ) {
+        // Highjack the IPyKernel not installed prompt and click the appropriate button.
+        let promptToInstall = await (interpreterOfNewKernelToSelect
+            ? selectKernelFromIPyKernelPrompt()
+            : clickInstallFromIPyKernelPrompt());
+
+        installerSpy = sinon.spy(installer, 'install');
+
+        let selectADifferentKernelStub: undefined | sinon.SinonStub<any[], any>;
+        try {
+            if (!workspace.notebookDocuments.some((item) => item.uri.fsPath.toLowerCase() === nbFile.toLowerCase())) {
+                await openNotebook(nbFile);
+                await waitForKernelToChange({ interpreterPath });
+            }
+
+            if (interpreterOfNewKernelToSelect) {
+                // If we have a separate interpreter specified then configure the prompts such that
+                // this will be selected as the new kernel when we display the ipykernel not installed prompt.
+                const result = hookupKernelSelected(
+                    promptToInstall,
+                    interpreterOfNewKernelToSelect,
+                    ipykernelInstallRequirement
+                );
+                selectADifferentKernelStub = result.selectADifferentKernelStub;
+            }
+            const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+
+            await Promise.all([
+                runAllCellsInActiveNotebook(),
+                waitForCondition(
+                    async () => promptToInstall.displayed.then(() => true),
+                    delayForUITest,
+                    'Prompt not displayed'
+                ),
+                ipykernelInstallRequirement === 'DoNotInstallIPyKernel'
+                    ? Promise.resolve()
+                    : waitForIPyKernelToGetInstalled(),
+                waitForExecutionCompletedSuccessfully(cell),
+                waitForCondition(async () => cell.outputs.length > 0, defaultNotebookTestTimeout, 'No cell output')
+            ]);
+
+            // Verify the kernel points to the expected interpreter.
+            const output = getCellOutputs(cell).trim();
+            const expectedInterpreterPath = interpreterOfNewKernelToSelect || interpreterPath;
+            assert.isTrue(
+                areInterpreterPathsSame(expectedInterpreterPath.toLowerCase(), output.toLocaleLowerCase()),
+                `Kernel points to ${getDisplayPath(output)} but expected ${getDisplayPath(expectedInterpreterPath)}`
+            );
+
+            // Verify ipykernel was not installed if not required && vice versa.
+            if (ipykernelInstallRequirement === 'DoNotInstallIPyKernel') {
+                if (installerSpy.callCount > 0) {
+                    IInstaller;
+                    assert.fail(
+                        `IPyKernel was installed when it should not have been, here are the calls: ${installerSpy
+                            .getCalls()
+                            .map((call) => {
+                                const args: Parameters<IInstaller['install']> = call.args as any;
+                                return `${ProductNames.get(args[0])} ${getDisplayPath(args[1]?.path.toString())}`;
+                            })
+                            .join('\n')}`
+                    );
+                }
+            }
+        } finally {
+            promptToInstall.dispose();
+            selectADifferentKernelStub?.restore();
+            installerSpy.restore();
+        }
+    }
+    function waitForIPyKernelToGetInstalled() {
+        return waitForCondition(
+            async () => verifyIPyKernelWasInstalled(),
+            delayForUITest,
+            () =>
+                `Prompt not displayed or not installed successfully, call count = ${installerSpy.callCount}, arg0 ${
+                    installerSpy.callCount ? installerSpy.getCall(0).args[0] : undefined
+                }, result ${installerSpy.callCount ? installerSpy.getCall(0).returnValue : undefined}`
+        );
+    }
+    async function verifyIPyKernelWasInstalled() {
+        assert.strictEqual(installerSpy.callCount, 1);
+        assert.strictEqual(installerSpy.getCall(0).args[0], Product.ipykernel);
+        assert.strictEqual(await installerSpy.getCall(0).returnValue, InstallerResponse.Installed);
+        return true;
+    }
+
+    type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
+    function hookupKernelSelected(
+        promptToInstall: Awaited<ReturnType<typeof selectKernelFromIPyKernelPrompt>>,
+        pythonPathToNewKernel: string,
+        ipykernelInstallRequirement: 'DoNotInstallIPyKernel' | 'ShouldInstallIPYKernel' = 'ShouldInstallIPYKernel'
+    ) {
+        // Get the controller that should be selected.
+        const controllerManager = api.serviceContainer.get<INotebookControllerManager>(INotebookControllerManager);
+        const controller = controllerManager
+            .registeredNotebookControllers()
+            .find(
+                (item) =>
+                    item.controller.notebookType === JupyterNotebookView &&
+                    item.connection.kind === 'startUsingPythonInterpreter' &&
+                    areInterpreterPathsSame(item.connection.interpreter.path, pythonPathToNewKernel)
+            );
+        if (!controller) {
+            throw new Error(`Unable to find a controller for ${pythonPathToNewKernel}`);
+        }
+
+        const kernelSelected = createDeferred<boolean>();
+        const selectADifferentKernelStub = sinon
+            .stub(commandManager, 'executeCommand')
+            .callsFake(async function (cmd: string) {
+                if (cmd === 'notebook.selectKernel') {
+                    // After we change the kernel, we might get a prompt to install ipykernel.
+                    // Ensure we click ok to install.
+                    if (promptToInstall.getDisplayCount() > 0) {
+                        promptToInstall.dispose();
+                        if (ipykernelInstallRequirement === 'ShouldInstallIPYKernel') {
+                            await clickInstallFromIPyKernelPrompt();
+                        }
+                    }
+                    await commands.executeCommand('notebook.selectKernel', {
+                        id: controller.controller.id,
+                        extension: JVSC_EXTENSION_ID_FOR_TESTS
+                    });
+
+                    kernelSelected.resolve(true);
+                    return Promise.resolve(true);
+                } else {
+                    return commands.executeCommand.apply(commands, [cmd, ...Array.from(arguments).slice(1)]);
+                }
+            });
+
+        return { kernelSelected: kernelSelected.promise, selectADifferentKernelStub };
+    }
 });

--- a/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
@@ -4,17 +4,24 @@
 'use strict';
 
 import { assert } from 'chai';
-import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { CancellationTokenSource, Memento, NotebookDocument, NotebookEditor, Uri } from 'vscode';
 import { IApplicationShell, ICommandManager, IVSCodeNotebook } from '../../../../client/common/application/types';
+import { WrappedError } from '../../../../client/common/errors/types';
 import { IInstaller, InstallerResponse, Product } from '../../../../client/common/types';
 import { Common, DataScience } from '../../../../client/common/utils/localize';
 import { getResourceType } from '../../../../client/datascience/common';
 import { DisplayOptions } from '../../../../client/datascience/displayOptions';
+import { IpyKernelNotInstalledError } from '../../../../client/datascience/errors/ipyKernelNotInstalledError';
 import { createInterpreterKernelSpec } from '../../../../client/datascience/jupyter/kernels/helpers';
 import { KernelDependencyService } from '../../../../client/datascience/jupyter/kernels/kernelDependencyService';
 import { IKernelProvider, PythonKernelConnectionMetadata } from '../../../../client/datascience/jupyter/kernels/types';
-import { IInteractiveWindow, IInteractiveWindowProvider } from '../../../../client/datascience/types';
+import {
+    IInteractiveWindow,
+    IInteractiveWindowProvider,
+    IRawNotebookSupportedService,
+    KernelInterpreterDependencyResponse
+} from '../../../../client/datascience/types';
 import { IServiceContainer } from '../../../../client/ioc/types';
 import { EnvironmentType } from '../../../../client/pythonEnvironments/info';
 import { createPythonInterpreter } from '../../../utils/interpreters';
@@ -29,7 +36,6 @@ suite('DataScience - Kernel Dependency Service', () => {
     let cmdManager: ICommandManager;
     let installer: IInstaller;
     let serviceContainer: IServiceContainer;
-    let vscNotebooks: IVSCodeNotebook;
     let kernelProvider: IKernelProvider;
     let memento: Memento;
     let editor: NotebookEditor;
@@ -47,7 +53,6 @@ suite('DataScience - Kernel Dependency Service', () => {
         cmdManager = mock<ICommandManager>();
         serviceContainer = mock<IServiceContainer>();
         memento = mock<Memento>();
-        vscNotebooks = mock<IVSCodeNotebook>();
         kernelProvider = mock<IKernelProvider>();
         notebooks = mock<IVSCodeNotebook>();
         when(kernelProvider.kernels).thenReturn([]);
@@ -56,14 +61,14 @@ suite('DataScience - Kernel Dependency Service', () => {
         when(serviceContainer.get<IKernelProvider>(IKernelProvider)).thenReturn(instance(kernelProvider));
         when(cmdManager.executeCommand('notebook.selectKernel', anything())).thenResolve();
         when(notebooks.notebookDocuments).thenReturn([]);
+        const rawSupport = mock<IRawNotebookSupportedService>();
+        when(rawSupport.isSupported).thenReturn(true);
         dependencyService = new KernelDependencyService(
             instance(appShell),
             instance(installer),
             instance(memento),
             false,
-            instance(cmdManager),
-            instance(notebooks),
-            instance(vscNotebooks),
+            instance(rawSupport),
             instance(serviceContainer)
         );
     });
@@ -202,18 +207,19 @@ suite('DataScience - Kernel Dependency Service', () => {
                     DataScience.selectKernel() as any
                 );
 
-                const promise = dependencyService.installMissingDependencies(
-                    resource,
-                    metadata,
-                    new DisplayOptions(false),
-                    token.token
-                );
-
-                await assert.isRejected(promise, 'IPyKernel not installed into interpreter name:abc');
-
-                verify(
-                    cmdManager.executeCommand('notebook.selectKernel', deepEqual({ notebookEditor: instance(editor) }))
-                ).once();
+                try {
+                    await dependencyService.installMissingDependencies(
+                        resource,
+                        metadata,
+                        new DisplayOptions(false),
+                        token.token
+                    );
+                    assert.fail('Should have failed with an exception');
+                } catch (ex) {
+                    const err = WrappedError.unwrap(ex) as IpyKernelNotInstalledError;
+                    assert.instanceOf(err, IpyKernelNotInstalledError, 'IPyKernel not installed error not thrown');
+                    assert.strictEqual(err.reason, KernelInterpreterDependencyResponse.selectDifferentKernel);
+                }
             });
             test('Throw an error if cancelling the prompt', async function () {
                 if (resource === undefined) {

--- a/src/test/datascience/jupyter/kernels/nbWithKernel.ipynb
+++ b/src/test/datascience/jupyter/kernels/nbWithKernel.ipynb
@@ -6,17 +6,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "1\n"
+    "import sys\n",
+    "print(sys.executable)"
    ]
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "name": "Python",
-   "display_name": ".venvnokernel"
+  "interpreter": {
+   "hash": "<hash>"
   },
-  "interpreter":{
-    "hash":"<hash>"
+  "kernelspec": {
+   "display_name": ".venvnokernel",
+   "name": "Python"
   },
   "language_info": {
    "codemirror_mode": {

--- a/src/test/datascience/jupyter/serverSelector.unit.test.ts
+++ b/src/test/datascience/jupyter/serverSelector.unit.test.ts
@@ -111,22 +111,26 @@ suite('DataScience - Jupyter Server URI Selector', () => {
 
     test('Quick pick MRU tests', async () => {
         const { selector, storage } = createDataScienceObject('$(zap) Default', '', true);
-
+        console.log('Step1');
         await selector.selectJupyterURI(true);
         // Verify initial default items
         assert.equal(quickPick?.items.length, 2, 'Wrong number of items in the quick pick');
 
         // Add in a new server
         const serverA1 = { uri: 'ServerA', time: 1, date: new Date(1) };
+        console.log('Step2');
         await storage.addToUriList(serverA1.uri, serverA1.time, serverA1.uri);
 
+        console.log('Step3');
         await selector.selectJupyterURI(true);
         assert.equal(quickPick?.items.length, 3, 'Wrong number of items in the quick pick');
         quickPickCheck(quickPick?.items[2], serverA1);
 
         // Add in a second server, the newer server should be higher in the list due to newer time
         const serverB1 = { uri: 'ServerB', time: 2, date: new Date(2) };
+        console.log('Step4');
         await storage.addToUriList(serverB1.uri, serverB1.time, serverB1.uri);
+        console.log('Step5');
         await selector.selectJupyterURI(true);
         assert.equal(quickPick?.items.length, 4, 'Wrong number of items in the quick pick');
         quickPickCheck(quickPick?.items[2], serverB1);
@@ -134,7 +138,9 @@ suite('DataScience - Jupyter Server URI Selector', () => {
 
         // Reconnect to server A with a new time, it should now be higher in the list
         const serverA3 = { uri: 'ServerA', time: 3, date: new Date(3) };
+        console.log('Step6');
         await storage.addToUriList(serverA3.uri, serverA3.time, serverA3.uri);
+        console.log('Step7');
         await selector.selectJupyterURI(true);
         assert.equal(quickPick?.items.length, 4, 'Wrong number of items in the quick pick');
         quickPickCheck(quickPick?.items[3], serverB1);
@@ -142,9 +148,11 @@ suite('DataScience - Jupyter Server URI Selector', () => {
 
         // Verify that we stick to our settings limit
         for (let i = 0; i < Settings.JupyterServerUriListMax + 10; i = i + 1) {
+            console.log(`Step8 ${i} of ${Settings.JupyterServerUriListMax + 10}`);
             await storage.addToUriList(i.toString(), i, i.toString());
         }
 
+        console.log('Step9');
         await selector.selectJupyterURI(true);
         // Need a plus 2 here for the two default items
         assert.equal(

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -816,7 +816,7 @@ export async function runAllCellsInActiveNotebook() {
  */
 export async function hijackPrompt(
     promptType: 'showErrorMessage' | 'showInformationMessage',
-    message: { exactMatch: string } | { endsWith: string },
+    message: { exactMatch: string } | { endsWith: string } | { contains: string },
     buttonToClick?: { text?: string; clickImmediately?: boolean; dismissPrompt?: boolean },
     disposables: IDisposable[] = []
 ): Promise<{
@@ -838,6 +838,7 @@ export async function hijackPrompt(
         traceInfo(`Message displayed to user '${msg}', condition ${JSON.stringify(message)}`);
         if (
             ('exactMatch' in message && msg.trim() === message.exactMatch.trim()) ||
+            ('contains' in message && msg.trim().includes(message.contains.trim())) ||
             ('endsWith' in message && msg.endsWith(message.endsWith))
         ) {
             traceInfo(`Exact Message found '${msg}'`);

--- a/src/test/mocks/vsc/index.ts
+++ b/src/test/mocks/vsc/index.ts
@@ -31,6 +31,30 @@ export namespace vscMock {
         Workspace = 2
     }
 
+    /**
+     * The ExtensionMode is provided on the `ExtensionContext` and indicates the
+     * mode the specific extension is running in.
+     */
+    export enum ExtensionMode {
+        /**
+         * The extension is installed normally (for example, from the marketplace
+         * or VSIX) in the editor.
+         */
+        Production = 1,
+
+        /**
+         * The extension is running from an `--extensionDevelopmentPath` provided
+         * when launching the editor.
+         */
+        Development = 2,
+
+        /**
+         * The extension is running from an `--extensionTestsPath` and
+         * the extension host is running unit tests.
+         */
+        Test = 3
+    }
+
     export class Disposable {
         constructor(private callOnDispose: Function) {}
         public dispose(): any {

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -98,6 +98,7 @@ mockedVSCode.MarkdownString = vscodeMocks.vscMock.MarkdownString;
 mockedVSCode.Hover = vscodeMocks.vscMock.Hover;
 mockedVSCode.Disposable = vscodeMocks.vscMock.Disposable as any;
 mockedVSCode.ExtensionKind = vscodeMocks.vscMock.ExtensionKind;
+mockedVSCode.ExtensionMode = vscodeMocks.vscMock.ExtensionMode;
 mockedVSCode.CodeAction = vscodeMocks.vscMock.CodeAction;
 mockedVSCode.EventEmitter = vscodeMocks.vscMock.EventEmitter;
 mockedVSCode.CancellationError = vscodeMocks.vscMock.CancellationError;


### PR DESCRIPTION
… users re-create the same env (#9136)Fixes #

Ports the fixes to ensure we don't use the cache when starting with Jupyter.
This is because The kernel process starts and Jupyter hangs for a long time.
& when it fails we don't check if ipykenrel is isntalled or not.

The fix now doesn't cache & also prompts users to install ipykernel after kernel fails to start.