### PR TITLE
Update selector to accomodate new filters

### DIFF
--- a/news/2 Fixes/9385.md
+++ b/news/2 Fixes/9385.md
@@ -1,0 +1,1 @@
+Fix notebook intellisense to work again after recent regression.

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -13,9 +13,12 @@ export const PYTHON_ALLFILES = [{ language: PYTHON_LANGUAGE }];
 export const GITHUB_ISSUE_MARKDOWN_FILE = [{ language: MARKDOWN_LANGUAGE, scheme: 'untitled', pattern: '**/issue.md' }];
 
 export const InteractiveInputScheme = 'vscode-interactive-input';
+export const InteractiveScheme = 'vscode-interactive';
+
 export const NOTEBOOK_SELECTOR = [
     { language: PYTHON_LANGUAGE, notebookType: JupyterNotebookView },
     { scheme: InteractiveInputScheme, language: PYTHON_LANGUAGE },
+    { scheme: InteractiveScheme, language: PYTHON_LANGUAGE },
     { scheme: NotebookCellScheme, language: PYTHON_LANGUAGE }
 ];
 

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -11,10 +11,7 @@ export const PYTHON_ALLFILES = [{ language: PYTHON_LANGUAGE }];
 export const GITHUB_ISSUE_MARKDOWN_FILE = [{ language: MARKDOWN_LANGUAGE, scheme: 'untitled', pattern: '**/issue.md' }];
 
 export const InteractiveInputScheme = 'vscode-interactive-input';
-export const NOTEBOOK_SELECTOR = [
-    { scheme: NotebookCellScheme, language: PYTHON_LANGUAGE },
-    { scheme: InteractiveInputScheme, language: PYTHON_LANGUAGE }
-];
+export const NOTEBOOK_SELECTOR = [{ language: PYTHON_LANGUAGE, notebookType: 'jupyter-notebook' }];
 
 export const JVSC_EXTENSION_ID = 'ms-toolsai.jupyter';
 export const JVSC_EXTENSION_DisplayName = 'Jupyter';

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -1,3 +1,5 @@
+import { JupyterNotebookView } from '../../notebooks/constants';
+
 export const PYTHON_LANGUAGE = 'python';
 export const MARKDOWN_LANGUAGE = 'markdown';
 export const JUPYTER_LANGUAGE = 'jupyter';
@@ -11,7 +13,11 @@ export const PYTHON_ALLFILES = [{ language: PYTHON_LANGUAGE }];
 export const GITHUB_ISSUE_MARKDOWN_FILE = [{ language: MARKDOWN_LANGUAGE, scheme: 'untitled', pattern: '**/issue.md' }];
 
 export const InteractiveInputScheme = 'vscode-interactive-input';
-export const NOTEBOOK_SELECTOR = [{ language: PYTHON_LANGUAGE, notebookType: 'jupyter-notebook' }, { scheme: InteractiveInputScheme, language: PYTHON_LANGUAGE }];
+export const NOTEBOOK_SELECTOR = [
+    { language: PYTHON_LANGUAGE, notebookType: JupyterNotebookView },
+    { scheme: InteractiveInputScheme, language: PYTHON_LANGUAGE },
+    { scheme: NotebookCellScheme, language: PYTHON_LANGUAGE }
+];
 
 export const JVSC_EXTENSION_ID = 'ms-toolsai.jupyter';
 export const JVSC_EXTENSION_DisplayName = 'Jupyter';

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -11,7 +11,7 @@ export const PYTHON_ALLFILES = [{ language: PYTHON_LANGUAGE }];
 export const GITHUB_ISSUE_MARKDOWN_FILE = [{ language: MARKDOWN_LANGUAGE, scheme: 'untitled', pattern: '**/issue.md' }];
 
 export const InteractiveInputScheme = 'vscode-interactive-input';
-export const NOTEBOOK_SELECTOR = [{ language: PYTHON_LANGUAGE, notebookType: 'jupyter-notebook' }];
+export const NOTEBOOK_SELECTOR = [{ language: PYTHON_LANGUAGE, notebookType: 'jupyter-notebook' }, { scheme: InteractiveInputScheme, language: PYTHON_LANGUAGE }];
 
 export const JVSC_EXTENSION_ID = 'ms-toolsai.jupyter';
 export const JVSC_EXTENSION_DisplayName = 'Jupyter';


### PR DESCRIPTION
Fixes #9385

This was caused by the change here:
https://github.com/microsoft/vscode/commit/afcebfa6ae642564d43165e1e72375361e2338ed

The root cause being that notebook cells are no longer compared against the cell for scheme, but rather against the notebook. 

I believe this makes it impossible to specify a selector that only applies to notebook cells of a specific language. 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
