### PR TITLE
Replace Buffer constructors with safer methods

### DIFF
--- a/news/2 Fixes/9589.md
+++ b/news/2 Fixes/9589.md
@@ -1,0 +1,1 @@
+Replace `Buffer` constructors with safer methods to reduce security concerns. (Thanks [caphosra](https://github.com/caphosra))

--- a/src/platform/debugger/extension/helpers/protocolParser.node.ts
+++ b/src/platform/debugger/extension/helpers/protocolParser.node.ts
@@ -28,7 +28,7 @@ type Listener = (...args: any[]) => void;
  */
 @injectable()
 export class ProtocolParser implements IProtocolParser {
-    private rawData = new Buffer(0);
+    private rawData = Buffer.concat([]);
     private contentLength: number = -1;
     private disposed: boolean = false;
     private stream?: Readable;

--- a/src/webviews/extension-side/plotting/plotViewer.node.ts
+++ b/src/webviews/extension-side/plotting/plotViewer.node.ts
@@ -143,7 +143,7 @@ export class PlotViewer extends WebviewPanelHost<IPlotViewerMapping> implements 
                         break;
 
                     case '.png':
-                        const buffer = new Buffer(payload.png.replace('data:image/png;base64', ''), 'base64');
+                        const buffer = Buffer.from(payload.png.replace('data:image/png;base64', ''), 'base64');
                         await this.fs.writeLocalFile(file.fsPath, buffer);
                         break;
 


### PR DESCRIPTION
Fixes #9562.

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
