### PR TITLE
Remove forcing npm package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2046,7 +2046,7 @@
         "compile-widgetTester": "cross-env NODE_OPTIONS=--max_old_space_size=9096 webpack --config ./build/webpack/webpack.datascience-ui-widgetTester.config.js --watch",
         "kill-compile-webviews-watchd": "deemon --kill npm run compile-webviews-watch",
         "checkDependencies": "gulp checkDependencies",
-        "preinstall": "npx npm-force-resolutions",
+        "preinstall_Enable_When_Pinning_packages_with_npm6": "npx npm-force-resolutions",
         "postinstall": "npm run download-api && node ./build/ci/postInstall.js",
         "installPythonLibs": "gulp installPythonLibs",
         "test:unittests": "mocha --config ./build/.mocha.unittests.js.json ./out/**/*.unit.test.js",

--- a/package.json
+++ b/package.json
@@ -2329,11 +2329,5 @@
     "optionalDependencies": {
         "canvas": "^2.7.0"
     },
-    "resolutions": {
-        "marked": "4.0.10",
-        "tar": "4.4.18",
-        "simple-get": "3.1.1",
-        "url-parse": "1.5.8",
-        "fs-path": "0.0.25"
-    }
+    "resolutions": {}
 }


### PR DESCRIPTION
We forced (pinned) npm packages to specific versions due to some vulnerabilities, they have since been fixed upstream.
