### PR TITLE
Fix failing unit test

### DIFF
--- a/news/2 Fixes/9560.md
+++ b/news/2 Fixes/9560.md
@@ -1,0 +1,1 @@
+Fix problem with path names in overriding modules.

--- a/src/platform/common/platform/fs-paths.ts
+++ b/src/platform/common/platform/fs-paths.ts
@@ -6,9 +6,7 @@ export function getDisplayPath(
     workspaceFolders: readonly WorkspaceFolder[] | WorkspaceFolder[] = []
 ) {
     const relativeToHome = getDisplayPathImpl(filename);
-    const relativeToWorkspaceFolders = workspaceFolders.map((folder) =>
-        getDisplayPathImpl(filename, folder.uri.fsPath)
-    );
+    const relativeToWorkspaceFolders = workspaceFolders.map((folder) => getDisplayPathImpl(filename, folder.uri.path));
     // Pick the shortest path for display purposes.
     // As those are most likely relative to some workspace folder.
     let bestDisplayPath = relativeToHome;
@@ -28,7 +26,7 @@ function getDisplayPathImpl(filename?: string | Uri, cwd?: string): string {
     } else if (!filename) {
         file = '';
     } else if (filename.scheme === 'file') {
-        file = filename.fsPath;
+        file = filename.path;
     } else {
         file = filename.toString();
     }

--- a/src/platform/common/platform/fs-paths.ts
+++ b/src/platform/common/platform/fs-paths.ts
@@ -20,24 +20,29 @@ export function getDisplayPath(
 }
 
 function getDisplayPathImpl(filename?: string | Uri, cwd?: string): string {
+    // Common file separator is unix based '/'. Handle mixing of paths
+    let cwdReplaced = cwd ? cwd.replace(/\\/g, '/') : undefined;
+    if (cwdReplaced?.includes(':') && cwdReplaced.startsWith('/')) {
+        cwdReplaced = cwdReplaced.slice(1);
+    }
     let file = '';
     if (typeof filename === 'string') {
-        file = filename;
+        file = filename.replace(/\\/g, '/');
     } else if (!filename) {
         file = '';
     } else if (filename.scheme === 'file') {
         file = filename.path;
     } else {
-        file = filename.toString();
+        file = filename.toString().replace(/\\/g, '/');
     }
     if (!file) {
         return '';
-    } else if (cwd && file.startsWith(cwd)) {
-        const relativePath = `.${path.sep}${path.relative(cwd, file)}`;
+    } else if (cwdReplaced && file.startsWith(cwdReplaced)) {
+        const relativePath = `.${path.sep}${path.relative(cwdReplaced, file)}`;
         // On CI the relative path might not work as expected as when testing we might have windows paths
         // and the code is running on a unix machine.
-        return relativePath === file || relativePath.includes(cwd)
-            ? `.${path.sep}${file.substring(file.indexOf(cwd) + cwd.length)}`
+        return relativePath === file || relativePath.includes(cwdReplaced)
+            ? `.${path.sep}${file.substring(file.indexOf(cwdReplaced) + cwdReplaced.length)}`
             : relativePath;
     } else {
         return file;

--- a/src/test/datascience/errorHandler.unit.test.ts
+++ b/src/test/datascience/errorHandler.unit.test.ts
@@ -231,7 +231,7 @@ suite('DataScience Error Handler Unit Tests', () => {
 
             const expectedMessage = DataScience.failedToStartKernelDueToImportFailureFromFile().format(
                 'Random',
-                getDisplayPath('c:\\Development\\samples\\pySamples\\sample1\\kernel_issues\\start\\random.py', [])
+                'c:\\Development\\samples\\pySamples\\sample1\\kernel_issues\\start\\random.py'
             );
 
             verifyErrorMessage(expectedMessage, 'https://aka.ms/kernelFailuresModuleImportErrFromFile');

--- a/src/test/datascience/errorHandler.unit.test.ts
+++ b/src/test/datascience/errorHandler.unit.test.ts
@@ -7,7 +7,7 @@ import { assert } from 'chai';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { Uri, WorkspaceFolder } from 'vscode';
 import { IApplicationShell, IWorkspaceService } from '../../platform/common/application/types';
-import { getDisplayPath } from '../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../platform/common/platform/fs-paths';
 import { Common, DataScience } from '../../platform/common/utils/localize';
 import { IBrowserService, IConfigurationService } from '../../platform/common/types';
 import {


### PR DESCRIPTION
merge problems prevented unit tests from running on last submission. This fixes the path checking to use the same algorithm as the errorUtils.

Fixes #9560