### PR TITLE
Switch to using the vscode common path implementation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,7 +40,6 @@ module.exports = {
         'src/test/mocks/vsc/htmlContent.ts',
         'src/test/mocks/vsc/selection.ts',
         'src/test/mocks/vsc/position.ts',
-        'src/test/mocks/vsc/uri.ts',
         'src/test/mocks/vsc/telemetryReporter.ts',
         'src/test/mocks/vsc/range.ts',
         'src/test/mocks/vsc/arrays.ts',

--- a/build/eslint-rules/index.js
+++ b/build/eslint-rules/index.js
@@ -16,6 +16,10 @@ function reportIfMissing(context, node, allowed, name) {
     ) {
         context.report(node, `Do not import Node.js builtin module "${name}"`);
     }
+    // Special case 'path'. Force everything to use the custom path
+    if (importType.default(name, context) === 'builtin' && name === 'path') {
+        context.report(node, `Do not import path builtin module. Use the custom vscode-path instead.`);
+    }
 }
 
 module.exports = {

--- a/build/webpack/webpack.extension.web.config.js
+++ b/build/webpack/webpack.extension.web.config.js
@@ -101,7 +101,7 @@ const config = {
             // Definitions...
             BROWSER: JSON.stringify(true),
             process: {
-                platform: 'web'
+                platform: JSON.stringify('web')
             }
         }),
         new CleanTerminalPlugin()

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -264,6 +264,9 @@ function getAllowedWarningsForWebPack(buildConfig) {
             ];
         case 'extension':
             return [
+                'WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).',
+                'WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.',
+                'WARNING in webpack performance recommendations:',
                 'WARNING in ./node_modules/cacheable-request/node_modules/keyv/src/index.js',
                 'WARNING in ./node_modules/encoding/lib/iconv-loader.js',
                 'WARNING in ./node_modules/keyv/src/index.js',

--- a/src/extension.node.ts
+++ b/src/extension.node.ts
@@ -40,7 +40,7 @@ import {
     workspace
 } from 'vscode';
 import * as fsExtra from 'fs-extra';
-import * as path from 'path';
+import * as path from './platform/vscode-path/path';
 import { buildApi, IExtensionApi } from './platform/api';
 import { IApplicationEnvironment, ICommandManager } from './platform/common/application/types';
 import { setHomeDirectory, traceError } from './platform/logging';

--- a/src/intellisense/fileBasedCancellationStrategy.node.ts
+++ b/src/intellisense/fileBasedCancellationStrategy.node.ts
@@ -10,7 +10,7 @@
 import { randomBytes } from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import {
     CancellationReceiverStrategy,
     CancellationSenderStrategy,

--- a/src/intellisense/languageServer.node.ts
+++ b/src/intellisense/languageServer.node.ts
@@ -17,7 +17,7 @@ import {
     StaticFeature,
     TransportKind
 } from 'vscode-languageclient/node';
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import * as fs from 'fs-extra';
 import { FileBasedCancellationStrategy } from './fileBasedCancellationStrategy.node';
 import { createNotebookMiddleware, createPylanceMiddleware, NotebookMiddleware } from '@vscode/jupyter-lsp-middleware';

--- a/src/interactive-window/identity.node.ts
+++ b/src/interactive-window/identity.node.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import * as uuid from 'uuid/v4';
 import { Uri } from 'vscode';
 import '../platform/common/extensions';

--- a/src/interactive-window/interactiveWindow.node.ts
+++ b/src/interactive-window/interactiveWindow.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import type * as nbformat from '@jupyterlab/nbformat';
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import {
     Event,
     EventEmitter,

--- a/src/kernels/debugging/jupyterDebugService.node.ts
+++ b/src/kernels/debugging/jupyterDebugService.node.ts
@@ -3,7 +3,7 @@
 import { IDisposable } from '@fluentui/react';
 import { inject, injectable } from 'inversify';
 import * as net from 'net';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import * as uuid from 'uuid/v4';
 import {
     Breakpoint,

--- a/src/kernels/helpers.node.ts
+++ b/src/kernels/helpers.node.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 'use strict';
 
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import * as url from 'url';
 import type { KernelSpec } from '@jupyterlab/services';
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports

--- a/src/kernels/installer/condaInstaller.node.ts
+++ b/src/kernels/installer/condaInstaller.node.ts
@@ -8,7 +8,7 @@ import { CondaService } from '../../platform/common/process/condaService.node';
 import { IServiceContainer } from '../../platform/ioc/types';
 import { ExecutionInstallArgs, ModuleInstaller, translateProductToModule } from './moduleInstaller.node';
 import { ModuleInstallerType, ModuleInstallFlags, Product } from './types';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 
 /**
  * A Python module installer for a conda environment.

--- a/src/kernels/installer/pipInstaller.node.ts
+++ b/src/kernels/installer/pipInstaller.node.ts
@@ -3,7 +3,7 @@
 
 import { inject, injectable } from 'inversify';
 import { ExecutionInstallArgs, ModuleInstaller, translateProductToModule } from './moduleInstaller.node';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { IWorkspaceService } from '../../platform/common/application/types';
 import { _SCRIPTS_DIR } from '../../platform/common/process/internal/scripts/index.node';
 import { IPythonExecutionFactory } from '../../platform/common/process/types.node';

--- a/src/kernels/installer/pipenv.node.ts
+++ b/src/kernels/installer/pipenv.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { traceError } from '../../platform/logging';
 import { getEnvironmentVariable } from '../../platform/common/utils/platform.node';
 import { pathExists, readFile, arePathsSame, normCasePath } from '../../platform/common/platform/fileUtils.node';

--- a/src/kernels/installer/poetry.node.ts
+++ b/src/kernels/installer/poetry.node.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { traceVerbose, traceError } from '../../platform/logging';
 import { cache } from '../../platform/common/utils/decorators';
 import { getOSType, getUserHomeDir, OSType } from '../../platform/common/utils/platform.node';

--- a/src/kernels/installer/productPath.node.ts
+++ b/src/kernels/installer/productPath.node.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { injectable, inject } from 'inversify';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { Uri } from 'vscode';
 import { IConfigurationService } from '../../platform/common/types';
 import { IServiceContainer } from '../../platform/ioc/types';

--- a/src/kernels/installer/pyenv.node.ts
+++ b/src/kernels/installer/pyenv.node.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { getEnvironmentVariable, getOSType, getUserHomeDir, OSType } from '../../platform/common/utils/platform.node';
 import { arePathsSame, isParentPath, pathExists } from '../../platform/common/platform/fileUtils.node';
 

--- a/src/kernels/ipywidgets-message-coordination/cdnWidgetScriptSourceProvider.node.ts
+++ b/src/kernels/ipywidgets-message-coordination/cdnWidgetScriptSourceProvider.node.ts
@@ -5,7 +5,7 @@
 
 import * as download from 'download';
 import { sha256 } from 'hash.js';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { Uri } from 'vscode';
 import { traceError, traceInfo, traceInfoIfCI } from '../../platform/logging';
 import { TemporaryFile } from '../../platform/common/platform/types';

--- a/src/kernels/ipywidgets-message-coordination/ipyWidgetScriptSource.node.ts
+++ b/src/kernels/ipywidgets-message-coordination/ipyWidgetScriptSource.node.ts
@@ -4,7 +4,7 @@
 'use strict';
 import type * as jupyterlabService from '@jupyterlab/services';
 import { sha256 } from 'hash.js';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { Event, EventEmitter, NotebookDocument, Uri } from 'vscode';
 import { IApplicationShell, IWorkspaceService } from '../../platform/common/application/types';
 import { traceError, traceInfo, traceVerbose } from '../../platform/logging';

--- a/src/kernels/ipywidgets-message-coordination/localWidgetScriptSourceProvider.node.ts
+++ b/src/kernels/ipywidgets-message-coordination/localWidgetScriptSourceProvider.node.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { Uri } from 'vscode';
 import { traceError } from '../../platform/logging';
 import { IFileSystem } from '../../platform/common/platform/types.node';

--- a/src/kernels/jupyter/import-export/jupyterExporter.node.ts
+++ b/src/kernels/jupyter/import-export/jupyterExporter.node.ts
@@ -4,7 +4,7 @@
 import type * as nbformat from '@jupyterlab/nbformat';
 import { inject, injectable } from 'inversify';
 import * as os from 'os';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 
 import { Uri } from 'vscode';
 import { createCodeCell } from '../../../interactive-window/editor-integration/cellFactory.node';

--- a/src/kernels/jupyter/import-export/jupyterImporter.node.ts
+++ b/src/kernels/jupyter/import-export/jupyterImporter.node.ts
@@ -5,7 +5,7 @@ import '../../../platform/common/extensions';
 
 import { inject, injectable } from 'inversify';
 import * as os from 'os';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 
 import { Uri } from 'vscode';
 import { IWorkspaceService } from '../../../platform/common/application/types';

--- a/src/kernels/jupyter/interpreter/jupyterCommand.node.ts
+++ b/src/kernels/jupyter/interpreter/jupyterCommand.node.ts
@@ -3,7 +3,7 @@
 'use strict';
 import { SpawnOptions } from 'child_process';
 import { inject, injectable } from 'inversify';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { traceError } from '../../../platform/logging';
 import {
     IPythonExecutionService,

--- a/src/kernels/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.node.ts
+++ b/src/kernels/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.node.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { inject, injectable, named } from 'inversify';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { CancellationToken } from 'vscode';
 import { traceWarning } from '../../../platform/logging';
 import {

--- a/src/kernels/jupyter/jupyterKernelService.node.ts
+++ b/src/kernels/jupyter/jupyterKernelService.node.ts
@@ -5,7 +5,7 @@
 
 import type { KernelSpec } from '@jupyterlab/services';
 import { inject, injectable } from 'inversify';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { CancellationToken } from 'vscode';
 import { Cancellation } from '../../platform/common/cancellation.node';
 import '../../platform/common/extensions';

--- a/src/kernels/jupyter/jupyterUtils.node.ts
+++ b/src/kernels/jupyter/jupyterUtils.node.ts
@@ -4,7 +4,7 @@
 import '../../platform/common/extensions';
 
 import * as fs from 'fs-extra';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { Uri } from 'vscode';
 import { IWorkspaceService } from '../../platform/common/application/types';
 import { Resource } from '../../platform/common/types';

--- a/src/kernels/jupyter/launcher/jupyterExecution.node.ts
+++ b/src/kernels/jupyter/launcher/jupyterExecution.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as uuid from 'uuid/v4';
 import { CancellationToken } from 'vscode';
 import { IWorkspaceService } from '../../../platform/common/application/types';

--- a/src/kernels/jupyter/launcher/notebookStarter.node.ts
+++ b/src/kernels/jupyter/launcher/notebookStarter.node.ts
@@ -7,7 +7,7 @@ import * as cp from 'child_process';
 import * as url from 'url';
 import { inject, injectable, named } from 'inversify';
 import * as os from 'os';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as uuid from 'uuid/v4';
 import { CancellationError, CancellationToken, Disposable } from 'vscode';
 import { IDisposable } from '@fluentui/react';

--- a/src/kernels/jupyter/session/jupyterSession.node.ts
+++ b/src/kernels/jupyter/session/jupyterSession.node.ts
@@ -9,7 +9,7 @@ import type {
     Session,
     SessionManager
 } from '@jupyterlab/services';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as uuid from 'uuid/v4';
 import { CancellationToken, CancellationTokenSource } from 'vscode-jsonrpc';
 import { Cancellation } from '../../../platform/common/cancellation.node';

--- a/src/kernels/raw/finder/jupyterPaths.node.ts
+++ b/src/kernels/raw/finder/jupyterPaths.node.ts
@@ -3,7 +3,7 @@
 'use strict';
 
 import { inject, injectable, named } from 'inversify';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { CancellationToken, Memento } from 'vscode';
 import { IPlatformService } from '../../../platform/common/platform/types';
 import { IFileSystem } from '../../../platform/common/platform/types.node';

--- a/src/kernels/raw/finder/localKernelSpecFinderBase.node.ts
+++ b/src/kernels/raw/finder/localKernelSpecFinderBase.node.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { CancellationToken, Memento } from 'vscode';
 import { IPythonExtensionChecker } from '../../../platform/api/types';
 import { IWorkspaceService } from '../../../platform/common/application/types';

--- a/src/kernels/raw/finder/localPythonAndRelatedNonPythonKernelSpecFinder.node.ts
+++ b/src/kernels/raw/finder/localPythonAndRelatedNonPythonKernelSpecFinder.node.ts
@@ -3,7 +3,7 @@
 'use strict';
 
 import { inject, injectable, named } from 'inversify';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { CancellationToken, Memento } from 'vscode';
 import { createInterpreterKernelSpec, getKernelId, getKernelRegistrationInfo } from '../../../kernels/helpers.node';
 import {

--- a/src/kernels/raw/launcher/kernelEnvVarsService.node.ts
+++ b/src/kernels/raw/launcher/kernelEnvVarsService.node.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { traceInfo, traceError } from '../../../platform/logging';
 import { getDisplayPath } from '../../../platform/common/platform/fs-paths.node';
 import { Resource } from '../../../platform/common/types';

--- a/src/kernels/raw/launcher/kernelLauncher.node.ts
+++ b/src/kernels/raw/launcher/kernelLauncher.node.ts
@@ -5,7 +5,7 @@
 import * as fsextra from 'fs-extra';
 import { inject, injectable } from 'inversify';
 import * as os from 'os';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as portfinder from 'portfinder';
 import { promisify } from 'util';
 import * as uuid from 'uuid/v4';

--- a/src/kernels/raw/launcher/kernelProcess.node.ts
+++ b/src/kernels/raw/launcher/kernelProcess.node.ts
@@ -6,7 +6,7 @@ import { ChildProcess } from 'child_process';
 import { kill } from 'process';
 import * as fs from 'fs-extra';
 import * as os from 'os';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { CancellationError, CancellationToken, Event, EventEmitter } from 'vscode';
 import {
     connectionFilePlaceholder,

--- a/src/kernels/variables/debuggerVariables.node.ts
+++ b/src/kernels/variables/debuggerVariables.node.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import { inject, injectable, named } from 'inversify';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 
 import { DebugAdapterTracker, Disposable, Event, EventEmitter } from 'vscode';
 import { DebugProtocol } from 'vscode-debugprotocol';

--- a/src/kernels/variables/pythonVariableRequester.node.ts
+++ b/src/kernels/variables/pythonVariableRequester.node.ts
@@ -1,7 +1,7 @@
 import { IDisposable } from '@fluentui/react';
 import type * as nbformat from '@jupyterlab/nbformat';
 import { inject, injectable } from 'inversify';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { CancellationToken, NotebookDocument } from 'vscode';
 import { traceError } from '../../platform/logging';
 import { IFileSystem } from '../../platform/common/platform/types.node';

--- a/src/kernels/variables/variableScriptLoader.node.ts
+++ b/src/kernels/variables/variableScriptLoader.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { IFileSystem } from '../../platform/common/platform/types.node';
 import { EXTENSION_ROOT_DIR } from '../../platform/constants.node';
 import { IJupyterVariable } from './types';

--- a/src/notebooks/controllers/vscodeNotebookController.node.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { join } from 'path';
+import { join } from '../../platform/vscode-path/path';
 import {
     CancellationError,
     CancellationError as VscCancellationError,

--- a/src/notebooks/helpers.node.ts
+++ b/src/notebooks/helpers.node.ts
@@ -24,7 +24,7 @@ import { KernelMessage } from '@jupyterlab/services';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import cloneDeep = require('lodash/cloneDeep');
 import fastDeepEqual = require('fast-deep-equal');
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import { IVSCodeNotebook, IDocumentManager } from '../platform/common/application/types';
 import { PYTHON_LANGUAGE, MARKDOWN_LANGUAGE } from '../platform/common/constants';
 import { traceInfoIfCI, traceError, traceWarning } from '../platform/logging';

--- a/src/notebooks/outputs/plotSaveHandler.node.ts
+++ b/src/notebooks/outputs/plotSaveHandler.node.ts
@@ -1,6 +1,6 @@
 import { inject, injectable } from 'inversify';
 import { NotebookCellOutput, NotebookDocument, Uri } from 'vscode';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { IApplicationShell, IWorkspaceService } from '../../platform/common/application/types';
 import { traceError } from '../../platform/logging';
 import { getDisplayPath } from '../../platform/common/platform/fs-paths.node';

--- a/src/platform/common/application/applicationEnvironment.node.ts
+++ b/src/platform/common/application/applicationEnvironment.node.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { IPlatformService } from '../platform/types';
 import { IExtensionContext, IPathUtils } from '../types';
 import { OSType } from '../utils/platform';

--- a/src/platform/common/application/extensions.node.ts
+++ b/src/platform/common/application/extensions.node.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { Event, Extension, extensions, Uri } from 'vscode';
 import { IExtensions } from '../types';
 import { DataScience } from '../utils/localize';

--- a/src/platform/common/application/workspace.ts
+++ b/src/platform/common/application/workspace.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { injectable } from 'inversify';
-import * as path from 'path-browserify';
+import * as path from '../../vscode-path/path';
 import {
     CancellationToken,
     ConfigurationChangeEvent,

--- a/src/platform/common/constants.node.ts
+++ b/src/platform/common/constants.node.ts
@@ -1,5 +1,5 @@
 import { EXTENSION_ROOT_DIR } from '../constants.node';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 
 export * from './constants';
 

--- a/src/platform/common/platform/fileUtils.node.ts
+++ b/src/platform/common/platform/fileUtils.node.ts
@@ -3,7 +3,7 @@
 
 import { IDisposable } from '@fluentui/react';
 import * as fsapi from 'fs-extra';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as vscode from 'vscode';
 import { ShellOptions, ExecutionResult, IProcessServiceFactory, SpawnOptions } from '../process/types.node';
 import { IConfigurationService } from '../types';

--- a/src/platform/common/platform/fs-paths.node.ts
+++ b/src/platform/common/platform/fs-paths.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as nodepath from 'path';
+import * as path from '../../vscode-path/path';
 import { Uri, WorkspaceFolder } from 'vscode';
 import { getOSType, OSType } from '../utils/platform';
 import { IExecutables, IFileSystemPaths, IFileSystemPathUtils } from './types';
@@ -39,7 +39,7 @@ export class FileSystemPaths implements IFileSystemPaths {
         return new FileSystemPaths(
             isCaseInsensitive,
             // Use the actual node "path" module.
-            nodepath
+            path
         );
     }
 
@@ -82,7 +82,7 @@ export class Executables {
     public static withDefaults(): Executables {
         return new Executables(
             // Use node's value.
-            nodepath.delimiter,
+            path.delimiter,
             // Use the current OS.
             getOSType()
         );
@@ -125,7 +125,7 @@ export class FileSystemPathUtils implements IFileSystemPathUtils {
             paths,
             Executables.withDefaults(),
             // Use the actual node "path" module.
-            nodepath
+            path
         );
     }
 
@@ -179,14 +179,14 @@ function getDisplayPathImpl(filename?: string | Uri, cwd?: string): string {
     if (!file) {
         return '';
     } else if (cwd && file.startsWith(cwd)) {
-        const relativePath = `.${nodepath.sep}${nodepath.relative(cwd, file)}`;
+        const relativePath = `.${path.sep}${path.relative(cwd, file)}`;
         // On CI the relative path might not work as expected as when testing we might have windows paths
         // and the code is running on a unix machine.
         return relativePath === file || relativePath.includes(cwd)
-            ? `.${nodepath.sep}${file.substring(file.indexOf(cwd) + cwd.length)}`
+            ? `.${path.sep}${file.substring(file.indexOf(cwd) + cwd.length)}`
             : relativePath;
     } else if (file.startsWith(homePath)) {
-        return `~${nodepath.sep}${nodepath.relative(homePath, file)}`;
+        return `~${path.sep}${path.relative(homePath, file)}`;
     } else {
         return file;
     }

--- a/src/platform/common/platform/fs-paths.ts
+++ b/src/platform/common/platform/fs-paths.ts
@@ -1,5 +1,5 @@
 import { Uri, WorkspaceFolder } from 'vscode';
-import * as path from 'path-browserify';
+import * as path from '../../vscode-path/path';
 
 export function getDisplayPath(
     filename?: string | Uri,

--- a/src/platform/common/platform/pathUtils.node.ts
+++ b/src/platform/common/platform/pathUtils.node.ts
@@ -3,7 +3,7 @@
 // See https://github.com/microsoft/vscode-python/issues/8542.
 
 import { inject, injectable } from 'inversify';
-import * as path from 'path';
+import * as path from '../../vscode-path/path';
 import { IPathUtils, IsWindows } from '../types';
 import { OSType } from '../utils/platform';
 import { Executables, FileSystemPaths, FileSystemPathUtils, homePath } from './fs-paths.node';

--- a/src/platform/common/process/condaService.node.ts
+++ b/src/platform/common/process/condaService.node.ts
@@ -10,7 +10,7 @@ import { traceDecoratorVerbose, traceError, traceVerbose } from '../../logging';
 import { IPlatformService } from '../platform/types';
 import { GLOBAL_MEMENTO, IDisposable, IDisposableRegistry, IMemento } from '../types';
 import { createDeferredFromPromise } from '../utils/async';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { swallowExceptions } from '../utils/decorators';
 import { IFileSystem } from '../platform/types.node';
 import { homePath } from '../platform/fs-paths.node';

--- a/src/platform/common/process/internal/scripts/index.node.ts
+++ b/src/platform/common/process/internal/scripts/index.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as path from 'path';
+import * as path from '../../../../vscode-path/path';
 import { EXTENSION_ROOT_DIR } from '../../../../constants.node';
 
 // It is simpler to hard-code it instead of using vscode.ExtensionContext.extensionPath.

--- a/src/platform/common/process/internal/scripts/testing_tools.node.ts
+++ b/src/platform/common/process/internal/scripts/testing_tools.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as path from 'path';
+import * as path from '../../../../vscode-path/path';
 import { _SCRIPTS_DIR } from './index.node';
 
 const SCRIPTS_DIR = path.join(_SCRIPTS_DIR, 'testing_tools');

--- a/src/platform/common/process/internal/scripts/vscode_datascience_helpers.node.ts
+++ b/src/platform/common/process/internal/scripts/vscode_datascience_helpers.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as path from 'path';
+import * as path from '../../../../vscode-path/path';
 import { _SCRIPTS_DIR } from './index.node';
 
 const SCRIPTS_DIR = path.join(_SCRIPTS_DIR, 'vscode_datascience_helpers');

--- a/src/platform/common/process/pythonDaemonFactory.node.ts
+++ b/src/platform/common/process/pythonDaemonFactory.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ChildProcess } from 'child_process';
-import * as path from 'path';
+import * as path from '../../vscode-path/path';
 import {
     createMessageConnection,
     MessageConnection,

--- a/src/platform/common/utils.node.ts
+++ b/src/platform/common/utils.node.ts
@@ -4,7 +4,7 @@
 
 import type * as nbformat from '@jupyterlab/nbformat';
 import * as os from 'os';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import * as fsExtra from 'fs-extra';
 import { SemVer, parse } from 'semver';
 import untildify = require('untildify');

--- a/src/platform/common/utils/icons.node.ts
+++ b/src/platform/common/utils/icons.node.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import * as path from 'path';
+import * as path from '../../vscode-path/path';
 import { Uri } from 'vscode';
 import { EXTENSION_ROOT_DIR } from '../../constants.node';
 

--- a/src/platform/common/variables/environment.node.ts
+++ b/src/platform/common/variables/environment.node.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import * as path from 'path';
+import * as path from '../../vscode-path/path';
 import { sendTelemetryEvent } from '../../../telemetry';
 import { EventName } from '../../../telemetry/constants';
 import { traceError } from '../../logging';

--- a/src/platform/common/variables/environmentVariablesProvider.node.ts
+++ b/src/platform/common/variables/environmentVariablesProvider.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { inject, injectable, optional } from 'inversify';
-import * as path from 'path';
+import * as path from '../../vscode-path/path';
 import { ConfigurationChangeEvent, Disposable, Event, EventEmitter, FileSystemWatcher, Uri } from 'vscode';
 import { TraceOptions } from '../../logging/types';
 import { sendFileCreationTelemetry } from '../../../telemetry/envFileTelemetry.node';

--- a/src/platform/common/variables/systemVariables.node.ts
+++ b/src/platform/common/variables/systemVariables.node.ts
@@ -4,7 +4,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 'use strict';
-import * as Path from 'path';
+import * as path from '../../vscode-path/path';
 import { Uri, Range } from 'vscode';
 import { IWorkspaceService, IDocumentManager } from '../application/types';
 import { AbstractSystemVariables } from './systemVariables';
@@ -26,7 +26,7 @@ export class SystemVariables extends AbstractSystemVariables {
         super();
         const workspaceFolder = workspace && file ? workspace.getWorkspaceFolder(file) : undefined;
         this._workspaceFolder = workspaceFolder ? workspaceFolder.uri.fsPath : rootFolder || __dirname;
-        this._workspaceFolderName = Path.basename(this._workspaceFolder);
+        this._workspaceFolderName = path.basename(this._workspaceFolder);
         this._filePath = file ? file.fsPath : undefined;
         if (documentManager && documentManager.activeTextEditor) {
             this._lineNumber = documentManager.activeTextEditor.selection.anchor.line + 1;
@@ -70,27 +70,27 @@ export class SystemVariables extends AbstractSystemVariables {
     }
 
     public get relativeFile(): string | undefined {
-        return this.file ? Path.relative(this._workspaceFolder, this.file) : undefined;
+        return this.file ? path.relative(this._workspaceFolder, this.file) : undefined;
     }
 
     public get relativeFileDirname(): string | undefined {
-        return this.relativeFile ? Path.dirname(this.relativeFile) : undefined;
+        return this.relativeFile ? path.dirname(this.relativeFile) : undefined;
     }
 
     public get fileBasename(): string | undefined {
-        return this.file ? Path.basename(this.file) : undefined;
+        return this.file ? path.basename(this.file) : undefined;
     }
 
     public get fileBasenameNoExtension(): string | undefined {
-        return this.file ? Path.parse(this.file).name : undefined;
+        return this.file ? path.parse(this.file).name : undefined;
     }
 
     public get fileDirname(): string | undefined {
-        return this.file ? Path.dirname(this.file) : undefined;
+        return this.file ? path.dirname(this.file) : undefined;
     }
 
     public get fileExtname(): string | undefined {
-        return this.file ? Path.extname(this.file) : undefined;
+        return this.file ? path.extname(this.file) : undefined;
     }
 
     public get lineNumber(): number | undefined {

--- a/src/platform/constants.node.ts
+++ b/src/platform/constants.node.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import * as path from 'path';
+import * as path from './vscode-path/path';
 
 const webpacked = !path.basename(__dirname).includes('platform');
 

--- a/src/platform/debugger/jupyter/debugControllers.node.ts
+++ b/src/platform/debugger/jupyter/debugControllers.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { DebugProtocolMessage, NotebookCell } from 'vscode';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { parseForComments } from '../../../webviews/webview-side/common';

--- a/src/platform/debugger/jupyter/debuggingManager.node.ts
+++ b/src/platform/debugger/jupyter/debuggingManager.node.ts
@@ -17,7 +17,7 @@ import {
     EventEmitter,
     NotebookEditor
 } from 'vscode';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { IKernel, IKernelProvider } from '../../../kernels/types';
 import { IConfigurationService, IDisposable } from '../../common/types';
 import { KernelDebugAdapter } from './kernelDebugAdapter.node';

--- a/src/platform/debugger/jupyter/kernelDebugAdapter.node.ts
+++ b/src/platform/debugger/jupyter/kernelDebugAdapter.node.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { KernelMessage } from '@jupyterlab/services';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import {
     debug,
     DebugAdapter,

--- a/src/platform/export/exportBase.node.ts
+++ b/src/platform/export/exportBase.node.ts
@@ -1,5 +1,5 @@
 import { inject, injectable } from 'inversify';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { CancellationToken, Uri } from 'vscode';
 import { INotebookImporter } from '../../kernels/jupyter/types';
 import { IJupyterSubCommandExecutionService } from '../../kernels/jupyter/types.node';

--- a/src/platform/export/exportDialog.node.ts
+++ b/src/platform/export/exportDialog.node.ts
@@ -1,5 +1,5 @@
 import { inject, injectable } from 'inversify';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { SaveDialogOptions, Uri } from 'vscode';
 import { computeWorkingDirectory } from '../../kernels/jupyter/jupyterUtils.node';
 import { IApplicationShell, IWorkspaceService } from '../common/application/types';

--- a/src/platform/export/exportUtil.node.ts
+++ b/src/platform/export/exportUtil.node.ts
@@ -1,7 +1,7 @@
 import type * as nbformat from '@jupyterlab/nbformat';
 import { inject, injectable } from 'inversify';
 import * as os from 'os';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import * as uuid from 'uuid/v4';
 import { Uri } from 'vscode';
 import { TemporaryDirectory } from '../common/platform/types';

--- a/src/platform/export/fileConverter.node.ts
+++ b/src/platform/export/fileConverter.node.ts
@@ -1,5 +1,5 @@
 import { inject, injectable, named } from 'inversify';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { CancellationToken, NotebookCellData, NotebookData, NotebookDocument, Uri, workspace } from 'vscode';
 import { IApplicationShell } from '../common/application/types';
 import { traceError } from '../logging';

--- a/src/platform/logging/gitHubIssueCommandListener.node.ts
+++ b/src/platform/logging/gitHubIssueCommandListener.node.ts
@@ -1,5 +1,5 @@
 import { inject, injectable } from 'inversify';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import {
     Diagnostic,
     DiagnosticCollection,

--- a/src/platform/vscode-path/path.ts
+++ b/src/platform/vscode-path/path.ts
@@ -1,0 +1,1497 @@
+/* eslint-disable local-rules/dont-use-process */
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// NOTE: VSCode's copy of nodejs path library to be usable in common (non-node) namespace
+// Copied from: https://github.com/nodejs/node/blob/v14.16.0/lib/path.js
+
+/**
+ * Copyright Joyent, Inc. and other Node contributors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import * as process from './process';
+
+const CHAR_UPPERCASE_A = 65; /* A */
+const CHAR_LOWERCASE_A = 97; /* a */
+const CHAR_UPPERCASE_Z = 90; /* Z */
+const CHAR_LOWERCASE_Z = 122; /* z */
+const CHAR_DOT = 46; /* . */
+const CHAR_FORWARD_SLASH = 47; /* / */
+const CHAR_BACKWARD_SLASH = 92; /* \ */
+const CHAR_COLON = 58; /* : */
+const CHAR_QUESTION_MARK = 63; /* ? */
+
+class ErrorInvalidArgType extends Error {
+    code: 'ERR_INVALID_ARG_TYPE';
+    constructor(name: string, expected: string, actual: unknown) {
+        // determiner: 'must be' or 'must not be'
+        let determiner;
+        if (typeof expected === 'string' && expected.indexOf('not ') === 0) {
+            determiner = 'must not be';
+            expected = expected.replace(/^not /, '');
+        } else {
+            determiner = 'must be';
+        }
+
+        const type = name.indexOf('.') !== -1 ? 'property' : 'argument';
+        let msg = `The "${name}" ${type} ${determiner} of type ${expected}`;
+
+        msg += `. Received type ${typeof actual}`;
+        super(msg);
+
+        this.code = 'ERR_INVALID_ARG_TYPE';
+    }
+}
+
+function validateString(value: string, name: string) {
+    if (typeof value !== 'string') {
+        throw new ErrorInvalidArgType(name, 'string', value);
+    }
+}
+
+function isPathSeparator(code: number | undefined) {
+    return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
+}
+
+function isPosixPathSeparator(code: number | undefined) {
+    return code === CHAR_FORWARD_SLASH;
+}
+
+function isWindowsDeviceRoot(code: number) {
+    return (
+        (code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z) || (code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z)
+    );
+}
+
+// Resolves . and .. elements in a path with directory names
+function normalizeString(
+    path: string,
+    allowAboveRoot: boolean,
+    separator: string,
+    isPathSeparator: (code?: number) => boolean
+) {
+    let res = '';
+    let lastSegmentLength = 0;
+    let lastSlash = -1;
+    let dots = 0;
+    let code = 0;
+    for (let i = 0; i <= path.length; ++i) {
+        if (i < path.length) {
+            code = path.charCodeAt(i);
+        } else if (isPathSeparator(code)) {
+            break;
+        } else {
+            code = CHAR_FORWARD_SLASH;
+        }
+
+        if (isPathSeparator(code)) {
+            if (lastSlash === i - 1 || dots === 1) {
+                // NOOP
+            } else if (dots === 2) {
+                if (
+                    res.length < 2 ||
+                    lastSegmentLength !== 2 ||
+                    res.charCodeAt(res.length - 1) !== CHAR_DOT ||
+                    res.charCodeAt(res.length - 2) !== CHAR_DOT
+                ) {
+                    if (res.length > 2) {
+                        const lastSlashIndex = res.lastIndexOf(separator);
+                        if (lastSlashIndex === -1) {
+                            res = '';
+                            lastSegmentLength = 0;
+                        } else {
+                            res = res.slice(0, lastSlashIndex);
+                            lastSegmentLength = res.length - 1 - res.lastIndexOf(separator);
+                        }
+                        lastSlash = i;
+                        dots = 0;
+                        continue;
+                    } else if (res.length !== 0) {
+                        res = '';
+                        lastSegmentLength = 0;
+                        lastSlash = i;
+                        dots = 0;
+                        continue;
+                    }
+                }
+                if (allowAboveRoot) {
+                    res += res.length > 0 ? `${separator}..` : '..';
+                    lastSegmentLength = 2;
+                }
+            } else {
+                if (res.length > 0) {
+                    res += `${separator}${path.slice(lastSlash + 1, i)}`;
+                } else {
+                    res = path.slice(lastSlash + 1, i);
+                }
+                lastSegmentLength = i - lastSlash - 1;
+            }
+            lastSlash = i;
+            dots = 0;
+        } else if (code === CHAR_DOT && dots !== -1) {
+            ++dots;
+        } else {
+            dots = -1;
+        }
+    }
+    return res;
+}
+
+function _format(sep: string, pathObject: ParsedPath) {
+    if (pathObject === null || typeof pathObject !== 'object') {
+        throw new ErrorInvalidArgType('pathObject', 'Object', pathObject);
+    }
+    const dir = pathObject.dir || pathObject.root;
+    const base = pathObject.base || `${pathObject.name || ''}${pathObject.ext || ''}`;
+    if (!dir) {
+        return base;
+    }
+    return dir === pathObject.root ? `${dir}${base}` : `${dir}${sep}${base}`;
+}
+
+export interface ParsedPath {
+    root: string;
+    dir: string;
+    base: string;
+    ext: string;
+    name: string;
+}
+
+export interface IPath {
+    normalize(path: string): string;
+    isAbsolute(path: string): boolean;
+    join(...paths: string[]): string;
+    resolve(...pathSegments: string[]): string;
+    relative(from: string, to: string): string;
+    dirname(path: string): string;
+    basename(path: string, ext?: string): string;
+    extname(path: string): string;
+    format(pathObject: ParsedPath): string;
+    parse(path: string): ParsedPath;
+    toNamespacedPath(path: string): string;
+    sep: '\\' | '/';
+    delimiter: string;
+    win32: IPath | null;
+    posix: IPath | null;
+}
+
+export const win32: IPath = {
+    // path.resolve([from ...], to)
+    resolve(...pathSegments: string[]): string {
+        let resolvedDevice = '';
+        let resolvedTail = '';
+        let resolvedAbsolute = false;
+
+        for (let i = pathSegments.length - 1; i >= -1; i--) {
+            let path;
+            if (i >= 0) {
+                path = pathSegments[i];
+                validateString(path, 'path');
+
+                // Skip empty entries
+                if (path.length === 0) {
+                    continue;
+                }
+            } else if (resolvedDevice.length === 0) {
+                path = process.cwd();
+            } else {
+                // Windows has the concept of drive-specific current working
+                // directories. If we've resolved a drive letter but not yet an
+                // absolute path, get cwd for that drive, or the process cwd if
+                // the drive cwd is not available. We're sure the device is not
+                // a UNC path at this points, because UNC paths are always absolute.
+                path = process.env[`=${resolvedDevice}`] || process.cwd();
+
+                // Verify that a cwd was found and that it actually points
+                // to our drive. If not, default to the drive's root.
+                if (
+                    path === undefined ||
+                    (path.slice(0, 2).toLowerCase() !== resolvedDevice.toLowerCase() &&
+                        path.charCodeAt(2) === CHAR_BACKWARD_SLASH)
+                ) {
+                    path = `${resolvedDevice}\\`;
+                }
+            }
+
+            const len = path.length;
+            let rootEnd = 0;
+            let device = '';
+            let isAbsolute = false;
+            const code = path.charCodeAt(0);
+
+            // Try to match a root
+            if (len === 1) {
+                if (isPathSeparator(code)) {
+                    // `path` contains just a path separator
+                    rootEnd = 1;
+                    isAbsolute = true;
+                }
+            } else if (isPathSeparator(code)) {
+                // Possible UNC root
+
+                // If we started with a separator, we know we at least have an
+                // absolute path of some kind (UNC or otherwise)
+                isAbsolute = true;
+
+                if (isPathSeparator(path.charCodeAt(1))) {
+                    // Matched double path separator at beginning
+                    let j = 2;
+                    let last = j;
+                    // Match 1 or more non-path separators
+                    while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+                        j++;
+                    }
+                    if (j < len && j !== last) {
+                        const firstPart = path.slice(last, j);
+                        // Matched!
+                        last = j;
+                        // Match 1 or more path separators
+                        while (j < len && isPathSeparator(path.charCodeAt(j))) {
+                            j++;
+                        }
+                        if (j < len && j !== last) {
+                            // Matched!
+                            last = j;
+                            // Match 1 or more non-path separators
+                            while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+                                j++;
+                            }
+                            if (j === len || j !== last) {
+                                // We matched a UNC root
+                                device = `\\\\${firstPart}\\${path.slice(last, j)}`;
+                                rootEnd = j;
+                            }
+                        }
+                    }
+                } else {
+                    rootEnd = 1;
+                }
+            } else if (isWindowsDeviceRoot(code) && path.charCodeAt(1) === CHAR_COLON) {
+                // Possible device root
+                device = path.slice(0, 2);
+                rootEnd = 2;
+                if (len > 2 && isPathSeparator(path.charCodeAt(2))) {
+                    // Treat separator following drive name as an absolute path
+                    // indicator
+                    isAbsolute = true;
+                    rootEnd = 3;
+                }
+            }
+
+            if (device.length > 0) {
+                if (resolvedDevice.length > 0) {
+                    if (device.toLowerCase() !== resolvedDevice.toLowerCase()) {
+                        // This path points to another device so it is not applicable
+                        continue;
+                    }
+                } else {
+                    resolvedDevice = device;
+                }
+            }
+
+            if (resolvedAbsolute) {
+                if (resolvedDevice.length > 0) {
+                    break;
+                }
+            } else {
+                resolvedTail = `${path.slice(rootEnd)}\\${resolvedTail}`;
+                resolvedAbsolute = isAbsolute;
+                if (isAbsolute && resolvedDevice.length > 0) {
+                    break;
+                }
+            }
+        }
+
+        // At this point the path should be resolved to a full absolute path,
+        // but handle relative paths to be safe (might happen when process.cwd()
+        // fails)
+
+        // Normalize the tail path
+        resolvedTail = normalizeString(resolvedTail, !resolvedAbsolute, '\\', isPathSeparator);
+
+        return resolvedAbsolute ? `${resolvedDevice}\\${resolvedTail}` : `${resolvedDevice}${resolvedTail}` || '.';
+    },
+
+    normalize(path: string): string {
+        validateString(path, 'path');
+        const len = path.length;
+        if (len === 0) {
+            return '.';
+        }
+        let rootEnd = 0;
+        let device;
+        let isAbsolute = false;
+        const code = path.charCodeAt(0);
+
+        // Try to match a root
+        if (len === 1) {
+            // `path` contains just a single char, exit early to avoid
+            // unnecessary work
+            return isPosixPathSeparator(code) ? '\\' : path;
+        }
+        if (isPathSeparator(code)) {
+            // Possible UNC root
+
+            // If we started with a separator, we know we at least have an absolute
+            // path of some kind (UNC or otherwise)
+            isAbsolute = true;
+
+            if (isPathSeparator(path.charCodeAt(1))) {
+                // Matched double path separator at beginning
+                let j = 2;
+                let last = j;
+                // Match 1 or more non-path separators
+                while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+                    j++;
+                }
+                if (j < len && j !== last) {
+                    const firstPart = path.slice(last, j);
+                    // Matched!
+                    last = j;
+                    // Match 1 or more path separators
+                    while (j < len && isPathSeparator(path.charCodeAt(j))) {
+                        j++;
+                    }
+                    if (j < len && j !== last) {
+                        // Matched!
+                        last = j;
+                        // Match 1 or more non-path separators
+                        while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+                            j++;
+                        }
+                        if (j === len) {
+                            // We matched a UNC root only
+                            // Return the normalized version of the UNC root since there
+                            // is nothing left to process
+                            return `\\\\${firstPart}\\${path.slice(last)}\\`;
+                        }
+                        if (j !== last) {
+                            // We matched a UNC root with leftovers
+                            device = `\\\\${firstPart}\\${path.slice(last, j)}`;
+                            rootEnd = j;
+                        }
+                    }
+                }
+            } else {
+                rootEnd = 1;
+            }
+        } else if (isWindowsDeviceRoot(code) && path.charCodeAt(1) === CHAR_COLON) {
+            // Possible device root
+            device = path.slice(0, 2);
+            rootEnd = 2;
+            if (len > 2 && isPathSeparator(path.charCodeAt(2))) {
+                // Treat separator following drive name as an absolute path
+                // indicator
+                isAbsolute = true;
+                rootEnd = 3;
+            }
+        }
+
+        let tail = rootEnd < len ? normalizeString(path.slice(rootEnd), !isAbsolute, '\\', isPathSeparator) : '';
+        if (tail.length === 0 && !isAbsolute) {
+            tail = '.';
+        }
+        if (tail.length > 0 && isPathSeparator(path.charCodeAt(len - 1))) {
+            tail += '\\';
+        }
+        if (device === undefined) {
+            return isAbsolute ? `\\${tail}` : tail;
+        }
+        return isAbsolute ? `${device}\\${tail}` : `${device}${tail}`;
+    },
+
+    isAbsolute(path: string): boolean {
+        validateString(path, 'path');
+        const len = path.length;
+        if (len === 0) {
+            return false;
+        }
+
+        const code = path.charCodeAt(0);
+        return (
+            isPathSeparator(code) ||
+            // Possible device root
+            (len > 2 &&
+                isWindowsDeviceRoot(code) &&
+                path.charCodeAt(1) === CHAR_COLON &&
+                isPathSeparator(path.charCodeAt(2)))
+        );
+    },
+
+    join(...paths: string[]): string {
+        if (paths.length === 0) {
+            return '.';
+        }
+
+        let joined;
+        let firstPart: string | undefined;
+        for (let i = 0; i < paths.length; ++i) {
+            const arg = paths[i];
+            validateString(arg, 'path');
+            if (arg.length > 0) {
+                if (joined === undefined) {
+                    joined = firstPart = arg;
+                } else {
+                    joined += `\\${arg}`;
+                }
+            }
+        }
+
+        if (joined === undefined) {
+            return '.';
+        }
+
+        // Make sure that the joined path doesn't start with two slashes, because
+        // normalize() will mistake it for a UNC path then.
+        //
+        // This step is skipped when it is very clear that the user actually
+        // intended to point at a UNC path. This is assumed when the first
+        // non-empty string arguments starts with exactly two slashes followed by
+        // at least one more non-slash character.
+        //
+        // Note that for normalize() to treat a path as a UNC path it needs to
+        // have at least 2 components, so we don't filter for that here.
+        // This means that the user can use join to construct UNC paths from
+        // a server name and a share name; for example:
+        //   path.join('//server', 'share') -> '\\\\server\\share\\')
+        let needsReplace = true;
+        let slashCount = 0;
+        if (typeof firstPart === 'string' && isPathSeparator(firstPart.charCodeAt(0))) {
+            ++slashCount;
+            const firstLen = firstPart.length;
+            if (firstLen > 1 && isPathSeparator(firstPart.charCodeAt(1))) {
+                ++slashCount;
+                if (firstLen > 2) {
+                    if (isPathSeparator(firstPart.charCodeAt(2))) {
+                        ++slashCount;
+                    } else {
+                        // We matched a UNC path in the first part
+                        needsReplace = false;
+                    }
+                }
+            }
+        }
+        if (needsReplace) {
+            // Find any more consecutive slashes we need to replace
+            while (slashCount < joined.length && isPathSeparator(joined.charCodeAt(slashCount))) {
+                slashCount++;
+            }
+
+            // Replace the slashes if needed
+            if (slashCount >= 2) {
+                joined = `\\${joined.slice(slashCount)}`;
+            }
+        }
+
+        return win32.normalize(joined);
+    },
+
+    // It will solve the relative path from `from` to `to`, for instance:
+    //  from = 'C:\\orandea\\test\\aaa'
+    //  to = 'C:\\orandea\\impl\\bbb'
+    // The output of the function should be: '..\\..\\impl\\bbb'
+    relative(from: string, to: string): string {
+        validateString(from, 'from');
+        validateString(to, 'to');
+
+        if (from === to) {
+            return '';
+        }
+
+        const fromOrig = win32.resolve(from);
+        const toOrig = win32.resolve(to);
+
+        if (fromOrig === toOrig) {
+            return '';
+        }
+
+        from = fromOrig.toLowerCase();
+        to = toOrig.toLowerCase();
+
+        if (from === to) {
+            return '';
+        }
+
+        // Trim any leading backslashes
+        let fromStart = 0;
+        while (fromStart < from.length && from.charCodeAt(fromStart) === CHAR_BACKWARD_SLASH) {
+            fromStart++;
+        }
+        // Trim trailing backslashes (applicable to UNC paths only)
+        let fromEnd = from.length;
+        while (fromEnd - 1 > fromStart && from.charCodeAt(fromEnd - 1) === CHAR_BACKWARD_SLASH) {
+            fromEnd--;
+        }
+        const fromLen = fromEnd - fromStart;
+
+        // Trim any leading backslashes
+        let toStart = 0;
+        while (toStart < to.length && to.charCodeAt(toStart) === CHAR_BACKWARD_SLASH) {
+            toStart++;
+        }
+        // Trim trailing backslashes (applicable to UNC paths only)
+        let toEnd = to.length;
+        while (toEnd - 1 > toStart && to.charCodeAt(toEnd - 1) === CHAR_BACKWARD_SLASH) {
+            toEnd--;
+        }
+        const toLen = toEnd - toStart;
+
+        // Compare paths to find the longest common path from root
+        const length = fromLen < toLen ? fromLen : toLen;
+        let lastCommonSep = -1;
+        let i = 0;
+        for (; i < length; i++) {
+            const fromCode = from.charCodeAt(fromStart + i);
+            if (fromCode !== to.charCodeAt(toStart + i)) {
+                break;
+            } else if (fromCode === CHAR_BACKWARD_SLASH) {
+                lastCommonSep = i;
+            }
+        }
+
+        // We found a mismatch before the first common path separator was seen, so
+        // return the original `to`.
+        if (i !== length) {
+            if (lastCommonSep === -1) {
+                return toOrig;
+            }
+        } else {
+            if (toLen > length) {
+                if (to.charCodeAt(toStart + i) === CHAR_BACKWARD_SLASH) {
+                    // We get here if `from` is the exact base path for `to`.
+                    // For example: from='C:\\foo\\bar'; to='C:\\foo\\bar\\baz'
+                    return toOrig.slice(toStart + i + 1);
+                }
+                if (i === 2) {
+                    // We get here if `from` is the device root.
+                    // For example: from='C:\\'; to='C:\\foo'
+                    return toOrig.slice(toStart + i);
+                }
+            }
+            if (fromLen > length) {
+                if (from.charCodeAt(fromStart + i) === CHAR_BACKWARD_SLASH) {
+                    // We get here if `to` is the exact base path for `from`.
+                    // For example: from='C:\\foo\\bar'; to='C:\\foo'
+                    lastCommonSep = i;
+                } else if (i === 2) {
+                    // We get here if `to` is the device root.
+                    // For example: from='C:\\foo\\bar'; to='C:\\'
+                    lastCommonSep = 3;
+                }
+            }
+            if (lastCommonSep === -1) {
+                lastCommonSep = 0;
+            }
+        }
+
+        let out = '';
+        // Generate the relative path based on the path difference between `to` and
+        // `from`
+        for (i = fromStart + lastCommonSep + 1; i <= fromEnd; ++i) {
+            if (i === fromEnd || from.charCodeAt(i) === CHAR_BACKWARD_SLASH) {
+                out += out.length === 0 ? '..' : '\\..';
+            }
+        }
+
+        toStart += lastCommonSep;
+
+        // Lastly, append the rest of the destination (`to`) path that comes after
+        // the common path parts
+        if (out.length > 0) {
+            return `${out}${toOrig.slice(toStart, toEnd)}`;
+        }
+
+        if (toOrig.charCodeAt(toStart) === CHAR_BACKWARD_SLASH) {
+            ++toStart;
+        }
+
+        return toOrig.slice(toStart, toEnd);
+    },
+
+    toNamespacedPath(path: string): string {
+        // Note: this will *probably* throw somewhere.
+        if (typeof path !== 'string') {
+            return path;
+        }
+
+        if (path.length === 0) {
+            return '';
+        }
+
+        const resolvedPath = win32.resolve(path);
+
+        if (resolvedPath.length <= 2) {
+            return path;
+        }
+
+        if (resolvedPath.charCodeAt(0) === CHAR_BACKWARD_SLASH) {
+            // Possible UNC root
+            if (resolvedPath.charCodeAt(1) === CHAR_BACKWARD_SLASH) {
+                const code = resolvedPath.charCodeAt(2);
+                if (code !== CHAR_QUESTION_MARK && code !== CHAR_DOT) {
+                    // Matched non-long UNC root, convert the path to a long UNC path
+                    return `\\\\?\\UNC\\${resolvedPath.slice(2)}`;
+                }
+            }
+        } else if (
+            isWindowsDeviceRoot(resolvedPath.charCodeAt(0)) &&
+            resolvedPath.charCodeAt(1) === CHAR_COLON &&
+            resolvedPath.charCodeAt(2) === CHAR_BACKWARD_SLASH
+        ) {
+            // Matched device root, convert the path to a long UNC path
+            return `\\\\?\\${resolvedPath}`;
+        }
+
+        return path;
+    },
+
+    dirname(path: string): string {
+        validateString(path, 'path');
+        const len = path.length;
+        if (len === 0) {
+            return '.';
+        }
+        let rootEnd = -1;
+        let offset = 0;
+        const code = path.charCodeAt(0);
+
+        if (len === 1) {
+            // `path` contains just a path separator, exit early to avoid
+            // unnecessary work or a dot.
+            return isPathSeparator(code) ? path : '.';
+        }
+
+        // Try to match a root
+        if (isPathSeparator(code)) {
+            // Possible UNC root
+
+            rootEnd = offset = 1;
+
+            if (isPathSeparator(path.charCodeAt(1))) {
+                // Matched double path separator at beginning
+                let j = 2;
+                let last = j;
+                // Match 1 or more non-path separators
+                while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+                    j++;
+                }
+                if (j < len && j !== last) {
+                    // Matched!
+                    last = j;
+                    // Match 1 or more path separators
+                    while (j < len && isPathSeparator(path.charCodeAt(j))) {
+                        j++;
+                    }
+                    if (j < len && j !== last) {
+                        // Matched!
+                        last = j;
+                        // Match 1 or more non-path separators
+                        while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+                            j++;
+                        }
+                        if (j === len) {
+                            // We matched a UNC root only
+                            return path;
+                        }
+                        if (j !== last) {
+                            // We matched a UNC root with leftovers
+
+                            // Offset by 1 to include the separator after the UNC root to
+                            // treat it as a "normal root" on top of a (UNC) root
+                            rootEnd = offset = j + 1;
+                        }
+                    }
+                }
+            }
+            // Possible device root
+        } else if (isWindowsDeviceRoot(code) && path.charCodeAt(1) === CHAR_COLON) {
+            rootEnd = len > 2 && isPathSeparator(path.charCodeAt(2)) ? 3 : 2;
+            offset = rootEnd;
+        }
+
+        let end = -1;
+        let matchedSlash = true;
+        for (let i = len - 1; i >= offset; --i) {
+            if (isPathSeparator(path.charCodeAt(i))) {
+                if (!matchedSlash) {
+                    end = i;
+                    break;
+                }
+            } else {
+                // We saw the first non-path separator
+                matchedSlash = false;
+            }
+        }
+
+        if (end === -1) {
+            if (rootEnd === -1) {
+                return '.';
+            }
+
+            end = rootEnd;
+        }
+        return path.slice(0, end);
+    },
+
+    basename(path: string, ext?: string): string {
+        if (ext !== undefined) {
+            validateString(ext, 'ext');
+        }
+        validateString(path, 'path');
+        let start = 0;
+        let end = -1;
+        let matchedSlash = true;
+        let i;
+
+        // Check for a drive letter prefix so as not to mistake the following
+        // path separator as an extra separator at the end of the path that can be
+        // disregarded
+        if (path.length >= 2 && isWindowsDeviceRoot(path.charCodeAt(0)) && path.charCodeAt(1) === CHAR_COLON) {
+            start = 2;
+        }
+
+        if (ext !== undefined && ext.length > 0 && ext.length <= path.length) {
+            if (ext === path) {
+                return '';
+            }
+            let extIdx = ext.length - 1;
+            let firstNonSlashEnd = -1;
+            for (i = path.length - 1; i >= start; --i) {
+                const code = path.charCodeAt(i);
+                if (isPathSeparator(code)) {
+                    // If we reached a path separator that was not part of a set of path
+                    // separators at the end of the string, stop now
+                    if (!matchedSlash) {
+                        start = i + 1;
+                        break;
+                    }
+                } else {
+                    if (firstNonSlashEnd === -1) {
+                        // We saw the first non-path separator, remember this index in case
+                        // we need it if the extension ends up not matching
+                        matchedSlash = false;
+                        firstNonSlashEnd = i + 1;
+                    }
+                    if (extIdx >= 0) {
+                        // Try to match the explicit extension
+                        if (code === ext.charCodeAt(extIdx)) {
+                            if (--extIdx === -1) {
+                                // We matched the extension, so mark this as the end of our path
+                                // component
+                                end = i;
+                            }
+                        } else {
+                            // Extension does not match, so our result is the entire path
+                            // component
+                            extIdx = -1;
+                            end = firstNonSlashEnd;
+                        }
+                    }
+                }
+            }
+
+            if (start === end) {
+                end = firstNonSlashEnd;
+            } else if (end === -1) {
+                end = path.length;
+            }
+            return path.slice(start, end);
+        }
+        for (i = path.length - 1; i >= start; --i) {
+            if (isPathSeparator(path.charCodeAt(i))) {
+                // If we reached a path separator that was not part of a set of path
+                // separators at the end of the string, stop now
+                if (!matchedSlash) {
+                    start = i + 1;
+                    break;
+                }
+            } else if (end === -1) {
+                // We saw the first non-path separator, mark this as the end of our
+                // path component
+                matchedSlash = false;
+                end = i + 1;
+            }
+        }
+
+        if (end === -1) {
+            return '';
+        }
+        return path.slice(start, end);
+    },
+
+    extname(path: string): string {
+        validateString(path, 'path');
+        let start = 0;
+        let startDot = -1;
+        let startPart = 0;
+        let end = -1;
+        let matchedSlash = true;
+        // Track the state of characters (if any) we see before our first dot and
+        // after any path separator we find
+        let preDotState = 0;
+
+        // Check for a drive letter prefix so as not to mistake the following
+        // path separator as an extra separator at the end of the path that can be
+        // disregarded
+
+        if (path.length >= 2 && path.charCodeAt(1) === CHAR_COLON && isWindowsDeviceRoot(path.charCodeAt(0))) {
+            start = startPart = 2;
+        }
+
+        for (let i = path.length - 1; i >= start; --i) {
+            const code = path.charCodeAt(i);
+            if (isPathSeparator(code)) {
+                // If we reached a path separator that was not part of a set of path
+                // separators at the end of the string, stop now
+                if (!matchedSlash) {
+                    startPart = i + 1;
+                    break;
+                }
+                continue;
+            }
+            if (end === -1) {
+                // We saw the first non-path separator, mark this as the end of our
+                // extension
+                matchedSlash = false;
+                end = i + 1;
+            }
+            if (code === CHAR_DOT) {
+                // If this is our first dot, mark it as the start of our extension
+                if (startDot === -1) {
+                    startDot = i;
+                } else if (preDotState !== 1) {
+                    preDotState = 1;
+                }
+            } else if (startDot !== -1) {
+                // We saw a non-dot and non-path separator before our dot, so we should
+                // have a good chance at having a non-empty extension
+                preDotState = -1;
+            }
+        }
+
+        if (
+            startDot === -1 ||
+            end === -1 ||
+            // We saw a non-dot character immediately before the dot
+            preDotState === 0 ||
+            // The (right-most) trimmed path component is exactly '..'
+            (preDotState === 1 && startDot === end - 1 && startDot === startPart + 1)
+        ) {
+            return '';
+        }
+        return path.slice(startDot, end);
+    },
+
+    format: _format.bind(null, '\\'),
+
+    parse(path) {
+        validateString(path, 'path');
+
+        const ret = { root: '', dir: '', base: '', ext: '', name: '' };
+        if (path.length === 0) {
+            return ret;
+        }
+
+        const len = path.length;
+        let rootEnd = 0;
+        let code = path.charCodeAt(0);
+
+        if (len === 1) {
+            if (isPathSeparator(code)) {
+                // `path` contains just a path separator, exit early to avoid
+                // unnecessary work
+                ret.root = ret.dir = path;
+                return ret;
+            }
+            ret.base = ret.name = path;
+            return ret;
+        }
+        // Try to match a root
+        if (isPathSeparator(code)) {
+            // Possible UNC root
+
+            rootEnd = 1;
+            if (isPathSeparator(path.charCodeAt(1))) {
+                // Matched double path separator at beginning
+                let j = 2;
+                let last = j;
+                // Match 1 or more non-path separators
+                while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+                    j++;
+                }
+                if (j < len && j !== last) {
+                    // Matched!
+                    last = j;
+                    // Match 1 or more path separators
+                    while (j < len && isPathSeparator(path.charCodeAt(j))) {
+                        j++;
+                    }
+                    if (j < len && j !== last) {
+                        // Matched!
+                        last = j;
+                        // Match 1 or more non-path separators
+                        while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+                            j++;
+                        }
+                        if (j === len) {
+                            // We matched a UNC root only
+                            rootEnd = j;
+                        } else if (j !== last) {
+                            // We matched a UNC root with leftovers
+                            rootEnd = j + 1;
+                        }
+                    }
+                }
+            }
+        } else if (isWindowsDeviceRoot(code) && path.charCodeAt(1) === CHAR_COLON) {
+            // Possible device root
+            if (len <= 2) {
+                // `path` contains just a drive root, exit early to avoid
+                // unnecessary work
+                ret.root = ret.dir = path;
+                return ret;
+            }
+            rootEnd = 2;
+            if (isPathSeparator(path.charCodeAt(2))) {
+                if (len === 3) {
+                    // `path` contains just a drive root, exit early to avoid
+                    // unnecessary work
+                    ret.root = ret.dir = path;
+                    return ret;
+                }
+                rootEnd = 3;
+            }
+        }
+        if (rootEnd > 0) {
+            ret.root = path.slice(0, rootEnd);
+        }
+
+        let startDot = -1;
+        let startPart = rootEnd;
+        let end = -1;
+        let matchedSlash = true;
+        let i = path.length - 1;
+
+        // Track the state of characters (if any) we see before our first dot and
+        // after any path separator we find
+        let preDotState = 0;
+
+        // Get non-dir info
+        for (; i >= rootEnd; --i) {
+            code = path.charCodeAt(i);
+            if (isPathSeparator(code)) {
+                // If we reached a path separator that was not part of a set of path
+                // separators at the end of the string, stop now
+                if (!matchedSlash) {
+                    startPart = i + 1;
+                    break;
+                }
+                continue;
+            }
+            if (end === -1) {
+                // We saw the first non-path separator, mark this as the end of our
+                // extension
+                matchedSlash = false;
+                end = i + 1;
+            }
+            if (code === CHAR_DOT) {
+                // If this is our first dot, mark it as the start of our extension
+                if (startDot === -1) {
+                    startDot = i;
+                } else if (preDotState !== 1) {
+                    preDotState = 1;
+                }
+            } else if (startDot !== -1) {
+                // We saw a non-dot and non-path separator before our dot, so we should
+                // have a good chance at having a non-empty extension
+                preDotState = -1;
+            }
+        }
+
+        if (end !== -1) {
+            if (
+                startDot === -1 ||
+                // We saw a non-dot character immediately before the dot
+                preDotState === 0 ||
+                // The (right-most) trimmed path component is exactly '..'
+                (preDotState === 1 && startDot === end - 1 && startDot === startPart + 1)
+            ) {
+                ret.base = ret.name = path.slice(startPart, end);
+            } else {
+                ret.name = path.slice(startPart, startDot);
+                ret.base = path.slice(startPart, end);
+                ret.ext = path.slice(startDot, end);
+            }
+        }
+
+        // If the directory is the root, use the entire root as the `dir` including
+        // the trailing slash if any (`C:\abc` -> `C:\`). Otherwise, strip out the
+        // trailing slash (`C:\abc\def` -> `C:\abc`).
+        if (startPart > 0 && startPart !== rootEnd) {
+            ret.dir = path.slice(0, startPart - 1);
+        } else {
+            ret.dir = ret.root;
+        }
+
+        return ret;
+    },
+
+    sep: '\\',
+    delimiter: ';',
+    win32: null,
+    posix: null
+};
+
+export const posix: IPath = {
+    // path.resolve([from ...], to)
+    resolve(...pathSegments: string[]): string {
+        let resolvedPath = '';
+        let resolvedAbsolute = false;
+
+        for (let i = pathSegments.length - 1; i >= -1 && !resolvedAbsolute; i--) {
+            const path = i >= 0 ? pathSegments[i] : process.cwd();
+
+            validateString(path, 'path');
+
+            // Skip empty entries
+            if (path.length === 0) {
+                continue;
+            }
+
+            resolvedPath = `${path}/${resolvedPath}`;
+            resolvedAbsolute = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
+        }
+
+        // At this point the path should be resolved to a full absolute path, but
+        // handle relative paths to be safe (might happen when process.cwd() fails)
+
+        // Normalize the path
+        resolvedPath = normalizeString(resolvedPath, !resolvedAbsolute, '/', isPosixPathSeparator);
+
+        if (resolvedAbsolute) {
+            return `/${resolvedPath}`;
+        }
+        return resolvedPath.length > 0 ? resolvedPath : '.';
+    },
+
+    normalize(path: string): string {
+        validateString(path, 'path');
+
+        if (path.length === 0) {
+            return '.';
+        }
+
+        const isAbsolute = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
+        const trailingSeparator = path.charCodeAt(path.length - 1) === CHAR_FORWARD_SLASH;
+
+        // Normalize the path
+        path = normalizeString(path, !isAbsolute, '/', isPosixPathSeparator);
+
+        if (path.length === 0) {
+            if (isAbsolute) {
+                return '/';
+            }
+            return trailingSeparator ? './' : '.';
+        }
+        if (trailingSeparator) {
+            path += '/';
+        }
+
+        return isAbsolute ? `/${path}` : path;
+    },
+
+    isAbsolute(path: string): boolean {
+        validateString(path, 'path');
+        return path.length > 0 && path.charCodeAt(0) === CHAR_FORWARD_SLASH;
+    },
+
+    join(...paths: string[]): string {
+        if (paths.length === 0) {
+            return '.';
+        }
+        let joined;
+        for (let i = 0; i < paths.length; ++i) {
+            const arg = paths[i];
+            validateString(arg, 'path');
+            if (arg.length > 0) {
+                if (joined === undefined) {
+                    joined = arg;
+                } else {
+                    joined += `/${arg}`;
+                }
+            }
+        }
+        if (joined === undefined) {
+            return '.';
+        }
+        return posix.normalize(joined);
+    },
+
+    relative(from: string, to: string): string {
+        validateString(from, 'from');
+        validateString(to, 'to');
+
+        if (from === to) {
+            return '';
+        }
+
+        // Trim leading forward slashes.
+        from = posix.resolve(from);
+        to = posix.resolve(to);
+
+        if (from === to) {
+            return '';
+        }
+
+        const fromStart = 1;
+        const fromEnd = from.length;
+        const fromLen = fromEnd - fromStart;
+        const toStart = 1;
+        const toLen = to.length - toStart;
+
+        // Compare paths to find the longest common path from root
+        const length = fromLen < toLen ? fromLen : toLen;
+        let lastCommonSep = -1;
+        let i = 0;
+        for (; i < length; i++) {
+            const fromCode = from.charCodeAt(fromStart + i);
+            if (fromCode !== to.charCodeAt(toStart + i)) {
+                break;
+            } else if (fromCode === CHAR_FORWARD_SLASH) {
+                lastCommonSep = i;
+            }
+        }
+        if (i === length) {
+            if (toLen > length) {
+                if (to.charCodeAt(toStart + i) === CHAR_FORWARD_SLASH) {
+                    // We get here if `from` is the exact base path for `to`.
+                    // For example: from='/foo/bar'; to='/foo/bar/baz'
+                    return to.slice(toStart + i + 1);
+                }
+                if (i === 0) {
+                    // We get here if `from` is the root
+                    // For example: from='/'; to='/foo'
+                    return to.slice(toStart + i);
+                }
+            } else if (fromLen > length) {
+                if (from.charCodeAt(fromStart + i) === CHAR_FORWARD_SLASH) {
+                    // We get here if `to` is the exact base path for `from`.
+                    // For example: from='/foo/bar/baz'; to='/foo/bar'
+                    lastCommonSep = i;
+                } else if (i === 0) {
+                    // We get here if `to` is the root.
+                    // For example: from='/foo/bar'; to='/'
+                    lastCommonSep = 0;
+                }
+            }
+        }
+
+        let out = '';
+        // Generate the relative path based on the path difference between `to`
+        // and `from`.
+        for (i = fromStart + lastCommonSep + 1; i <= fromEnd; ++i) {
+            if (i === fromEnd || from.charCodeAt(i) === CHAR_FORWARD_SLASH) {
+                out += out.length === 0 ? '..' : '/..';
+            }
+        }
+
+        // Lastly, append the rest of the destination (`to`) path that comes after
+        // the common path parts.
+        return `${out}${to.slice(toStart + lastCommonSep)}`;
+    },
+
+    toNamespacedPath(path: string): string {
+        // Non-op on posix systems
+        return path;
+    },
+
+    dirname(path: string): string {
+        validateString(path, 'path');
+        if (path.length === 0) {
+            return '.';
+        }
+        const hasRoot = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
+        let end = -1;
+        let matchedSlash = true;
+        for (let i = path.length - 1; i >= 1; --i) {
+            if (path.charCodeAt(i) === CHAR_FORWARD_SLASH) {
+                if (!matchedSlash) {
+                    end = i;
+                    break;
+                }
+            } else {
+                // We saw the first non-path separator
+                matchedSlash = false;
+            }
+        }
+
+        if (end === -1) {
+            return hasRoot ? '/' : '.';
+        }
+        if (hasRoot && end === 1) {
+            return '//';
+        }
+        return path.slice(0, end);
+    },
+
+    basename(path: string, ext?: string): string {
+        if (ext !== undefined) {
+            validateString(ext, 'ext');
+        }
+        validateString(path, 'path');
+
+        let start = 0;
+        let end = -1;
+        let matchedSlash = true;
+        let i;
+
+        if (ext !== undefined && ext.length > 0 && ext.length <= path.length) {
+            if (ext === path) {
+                return '';
+            }
+            let extIdx = ext.length - 1;
+            let firstNonSlashEnd = -1;
+            for (i = path.length - 1; i >= 0; --i) {
+                const code = path.charCodeAt(i);
+                if (code === CHAR_FORWARD_SLASH) {
+                    // If we reached a path separator that was not part of a set of path
+                    // separators at the end of the string, stop now
+                    if (!matchedSlash) {
+                        start = i + 1;
+                        break;
+                    }
+                } else {
+                    if (firstNonSlashEnd === -1) {
+                        // We saw the first non-path separator, remember this index in case
+                        // we need it if the extension ends up not matching
+                        matchedSlash = false;
+                        firstNonSlashEnd = i + 1;
+                    }
+                    if (extIdx >= 0) {
+                        // Try to match the explicit extension
+                        if (code === ext.charCodeAt(extIdx)) {
+                            if (--extIdx === -1) {
+                                // We matched the extension, so mark this as the end of our path
+                                // component
+                                end = i;
+                            }
+                        } else {
+                            // Extension does not match, so our result is the entire path
+                            // component
+                            extIdx = -1;
+                            end = firstNonSlashEnd;
+                        }
+                    }
+                }
+            }
+
+            if (start === end) {
+                end = firstNonSlashEnd;
+            } else if (end === -1) {
+                end = path.length;
+            }
+            return path.slice(start, end);
+        }
+        for (i = path.length - 1; i >= 0; --i) {
+            if (path.charCodeAt(i) === CHAR_FORWARD_SLASH) {
+                // If we reached a path separator that was not part of a set of path
+                // separators at the end of the string, stop now
+                if (!matchedSlash) {
+                    start = i + 1;
+                    break;
+                }
+            } else if (end === -1) {
+                // We saw the first non-path separator, mark this as the end of our
+                // path component
+                matchedSlash = false;
+                end = i + 1;
+            }
+        }
+
+        if (end === -1) {
+            return '';
+        }
+        return path.slice(start, end);
+    },
+
+    extname(path: string): string {
+        validateString(path, 'path');
+        let startDot = -1;
+        let startPart = 0;
+        let end = -1;
+        let matchedSlash = true;
+        // Track the state of characters (if any) we see before our first dot and
+        // after any path separator we find
+        let preDotState = 0;
+        for (let i = path.length - 1; i >= 0; --i) {
+            const code = path.charCodeAt(i);
+            if (code === CHAR_FORWARD_SLASH) {
+                // If we reached a path separator that was not part of a set of path
+                // separators at the end of the string, stop now
+                if (!matchedSlash) {
+                    startPart = i + 1;
+                    break;
+                }
+                continue;
+            }
+            if (end === -1) {
+                // We saw the first non-path separator, mark this as the end of our
+                // extension
+                matchedSlash = false;
+                end = i + 1;
+            }
+            if (code === CHAR_DOT) {
+                // If this is our first dot, mark it as the start of our extension
+                if (startDot === -1) {
+                    startDot = i;
+                } else if (preDotState !== 1) {
+                    preDotState = 1;
+                }
+            } else if (startDot !== -1) {
+                // We saw a non-dot and non-path separator before our dot, so we should
+                // have a good chance at having a non-empty extension
+                preDotState = -1;
+            }
+        }
+
+        if (
+            startDot === -1 ||
+            end === -1 ||
+            // We saw a non-dot character immediately before the dot
+            preDotState === 0 ||
+            // The (right-most) trimmed path component is exactly '..'
+            (preDotState === 1 && startDot === end - 1 && startDot === startPart + 1)
+        ) {
+            return '';
+        }
+        return path.slice(startDot, end);
+    },
+
+    format: _format.bind(null, '/'),
+
+    parse(path: string): ParsedPath {
+        validateString(path, 'path');
+
+        const ret = { root: '', dir: '', base: '', ext: '', name: '' };
+        if (path.length === 0) {
+            return ret;
+        }
+        const isAbsolute = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
+        let start;
+        if (isAbsolute) {
+            ret.root = '/';
+            start = 1;
+        } else {
+            start = 0;
+        }
+        let startDot = -1;
+        let startPart = 0;
+        let end = -1;
+        let matchedSlash = true;
+        let i = path.length - 1;
+
+        // Track the state of characters (if any) we see before our first dot and
+        // after any path separator we find
+        let preDotState = 0;
+
+        // Get non-dir info
+        for (; i >= start; --i) {
+            const code = path.charCodeAt(i);
+            if (code === CHAR_FORWARD_SLASH) {
+                // If we reached a path separator that was not part of a set of path
+                // separators at the end of the string, stop now
+                if (!matchedSlash) {
+                    startPart = i + 1;
+                    break;
+                }
+                continue;
+            }
+            if (end === -1) {
+                // We saw the first non-path separator, mark this as the end of our
+                // extension
+                matchedSlash = false;
+                end = i + 1;
+            }
+            if (code === CHAR_DOT) {
+                // If this is our first dot, mark it as the start of our extension
+                if (startDot === -1) {
+                    startDot = i;
+                } else if (preDotState !== 1) {
+                    preDotState = 1;
+                }
+            } else if (startDot !== -1) {
+                // We saw a non-dot and non-path separator before our dot, so we should
+                // have a good chance at having a non-empty extension
+                preDotState = -1;
+            }
+        }
+
+        if (end !== -1) {
+            const start = startPart === 0 && isAbsolute ? 1 : startPart;
+            if (
+                startDot === -1 ||
+                // We saw a non-dot character immediately before the dot
+                preDotState === 0 ||
+                // The (right-most) trimmed path component is exactly '..'
+                (preDotState === 1 && startDot === end - 1 && startDot === startPart + 1)
+            ) {
+                ret.base = ret.name = path.slice(start, end);
+            } else {
+                ret.name = path.slice(start, startDot);
+                ret.base = path.slice(start, end);
+                ret.ext = path.slice(startDot, end);
+            }
+        }
+
+        if (startPart > 0) {
+            ret.dir = path.slice(0, startPart - 1);
+        } else if (isAbsolute) {
+            ret.dir = '/';
+        }
+
+        return ret;
+    },
+
+    sep: '/',
+    delimiter: ':',
+    win32: null,
+    posix: null
+};
+
+posix.win32 = win32.win32 = win32;
+posix.posix = win32.posix = posix;
+
+export const normalize = process.platform === 'win32' ? win32.normalize : posix.normalize;
+export const isAbsolute = process.platform === 'win32' ? win32.isAbsolute : posix.isAbsolute;
+export const join = process.platform === 'win32' ? win32.join : posix.join;
+export const resolve = process.platform === 'win32' ? win32.resolve : posix.resolve;
+export const relative = process.platform === 'win32' ? win32.relative : posix.relative;
+export const dirname = process.platform === 'win32' ? win32.dirname : posix.dirname;
+export const basename = process.platform === 'win32' ? win32.basename : posix.basename;
+export const extname = process.platform === 'win32' ? win32.extname : posix.extname;
+export const format = process.platform === 'win32' ? win32.format : posix.format;
+export const parse = process.platform === 'win32' ? win32.parse : posix.parse;
+export const toNamespacedPath = process.platform === 'win32' ? win32.toNamespacedPath : posix.toNamespacedPath;
+export const sep = process.platform === 'win32' ? win32.sep : posix.sep;
+export const delimiter = process.platform === 'win32' ? win32.delimiter : posix.delimiter;

