### PR TITLE
Handle scenarios when we do not get prompted to install ipykernel (fix test failure)

### DIFF
--- a/src/extension/errors/errorHandler.ts
+++ b/src/extension/errors/errorHandler.ts
@@ -106,7 +106,7 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
             traceWarning(`Cancelled by user`, error);
             return '';
         } else if (
-            error instanceof KernelDiedError &&
+            (error instanceof KernelDiedError || error instanceof KernelProcessExitedError) &&
             (error.kernelConnectionMetadata.kind === 'startUsingLocalKernelSpec' ||
                 error.kernelConnectionMetadata.kind === 'startUsingPythonInterpreter') &&
             error.kernelConnectionMetadata.interpreter &&

--- a/src/kernels/raw/launcher/kernelProcess.ts
+++ b/src/kernels/raw/launcher/kernelProcess.ts
@@ -23,7 +23,7 @@ import {
     getErrorMessageFromPythonTraceback
 } from '../../../client/../extension/errors/errorUtils';
 import { BaseError } from '../../../client/../extension/errors/types';
-import { traceInfo, traceError, traceVerbose, traceWarning } from '../../../client/common/logger';
+import { traceInfo, traceError, traceVerbose, traceWarning, traceInfoIfCI } from '../../../client/common/logger';
 import { IFileSystem } from '../../../client/common/platform/types';
 import {
     IProcessServiceFactory,
@@ -152,6 +152,7 @@ export class KernelProcess implements IKernelProcess {
                 exitEventFired = true;
             }
             if (!cancelToken.isCancellationRequested) {
+                traceInfoIfCI(`KernelProcessExitedError raised`, stderr);
                 deferred.reject(new KernelProcessExitedError(exitCode || -1, stderr, this.kernelConnectionMetadata));
             }
         });
@@ -240,6 +241,7 @@ export class KernelProcess implements IKernelProcess {
                 const errorMessage =
                     getErrorMessageFromPythonTraceback(stderrProc || stderr) ||
                     (stderrProc || stderr).substring(0, 100);
+                traceInfoIfCI(`KernelDiedError raised`, errorMessage, stderrProc + '\n' + stderr + '\n');
                 throw new KernelDiedError(
                     DataScience.kernelDied().format(errorMessage),
                     // Include what ever we have as the stderr.

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -361,7 +361,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
             waitForIPyKernelToGetInstalled()
         ]);
     });
-    test('Ensure ipykernel install prompt is displayed and we can select another kernel after uninstalling IPyKernel from a live notebook and then restarting the kernel (VSCode Notebook)', async function () {
+    test.skip('Ensure ipykernel install prompt is displayed and we can select another kernel after uninstalling IPyKernel from a live notebook and then restarting the kernel (VSCode Notebook)', async function () {
         if (IS_REMOTE_NATIVE_TEST) {
             return this.skip();
         }
@@ -448,7 +448,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         await waitForExecutionCompletedSuccessfully(cell);
     });
 
-    test('Ensure ipykernel install prompt is NOT displayed when auto start is enabled & ipykernel is missing (VSCode Notebook)', async function () {
+    test.skip('Ensure ipykernel install prompt is NOT displayed when auto start is enabled & ipykernel is missing (VSCode Notebook)', async function () {
         // Ensure we have auto start enabled, and verify kernel startup fails silently without any notifications.
         // When running a cell we should get an install prompt.
         configSettings.disableJupyterAutoStart = false;

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -209,7 +209,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
                 assertVSCCellIsNotRunning(cell) &&
                 verifyInstallIPyKernelInstructionsInOutput(cell),
             defaultNotebookTestTimeout,
-            'No errors in cell'
+            'No errors in cell (first time)'
         );
 
         // Execute notebook once again & we should get another prompted to install ipykernel.
@@ -225,7 +225,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         await waitForCondition(
             async () => hasErrorOutput(cell.outputs) && assertVSCCellIsNotRunning(cell),
             defaultNotebookTestTimeout,
-            'No errors in cell'
+            'No errors in cell (second time)'
         );
 
         // Execute a cell this time & we should get yet another prompted to install ipykernel.
@@ -241,7 +241,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         await waitForCondition(
             async () => hasErrorOutput(cell.outputs) && assertVSCCellIsNotRunning(cell),
             defaultNotebookTestTimeout,
-            'No errors in cell'
+            'No errors in cell (third time)'
         );
     });
     test('Ensure ipykernel install prompt is displayed every time you try to run a cell in an Interactive Window', async function () {

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -361,7 +361,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
             waitForIPyKernelToGetInstalled()
         ]);
     });
-    test.skip('Ensure ipykernel install prompt is displayed and we can select another kernel after uninstalling IPyKernel from a live notebook and then restarting the kernel (VSCode Notebook)', async function () {
+    test('Ensure ipykernel install prompt is displayed and we can select another kernel after uninstalling IPyKernel from a live notebook and then restarting the kernel (VSCode Notebook)', async function () {
         if (IS_REMOTE_NATIVE_TEST) {
             return this.skip();
         }
@@ -448,7 +448,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         await waitForExecutionCompletedSuccessfully(cell);
     });
 
-    test.skip('Ensure ipykernel install prompt is NOT displayed when auto start is enabled & ipykernel is missing (VSCode Notebook)', async function () {
+    test('Ensure ipykernel install prompt is NOT displayed when auto start is enabled & ipykernel is missing (VSCode Notebook)', async function () {
         // Ensure we have auto start enabled, and verify kernel startup fails silently without any notifications.
         // When running a cell we should get an install prompt.
         configSettings.disableJupyterAutoStart = false;


### PR DESCRIPTION
In this test run https://github.com/microsoft/vscode-jupyter/runs/5547740604?check_suite_focus=true
we can see that we didn't get a prompt for ipykernel not installed error message.
Instead we just dump an error `Kernel died`
