### PR TITLE
Fix auto scrolling

### DIFF
--- a/news/2 Fixes/9259.md
+++ b/news/2 Fixes/9259.md
@@ -1,0 +1,1 @@
+Fix auto scrolling in the interactive window.

--- a/src/client/datascience/interactive-window/interactiveWindow.ts
+++ b/src/client/datascience/interactive-window/interactiveWindow.ts
@@ -747,7 +747,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         // since the notebook cell we're going to add is by definition not visible
         const shouldScroll =
             editor?.visibleRanges.find((r) => {
-                return r.end === editor.document.cellCount - 1;
+                return r.end === editor.document.cellCount;
             }) != undefined ||
             this.pendingNotebookScrolls.find((r) => r.end == editor.document.cellCount - 1) != undefined;
 


### PR DESCRIPTION
Fixes #9259 

NotebookEditor.visibleRanges seems to end one past the actual visible range now. Not sure where this changed but @rebornix said this was the expected behavior for visibleRanges.