--- a/src/platform/vscode-path/platform.ts
+++ b/src/platform/vscode-path/platform.ts
@@ -1,0 +1,272 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const LANGUAGE_DEFAULT = 'en';
+
+let _isWindows = false;
+let _isMacintosh = false;
+let _isLinux = false;
+let _isLinuxSnap = false;
+let _isNative = false;
+let _isWeb = false;
+let _isElectron = false;
+let _isIOS = false;
+let _isCI = false;
+let _locale: string | undefined = undefined;
+let _language: string = LANGUAGE_DEFAULT;
+let _translationsConfigFile: string | undefined = undefined;
+let _userAgent: string | undefined = undefined;
+
+interface NLSConfig {
+    locale: string;
+    availableLanguages: { [key: string]: string };
+    _translationsConfigFile: string;
+}
+
+export interface IProcessEnvironment {
+    [key: string]: string | undefined;
+}
+
+/**
+ * This interface is intentionally not identical to node.js
+ * process because it also works in sandboxed environments
+ * where the process object is implemented differently. We
+ * define the properties here that we need for `platform`
+ * to work and nothing else.
+ */
+export interface INodeProcess {
+    platform: string;
+    arch: string;
+    env: IProcessEnvironment;
+    versions?: {
+        electron?: string;
+    };
+    sandboxed?: boolean;
+    type?: string;
+    cwd: () => string;
+}
+
+declare const process: INodeProcess;
+declare const global: unknown;
+declare const self: unknown;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const globals: any = typeof self === 'object' ? self : typeof global === 'object' ? global : {};
+
+let nodeProcess: INodeProcess | undefined = undefined;
+if (typeof globals.vscode !== 'undefined' && typeof globals.vscode.process !== 'undefined') {
+    // Native environment (sandboxed)
+    nodeProcess = globals.vscode.process;
+} else if (typeof process !== 'undefined') {
+    // Native environment (non-sandboxed)
+    nodeProcess = process;
+}
+
+const isElectronProcess = typeof nodeProcess?.versions?.electron === 'string';
+const isElectronRenderer = isElectronProcess && nodeProcess?.type === 'renderer';
+export const isElectronSandboxed = isElectronRenderer && nodeProcess?.sandboxed;
+
+interface INavigator {
+    userAgent: string;
+    language: string;
+    maxTouchPoints?: number;
+}
+declare const navigator: INavigator;
+
+// Web environment
+if (typeof navigator === 'object' && !isElectronRenderer) {
+    _userAgent = navigator.userAgent;
+    _isWindows = _userAgent.indexOf('Windows') >= 0;
+    _isMacintosh = _userAgent.indexOf('Macintosh') >= 0;
+    _isIOS =
+        (_userAgent.indexOf('Macintosh') >= 0 ||
+            _userAgent.indexOf('iPad') >= 0 ||
+            _userAgent.indexOf('iPhone') >= 0) &&
+        !!navigator.maxTouchPoints &&
+        navigator.maxTouchPoints > 0;
+    _isLinux = _userAgent.indexOf('Linux') >= 0;
+    _isWeb = true;
+    _locale = navigator.language;
+    _language = _locale;
+}
+
+// Native environment
+else if (typeof nodeProcess === 'object') {
+    _isWindows = nodeProcess.platform === 'win32';
+    _isMacintosh = nodeProcess.platform === 'darwin';
+    _isLinux = nodeProcess.platform === 'linux';
+    _isLinuxSnap = _isLinux && !!nodeProcess.env['SNAP'] && !!nodeProcess.env['SNAP_REVISION'];
+    _isElectron = isElectronProcess;
+    _isCI = !!nodeProcess.env['CI'] || !!nodeProcess.env['BUILD_ARTIFACTSTAGINGDIRECTORY'];
+    _locale = LANGUAGE_DEFAULT;
+    _language = LANGUAGE_DEFAULT;
+    const rawNlsConfig = nodeProcess.env['VSCODE_NLS_CONFIG'];
+    if (rawNlsConfig) {
+        try {
+            const nlsConfig: NLSConfig = JSON.parse(rawNlsConfig);
+            const resolved = nlsConfig.availableLanguages['*'];
+            _locale = nlsConfig.locale;
+            // VSCode's default language is 'en'
+            _language = resolved ? resolved : LANGUAGE_DEFAULT;
+            _translationsConfigFile = nlsConfig._translationsConfigFile;
+        } catch (e) {}
+    }
+    _isNative = true;
+}
+
+// Unknown environment
+else {
+    console.error('Unable to resolve platform.');
+}
+
+export const enum Platform {
+    Web,
+    Mac,
+    Linux,
+    Windows
+}
+export function PlatformToString(platform: Platform) {
+    switch (platform) {
+        case Platform.Web:
+            return 'Web';
+        case Platform.Mac:
+            return 'Mac';
+        case Platform.Linux:
+            return 'Linux';
+        case Platform.Windows:
+            return 'Windows';
+    }
+}
+
+let _platform: Platform = Platform.Web;
+if (_isMacintosh) {
+    _platform = Platform.Mac;
+} else if (_isWindows) {
+    _platform = Platform.Windows;
+} else if (_isLinux) {
+    _platform = Platform.Linux;
+}
+
+export const isWindows = _isWindows;
+export const isMacintosh = _isMacintosh;
+export const isLinux = _isLinux;
+export const isLinuxSnap = _isLinuxSnap;
+export const isNative = _isNative;
+export const isElectron = _isElectron;
+export const isWeb = _isWeb;
+export const isWebWorker = _isWeb && typeof globals.importScripts === 'function';
+export const isIOS = _isIOS;
+/**
+ * Whether we run inside a CI environment, such as
+ * GH actions or Azure Pipelines.
+ */
+export const isCI = _isCI;
+export const platform = _platform;
+export const userAgent = _userAgent;
+
+/**
+ * The language used for the user interface. The format of
+ * the string is all lower case (e.g. zh-tw for Traditional
+ * Chinese)
+ */
+export const language = _language;
+
+export namespace Language {
+    export function value(): string {
+        return language;
+    }
+
+    export function isDefaultVariant(): boolean {
+        if (language.length === 2) {
+            return language === 'en';
+        } else if (language.length >= 3) {
+            return language[0] === 'e' && language[1] === 'n' && language[2] === '-';
+        } else {
+            return false;
+        }
+    }
+
+    export function isDefault(): boolean {
+        return language === 'en';
+    }
+}
+
+/**
+ * The OS locale or the locale specified by --locale. The format of
+ * the string is all lower case (e.g. zh-tw for Traditional
+ * Chinese). The UI is not necessarily shown in the provided locale.
+ */
+export const locale = _locale;
+
+/**
+ * The translations that are available through language packs.
+ */
+export const translationsConfigFile = _translationsConfigFile;
+
+/**
+ * See https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#:~:text=than%204%2C%20then-,set%20timeout%20to%204,-.
+ *
+ * Works similarly to `setTimeout(0)` but doesn't suffer from the 4ms artificial delay
+ * that browsers set when the nesting level is > 5.
+ */
+export const setTimeout0 = (() => {
+    if (typeof globals.postMessage === 'function' && !globals.importScripts) {
+        interface IQueueElement {
+            id: number;
+            callback: () => void;
+        }
+        let pending: IQueueElement[] = [];
+        globals.addEventListener('message', (e: MessageEvent) => {
+            if (e.data && e.data.vscodeScheduleAsyncWork) {
+                for (let i = 0, len = pending.length; i < len; i++) {
+                    const candidate = pending[i];
+                    if (candidate.id === e.data.vscodeScheduleAsyncWork) {
+                        pending.splice(i, 1);
+                        candidate.callback();
+                        return;
+                    }
+                }
+            }
+        });
+        let lastId = 0;
+        return (callback: () => void) => {
+            const myId = ++lastId;
+            pending.push({
+                id: myId,
+                callback: callback
+            });
+            globals.postMessage({ vscodeScheduleAsyncWork: myId }, '*');
+        };
+    }
+    return (callback: () => void) => setTimeout(callback);
+})();
+
+export const enum OperatingSystem {
+    Windows = 1,
+    Macintosh = 2,
+    Linux = 3
+}
+export const OS =
+    _isMacintosh || _isIOS ? OperatingSystem.Macintosh : _isWindows ? OperatingSystem.Windows : OperatingSystem.Linux;
+
+let _isLittleEndian = true;
+let _isLittleEndianComputed = false;
+export function isLittleEndian(): boolean {
+    if (!_isLittleEndianComputed) {
+        _isLittleEndianComputed = true;
+        const test = new Uint8Array(2);
+        test[0] = 1;
+        test[1] = 2;
+        const view = new Uint16Array(test.buffer);
+        _isLittleEndian = view[0] === (2 << 8) + 1;
+    }
+    return _isLittleEndian;
+}
+
+export const isChrome = !!(userAgent && userAgent.indexOf('Chrome') >= 0);
+export const isFirefox = !!(userAgent && userAgent.indexOf('Firefox') >= 0);
+export const isSafari = !!(!isChrome && userAgent && userAgent.indexOf('Safari') >= 0);
+export const isEdge = !!(userAgent && userAgent.indexOf('Edg/') >= 0);
+export const isAndroid = !!(userAgent && userAgent.indexOf('Android') >= 0);

