### PR TITLE
Revert "Do not use daemon for Jupyter servers (#9032)"

### DIFF
--- a/src/kernels/jupyter/interpreter/jupyterCommand.ts
+++ b/src/kernels/jupyter/interpreter/jupyterCommand.ts
@@ -8,25 +8,68 @@ import { traceError } from '../../../platform/common/logger';
 import {
     IPythonExecutionService,
     IPythonExecutionFactory,
+    IPythonDaemonExecutionService,
     ExecutionResult
 } from '../../../platform/common/process/types';
 import { EXTENSION_ROOT_DIR } from '../../../platform/constants';
 import { IJupyterCommand, IJupyterCommandFactory } from '../../../platform/datascience/types';
 import { PythonEnvironment } from '../../../platform/pythonEnvironments/info';
-import { JupyterCommands } from '../../../datascience-ui/common/constants';
+import { JupyterDaemonModule, JupyterCommands } from '../../../datascience-ui/common/constants';
 
 class InterpreterJupyterCommand implements IJupyterCommand {
+    protected interpreterPromise: Promise<PythonEnvironment>;
     private pythonLauncher: Promise<IPythonExecutionService>;
 
     constructor(
         protected readonly moduleName: string,
         protected args: string[],
         protected readonly pythonExecutionFactory: IPythonExecutionFactory,
-        public readonly interpreter: PythonEnvironment
+        private readonly _interpreter: PythonEnvironment,
+        isActiveInterpreter: boolean
     ) {
-        this.pythonLauncher = pythonExecutionFactory.createActivatedEnvironment({
-            interpreter
+        this.interpreterPromise = Promise.resolve(this._interpreter);
+        this.pythonLauncher = this.interpreterPromise.then(async (interpreter) => {
+            // Create a daemon only if the interpreter is the same as the current interpreter.
+            // We don't want too many daemons (we don't want one for each of the users interpreter on their machine).
+            if (isActiveInterpreter) {
+                const svc = await pythonExecutionFactory.createDaemon<IPythonDaemonExecutionService>({
+                    daemonModule: JupyterDaemonModule,
+                    interpreter
+                });
+
+                // If we're using this command to start notebook, then ensure the daemon can start a notebook inside it.
+                if (
+                    (moduleName.toLowerCase() === 'jupyter' &&
+                        args.join(' ').toLowerCase().startsWith('-m jupyter notebook')) ||
+                    (moduleName.toLowerCase() === 'notebook' && args.join(' ').toLowerCase().startsWith('-m notebook'))
+                ) {
+                    try {
+                        const output = await svc.exec(
+                            [
+                                path.join(
+                                    EXTENSION_ROOT_DIR,
+                                    'pythonFiles',
+                                    'vscode_datascience_helpers',
+                                    'jupyter_nbInstalled.py'
+                                )
+                            ],
+                            {}
+                        );
+                        if (output.stdout.toLowerCase().includes('available')) {
+                            return svc;
+                        }
+                    } catch (ex) {
+                        traceError('Checking whether notebook is importable failed', ex);
+                    }
+                }
+            }
+            return pythonExecutionFactory.createActivatedEnvironment({
+                interpreter: this._interpreter
+            });
         });
+    }
+    public interpreter(): Promise<PythonEnvironment | undefined> {
+        return this.interpreterPromise;
     }
 
     public async exec(args: string[], options: SpawnOptions): Promise<ExecutionResult<string>> {
@@ -53,9 +96,10 @@ export class InterpreterJupyterNotebookCommand extends InterpreterJupyterCommand
         moduleName: string,
         args: string[],
         pythonExecutionFactory: IPythonExecutionFactory,
-        interpreter: PythonEnvironment
+        interpreter: PythonEnvironment,
+        isActiveInterpreter: boolean
     ) {
-        super(moduleName, args, pythonExecutionFactory, interpreter);
+        super(moduleName, args, pythonExecutionFactory, interpreter, isActiveInterpreter);
     }
 }
 
@@ -73,9 +117,10 @@ export class InterpreterJupyterKernelSpecCommand extends InterpreterJupyterComma
         moduleName: string,
         args: string[],
         pythonExecutionFactory: IPythonExecutionFactory,
-        interpreter: PythonEnvironment
+        interpreter: PythonEnvironment,
+        isActiveInterpreter: boolean
     ) {
-        super(moduleName, args, pythonExecutionFactory, interpreter);
+        super(moduleName, args, pythonExecutionFactory, interpreter, isActiveInterpreter);
     }
 
     /**
@@ -122,7 +167,9 @@ export class InterpreterJupyterKernelSpecCommand extends InterpreterJupyterComma
         };
 
         // We're only interested in `python -m jupyter kernelspec`
+        const interpreter = await this.interpreter();
         if (
+            !interpreter ||
             this.moduleName.toLowerCase() !== 'jupyter' ||
             this.args.join(' ').toLowerCase() !== `-m jupyter ${JupyterCommands.KernelSpecCommand}`.toLowerCase()
         ) {
@@ -133,11 +180,11 @@ export class InterpreterJupyterKernelSpecCommand extends InterpreterJupyterComma
         try {
             if (args.join(' ').toLowerCase() === 'list --json') {
                 // Try getting kernels using python script, if that fails (even if there's output in stderr) rethrow original exception.
-                output = await this.getKernelSpecList(this.interpreter, options);
+                output = await this.getKernelSpecList(interpreter, options);
                 return output;
             } else if (args.join(' ').toLowerCase() === '--version') {
                 // Try getting kernelspec version using python script, if that fails (even if there's output in stderr) rethrow original exception.
-                output = await this.getKernelSpecVersion(this.interpreter, options);
+                output = await this.getKernelSpecVersion(interpreter, options);
                 return output;
             }
         } catch (innerEx) {
@@ -184,13 +231,26 @@ export class JupyterCommandFactory implements IJupyterCommandFactory {
         command: JupyterCommands,
         moduleName: string,
         args: string[],
-        interpreter: PythonEnvironment
+        interpreter: PythonEnvironment,
+        isActiveInterpreter: boolean
     ): IJupyterCommand {
         if (command === JupyterCommands.NotebookCommand) {
-            return new InterpreterJupyterNotebookCommand(moduleName, args, this.executionFactory, interpreter);
+            return new InterpreterJupyterNotebookCommand(
+                moduleName,
+                args,
+                this.executionFactory,
+                interpreter,
+                isActiveInterpreter
+            );
         } else if (command === JupyterCommands.KernelSpecCommand) {
-            return new InterpreterJupyterKernelSpecCommand(moduleName, args, this.executionFactory, interpreter);
+            return new InterpreterJupyterKernelSpecCommand(
+                moduleName,
+                args,
+                this.executionFactory,
+                interpreter,
+                isActiveInterpreter
+            );
         }
-        return new InterpreterJupyterCommand(moduleName, args, this.executionFactory, interpreter);
+        return new InterpreterJupyterCommand(moduleName, args, this.executionFactory, interpreter, isActiveInterpreter);
     }
 }

--- a/src/kernels/jupyter/interpreter/jupyterInterpreterDependencyService.ts
+++ b/src/kernels/jupyter/interpreter/jupyterInterpreterDependencyService.ts
@@ -294,7 +294,8 @@ export class JupyterInterpreterDependencyService {
             JupyterCommands.KernelSpecCommand,
             'jupyter',
             ['-m', 'jupyter', 'kernelspec'],
-            interpreter
+            interpreter,
+            false
         );
         return command
             .exec(['--version'], { throwOnStdErr: true })

--- a/src/kernels/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
+++ b/src/kernels/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
@@ -10,7 +10,8 @@ import { traceWarning } from '../../../platform/common/logger';
 import {
     IPythonExecutionFactory,
     SpawnOptions,
-    ObservableExecutionResult
+    ObservableExecutionResult,
+    IPythonDaemonExecutionService
 } from '../../../platform/common/process/types';
 import { IOutputChannel, IPathUtils } from '../../../platform/common/types';
 import { DataScience } from '../../../platform/common/utils/localize';
@@ -24,7 +25,7 @@ import { IEnvironmentActivationService } from '../../../platform/interpreter/act
 import { IInterpreterService } from '../../../platform/interpreter/contracts';
 import { PythonEnvironment } from '../../../platform/pythonEnvironments/info';
 import { sendTelemetryEvent } from '../../../telemetry';
-import { JUPYTER_OUTPUT_CHANNEL, Telemetry } from '../../../datascience-ui/common/constants';
+import { JUPYTER_OUTPUT_CHANNEL, Telemetry, JupyterDaemonModule } from '../../../datascience-ui/common/constants';
 import { JupyterInstallError } from '../../../platform/errors/jupyterInstallError';
 import { Product } from '../../installer/types';
 import { JupyterPaths } from '../../raw/finder/jupyterPaths';
@@ -114,9 +115,9 @@ export class JupyterInterpreterSubCommandExecutionService
                 notebookArgs.join(' ')
             )
         );
-        const executionService = await this.pythonExecutionFactory.createActivatedEnvironment({
-            interpreter: interpreter,
-            allowEnvironmentFetchExceptions: true
+        const executionService = await this.pythonExecutionFactory.createDaemon<IPythonDaemonExecutionService>({
+            daemonModule: JupyterDaemonModule,
+            interpreter: interpreter
         });
         // We should never set token for long running processes.
         // We don't want the process to die when the token is cancelled.
@@ -138,14 +139,15 @@ export class JupyterInterpreterSubCommandExecutionService
 
     public async getRunningJupyterServers(token?: CancellationToken): Promise<JupyterServerInfo[] | undefined> {
         const interpreter = await this.getSelectedInterpreterAndThrowIfNotAvailable(token);
-        const executionService = await this.pythonExecutionFactory.createActivatedEnvironment({
-            interpreter
+        const daemon = await this.pythonExecutionFactory.createDaemon<IPythonDaemonExecutionService>({
+            daemonModule: JupyterDaemonModule,
+            interpreter: interpreter
         });
 
         // We have a small python file here that we will execute to get the server info from all running Jupyter instances
         const newOptions: SpawnOptions = { mergeStdOutErr: true, token: token };
         const file = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'vscode_datascience_helpers', 'getServerInfo.py');
-        const serverInfoString = await executionService.exec([file], newOptions);
+        const serverInfoString = await daemon.exec([file], newOptions);
 
         let serverInfos: JupyterServerInfo[];
         try {

--- a/src/kernels/jupyter/interpreter/nbconvertInterpreterDependencyChecker.ts
+++ b/src/kernels/jupyter/interpreter/nbconvertInterpreterDependencyChecker.ts
@@ -45,7 +45,8 @@ export class NbConvertInterpreterDependencyChecker implements INbConvertInterpre
             JupyterCommands.ConvertCommand,
             'jupyter',
             ['-m', 'jupyter', 'nbconvert'],
-            interpreter
+            interpreter,
+            false
         );
 
         const result = await command.exec(['--version'], { throwOnStdErr: true });

--- a/src/platform/datascience/types.ts
+++ b/src/platform/datascience/types.ts
@@ -574,6 +574,7 @@ export interface IStatusProvider {
 }
 
 export interface IJupyterCommand {
+    interpreter(): Promise<PythonEnvironment | undefined>;
     exec(args: string[], options: SpawnOptions): Promise<ExecutionResult<string>>;
 }
 
@@ -583,7 +584,8 @@ export interface IJupyterCommandFactory {
         command: JupyterCommands,
         moduleName: string,
         args: string[],
-        interpreter: PythonEnvironment
+        interpreter: PythonEnvironment,
+        isActiveInterpreter: boolean
     ): IJupyterCommand;
 }
 

--- a/src/test/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.unit.test.ts
+++ b/src/test/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.unit.test.ts
@@ -41,9 +41,9 @@ suite('DataScience - Jupyter Interpreter Configuration', () => {
         command = mock(InterpreterJupyterKernelSpecCommand);
         instance(commandFactory as any).then = undefined;
         instance(command as any).then = undefined;
-        when(commandFactory.createInterpreterCommand(anything(), anything(), anything(), anything())).thenReturn(
-            instance(command)
-        );
+        when(
+            commandFactory.createInterpreterCommand(anything(), anything(), anything(), anything(), anything())
+        ).thenReturn(instance(command));
         when(command.exec(anything(), anything())).thenResolve({ stdout: '' });
 
         configuration = new JupyterInterpreterDependencyService(


### PR DESCRIPTION
This reverts commit 867d2edd1e81e3d96fb15a307b8598e67ba800cf.

Fixes #9511

See original thread here https://github.com/microsoft/vscode-jupyter/pull/9032#issuecomment-1040668737
Basically @rchiodo  brought this up, and a client confirmed it worked without daemon, however we still have others that can't get it working , hence reverting this change.

I just wish we knew the root cause (as daemons were added later). Anyways, cannot break users.