### PR TITLE
Enable Jupyter walkthrough to everyone (but web)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
                 "id": "jupyterWelcome",
                 "title": "Get started with Jupyter Notebooks",
                 "description": "Your first steps to set up a Jupyter project with all the powerful tools and features that the Jupyter extension has to offer!",
-                "when": "false",
+                "when": "workspacePlatform != webworker",
                 "steps": [
                     {
                         "id": "ipynb.newUntitledIpynb",


### PR DESCRIPTION
This PR enables the Jupyter walkthrough to everyone but web. This is so we can stop the experiment for insiders users in the control tower, and then once the Python and the Jupyter extensions are released, we can stop the experiment for the public ring as well. 