--- a/src/platform/vscode-path/process.ts
+++ b/src/platform/vscode-path/process.ts
@@ -1,0 +1,97 @@
+/* eslint-disable local-rules/dont-use-process */
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { globals, INodeProcess, isMacintosh, isWindows } from './platform';
+
+let safeProcess: Omit<INodeProcess, 'arch'> & { arch: string | undefined };
+declare const process: INodeProcess;
+
+// Native sandbox environment
+if (typeof globals.vscode !== 'undefined' && typeof globals.vscode.process !== 'undefined') {
+    const sandboxProcess: INodeProcess = globals.vscode.process;
+    safeProcess = {
+        get platform() {
+            return sandboxProcess.platform;
+        },
+        get arch() {
+            return sandboxProcess.arch;
+        },
+        get env() {
+            return sandboxProcess.env;
+        },
+        cwd() {
+            return sandboxProcess.cwd();
+        }
+    };
+}
+
+// Native node.js environment
+else if (typeof process !== 'undefined') {
+    safeProcess = {
+        get platform() {
+            return process.platform;
+        },
+        get arch() {
+            return process.arch;
+        },
+        get env() {
+            return process.env;
+        },
+        cwd() {
+            return process.env['VSCODE_CWD'] || process.cwd();
+        }
+    };
+}
+
+// Web environment
+else {
+    safeProcess = {
+        // Supported
+        get platform() {
+            return isWindows ? 'win32' : isMacintosh ? 'darwin' : 'linux';
+        },
+        get arch() {
+            return undefined; /* arch is undefined in web */
+        },
+
+        // Unsupported
+        get env() {
+            return {};
+        },
+        cwd() {
+            return '/';
+        }
+    };
+}
+
+/**
+ * Provides safe access to the `cwd` property in node.js, sandboxed or web
+ * environments.
+ *
+ * Note: in web, this property is hardcoded to be `/`.
+ */
+export const cwd = safeProcess.cwd;
+
+/**
+ * Provides safe access to the `env` property in node.js, sandboxed or web
+ * environments.
+ *
+ * Note: in web, this property is hardcoded to be `{}`.
+ */
+export const env = safeProcess.env;
+
+/**
+ * Provides safe access to the `platform` property in node.js, sandboxed or web
+ * environments.
+ */
+export const platform = safeProcess.platform;
+
+/**
+ * Provides safe access to the `arch` method in node.js, sandboxed or web
+ * environments.
+ * Note: `arch` is `undefined` in web
+ */
+export const arch = safeProcess.arch;

