### PR TITLE
Install compatible version of click

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -221,6 +221,7 @@ jobs:
 
       - name: Run Black on Python code
         run: |
+          python -m pip install click==8.0.4
           python -m pip install -U black
           python -m black . --check
         working-directory: pythonFiles


### PR DESCRIPTION
Click released version 8.1.0 an hour ago and that isn't compatible with black.
