### PR TITLE
Add more info when a failure in tracing causes telemetry to be sent

### DIFF
--- a/src/client/logging/trace.ts
+++ b/src/client/logging/trace.ts
@@ -202,7 +202,16 @@ function logResult(loggers: ILogger[], info: LogInfo, traced: TraceInfo, call?: 
         }
     } else {
         logToAll(loggers, LogLevel.Error, [formatted, traced.err]);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        sendTelemetryEvent('ERROR' as any, undefined, undefined, traced.err);
+        sendTelemetryEvent(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            'ERROR' as any,
+            undefined,
+            {
+                failureCategory: 'methodException',
+                failureSubCategory: call ? `${call.name}:${call.methodName}` : 'unknown'
+            },
+            traced.err,
+            true
+        );
     }
 }


### PR DESCRIPTION
This should add telemetry like so:

![image](https://user-images.githubusercontent.com/19672699/157971553-ccf0c3aa-2e3f-4054-9429-067f9b8b4c5c.png)

I repro'd this problem by forcing something to throw an exception.