### PR TITLE
Ensure disposeAllDisposables is non-node specific

### DIFF
--- a/src/intellisense/diagnosticsProvider.node.ts
+++ b/src/intellisense/diagnosticsProvider.node.ts
@@ -29,7 +29,7 @@ import {
 import { IExtensionSyncActivationService } from '../platform/activation/types';
 import { IVSCodeNotebook, IDocumentManager } from '../platform/common/application/types';
 import { PYTHON_LANGUAGE } from '../platform/common/constants';
-import { disposeAllDisposables } from '../platform/common/helpers.node';
+import { disposeAllDisposables } from '../platform/common/helpers';
 import { IDisposableRegistry } from '../platform/common/types';
 import { DataScience } from '../platform/common/utils/localize';
 import { JupyterNotebookView } from '../notebooks/constants';

--- a/src/interactive-window/editor-integration/codelensprovider.node.ts
+++ b/src/interactive-window/editor-integration/codelensprovider.node.ts
@@ -11,7 +11,7 @@ import {
     IWorkspaceService
 } from '../../platform/common/application/types';
 import { ContextKey } from '../../platform/common/contextKey.node';
-import { disposeAllDisposables } from '../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../platform/common/helpers';
 import { IFileSystem } from '../../platform/common/platform/types.node';
 
 import { IConfigurationService, IDisposable, IDisposableRegistry } from '../../platform/common/types';

--- a/src/kernels/common/baseJupyterSession.node.ts
+++ b/src/kernels/common/baseJupyterSession.node.ts
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs/Observable';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
 import { CancellationTokenSource, Event, EventEmitter } from 'vscode';
 import { WrappedError } from '../../platform/errors/types';
-import { disposeAllDisposables } from '../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../platform/common/helpers';
 import { traceInfo, traceVerbose, traceError, traceWarning, traceInfoIfCI } from '../../platform/logging';
 import { IDisposable, Resource } from '../../platform/common/types';
 import { createDeferred, sleep, waitForPromise } from '../../platform/common/utils/async';

--- a/src/kernels/ipywidgets-message-coordination/notebookIPyWidgetCoordinator.node.ts
+++ b/src/kernels/ipywidgets-message-coordination/notebookIPyWidgetCoordinator.node.ts
@@ -12,7 +12,7 @@ import {
 } from 'vscode';
 import { IVSCodeNotebook } from '../../platform/common/application/types';
 import { Cancellation } from '../../platform/common/cancellation.node';
-import { disposeAllDisposables } from '../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../platform/common/helpers';
 import { traceInfo, traceVerbose, traceInfoIfCI } from '../../platform/logging';
 import { getDisplayPath } from '../../platform/common/platform/fs-paths.node';
 import { IDisposableRegistry, IAsyncDisposableRegistry, IDisposable } from '../../platform/common/types';

--- a/src/kernels/jupyter/jupyterCellOutputMimeTypeTracker.node.ts
+++ b/src/kernels/jupyter/jupyterCellOutputMimeTypeTracker.node.ts
@@ -8,7 +8,7 @@ import { inject, injectable } from 'inversify';
 import { NotebookCell, NotebookCellExecutionStateChangeEvent, NotebookCellKind, NotebookDocument } from 'vscode';
 import { IExtensionSingleActivationService } from '../../platform/activation/types';
 import { IVSCodeNotebook } from '../../platform/common/application/types';
-import { disposeAllDisposables } from '../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../platform/common/helpers';
 import { IDisposableRegistry } from '../../platform/common/types';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { getTelemetrySafeHashedString } from '../../telemetry/helpers';

--- a/src/kernels/jupyter/launcher/notebookServerProvider.node.ts
+++ b/src/kernels/jupyter/launcher/notebookServerProvider.node.ts
@@ -6,7 +6,7 @@
 import { IDisposable } from '@fluentui/react';
 import { inject, injectable } from 'inversify';
 import { CancellationError, CancellationToken } from 'vscode';
-import { disposeAllDisposables } from '../../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../../platform/common/helpers';
 import { traceInfo } from '../../../platform/logging';
 import { IConfigurationService, IDisposableRegistry, Resource } from '../../../platform/common/types';
 import { testOnlyMethod } from '../../../platform/common/utils/decorators';

--- a/src/kernels/jupyter/launcher/notebookStarter.node.ts
+++ b/src/kernels/jupyter/launcher/notebookStarter.node.ts
@@ -12,7 +12,7 @@ import * as uuid from 'uuid/v4';
 import { CancellationError, CancellationToken, Disposable } from 'vscode';
 import { IDisposable } from '@fluentui/react';
 import { Cancellation, createPromiseFromCancellation } from '../../../platform/common/cancellation.node';
-import { disposeAllDisposables } from '../../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../../platform/common/helpers';
 import { traceInfo, traceError } from '../../../platform/logging';
 import { TemporaryDirectory } from '../../../platform/common/platform/types';
 import { IOutputChannel, Resource } from '../../../platform/common/types';

--- a/src/kernels/kernel.node.ts
+++ b/src/kernels/kernel.node.ts
@@ -18,7 +18,7 @@ import {
 } from 'vscode';
 import { IApplicationShell, IWorkspaceService } from '../platform/common/application/types';
 import { WrappedError } from '../platform/errors/types';
-import { disposeAllDisposables } from '../platform/common/helpers.node';
+import { disposeAllDisposables } from '../platform/common/helpers';
 import { traceInfo, traceInfoIfCI, traceError, traceVerbose, traceWarning } from '../platform/logging';
 import { getDisplayPath } from '../platform/common/platform/fs-paths.node';
 import { IFileSystem } from '../platform/common/platform/types.node';

--- a/src/notebooks/controllers/kernelFilter/kernelFilterService.node.ts
+++ b/src/notebooks/controllers/kernelFilter/kernelFilterService.node.ts
@@ -3,7 +3,7 @@
 import { inject, injectable } from 'inversify';
 import { ConfigurationTarget, EventEmitter } from 'vscode';
 import { IWorkspaceService } from '../../../platform/common/application/types';
-import { disposeAllDisposables } from '../../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../../platform/common/helpers';
 import { traceVerbose } from '../../../platform/logging';
 import { IConfigurationService, IDisposable, IDisposableRegistry, IPathUtils } from '../../../platform/common/types';
 import { KernelConnectionMetadata } from '../../../kernels/types';

--- a/src/notebooks/controllers/kernelFilter/kernelFilterUI.node.ts
+++ b/src/notebooks/controllers/kernelFilter/kernelFilterUI.node.ts
@@ -4,7 +4,7 @@ import { inject, injectable } from 'inversify';
 import { QuickPickItem } from 'vscode';
 import { IExtensionSyncActivationService } from '../../../platform/activation/types';
 import { ICommandManager, IApplicationShell, IWorkspaceService } from '../../../platform/common/application/types';
-import { disposeAllDisposables } from '../../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../../platform/common/helpers';
 import { IDisposable, IDisposableRegistry, IPathUtils } from '../../../platform/common/types';
 import { DataScience } from '../../../platform/common/utils/localize';
 import { noop } from '../../../platform/common/utils/misc';

--- a/src/notebooks/controllers/noPythonKernelsNotebookController.node.ts
+++ b/src/notebooks/controllers/noPythonKernelsNotebookController.node.ts
@@ -4,7 +4,7 @@
 import { Disposable, NotebookCell, NotebookController, NotebookControllerAffinity, NotebookDocument } from 'vscode';
 import { IPythonExtensionChecker } from '../../platform/api/types';
 import { IVSCodeNotebook, ICommandManager, IApplicationShell } from '../../platform/common/application/types';
-import { disposeAllDisposables } from '../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../platform/common/helpers';
 import { IDisposable, IDisposableRegistry } from '../../platform/common/types';
 import { DataScience, Common } from '../../platform/common/utils/localize';
 import { noop } from '../../platform/common/utils/misc';

--- a/src/notebooks/controllers/vscodeNotebookController.node.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.node.ts
@@ -28,7 +28,7 @@ import {
     IApplicationShell
 } from '../../platform/common/application/types';
 import { PYTHON_LANGUAGE } from '../../platform/common/constants';
-import { disposeAllDisposables } from '../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../platform/common/helpers';
 import {
     traceInfoIfCI,
     traceInfo,

--- a/src/notebooks/execution/cellExecution.node.ts
+++ b/src/notebooks/execution/cellExecution.node.ts
@@ -31,7 +31,7 @@ import { CellExecutionCreator } from './cellExecutionCreator';
 import { IApplicationShell } from '../../platform/common/application/types';
 import { analyzeKernelErrors, createOutputWithErrorMessageForDisplay } from '../../platform/errors/errorUtils';
 import { BaseError } from '../../platform/errors/types';
-import { disposeAllDisposables } from '../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../platform/common/helpers';
 import { traceError, traceInfoIfCI, traceWarning } from '../../platform/logging';
 import { RefBool } from '../../platform/common/refBool.node';
 import { IDisposable, IDisposableRegistry } from '../../platform/common/types';

--- a/src/notebooks/outputs/rendererCommunication.node.ts
+++ b/src/notebooks/outputs/rendererCommunication.node.ts
@@ -4,7 +4,7 @@
 import { inject, injectable } from 'inversify';
 import { Event, extensions, NotebookEditor, window } from 'vscode';
 import { IExtensionSingleActivationService } from '../../platform/activation/types';
-import { disposeAllDisposables } from '../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../platform/common/helpers';
 import { IDisposable } from '../../platform/common/types';
 import { noop } from '../../platform/common/utils/misc';
 import { PlotSaveHandler } from './plotSaveHandler.node';

--- a/src/platform/api/kernelApi.node.ts
+++ b/src/platform/api/kernelApi.node.ts
@@ -10,7 +10,7 @@ import {
     KernelConnectionMetadata as IKernelKernelConnectionMetadata
 } from '../../kernels/types';
 import { INotebookControllerManager } from '../../notebooks/types';
-import { disposeAllDisposables } from '../common/helpers.node';
+import { disposeAllDisposables } from '../common/helpers';
 import { traceInfo } from '../logging';
 import { IDisposable, IDisposableRegistry, IExtensions } from '../common/types';
 import { PromiseChain } from '../common/utils/async';

--- a/src/platform/common/extensionRecommendation.node.ts
+++ b/src/platform/common/extensionRecommendation.node.ts
@@ -5,7 +5,7 @@ import { inject, injectable, named } from 'inversify';
 import { Memento, NotebookDocument } from 'vscode';
 import { IExtensionSyncActivationService } from '../activation/types';
 import { IApplicationShell, ICommandManager, IVSCodeNotebook } from '../common/application/types';
-import { disposeAllDisposables } from '../common/helpers.node';
+import { disposeAllDisposables } from '../common/helpers';
 import { GLOBAL_MEMENTO, IDisposable, IDisposableRegistry, IExtensions, IMemento } from '../common/types';
 import { Common, DataScience } from './utils/localize';
 import { noop } from './utils/misc';

--- a/src/platform/common/helpers.node.ts
+++ b/src/platform/common/helpers.node.ts
@@ -4,7 +4,6 @@
 'use strict';
 
 import { ModuleNotInstalledError } from '../../platform/errors/moduleNotInstalledError.node';
-import { IDisposable } from './types';
 
 export function isNotInstalledError(error: Error): boolean {
     const isError = typeof error === 'object' && error !== null;
@@ -19,17 +18,4 @@ export function isNotInstalledError(error: Error): boolean {
 
     const isModuleNoInstalledError = error.message.indexOf('No module named') >= 0;
     return errorObj.code === 'ENOENT' || errorObj.code === 127 || isModuleNoInstalledError;
-}
-
-export function disposeAllDisposables(disposables: IDisposable[] = []) {
-    while (disposables.length) {
-        const disposable = disposables.shift();
-        if (disposable) {
-            try {
-                disposable.dispose();
-            } catch {
-                // Don't care.
-            }
-        }
-    }
 }

--- a/src/platform/common/helpers.ts
+++ b/src/platform/common/helpers.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+import { IDisposable } from './types';
+
+export function disposeAllDisposables(disposables: IDisposable[] = []) {
+    while (disposables.length) {
+        const disposable = disposables.shift();
+        if (disposable) {
+            try {
+                disposable.dispose();
+            } catch {
+                // Don't care.
+            }
+        }
+    }
+}

--- a/src/platform/progress/kernelProgressReporter.node.ts
+++ b/src/platform/progress/kernelProgressReporter.node.ts
@@ -5,7 +5,7 @@ import { inject, injectable } from 'inversify';
 import { CancellationToken, Disposable, Progress, ProgressLocation, window } from 'vscode';
 import { IExtensionSyncActivationService } from '../activation/types';
 import { createPromiseFromCancellation } from '../common/cancellation.node';
-import { disposeAllDisposables } from '../common/helpers.node';
+import { disposeAllDisposables } from '../common/helpers';
 import { IDisposable, IDisposableRegistry, Resource } from '../common/types';
 import { createDeferred } from '../common/utils/async';
 import { noop } from '../common/utils/misc';

--- a/src/telemetry/importTracker.node.ts
+++ b/src/telemetry/importTracker.node.ts
@@ -13,7 +13,7 @@ import { IExtensionSingleActivationService } from '../platform/activation/types'
 import { IDocumentManager, IVSCodeNotebook } from '../platform/common/application/types';
 import { isCI, isTestExecution, PYTHON_LANGUAGE } from '../platform/common/constants';
 import '../platform/common/extensions';
-import { disposeAllDisposables } from '../platform/common/helpers.node';
+import { disposeAllDisposables } from '../platform/common/helpers';
 import { IDisposable, IDisposableRegistry } from '../platform/common/types';
 import { noop } from '../platform/common/utils/misc';
 import { EventName } from './constants';

--- a/src/test/datascience/editor-integration/codewatcher.unit.test.ts
+++ b/src/test/datascience/editor-integration/codewatcher.unit.test.ts
@@ -36,7 +36,7 @@ import { MockDocumentManager } from '../mockDocumentManager';
 import { MockJupyterSettings } from '../mockJupyterSettings';
 import { MockEditor } from '../mockTextEditor';
 import { createDocument } from './helpers';
-import { disposeAllDisposables } from '../../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../../platform/common/helpers';
 import { CellHashProviderFactory } from '../../../interactive-window/editor-integration/cellHashProviderFactory.node';
 import { IKernel, IKernelProvider } from '../../../platform/../kernels/types';
 import { InteractiveCellResultError } from '../../../platform/errors/interactiveCellResultError.node';

--- a/src/test/datascience/editor-integration/hoverProvider.vscode.test.ts
+++ b/src/test/datascience/editor-integration/hoverProvider.vscode.test.ts
@@ -15,7 +15,7 @@ import { IExtensionTestApi, openFile, sleep } from '../../common.node';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../constants.node';
 import { initialize } from '../../initialize.node';
 import { HoverProvider } from '../../../interactive-window/editor-integration/hoverProvider.node';
-import { disposeAllDisposables } from '../../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../../platform/common/helpers';
 import { IKernelProvider } from '../../../platform/../kernels/types';
 import { IVSCodeNotebook } from '../../../platform/common/application/types';
 import { IFileSystem } from '../../../platform/common/platform/types.node';

--- a/src/test/datascience/extensionRecommendation.unit.test.ts
+++ b/src/test/datascience/extensionRecommendation.unit.test.ts
@@ -5,7 +5,7 @@ import type * as nbformat from '@jupyterlab/nbformat';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { EventEmitter, Memento, NotebookDocument } from 'vscode';
 import { IApplicationShell, ICommandManager, IVSCodeNotebook } from '../../platform/common/application/types';
-import { disposeAllDisposables } from '../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../platform/common/helpers';
 import { IDisposable, IExtensions } from '../../platform/common/types';
 import { sleep } from '../../platform/common/utils/async';
 import { Common } from '../../platform/common/utils/localize';

--- a/src/test/datascience/interactive-common/notebookServerProvider.unit.test.ts
+++ b/src/test/datascience/interactive-common/notebookServerProvider.unit.test.ts
@@ -5,7 +5,7 @@ import { SemVer } from 'semver';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import * as typemoq from 'typemoq';
 import { CancellationTokenSource, Disposable, EventEmitter } from 'vscode';
-import { disposeAllDisposables } from '../../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../../platform/common/helpers';
 import { IConfigurationService, IWatchableJupyterSettings } from '../../../platform/common/types';
 import { IInterpreterService } from '../../../platform/interpreter/contracts.node';
 import { PythonEnvironment } from '../../../platform/pythonEnvironments/info';

--- a/src/test/datascience/interpreters/environmentActivationService.vscode.test.ts
+++ b/src/test/datascience/interpreters/environmentActivationService.vscode.test.ts
@@ -18,7 +18,7 @@ import {
 import * as path from '../../../platform/vscode-path/path';
 import { IS_WINDOWS } from '../../../platform/common/platform/constants.node';
 import { IProcessServiceFactory } from '../../../platform/common/process/types.node';
-import { disposeAllDisposables } from '../../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../../platform/common/helpers';
 import { GLOBAL_MEMENTO, IDisposable, IMemento } from '../../../platform/common/types';
 import { createDeferred } from '../../../platform/common/utils/async';
 import { IPythonApiProvider, PythonApi } from '../../../platform/api/types';

--- a/src/test/datascience/jupyterServer.node.ts
+++ b/src/test/datascience/jupyterServer.node.ts
@@ -5,7 +5,7 @@ import * as getFreePort from 'get-port';
 import * as path from '../../platform/vscode-path/path';
 import * as tcpPortUsed from 'tcp-port-used';
 import { Uri } from 'vscode';
-import { disposeAllDisposables } from '../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../platform/common/helpers';
 import { traceError, traceInfo, traceInfoIfCI } from '../../platform/logging';
 import { IPythonExecutionFactory } from '../../platform/common/process/types.node';
 import { IAsyncDisposable, IDisposable, IDisposableRegistry } from '../../platform/common/types';

--- a/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
@@ -32,7 +32,7 @@ import { EventEmitter, Memento, Uri } from 'vscode';
 import { IDisposable, IExtensionContext } from '../../../platform/common/types';
 import { getInterpreterHash } from '../../../platform/pythonEnvironments/info/interpreter.node';
 import { OSType } from '../../../platform/common/utils/platform';
-import { disposeAllDisposables } from '../../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../../platform/common/helpers';
 import { KernelConnectionMetadata, LocalKernelConnectionMetadata } from '../../../platform/../kernels/types';
 import { getDisplayPath } from '../../../platform/common/platform/fs-paths.node';
 import { arePathsSame } from '../../../platform/common/platform/fileUtils.node';

--- a/src/test/datascience/kernelLauncher.vscode.test.ts
+++ b/src/test/datascience/kernelLauncher.vscode.test.ts
@@ -17,7 +17,7 @@ import { IS_REMOTE_NATIVE_TEST } from '../constants.node';
 import { initialize } from '../initialize.node';
 import { PortAttributesProviders } from '../../platform/common/net/portAttributeProvider.node';
 import { IDisposable } from '../../platform/common/types';
-import { disposeAllDisposables } from '../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../platform/common/helpers';
 import { CancellationTokenSource, PortAutoForwardAction } from 'vscode';
 import { createRawKernel } from '../../kernels/raw/session/rawKernel.node';
 import { IKernelConnection, IKernelLauncher } from '../../kernels/raw/types';

--- a/src/test/datascience/kernelProcess.unit.test.ts
+++ b/src/test/datascience/kernelProcess.unit.test.ts
@@ -27,7 +27,7 @@ import { IPythonExtensionChecker } from '../../platform/api/types';
 import { KernelEnvironmentVariablesService } from '../../kernels/raw/launcher/kernelEnvVarsService.node';
 import { IDisposable, IJupyterSettings, IOutputChannel } from '../../platform/common/types';
 import { CancellationTokenSource } from 'vscode';
-import { disposeAllDisposables } from '../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../platform/common/helpers';
 import { noop } from '../core';
 import { Observable, Subject } from 'rxjs';
 import { ChildProcess } from 'child_process';

--- a/src/test/datascience/kernelProcess.vscode.test.node.ts
+++ b/src/test/datascience/kernelProcess.vscode.test.node.ts
@@ -20,7 +20,7 @@ import { IFileSystem } from '../../platform/common/platform/types.node';
 import { IPythonExtensionChecker } from '../../platform/api/types';
 import { noop } from '../core';
 import { EventEmitter } from 'events';
-import { disposeAllDisposables } from '../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../platform/common/helpers';
 import { traceInfo } from '../../platform/logging';
 import { CancellationTokenSource } from 'vscode';
 import { IKernelConnection } from '../../kernels/raw/types';

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -34,7 +34,7 @@ import {
 } from 'vscode';
 import { IApplicationShell, IVSCodeNotebook } from '../../../platform/common/application/types';
 import { JVSC_EXTENSION_ID, MARKDOWN_LANGUAGE, PYTHON_LANGUAGE } from '../../../platform/common/constants';
-import { disposeAllDisposables } from '../../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../../platform/common/helpers';
 import { traceInfo, traceInfoIfCI } from '../../../platform/logging';
 import { GLOBAL_MEMENTO, IDisposable, IMemento } from '../../../platform/common/types';
 import { createDeferred } from '../../../platform/common/utils/async';

--- a/src/test/datascience/widgets/commUtils.ts
+++ b/src/test/datascience/widgets/commUtils.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { NotebookEditor, NotebookRendererMessaging, notebooks } from 'vscode';
-import { disposeAllDisposables } from '../../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../../platform/common/helpers';
 import { traceInfo } from '../../../platform/logging';
 import { IDisposable, IDisposableRegistry } from '../../../platform/common/types';
 import { createDeferred } from '../../../platform/common/utils/async';

--- a/src/test/initialize.node.ts
+++ b/src/test/initialize.node.ts
@@ -1,7 +1,7 @@
 import * as path from '../platform/vscode-path/path';
 import * as vscode from 'vscode';
 import type { IExtensionApi } from '../platform/api';
-import { disposeAllDisposables } from '../platform/common/helpers.node';
+import { disposeAllDisposables } from '../platform/common/helpers';
 import type { IDisposable } from '../platform/common/types';
 import { clearPendingChainedUpdatesForTests } from '../notebooks/execution/notebookUpdater.node';
 import { clearPendingTimers, IExtensionTestApi, PYTHON_PATH, setPythonPathInWorkspaceRoot } from './common.node';

--- a/src/test/kernels/kernelAutoRestartMonitor.unit.test.ts
+++ b/src/test/kernels/kernelAutoRestartMonitor.unit.test.ts
@@ -7,7 +7,7 @@ import { EventEmitter } from 'vscode';
 import { getDisplayNameOrNameOfKernelConnection } from '../../kernels/helpers.node';
 import { KernelAutoRestartMonitor } from '../../kernels/kernelAutoRestartMonitor.node';
 import { IJupyterSession, IKernel, IKernelProvider, KernelConnectionMetadata } from '../../kernels/types';
-import { disposeAllDisposables } from '../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../platform/common/helpers';
 import { IDisposable } from '../../platform/common/types';
 import { DataScience } from '../../platform/common/utils/localize';
 import { IStatusProvider } from '../../platform/progress/types';

--- a/src/test/telemetry/importTracker.unit.test.ts
+++ b/src/test/telemetry/importTracker.unit.test.ts
@@ -15,7 +15,7 @@ import {
     setTestExecution,
     setUnitTestExecution
 } from '../../platform/common/constants';
-import { disposeAllDisposables } from '../../platform/common/helpers.node';
+import { disposeAllDisposables } from '../../platform/common/helpers';
 import { IDisposable } from '../../platform/common/types';
 import { EventName } from '../../telemetry/constants';
 import { getTelemetrySafeHashedString } from '../../telemetry/helpers';


### PR DESCRIPTION
Wanted to add some telemetry for https://github.com/microsoft/vscode-jupyter/issues/9615 to figure out how many are using the Kernel filter, and came across the fact that KernelFilter was node specifci & found this to be one of the reasons