--- a/src/platform/vscode-path/readme.md
+++ b/src/platform/vscode-path/readme.md
@@ -1,0 +1,4 @@
+This directory is directly copied from the vscode source here:
+https://github.com/microsoft/vscode/tree/main/src/vs/base/common
+
+The intent is to provide a 'path' implementation that works the same in web as node.

--- a/src/telemetry/extensionInstallTelemetry.node.ts
+++ b/src/telemetry/extensionInstallTelemetry.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import { setSharedProperty } from '.';
 import { IFileSystem } from '../platform/common/platform/types.node';
 import { EXTENSION_ROOT_DIR } from '../platform/constants.node';

--- a/src/telemetry/importTracker.node.ts
+++ b/src/telemetry/importTracker.node.ts
@@ -4,7 +4,7 @@
 
 import type * as nbformat from '@jupyterlab/nbformat';
 import { inject, injectable } from 'inversify';
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import { NotebookCellExecutionStateChangeEvent, NotebookCellKind, NotebookDocument, TextDocument } from 'vscode';
 import { captureTelemetry, sendTelemetryEvent } from '.';
 import { splitMultilineString } from '../webviews/webview-side/common';

--- a/src/test/analysisEngineTest.node.ts
+++ b/src/test/analysisEngineTest.node.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 /* eslint-disable no-console, @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 
 process.env.CODE_TESTS_WORKSPACE = path.join(__dirname, '..', '..', 'src', 'test');
 process.env.IS_CI_SERVER_TEST_DEBUGGER = '';

--- a/src/test/client/api.vscode.test.ts
+++ b/src/test/client/api.vscode.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { assert } from 'chai';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { traceInfo } from '../../platform/logging';
 import { IDisposable } from '../../platform/common/types';
 import {

--- a/src/test/common.node.ts
+++ b/src/test/common.node.ts
@@ -6,7 +6,7 @@
 
 import * as assert from 'assert';
 import * as fs from 'fs-extra';
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import * as uuid from 'uuid/v4';
 import { coerce, SemVer } from 'semver';
 import type { ConfigurationTarget, Event, TextDocument, Uri } from 'vscode';

--- a/src/test/common/crypto.unit.test.ts
+++ b/src/test/common/crypto.unit.test.ts
@@ -5,7 +5,7 @@
 
 import { assert, expect } from 'chai';
 import * as fs from 'fs-extra';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { CryptoUtils } from '../../platform/common/crypto.node';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants.node';
 

--- a/src/test/common/exitCIAfterTestReporter.ts
+++ b/src/test/common/exitCIAfterTestReporter.ts
@@ -10,7 +10,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any, no-console, @typescript-eslint/no-extraneous-class, import/no-default-export */
 import * as fs from 'fs-extra';
 import * as net from 'net';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants.node';
 import { noop } from '../core';
 

