### PR TITLE
Fix es5 with a force dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -189,6 +189,7 @@
                 "enzyme": "^3.7.0",
                 "enzyme-adapter-react-16": "^1.6.0",
                 "es-abstract": "^1.19.1",
+                "es5-ext": "^0.10.53",
                 "eslint": "^7.32.0",
                 "eslint-config-airbnb": "^18.2.0",
                 "eslint-config-prettier": "^6.15.0",
@@ -9376,17 +9377,13 @@
             }
         },
         "node_modules/es5-ext": {
-            "version": "0.10.59",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.59.tgz",
-            "integrity": "sha512-cOgyhW0tIJyQY1Kfw6Kr0viu9ZlUctVchRMZ7R0HiH3dxTSp5zJDLecwxUqPUrGKMsgBI1wd1FL+d9Jxfi4cLw==",
-            "hasInstallScript": true,
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
             "dependencies": {
-                "es6-iterator": "^2.0.3",
-                "es6-symbol": "^3.1.3",
-                "next-tick": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.10"
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
             }
         },
         "node_modules/es6-error": {
@@ -17065,9 +17062,9 @@
             "dev": true
         },
         "node_modules/next-tick": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-            "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
         "node_modules/nice-try": {
             "version": "1.0.5",
@@ -33310,13 +33307,13 @@
             }
         },
         "es5-ext": {
-            "version": "0.10.59",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.59.tgz",
-            "integrity": "sha512-cOgyhW0tIJyQY1Kfw6Kr0viu9ZlUctVchRMZ7R0HiH3dxTSp5zJDLecwxUqPUrGKMsgBI1wd1FL+d9Jxfi4cLw==",
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
             "requires": {
-                "es6-iterator": "^2.0.3",
-                "es6-symbol": "^3.1.3",
-                "next-tick": "^1.1.0"
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
             }
         },
         "es6-error": {
@@ -39265,9 +39262,9 @@
             "dev": true
         },
         "next-tick": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-            "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
         "nice-try": {
             "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -2408,7 +2408,6 @@
     "overrides": {
         "simple-get": "3.1.1",
         "url-parse": "1.5.8",
-        "fs-path": "0.0.25",
-        "es5-ext": "0.10.53"
+        "fs-path": "0.0.25"
     }
 }

--- a/package.json
+++ b/package.json
@@ -2317,6 +2317,7 @@
         "enzyme": "^3.7.0",
         "enzyme-adapter-react-16": "^1.6.0",
         "es-abstract": "^1.19.1",
+        "es5-ext": "^0.10.53",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.0",
         "eslint-config-prettier": "^6.15.0",


### PR DESCRIPTION
For some reason the npm overrides are not working. So manually forcing es5-ext to the allowed version.