### PR TITLE
gitignore temp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ languageServer.*/**
 bin/**
 obj/**
 .pytest_cache
+temp/**
 tmp/**
 .python-version
 .vs/


### PR DESCRIPTION
The `temp` directory is where kernelspecs are registered.
I'm not using `tmp` as this gets blown away in tests.
`temp` is where we store runtime temporary files such as kernelspecs.