--- a/src/test/common/net/fileDownloader.unit.test.ts
+++ b/src/test/common/net/fileDownloader.unit.test.ts
@@ -8,7 +8,7 @@ import * as assert from 'assert';
 import { expect } from 'chai';
 import * as fsExtra from 'fs-extra';
 import * as nock from 'nock';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import rewiremock from 'rewiremock';
 import * as sinon from 'sinon';
 import { Readable } from 'stream';

--- a/src/test/common/platform/fs-paths.functional.test.ts
+++ b/src/test/common/platform/fs-paths.functional.test.ts
@@ -7,7 +7,7 @@
 
 import { expect } from 'chai';
 import * as os from 'os';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { Executables, FileSystemPaths, FileSystemPathUtils } from '../../../platform/common/platform/fs-paths.node';
 import { WINDOWS as IS_WINDOWS } from './utils';
 

--- a/src/test/common/platform/fs-paths.unit.test.ts
+++ b/src/test/common/platform/fs-paths.unit.test.ts
@@ -4,7 +4,7 @@
 /* eslint-disable  */
 
 import { expect } from 'chai';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as TypeMoq from 'typemoq';
 import { FileSystemPathUtils } from '../../../platform/common/platform/fs-paths.node';
 import { getNamesAndValues } from '../../utils/enum';

