### PR TITLE
Fix problem with 'install ipykernel' appearing twice if you hit Cancel on IW

### DIFF
--- a/build/webpack/webpack.datascience-ui.config.builder.js
+++ b/build/webpack/webpack.datascience-ui.config.builder.js
@@ -134,9 +134,8 @@ function buildConfiguration(bundle) {
                     from: path.join(
                         constants.ExtensionRootDir,
                         'src',
-                        'client',
-                        'datascience',
-                        'notebook',
+                        'notebooks',
+                        'controllers',
                         'fontAwesomeLoader.js'
                     ),
                     to: path.join(constants.ExtensionRootDir, 'out', 'fontAwesome')

--- a/news/2 Fixes/9267.md
+++ b/news/2 Fixes/9267.md
@@ -1,0 +1,1 @@
+Fix problem with double install ipykernel message when cancelling.

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -233,6 +233,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
                 this.finishSysInfoMessage(ex, sysInfoCell, SysInfoReason.Start);
                 this._kernelPromise.resolve(undefined);
                 this.disconnectKernel();
+                this._kernelConnectionId = controller.id;
             }
         }
     }
@@ -535,7 +536,6 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         if (this._kernelPromise.resolved) {
             this._kernelPromise = createDeferred<IKernel>();
         }
-        this._kernelConnectionId = undefined;
     }
 
     @chainable()

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -280,6 +280,9 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
             defaultNotebookTestTimeout,
             'No errors in cell'
         );
+
+        // Prompt should only be displayed once
+        assert.equal(prompt.getDisplayCount(), 1, 'Display prompt shown more than once');
     });
     test('Ensure ipykernel install prompt is displayed even after uninstalling ipykernel (VSCode Notebook)', async function () {
         if (IS_REMOTE_NATIVE_TEST) {


### PR DESCRIPTION
Fixes #9267

Root cause was opening an IW causes a selection to occur in the 'Select Kernel' box. This selection will call 'startKernel'. However opening the window also calls 'startKernel'. These two situations are chained together.

However if the first to enter is canceled, the 'kernelConnectionId' wasn't saved and the second would attempt to select a kernel a second time.

Also fixed a build problem I noticed with fontAwesomeLoader.js