### PR TITLE
Get interpreter for workspace and all

### DIFF
--- a/src/platform/api/pythonApi.ts
+++ b/src/platform/api/pythonApi.ts
@@ -357,7 +357,11 @@ export class InterpreterService implements IInterpreterService {
         // we want all interpreters regardless of workspace folder so call this multiple times
         const folders = this.workspace.workspaceFolders;
         const all = folders
-            ? await Promise.all(folders.map((f) => this.apiProvider.getApi().then((api) => api.getInterpreters(f.uri))))
+            ? await Promise.all(
+                  [...folders, undefined].map((f) =>
+                      this.apiProvider.getApi().then((api) => api.getInterpreters(f?.uri))
+                  )
+              )
             : await Promise.all([this.apiProvider.getApi().then((api) => api.getInterpreters(undefined))]);
 
         // Remove dupes


### PR DESCRIPTION
Found while testing that we don't get all of the interpreters.
I can see the environment showing up in Pythons Select Interpreter, but not in our kernel picker.
The difference was with the way get the list of interpreters, we provide a Uri.
I added an additional call to get interpreters without a Uri & that magically returned all interpreters.