--- a/src/test/common/platform/utils.ts
+++ b/src/test/common/platform/utils.ts
@@ -6,7 +6,7 @@
 import { expect } from 'chai';
 import * as fsextra from 'fs-extra';
 import * as net from 'net';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as tmpMod from 'tmp';
 import { CleanupFixture } from '../../fixtures';
 

--- a/src/test/common/process/logger.unit.test.ts
+++ b/src/test/common/process/logger.unit.test.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { expect } from 'chai';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as TypeMoq from 'typemoq';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import untildify = require('untildify');

--- a/src/test/common/process/pythonDaemon.functional.test.ts
+++ b/src/test/common/process/pythonDaemon.functional.test.ts
@@ -9,7 +9,7 @@ import { ChildProcess, spawn, spawnSync } from 'child_process';
 import * as dedent from 'dedent';
 import * as fs from 'fs-extra';
 import * as os from 'os';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { instance, mock } from 'ts-mockito';
 import {
     createMessageConnection,

--- a/src/test/common/process/pythonDaemonPool.functional.test.ts
+++ b/src/test/common/process/pythonDaemonPool.functional.test.ts
@@ -10,7 +10,7 @@ import * as dedent from 'dedent';
 import { EventEmitter } from 'events';
 import * as fs from 'fs-extra';
 import * as os from 'os';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { Observable } from 'rxjs/Observable';
 import * as sinon from 'sinon';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';

--- a/src/test/common/utils/localize.functional.test.ts
+++ b/src/test/common/utils/localize.functional.test.ts
@@ -7,7 +7,7 @@
 
 import * as assert from 'assert';
 import * as fs from 'fs';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { EXTENSION_ROOT_DIR } from '../../../platform/constants.node';
 import * as localize from '../../../platform/common/utils/localize';
 

--- a/src/test/common/variables/envVarsService.unit.test.ts
+++ b/src/test/common/variables/envVarsService.unit.test.ts
@@ -7,7 +7,7 @@
 
 import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as TypeMoq from 'typemoq';
 import { IFileSystem } from '../../../platform/common/platform/types.node';
 import { EnvironmentVariablesService, parseEnvFile } from '../../../platform/common/variables/environment.node';

--- a/src/test/common/variables/envVarsService.vscode.test.ts
+++ b/src/test/common/variables/envVarsService.vscode.test.ts
@@ -7,7 +7,7 @@
 
 import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { FileSystem } from '../../../platform/common/platform/fileSystem.node';
 import { EnvironmentVariablesService } from '../../../platform/common/variables/environment.node';
 import { IEnvironmentVariablesService } from '../../../platform/common/variables/types';

--- a/src/test/common/variables/kernelEnvVarsService.unit.test.ts
+++ b/src/test/common/variables/kernelEnvVarsService.unit.test.ts
@@ -7,7 +7,7 @@
 
 import { assert, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { IFileSystem } from '../../../platform/common/platform/types.node';
 import { EnvironmentVariablesService } from '../../../platform/common/variables/environment.node';
 import { IEnvironmentVariablesProvider } from '../../../platform/common/variables/types';

--- a/src/test/constants.node.ts
+++ b/src/test/constants.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import { setCI, setTestExecution, setUnitTestExecution } from '../platform/common/constants';
 import { IS_CI_SERVER, IS_CI_SERVER_TEST_DEBUGGER } from './ciConstants.node';
 

--- a/src/test/coverage.node.ts
+++ b/src/test/coverage.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from './constants.node';
 
 /**

--- a/src/test/datascience/data-viewing/dataViewerDependencyService.unit.test.ts
+++ b/src/test/datascience/data-viewing/dataViewerDependencyService.unit.test.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { assert } from 'chai';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { SemVer } from 'semver';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { ApplicationShell } from '../../../platform/common/application/applicationShell';

--- a/src/test/datascience/dsTestSetup.ts
+++ b/src/test/datascience/dsTestSetup.ts
@@ -3,7 +3,7 @@
 
 import * as fs from 'fs-extra';
 import { applyEdits, ModificationOptions, modify } from 'jsonc-parser';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants.node';
 
 const settingsFile = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src/test/datascience/.vscode/settings.json');

--- a/src/test/datascience/editor-integration/gotocell.functional.test.ts
+++ b/src/test/datascience/editor-integration/gotocell.functional.test.ts
@@ -9,7 +9,7 @@ suite('Dummy12', () => {
 });
 // import { assert } from 'chai';
 // import { ChildProcess } from 'child_process';
-// import * as path from 'path';
+// import * as path from '../../platform/vscode-path/path';
 // import * as uuid from 'uuid/v4';
 // import { CodeLens, Disposable, Position, Range, TextDocument } from 'vscode';
 // import { CancellationToken } from 'vscode-jsonrpc';

--- a/src/test/datascience/editor-integration/hoverProvider.vscode.test.ts
+++ b/src/test/datascience/editor-integration/hoverProvider.vscode.test.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import { cloneDeep } from 'lodash';
 import * as sinon from 'sinon';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as vscode from 'vscode';
 import {
     IConfigurationService,

--- a/src/test/datascience/execution.unit.test.ts
+++ b/src/test/datascience/execution.unit.test.ts
@@ -4,7 +4,7 @@
 import { assert } from 'chai';
 import * as fs from 'fs-extra';
 import * as os from 'os';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { Observable } from 'rxjs/Observable';
 import { SemVer } from 'semver';
 import { anything, instance, match, mock, reset, when } from 'ts-mockito';

--- a/src/test/datascience/export/exportToHTML.vscode.test.ts
+++ b/src/test/datascience/export/exportToHTML.vscode.test.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, no-invalid-this, @typescript-eslint/no-explicit-any */
 import { assert } from 'chai';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { CancellationTokenSource, Uri } from 'vscode';
 import { IFileSystem } from '../../../platform/common/platform/types.node';
 import { ExportInterpreterFinder } from '../../../platform/export/exportInterpreterFinder.node';

--- a/src/test/datascience/export/exportToPython.vscode.test.ts
+++ b/src/test/datascience/export/exportToPython.vscode.test.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, no-invalid-this, @typescript-eslint/no-explicit-any */
 import { assert } from 'chai';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { CancellationTokenSource, Uri } from 'vscode';
 import { IDocumentManager } from '../../../platform/common/application/types';
 import { IFileSystem } from '../../../platform/common/platform/types.node';

--- a/src/test/datascience/export/exportUtil.vscode.test.ts
+++ b/src/test/datascience/export/exportUtil.vscode.test.ts
@@ -5,7 +5,7 @@
 import type * as nbformat from '@jupyterlab/nbformat';
 import { assert } from 'chai';
 import * as fs from 'fs-extra';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { Uri } from 'vscode';
 import { IDisposable } from '../../../platform/common/types';
 import { ExportUtil } from '../../../platform/export/exportUtil.node';

--- a/src/test/datascience/interpreters/environmentActivationService.vscode.test.ts
+++ b/src/test/datascience/interpreters/environmentActivationService.vscode.test.ts
@@ -15,7 +15,7 @@ import {
     EnvironmentActivationService,
     EnvironmentVariablesCacheInformation
 } from '../../../platform/common/process/environmentActivationService.node';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { IS_WINDOWS } from '../../../platform/common/platform/constants.node';
 import { IProcessServiceFactory } from '../../../platform/common/process/types.node';
 import { disposeAllDisposables } from '../../../platform/common/helpers.node';

--- a/src/test/datascience/ipywidgets/cdnWidgetScriptSourceProvider.unit.test.ts
+++ b/src/test/datascience/ipywidgets/cdnWidgetScriptSourceProvider.unit.test.ts
@@ -4,7 +4,7 @@ import { assert } from 'chai';
 import * as fs from 'fs-extra';
 import { sha256 } from 'hash.js';
 import * as nock from 'nock';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { Readable } from 'stream';
 import { anything, instance, mock, when } from 'ts-mockito';
 import { Uri } from 'vscode';

--- a/src/test/datascience/ipywidgets/localWidgetScriptSourceProvider.unit.test.ts
+++ b/src/test/datascience/ipywidgets/localWidgetScriptSourceProvider.unit.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { assert } from 'chai';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { Uri } from 'vscode';
 import { PYTHON_LANGUAGE } from '../../../platform/common/constants';

--- a/src/test/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.unit.test.ts
+++ b/src/test/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.unit.test.ts
@@ -5,7 +5,7 @@
 
 import { assert, expect, use } from 'chai';
 import * as chaiPromise from 'chai-as-promised';
-import * as path from 'path';
+import * as path from '../../../../platform/vscode-path/path';
 import * as fsExtra from 'fs-extra';
 import * as sinon from 'sinon';
 import { Subject } from 'rxjs/Subject';

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -18,7 +18,7 @@ import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { CancellationTokenSource, Uri } from 'vscode';
 
 import { traceInfo } from '../../../platform/logging';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { ReadWrite, Resource } from '../../../platform/common/types';
 import { createDeferred, Deferred } from '../../../platform/common/utils/async';
 import { DataScience } from '../../../platform/common/utils/localize';

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -4,7 +4,7 @@
 import { assert } from 'chai';
 import * as fs from 'fs-extra';
 import { EOL } from 'os';
-import * as path from 'path';
+import * as path from '../../../../platform/vscode-path/path';
 import * as sinon from 'sinon';
 import { commands, Memento, workspace, window, Uri, NotebookCell, NotebookDocument, NotebookCellKind } from 'vscode';
 import { IPythonApiProvider } from '../../../../platform/api/types';

--- a/src/test/datascience/jupyter/kernels/jupyterKernelService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/jupyterKernelService.unit.test.ts
@@ -12,7 +12,7 @@ import { IKernelDependencyService, LocalKernelConnectionMetadata } from '../../.
 import { IEnvironmentActivationService } from '../../../../platform/interpreter/activation/types';
 import { EnvironmentType } from '../../../../platform/pythonEnvironments/info';
 import { EXTENSION_ROOT_DIR } from '../../../../platform/constants.node';
-import * as path from 'path';
+import * as path from '../../../../platform/vscode-path/path';
 import { getOSType, OSType } from '../../../common.node';
 import { CancellationTokenSource } from 'vscode';
 import { EnvironmentVariablesService } from '../../../../platform/common/variables/environment.node';

--- a/src/test/datascience/jupyterServer.node.ts
+++ b/src/test/datascience/jupyterServer.node.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as getFreePort from 'get-port';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import * as tcpPortUsed from 'tcp-port-used';
 import { Uri } from 'vscode';
 import { disposeAllDisposables } from '../../platform/common/helpers.node';

--- a/src/test/datascience/kernel-launcher/kernelFinder.vscode.test.node.ts
+++ b/src/test/datascience/kernel-launcher/kernelFinder.vscode.test.node.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { assert } from 'chai';
 import { Uri, workspace } from 'vscode';
 import { PYTHON_LANGUAGE } from '../../../platform/common/constants';

--- a/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { assert } from 'chai';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as fsExtra from 'fs-extra';
 import * as sinon from 'sinon';
 import { anything, instance, mock, when, verify } from 'ts-mockito';

--- a/src/test/datascience/kernelProcess.unit.test.ts
+++ b/src/test/datascience/kernelProcess.unit.test.ts
@@ -5,7 +5,7 @@
 
 import * as os from 'os';
 import { assert } from 'chai';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import rewiremock from 'rewiremock';
 import { anything, instance, mock, when, verify, capture, deepEqual } from 'ts-mockito';
 import { KernelProcess } from '../../kernels/raw/launcher/kernelProcess.node';

--- a/src/test/datascience/mockDocumentManager.ts
+++ b/src/test/datascience/mockDocumentManager.ts
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import {
     DecorationRenderOptions,
     Event,

--- a/src/test/datascience/mockFileSystem.ts
+++ b/src/test/datascience/mockFileSystem.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import * as fsextra from 'fs-extra';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { FileStat, FileType, Uri } from 'vscode';
 import { FileSystem } from '../../platform/common/platform/fileSystem.node';
 import { convertStat } from '../../platform/common/platform/fileSystemUtils.node';

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -13,7 +13,7 @@ suite('Dummy9', () => {
 // import * as fs from 'fs-extra';
 // import { injectable } from 'inversify';
 // import * as os from 'os';
-// import * as path from 'path';
+// import * as path from '../../platform/vscode-path/path';
 // import { SemVer } from 'semver';
 // import { Readable, Writable } from 'stream';
 // import { anything, instance, mock, when } from 'ts-mockito';

--- a/src/test/datascience/notebook/executionService.vscode.test.ts
+++ b/src/test/datascience/notebook/executionService.vscode.test.ts
@@ -6,7 +6,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 import { assert, expect } from 'chai';
 import * as fs from 'fs';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as dedent from 'dedent';
 import * as sinon from 'sinon';
 import { commands, NotebookCell, NotebookCellExecutionState, NotebookCellKind, NotebookCellOutput, Uri } from 'vscode';

--- a/src/test/datascience/notebook/exportFull.vscode.test.ts
+++ b/src/test/datascience/notebook/exportFull.vscode.test.ts
@@ -6,7 +6,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 import { assert, expect } from 'chai';
 import * as os from 'os';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as sinon from 'sinon';
 import { Common } from '../../../platform/common/utils/localize';
 import { IVSCodeNotebook } from '../../../platform/common/application/types';

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -5,7 +5,7 @@
 
 import { assert, expect } from 'chai';
 import * as fs from 'fs-extra';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as sinon from 'sinon';
 import * as tmp from 'tmp';
 import {

--- a/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 import { assert } from 'chai';
-import * as path from 'path';
+import * as path from '../../../../platform/vscode-path/path';
 import * as sinon from 'sinon';
 import {
     CancellationToken,

--- a/src/test/datascience/notebook/intellisense/interpreterSwitch.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/interpreterSwitch.vscode.test.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 import { assert } from 'chai';
-import * as path from 'path';
+import * as path from '../../../../platform/vscode-path/path';
 import * as fs from 'fs-extra';
 import * as sinon from 'sinon';
 import { languages } from 'vscode';

--- a/src/test/datascience/notebook/ipywidget.vscode.test.ts
+++ b/src/test/datascience/notebook/ipywidget.vscode.test.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as sinon from 'sinon';
 import { assert } from 'chai';
 import { NotebookDocument, Uri, window } from 'vscode';

--- a/src/test/datascience/notebook/kernelCrashes.vscode.test.ts
+++ b/src/test/datascience/notebook/kernelCrashes.vscode.test.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as fs from 'fs-extra';
 import { assert } from 'chai';
 import * as sinon from 'sinon';

--- a/src/test/datascience/notebook/kernelSelection.vscode.test.ts
+++ b/src/test/datascience/notebook/kernelSelection.vscode.test.ts
@@ -3,7 +3,7 @@
 
 import { assert } from 'chai';
 import * as fs from 'fs-extra';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as sinon from 'sinon';
 import { commands, window } from 'vscode';
 import { IPythonExtensionChecker } from '../../../platform/api/types';

--- a/src/test/datascience/notebook/memory.vscode.test.ts
+++ b/src/test/datascience/notebook/memory.vscode.test.ts
@@ -7,7 +7,7 @@
 import { assert } from 'chai';
 import * as fs from 'fs-extra';
 import * as v8 from 'v8';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { IVSCodeNotebook } from '../../../platform/common/application/types';

--- a/src/test/datascience/notebook/nonPythonKernels.vscode.test.node.ts
+++ b/src/test/datascience/notebook/nonPythonKernels.vscode.test.node.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as sinon from 'sinon';
 import * as assert from 'assert';
 import { Uri } from 'vscode';

--- a/src/test/datascience/notebook/outputDisplayOrder.vscode.test.ts
+++ b/src/test/datascience/notebook/outputDisplayOrder.vscode.test.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { assert } from 'chai';
 import { traceInfo } from '../../../platform/logging';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../constants.node';

--- a/src/test/datascience/notebook/remoteNotebookEditor.vscode.test.ts
+++ b/src/test/datascience/notebook/remoteNotebookEditor.vscode.test.ts
@@ -6,7 +6,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 import { assert } from 'chai';
 import * as sinon from 'sinon';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { commands, Memento, Uri } from 'vscode';
 import { IEncryptedStorage, IVSCodeNotebook } from '../../../platform/common/application/types';
 import { traceInfo, traceInfoIfCI } from '../../../platform/logging';

--- a/src/test/datascience/notebook/saving.vscode.test.ts
+++ b/src/test/datascience/notebook/saving.vscode.test.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 import { assert, expect } from 'chai';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as sinon from 'sinon';
 import { NotebookCell, Uri } from 'vscode';
 import { IVSCodeNotebook } from '../../../platform/common/application/types';

--- a/src/test/datascience/notebook/thirdPartyKernels.vscode.test.ts
+++ b/src/test/datascience/notebook/thirdPartyKernels.vscode.test.ts
@@ -4,7 +4,7 @@
 // import type * as nbformat from '@jupyterlab/nbformat';
 // import { assert } from 'chai';
 // import * as fs from 'fs-extra';
-// import * as path from 'path';
+// import * as path from '../../platform/vscode-path/path';
 // import * as sinon from 'sinon';
 // import { commands, notebook, NotebookController, workspace, WorkspaceEdit } from 'vscode';
 // import { boolean } from 'yargs';

--- a/src/test/datascience/widgets/ipywidget.ui.functional.test.ts
+++ b/src/test/datascience/widgets/ipywidget.ui.functional.test.ts
@@ -14,7 +14,7 @@ suite('Dummy14', () => {
 // import * as chaiAsPromised from 'chai-as-promised';
 // import * as fs from 'fs-extra';
 // import * as os from 'os';
-// import * as path from 'path';
+// import * as path from '../../platform/vscode-path/path';
 // import * as sinon from 'sinon';
 // import { Disposable } from 'vscode';
 // import { traceInfo } from '../../../platform/common/logger.node';

--- a/src/test/datascience/widgets/standard.vscode.test.ts
+++ b/src/test/datascience/widgets/standard.vscode.test.ts
@@ -5,7 +5,7 @@
 
 import { assert } from 'chai';
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as sinon from 'sinon';
 import { commands, NotebookCell, Uri } from 'vscode';
 import { IVSCodeNotebook } from '../../../platform/common/application/types';

--- a/src/test/debuggerTest.node.ts
+++ b/src/test/debuggerTest.node.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable no-console */
 
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import { runTests } from '@vscode/test-electron';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from './constants.node';
 

--- a/src/test/extension-version.functional.test.ts
+++ b/src/test/extension-version.functional.test.ts
@@ -8,7 +8,7 @@
 import { expect } from 'chai';
 import * as fs from 'fs';
 import * as glob from 'glob';
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import { EXTENSION_ROOT_DIR } from '../platform/constants.node';
 
 suite('Extension localization files', () => {

--- a/src/test/extension.serviceRegistry.vscode.test.ts
+++ b/src/test/extension.serviceRegistry.vscode.test.ts
@@ -12,7 +12,7 @@ import { captureScreenShot, IExtensionTestApi } from './common.node';
 import * as ts from 'typescript';
 import * as fs from 'fs-extra';
 import * as glob from 'glob';
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 
 import { initialize } from './initialize.node';
 import { interfaces } from 'inversify/lib/interfaces/interfaces';

--- a/src/test/format/extension.format.vscode.test.ts
+++ b/src/test/format/extension.format.vscode.test.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 // import { assert } from 'chai';
-// import * as path from 'path';
+// import * as path from '../../platform/vscode-path/path';
 // import * as sinon from 'sinon';
 // import { commands, ConfigurationTarget, Uri } from 'vscode';
 // import { IWorkspaceService } from '../../platform/common/application/types';

--- a/src/test/index.node.ts
+++ b/src/test/index.node.ts
@@ -17,7 +17,7 @@ const nyc = setupCoverage();
 
 import * as glob from 'glob';
 import * as Mocha from 'mocha';
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import * as v8 from 'v8';
 import { IS_CI_SERVER, IS_CI_SERVER_TEST_DEBUGGER } from './ciConstants.node';
 import {

--- a/src/test/initialize.node.ts
+++ b/src/test/initialize.node.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import * as vscode from 'vscode';
 import type { IExtensionApi } from '../platform/api';
 import { disposeAllDisposables } from '../platform/common/helpers.node';

--- a/src/test/interpreters/condaLocator.ts
+++ b/src/test/interpreters/condaLocator.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as fs from 'fs-extra';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 
 /**
  * Checks if the given interpreter path belongs to a conda environment. Using

--- a/src/test/interpreters/condaService.node.ts
+++ b/src/test/interpreters/condaService.node.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as glob from 'glob';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { parse, SemVer } from 'semver';
 import { promisify } from 'util';
 import { traceError, traceVerbose, traceWarning } from '../../platform/logging';

--- a/src/test/interpreters/index.node.ts
+++ b/src/test/interpreters/index.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import '../../platform/common/extensions';
 import { traceError } from '../../platform/logging';
 import { BufferDecoder } from '../../platform/common/process/decoder.node';

--- a/src/test/kernels/installer/pipenv.unit.test.ts
+++ b/src/test/kernels/installer/pipenv.unit.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import * as pathModule from 'path';
+import * as pathModule from '../../../platform/vscode-path/path';
 import * as sinon from 'sinon';
 import * as platformApis from '../../../platform/common/utils/platform.node';
 import * as fileUtils from '../../../platform/common/platform/fileUtils.node';

--- a/src/test/kernels/installer/poetry.unit.test.ts
+++ b/src/test/kernels/installer/poetry.unit.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { assert, expect } from 'chai';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as sinon from 'sinon';
 import { TEST_LAYOUT_ROOT } from '../../../test/pythonEnvironments/constants';
 import { ShellOptions, ExecutionResult } from '../../../platform/common/process/types.node';

--- a/src/test/kernels/installer/poetryInstaller.unit.test.ts
+++ b/src/test/kernels/installer/poetryInstaller.unit.test.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import * as sinon from 'sinon';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as assert from 'assert';
 import { expect } from 'chai';
 import { anything, instance, mock, when } from 'ts-mockito';

--- a/src/test/kernels/installer/pyenv.unit.test.ts
+++ b/src/test/kernels/installer/pyenv.unit.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as assert from 'assert';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as sinon from 'sinon';
 import * as platformUtilsNode from '../../../platform/common/utils/platform.node';
 import * as platformUtils from '../../../platform/common/utils/platform';

--- a/src/test/mocks/vsc/uri.ts
+++ b/src/test/mocks/vsc/uri.ts
@@ -7,7 +7,7 @@
 /* eslint-disable */
 
 import { CharCode } from './charCode';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 
 export namespace vscUri {
     const isWindows = /^win/.test(process.platform);

--- a/src/test/performance/load.perf.vscode.test.ts
+++ b/src/test/performance/load.perf.vscode.test.ts
@@ -8,7 +8,7 @@
 import { expect } from 'chai';
 import * as fs from 'fs-extra';
 import { EOL } from 'os';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { commands, extensions } from 'vscode';
 import { JVSC_EXTENSION_ID } from '../../platform/common/constants';
 import { StopWatch } from '../../platform/common/utils/stopWatch';

--- a/src/test/performanceTest.node.ts
+++ b/src/test/performanceTest.node.ts
@@ -20,7 +20,7 @@ process.env.VSC_JUPYTER_PERF_TEST = '1';
 import { spawn } from 'child_process';
 import * as download from 'download';
 import * as fs from 'fs-extra';
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import * as request from 'request';
 import { JVSC_EXTENSION_ID } from '../platform/common/constants';
 import { EXTENSION_ROOT_DIR } from '../platform/constants.node';

--- a/src/test/pythonEnvironments/constants.ts
+++ b/src/test/pythonEnvironments/constants.ts
@@ -1,5 +1,5 @@
 /* eslint-disable local-rules/dont-use-filename */
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 
 export const TEST_LAYOUT_ROOT = path.join(__dirname, '..', '..', '..', 'src', 'test', 'pythonEnvironments', 'common', 'envlayouts');
 

--- a/src/test/smoke/datascience.smoke.test.ts
+++ b/src/test/smoke/datascience.smoke.test.ts
@@ -7,7 +7,7 @@ import { assert } from 'chai';
 /* eslint-disable , no-invalid-this, @typescript-eslint/no-explicit-any */
 
 import * as fs from 'fs-extra';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import * as vscode from 'vscode';
 import { IInteractiveWindowProvider } from '../../interactive-window/types';
 import { traceInfo } from '../../platform/logging';

--- a/src/test/smokeTest.node.ts
+++ b/src/test/smokeTest.node.ts
@@ -8,7 +8,7 @@ process.env.VSC_JUPYTER_SMOKE_TEST = '1';
 
 import { spawn } from 'child_process';
 import * as fs from 'fs-extra';
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import { unzip } from './common.node';
 import { EXTENSION_ROOT_DIR_FOR_TESTS, SMOKE_TEST_EXTENSIONS_DIR } from './constants.node';
 

--- a/src/test/smokeTest.web.ts
+++ b/src/test/smokeTest.web.ts
@@ -1,5 +1,5 @@
 /* eslint-disable local-rules/dont-use-filename */
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import { runTests } from '@vscode/test-web';
 
 async function go() {

--- a/src/test/standardTest.node.ts
+++ b/src/test/standardTest.node.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 import { spawnSync } from 'child_process';
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import * as fs from 'fs-extra';
 import { downloadAndUnzipVSCode, resolveCliPathFromVSCodeExecutablePath, runTests } from '@vscode/test-electron';
 import { EXTENSION_ROOT_DIR_FOR_TESTS, IS_REMOTE_NATIVE_TEST } from './constants.node';

--- a/src/test/testBootstrap.node.ts
+++ b/src/test/testBootstrap.node.ts
@@ -6,7 +6,7 @@
 import { ChildProcess, spawn, SpawnOptions } from 'child_process';
 import * as fs from 'fs-extra';
 import { AddressInfo, createServer, Server } from 'net';
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from './constants.node';
 import { noop, sleep } from './core';
 

--- a/src/test/testHashPerf.ts
+++ b/src/test/testHashPerf.ts
@@ -1,5 +1,5 @@
 import * as crypto from 'crypto';
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import { getInterpreterHash } from '../platform/pythonEnvironments/info/interpreter.node';
 
 function doHash(p: string) {

--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -8,7 +8,7 @@
 'use strict';
 import * as glob from 'glob';
 import * as Mocha from 'mocha';
-import * as path from 'path';
+import * as path from '../platform/vscode-path/path';
 import { IS_SMOKE_TEST, MAX_EXTENSION_ACTIVATION_TIME } from './constants.node';
 import { noop } from './core';
 import { stopJupyterServer } from './datascience/notebook/helper';

--- a/src/webviews/extension-side/codeCssGenerator.node.ts
+++ b/src/webviews/extension-side/codeCssGenerator.node.ts
@@ -4,7 +4,7 @@
 import type { JSONArray, JSONObject } from '@lumino/coreutils';
 import { inject, injectable } from 'inversify';
 import { parse } from 'jsonc-parser';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { IWorkspaceService } from '../../platform/common/application/types';
 import { traceInfo, traceError, traceWarning } from '../../platform/logging';
 import { IFileSystem } from '../../platform/common/platform/types.node';

--- a/src/webviews/extension-side/dataviewer/dataViewer.node.ts
+++ b/src/webviews/extension-side/dataviewer/dataViewer.node.ts
@@ -4,7 +4,7 @@
 import '../../../platform/common/extensions';
 
 import { inject, injectable, named } from 'inversify';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { EventEmitter, Memento, ViewColumn } from 'vscode';
 
 import { sendTelemetryEvent } from '../../../telemetry';

--- a/src/webviews/extension-side/plotting/plotViewer.node.ts
+++ b/src/webviews/extension-side/plotting/plotViewer.node.ts
@@ -4,7 +4,7 @@
 import '../../../platform/common/extensions';
 
 import { inject, injectable } from 'inversify';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { Event, EventEmitter, Uri, ViewColumn } from 'vscode';
 
 import { traceError, traceInfo } from '../../../platform/logging';

--- a/src/webviews/extension-side/themeFinder.node.ts
+++ b/src/webviews/extension-side/themeFinder.node.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import { inject, injectable } from 'inversify';
-import * as path from 'path';
+import * as path from '../../platform/vscode-path/path';
 import { traceError } from '../../platform/logging';
 import { IFileSystem } from '../../platform/common/platform/types.node';
 import { IExtensions } from '../../platform/common/types';

--- a/src/webviews/extension-side/variablesView/variableView.node.ts
+++ b/src/webviews/extension-side/variablesView/variableView.node.ts
@@ -3,7 +3,7 @@
 'use strict';
 import '../../../platform/common/extensions';
 
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import * as pathBrowser from 'path-browserify';
 import { WebviewView as vscodeWebviewView } from 'vscode';
 

--- a/src/webviews/extension-side/webviewPanels/webviewPanelProvider.node.ts
+++ b/src/webviews/extension-side/webviewPanels/webviewPanelProvider.node.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import { inject, injectable } from 'inversify';
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import { Uri } from 'vscode';
 import { IFileSystem } from '../../../platform/common/platform/types.node';
 import { IDisposableRegistry, IExtensionContext } from '../../../platform/common/types';

--- a/src/webviews/extension-side/webviews/webview.node.ts
+++ b/src/webviews/extension-side/webviews/webview.node.ts
@@ -3,7 +3,7 @@
 'use strict';
 import '../../../platform/common/extensions';
 
-import * as path from 'path';
+import * as path from '../../../platform/vscode-path/path';
 import {
     Event,
     EventEmitter,


### PR DESCRIPTION
For #9586 

First step for 9586. Second step I'll go back and get rid of the 'web' version of files that were using path-browserify as they should work in both now.
