### PR TITLE
Fix minor regression with execution state

### DIFF
--- a/news/2 Fixes/9405.md
+++ b/news/2 Fixes/9405.md
@@ -1,0 +1,1 @@
+Fix all cells to not show a timer when queueing up multiple.

--- a/src/kernels/kernelCommandListener.ts
+++ b/src/kernels/kernelCommandListener.ts
@@ -24,7 +24,6 @@ import { getDisplayNameOrNameOfKernelConnection, wrapKernelMethod } from './help
 import { JupyterSession } from './jupyter/session/jupyterSession';
 import { RawJupyterSession } from './raw/session/rawJupyterSession';
 import { IKernel, IKernelProvider } from './types';
-import { CellExecutionCreator } from '../notebooks/execution/cellExecutionCreator';
 
 @injectable()
 export class KernelCommandListener implements IDataScienceCommandListener {
@@ -186,13 +185,12 @@ export class KernelCommandListener implements IDataScienceCommandListener {
                 );
             } catch (ex) {
                 if (currentCell) {
-                    const cellExecution = CellExecutionCreator.getOrCreate(currentCell, kernel.controller);
                     displayErrorsInCell(
                         currentCell,
-                        cellExecution,
-                        await this.errorHandler.getErrorMessageForDisplayInCell(ex, context)
+                        kernel.controller,
+                        await this.errorHandler.getErrorMessageForDisplayInCell(ex, context),
+                        false
                     );
-                    cellExecution.end(false);
                 } else {
                     void this.applicationShell.showErrorMessage(ex.toString());
                 }

--- a/src/notebooks/controllers/vscodeNotebookController.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.ts
@@ -10,6 +10,7 @@ import {
     ExtensionMode,
     languages,
     NotebookCell,
+    NotebookCellExecution,
     NotebookCellExecutionState,
     NotebookCellKind,
     NotebookController,
@@ -100,6 +101,7 @@ export class VSCodeNotebookController implements Disposable {
      */
     public static kernelAssociatedWithDocument?: boolean;
     private isDisposed = false;
+    private runningCellExecution: NotebookCellExecution | undefined;
     get id() {
         return this.controller.id;
     }
@@ -422,24 +424,38 @@ export class VSCodeNotebookController implements Disposable {
             .then(noop, (ex) => console.error(ex));
     }
 
+    private startCellExecutionIfNecessary(cell: NotebookCell, controller: NotebookController) {
+        // Only have one cell in the 'running' state.
+        if (!this.runningCellExecution || this.runningCellExecution.cell === cell) {
+            this.runningCellExecution?.end(undefined, undefined);
+            this.runningCellExecution = CellExecutionCreator.getOrCreate(cell, controller);
+
+            // When this execution ends, we don't have a current one anymore.
+            const originalEnd = this.runningCellExecution.end.bind(this.runningCellExecution);
+            this.runningCellExecution.end = (success: boolean | undefined, endTime?: number | undefined) => {
+                this.runningCellExecution = undefined;
+                originalEnd(success, endTime);
+            };
+            this.runningCellExecution.start(new Date().getTime());
+            void this.runningCellExecution.clearOutput(cell);
+        }
+    }
+
     private async executeCell(doc: NotebookDocument, cell: NotebookCell) {
         traceInfo(`Execute Cell ${cell.index} ${getDisplayPath(cell.notebook.uri)}`);
-        const startTime = new Date().getTime();
         // Start execution now (from the user's point of view)
-        let execution = CellExecutionCreator.getOrCreate(cell, this.controller);
-        execution.start(startTime);
-        void execution.clearOutput(cell);
+        this.startCellExecutionIfNecessary(cell, this.controller);
 
         // Connect to a matching kernel if possible (but user may pick a different one)
         let context: 'start' | 'execution' = 'start';
         let kernel: IKernel | undefined;
+        let controller = this.controller;
         try {
             kernel = await this.connectToKernel(doc, new DisplayOptions(false));
             // If the controller changed, then ensure to create a new cell execution object.
-            if (kernel && kernel.controller.id !== execution.controllerId) {
-                execution.end(undefined);
-                execution = CellExecutionCreator.getOrCreate(cell, kernel.controller);
-                execution.start(startTime);
+            if (kernel && kernel.controller.id !== controller.id) {
+                controller = kernel.controller;
+                this.startCellExecutionIfNecessary(cell, kernel.controller);
             }
             context = 'execution';
             if (kernel.controller.id === this.id) {
@@ -448,13 +464,16 @@ export class VSCodeNotebookController implements Disposable {
             return await kernel.executeCell(cell);
         } catch (ex) {
             const errorHandler = this.serviceContainer.get<IDataScienceErrorHandler>(IDataScienceErrorHandler);
-            // If there was a failure connecting or executing the kernel, stick it in this cell
-            displayErrorsInCell(cell, execution, await errorHandler.getErrorMessageForDisplayInCell(ex, context));
             ex = WrappedError.unwrap(ex);
             const isCancelled =
                 ex instanceof CancellationError || ex instanceof VscCancellationError || ex instanceof KernelDeadError;
-            // If user cancels the execution, then don't show error status against cell.
-            execution.end(isCancelled ? undefined : false);
+            // If there was a failure connecting or executing the kernel, stick it in this cell
+            displayErrorsInCell(
+                cell,
+                controller,
+                await errorHandler.getErrorMessageForDisplayInCell(ex, context),
+                isCancelled
+            );
             return NotebookCellExecutionState.Idle;
         }
 


### PR DESCRIPTION
Fixes #9405

We shouldn't create a new cell execution as soon as a cell is queued up. We should wait until we execute unless it's the first cell in a list.

This didn't seem like a big change and it's a regression caused by this month's changes, so thought maybe we should fix it.