### PR TITLE
Use a common displayPath function

### DIFF
--- a/src/extension.node.ts
+++ b/src/extension.node.ts
@@ -74,7 +74,7 @@ import { registerTypes as registerTelemetryTypes } from './telemetry/serviceRegi
 import { registerTypes as registerIntellisenseTypes } from './intellisense/serviceRegistry.node';
 import { IExtensionActivationManager } from './platform/activation/types';
 import { isCI, isTestExecution, STANDARD_OUTPUT_CHANNEL } from './platform/common/constants';
-import { getDisplayPath } from './platform/common/platform/fs-paths.node';
+import { getDisplayPath } from './platform/common/platform/fs-paths';
 import { IFileSystem } from './platform/common/platform/types.node';
 import { getJupyterOutputChannel } from './platform/devTools/jupyterOutputChannel';
 import { registerLogger, setLoggingLevel } from './platform/logging';

--- a/src/intellisense/pythonKernelCompletionProvider.node.ts
+++ b/src/intellisense/pythonKernelCompletionProvider.node.ts
@@ -17,7 +17,7 @@ import * as lsp from 'vscode-languageclient';
 import { IVSCodeNotebook } from '../platform/common/application/types';
 import { createPromiseFromCancellation } from '../platform/common/cancellation.node';
 import { traceError, traceInfoIfCI, traceVerbose } from '../platform/logging';
-import { getDisplayPath } from '../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../platform/common/platform/fs-paths';
 import { IConfigurationService, IDisposableRegistry } from '../platform/common/types';
 import { waitForPromise } from '../platform/common/utils/async';
 import { isNotebookCell } from '../platform/common/utils/misc';

--- a/src/interactive-window/interactiveWindowProvider.node.ts
+++ b/src/interactive-window/interactiveWindowProvider.node.ts
@@ -40,7 +40,7 @@ import {
 } from './types';
 import { getInteractiveWindowTitle } from './identity.node';
 import { createDeferred } from '../platform/common/utils/async';
-import { getDisplayPath } from '../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../platform/common/platform/fs-paths';
 import { INotebookExporter } from '../kernels/jupyter/types';
 import { IDataScienceErrorHandler } from '../platform/errors/types';
 import { IExportDialog } from '../platform/export/types';

--- a/src/kernels/helpers.node.ts
+++ b/src/kernels/helpers.node.ts
@@ -32,7 +32,7 @@ import {
 } from '../platform/common/application/types';
 import { PYTHON_LANGUAGE, Settings } from '../platform/common/constants';
 import { traceError, traceInfo, traceInfoIfCI, traceVerbose, traceWarning } from '../platform/logging';
-import { getDisplayPath } from '../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../platform/common/platform/fs-paths';
 import { IPythonExecutionFactory } from '../platform/common/process/types.node';
 import {
     IPathUtils,

--- a/src/kernels/ipywidgets-message-coordination/notebookIPyWidgetCoordinator.node.ts
+++ b/src/kernels/ipywidgets-message-coordination/notebookIPyWidgetCoordinator.node.ts
@@ -14,7 +14,7 @@ import { IVSCodeNotebook } from '../../platform/common/application/types';
 import { Cancellation } from '../../platform/common/cancellation.node';
 import { disposeAllDisposables } from '../../platform/common/helpers.node';
 import { traceInfo, traceVerbose, traceInfoIfCI } from '../../platform/logging';
-import { getDisplayPath } from '../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../platform/common/platform/fs-paths';
 import { IDisposableRegistry, IAsyncDisposableRegistry, IDisposable } from '../../platform/common/types';
 import { createDeferred } from '../../platform/common/utils/async';
 import { noop } from '../../platform/common/utils/misc';

--- a/src/kernels/jupyter/jupyterKernelService.node.ts
+++ b/src/kernels/jupyter/jupyterKernelService.node.ts
@@ -17,7 +17,7 @@ import {
     ignoreLogging,
     traceDecoratorError
 } from '../../platform/logging';
-import { getDisplayPath } from '../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../platform/common/platform/fs-paths';
 import { IFileSystem } from '../../platform/common/platform/types.node';
 import { Resource, ReadWrite, IDisplayOptions } from '../../platform/common/types';
 import { noop } from '../../platform/common/utils/misc';

--- a/src/kernels/jupyter/launcher/liveshare/hostJupyterServer.node.ts
+++ b/src/kernels/jupyter/launcher/liveshare/hostJupyterServer.node.ts
@@ -28,7 +28,7 @@ import { JupyterSessionManager } from '../../session/jupyterSessionManager.node'
 import { JupyterNotebook } from '../jupyterNotebook.node';
 import { noop } from '../../../../platform/common/utils/misc';
 import { Cancellation } from '../../../../platform/common/cancellation.node';
-import { getDisplayPath } from '../../../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../../../platform/common/platform/fs-paths';
 import { INotebookServer, IJupyterSessionManagerFactory } from '../../types';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 

--- a/src/kernels/kernel.node.ts
+++ b/src/kernels/kernel.node.ts
@@ -20,7 +20,7 @@ import { IApplicationShell, IWorkspaceService } from '../platform/common/applica
 import { WrappedError } from '../platform/errors/types';
 import { disposeAllDisposables } from '../platform/common/helpers.node';
 import { traceInfo, traceInfoIfCI, traceError, traceVerbose, traceWarning } from '../platform/logging';
-import { getDisplayPath } from '../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../platform/common/platform/fs-paths';
 import { IFileSystem } from '../platform/common/platform/types.node';
 import { IPythonExecutionFactory } from '../platform/common/process/types.node';
 import {

--- a/src/kernels/kernelDependencyService.node.ts
+++ b/src/kernels/kernelDependencyService.node.ts
@@ -15,7 +15,7 @@ import {
     ignoreLogging,
     logValue
 } from '../platform/logging';
-import { getDisplayPath } from '../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../platform/common/platform/fs-paths';
 import { IMemento, GLOBAL_MEMENTO, IsCodeSpace, Resource, IDisplayOptions } from '../platform/common/types';
 import { DataScience, Common } from '../platform/common/utils/localize';
 import { IServiceContainer } from '../platform/ioc/types';

--- a/src/kernels/kernelProvider.node.ts
+++ b/src/kernels/kernelProvider.node.ts
@@ -7,7 +7,7 @@ import { inject, injectable } from 'inversify';
 import { Event, EventEmitter, NotebookDocument, Uri, workspace } from 'vscode';
 import { IApplicationShell, IWorkspaceService, IVSCodeNotebook } from '../platform/common/application/types';
 import { traceInfoIfCI, traceVerbose, traceWarning } from '../platform/logging';
-import { getDisplayPath } from '../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../platform/common/platform/fs-paths';
 import { IFileSystem } from '../platform/common/platform/types.node';
 import { IPythonExecutionFactory } from '../platform/common/process/types.node';
 import {

--- a/src/kernels/raw/finder/localKernelSpecFinderBase.node.ts
+++ b/src/kernels/raw/finder/localKernelSpecFinderBase.node.ts
@@ -8,7 +8,7 @@ import { IPythonExtensionChecker } from '../../../platform/api/types';
 import { IWorkspaceService } from '../../../platform/common/application/types';
 import { PYTHON_LANGUAGE } from '../../../platform/common/constants';
 import { traceInfo, traceVerbose, traceError, traceDecoratorError } from '../../../platform/logging';
-import { getDisplayPath } from '../../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../../platform/common/platform/fs-paths';
 import { IFileSystem } from '../../../platform/common/platform/types.node';
 import { ReadWrite } from '../../../platform/common/types';
 import { testOnlyMethod } from '../../../platform/common/utils/decorators';

--- a/src/kernels/raw/finder/localPythonAndRelatedNonPythonKernelSpecFinder.node.ts
+++ b/src/kernels/raw/finder/localPythonAndRelatedNonPythonKernelSpecFinder.node.ts
@@ -18,7 +18,7 @@ import { IPythonExtensionChecker } from '../../../platform/api/types';
 import { IWorkspaceService } from '../../../platform/common/application/types';
 import { PYTHON_LANGUAGE } from '../../../platform/common/constants';
 import { traceInfoIfCI, traceVerbose, traceError } from '../../../platform/logging';
-import { getDisplayPath } from '../../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../../platform/common/platform/fs-paths';
 import { IFileSystem } from '../../../platform/common/platform/types.node';
 import { IMemento, GLOBAL_MEMENTO, Resource } from '../../../platform/common/types';
 import { IInterpreterService } from '../../../platform/interpreter/contracts.node';

--- a/src/kernels/raw/finder/preferredRemoteKernelIdProvider.node.ts
+++ b/src/kernels/raw/finder/preferredRemoteKernelIdProvider.node.ts
@@ -5,7 +5,7 @@ import { inject, injectable, named } from 'inversify';
 import { cloneDeep } from 'lodash';
 import { Memento, Uri } from 'vscode';
 import { traceInfo } from '../../../platform/logging';
-import { getDisplayPath } from '../../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../../platform/common/platform/fs-paths';
 import { IMemento, GLOBAL_MEMENTO, ICryptoUtils } from '../../../platform/common/types';
 import { sendTelemetryEvent } from '../../../telemetry';
 import { Telemetry } from '../../../webviews/webview-side/common/constants';

--- a/src/kernels/raw/launcher/kernelEnvVarsService.node.ts
+++ b/src/kernels/raw/launcher/kernelEnvVarsService.node.ts
@@ -4,7 +4,7 @@
 import { inject, injectable } from 'inversify';
 import * as path from '../../../platform/vscode-path/path';
 import { traceInfo, traceError } from '../../../platform/logging';
-import { getDisplayPath } from '../../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../../platform/common/platform/fs-paths';
 import { Resource } from '../../../platform/common/types';
 import { noop } from '../../../platform/common/utils/misc';
 import { IEnvironmentVariablesService, IEnvironmentVariablesProvider } from '../../../platform/common/variables/types';

--- a/src/kernels/raw/launcher/kernelLauncher.node.ts
+++ b/src/kernels/raw/launcher/kernelLauncher.node.ts
@@ -14,7 +14,7 @@ import { IPythonExtensionChecker } from '../../../platform/api/types';
 import { Cancellation, createPromiseFromCancellation } from '../../../platform/common/cancellation.node';
 import { getTelemetrySafeErrorMessageFromPythonTraceback } from '../../../platform/errors/errorUtils';
 import { traceInfo, traceWarning } from '../../../platform/logging';
-import { getDisplayPath } from '../../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../../platform/common/platform/fs-paths';
 import { IFileSystem } from '../../../platform/common/platform/types.node';
 import { IProcessServiceFactory, IPythonExecutionFactory } from '../../../platform/common/process/types.node';
 import { IDisposableRegistry, IConfigurationService, Resource } from '../../../platform/common/types';

--- a/src/kernels/raw/session/hostRawNotebookProvider.node.ts
+++ b/src/kernels/raw/session/hostRawNotebookProvider.node.ts
@@ -10,7 +10,7 @@ import { IPythonExtensionChecker } from '../../../platform/api/types';
 import { IWorkspaceService } from '../../../platform/common/application/types';
 import { STANDARD_OUTPUT_CHANNEL } from '../../../platform/common/constants';
 import { traceInfo, traceVerbose, traceError } from '../../../platform/logging';
-import { getDisplayPath } from '../../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../../platform/common/platform/fs-paths';
 import {
     IAsyncDisposableRegistry,
     IConfigurationService,

--- a/src/kernels/raw/session/rawJupyterSession.node.ts
+++ b/src/kernels/raw/session/rawJupyterSession.node.ts
@@ -8,7 +8,7 @@ import { CancellationToken } from 'vscode-jsonrpc';
 import { Cancellation, createPromiseFromCancellation } from '../../../platform/common/cancellation.node';
 import { getTelemetrySafeErrorMessageFromPythonTraceback } from '../../../platform/errors/errorUtils';
 import { traceInfo, traceError, traceVerbose, traceWarning } from '../../../platform/logging';
-import { getDisplayPath } from '../../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../../platform/common/platform/fs-paths';
 import { IDisplayOptions, IDisposable, IOutputChannel, Resource } from '../../../platform/common/types';
 import { TimedOutError, createDeferred, sleep } from '../../../platform/common/utils/async';
 import { DataScience } from '../../../platform/common/utils/localize';

--- a/src/notebooks/controllers/notebookControllerManager.node.ts
+++ b/src/notebooks/controllers/notebookControllerManager.node.ts
@@ -15,7 +15,7 @@ import {
 } from '../../platform/common/application/types';
 import { PYTHON_LANGUAGE } from '../../platform/common/constants';
 import { traceInfoIfCI, traceError, traceWarning, traceInfo, traceDecoratorVerbose } from '../../platform/logging';
-import { getDisplayPath } from '../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../platform/common/platform/fs-paths';
 import { CondaService } from '../../platform/common/process/condaService.node';
 import {
     IDisposableRegistry,

--- a/src/notebooks/controllers/vscodeNotebookController.node.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.node.ts
@@ -37,7 +37,7 @@ import {
     traceDecoratorVerbose,
     traceError
 } from '../../platform/logging';
-import { getDisplayPath } from '../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../platform/common/platform/fs-paths';
 import {
     IBrowserService,
     IConfigurationService,

--- a/src/notebooks/execution/kernelExecution.node.ts
+++ b/src/notebooks/execution/kernelExecution.node.ts
@@ -25,7 +25,7 @@ import {
     NotebookCellRunState
 } from '../../kernels/types';
 import { traceCellMessage } from '../helpers.node';
-import { getDisplayPath } from '../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../platform/common/platform/fs-paths';
 import { getAssociatedNotebookDocument } from '../controllers/kernelSelector.node';
 
 /**

--- a/src/notebooks/outputs/plotSaveHandler.node.ts
+++ b/src/notebooks/outputs/plotSaveHandler.node.ts
@@ -3,7 +3,7 @@ import { NotebookCellOutput, NotebookDocument, Uri } from 'vscode';
 import * as path from '../../platform/vscode-path/path';
 import { IApplicationShell, IWorkspaceService } from '../../platform/common/application/types';
 import { traceError } from '../../platform/logging';
-import { getDisplayPath } from '../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../platform/common/platform/fs-paths';
 import { IFileSystem } from '../../platform/common/platform/types.node';
 import { DataScience } from '../../platform/common/utils/localize';
 import { saveSvgToPdf } from '../../webviews/extension-side/plotting/plotViewer.node';

--- a/src/notebooks/outputs/plotViewHandler.node.ts
+++ b/src/notebooks/outputs/plotViewHandler.node.ts
@@ -2,7 +2,7 @@ import sizeOf from 'image-size';
 import { inject, injectable } from 'inversify';
 import { NotebookCellOutputItem, NotebookDocument } from 'vscode';
 import { traceError } from '../../platform/logging';
-import { getDisplayPath } from '../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../platform/common/platform/fs-paths';
 import { IPlotViewerProvider } from '../../webviews/extension-side/plotting/types';
 
 const svgMimeType = 'image/svg+xml';

--- a/src/platform/api/pythonApi.node.ts
+++ b/src/platform/api/pythonApi.node.ts
@@ -16,7 +16,7 @@ import { inject, injectable } from 'inversify';
 import { Disposable, Event, EventEmitter, Uri, workspace } from 'vscode';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../common/application/types';
 import { isCI, PythonExtension, Telemetry } from '../common/constants';
-import { getDisplayPath } from '../common/platform/fs-paths.node';
+import { getDisplayPath } from '../common/platform/fs-paths';
 import { IDisposableRegistry, IExtensions, InterpreterUri, Resource } from '../common/types';
 import { createDeferred } from '../common/utils/async';
 import * as localize from '../common/utils/localize';

--- a/src/platform/common/platform/fs-paths.node.ts
+++ b/src/platform/common/platform/fs-paths.node.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import * as path from '../../vscode-path/path';
-import { Uri, WorkspaceFolder } from 'vscode';
 import { getOSType, OSType } from '../utils/platform';
 import { IExecutables, IFileSystemPaths, IFileSystemPathUtils } from './types';
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
@@ -143,51 +142,5 @@ export class FileSystemPathUtils implements IFileSystemPathUtils {
         } else {
             return filename;
         }
-    }
-}
-export function getDisplayPath(
-    filename?: string | Uri,
-    workspaceFolders: readonly WorkspaceFolder[] | WorkspaceFolder[] = []
-) {
-    const relativeToHome = getDisplayPathImpl(filename);
-    const relativeToWorkspaceFolders = workspaceFolders.map((folder) =>
-        getDisplayPathImpl(filename, folder.uri.fsPath)
-    );
-    // Pick the shortest path for display purposes.
-    // As those are most likely relative to some workspace folder.
-    let bestDisplayPath = relativeToHome;
-    [relativeToHome, ...relativeToWorkspaceFolders].forEach((relativePath) => {
-        if (relativePath.length < bestDisplayPath.length) {
-            bestDisplayPath = relativePath;
-        }
-    });
-
-    return bestDisplayPath;
-}
-
-function getDisplayPathImpl(filename?: string | Uri, cwd?: string): string {
-    let file = '';
-    if (typeof filename === 'string') {
-        file = filename;
-    } else if (!filename) {
-        file = '';
-    } else if (filename.scheme === 'file') {
-        file = filename.fsPath;
-    } else {
-        file = filename.toString();
-    }
-    if (!file) {
-        return '';
-    } else if (cwd && file.startsWith(cwd)) {
-        const relativePath = `.${path.sep}${path.relative(cwd, file)}`;
-        // On CI the relative path might not work as expected as when testing we might have windows paths
-        // and the code is running on a unix machine.
-        return relativePath === file || relativePath.includes(cwd)
-            ? `.${path.sep}${file.substring(file.indexOf(cwd) + cwd.length)}`
-            : relativePath;
-    } else if (file.startsWith(homePath)) {
-        return `~${path.sep}${path.relative(homePath, file)}`;
-    } else {
-        return file;
     }
 }

--- a/src/platform/common/process/environmentActivationService.node.ts
+++ b/src/platform/common/process/environmentActivationService.node.ts
@@ -20,7 +20,7 @@ import { getInterpreterHash } from '../../pythonEnvironments/info/interpreter.no
 import { IPythonApiProvider } from '../../api/types';
 import { StopWatch } from '../utils/stopWatch';
 import { Memento } from 'vscode';
-import { getDisplayPath } from '../platform/fs-paths.node';
+import { getDisplayPath } from '../platform/fs-paths';
 import { IEnvironmentActivationService } from '../../interpreter/activation/types';
 import { IInterpreterService } from '../../interpreter/contracts.node';
 import { CurrentProcess } from './currentProcess.node';

--- a/src/platform/common/process/pythonDaemonPool.node.ts
+++ b/src/platform/common/process/pythonDaemonPool.node.ts
@@ -4,7 +4,7 @@
 import { IPlatformService } from '../../common/platform/types';
 import { PythonExecInfo } from '../../pythonEnvironments/exec';
 import { InterpreterInformation } from '../../pythonEnvironments/info';
-import { getDisplayPath } from '../platform/fs-paths.node';
+import { getDisplayPath } from '../platform/fs-paths';
 import { IDisposableRegistry } from '../types';
 import { sleep } from '../utils/async';
 import { noop } from '../utils/misc';

--- a/src/platform/common/process/pythonEnvironment.node.ts
+++ b/src/platform/common/process/pythonEnvironment.node.ts
@@ -11,7 +11,7 @@ import * as internalPython from './internal/python.node';
 import { ExecutionResult, IProcessService, ShellOptions, SpawnOptions } from './types.node';
 import { compare, SemVer } from 'semver';
 import type { PythonEnvironment as PyEnv } from '../../pythonEnvironments/info';
-import { getDisplayPath } from '../platform/fs-paths.node';
+import { getDisplayPath } from '../platform/fs-paths';
 class PythonEnvironment {
     private cachedInterpreterInformation: InterpreterInformation | undefined | null = null;
 

--- a/src/platform/common/process/pythonExecutionFactory.node.ts
+++ b/src/platform/common/process/pythonExecutionFactory.node.ts
@@ -9,7 +9,7 @@ import { sendTelemetryEvent } from '../../../telemetry';
 import { EventName } from '../../../telemetry/constants';
 import { IWorkspaceService } from '../application/types';
 import { ignoreLogging, traceDecoratorVerbose, traceError, traceInfo } from '../../logging';
-import { getDisplayPath } from '../platform/fs-paths.node';
+import { getDisplayPath } from '../platform/fs-paths';
 import { IFileSystem } from '../platform/types.node';
 import { IConfigurationService, IDisposable, IDisposableRegistry } from '../types';
 import { ProcessService } from './proc.node';

--- a/src/test/datascience/interactiveWindow.vscode.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.test.ts
@@ -8,7 +8,7 @@ import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { IPythonApiProvider } from '../../platform/api/types';
 import { traceInfo, traceInfoIfCI } from '../../platform/logging';
-import { getDisplayPath } from '../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../platform/common/platform/fs-paths';
 import { IDisposable } from '../../platform/common/types';
 import { InteractiveWindowProvider } from '../../interactive-window/interactiveWindowProvider.node';
 import { IKernelProvider } from '../../platform/../kernels/types';

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -10,7 +10,7 @@ import { commands, Memento, workspace, window, Uri, NotebookCell, NotebookDocume
 import { IPythonApiProvider } from '../../../../platform/api/types';
 import { ICommandManager, IVSCodeNotebook } from '../../../../platform/common/application/types';
 import { Kernel } from '../../../../platform/../kernels/kernel.node';
-import { getDisplayPath } from '../../../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../../../platform/common/platform/fs-paths';
 import { BufferDecoder } from '../../../../platform/common/process/decoder.node';
 import { ProcessService } from '../../../../platform/common/process/proc.node';
 import {

--- a/src/test/datascience/kernel-launcher/kernelFinder.vscode.test.node.ts
+++ b/src/test/datascience/kernel-launcher/kernelFinder.vscode.test.node.ts
@@ -13,7 +13,7 @@ import { IExtensionTestApi } from '../../common.node';
 import { initialize } from '../../initialize.node';
 import { traceInfo } from '../../../platform/logging';
 import { areInterpreterPathsSame } from '../../../platform/pythonEnvironments/info/interpreter.node';
-import { getDisplayPath } from '../../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../../platform/common/platform/fs-paths';
 import { ILocalKernelFinder } from '../../../kernels/raw/types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, no-invalid-this */

--- a/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
@@ -34,7 +34,7 @@ import { getInterpreterHash } from '../../../platform/pythonEnvironments/info/in
 import { OSType } from '../../../platform/common/utils/platform';
 import { disposeAllDisposables } from '../../../platform/common/helpers.node';
 import { KernelConnectionMetadata, LocalKernelConnectionMetadata } from '../../../platform/../kernels/types';
-import { getDisplayPath } from '../../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../../platform/common/platform/fs-paths';
 import { arePathsSame } from '../../../platform/common/platform/fileUtils.node';
 import { JupyterPaths } from '../../../kernels/raw/finder/jupyterPaths.node';
 import { LocalKernelFinder } from '../../../kernels/raw/finder/localKernelFinder.node';

--- a/src/test/datascience/notebook/executionService.vscode.test.ts
+++ b/src/test/datascience/notebook/executionService.vscode.test.ts
@@ -47,7 +47,7 @@ import {
 import { openNotebook } from '../helpers';
 import { noop } from '../../../platform/common/utils/misc';
 import { getTextOutputValue, hasErrorOutput, translateCellErrorOutput } from '../../../notebooks/helpers.node';
-import { getDisplayPath } from '../../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../../platform/common/platform/fs-paths';
 import { ProductNames } from '../../../kernels/installer/productNames.node';
 import { Product } from '../../../kernels/installer/types';
 import { IPYTHON_VERSION_CODE, IS_REMOTE_NATIVE_TEST } from '../../constants.node';

--- a/src/test/datascience/notebook/kernelCrashes.vscode.test.ts
+++ b/src/test/datascience/notebook/kernelCrashes.vscode.test.ts
@@ -38,7 +38,7 @@ import { createDeferred } from '../../../platform/common/utils/async';
 import { sleep } from '../../core';
 import { getDisplayNameOrNameOfKernelConnection } from '../../../platform/../kernels/helpers.node';
 import { Uri, window, workspace } from 'vscode';
-import { getDisplayPath } from '../../../platform/common/platform/fs-paths.node';
+import { getDisplayPath } from '../../../platform/common/platform/fs-paths';
 import { translateCellErrorOutput } from '../../../notebooks/helpers.node';
 import { INotebookEditorProvider } from '../../../notebooks/types';
 


### PR DESCRIPTION
Found that getDisplayNameOfKernel is still node specific because of a few things & one of the biggest blocker was the usage of `path`, But thats no longer the case, hense removed the node specific `getDIsplayPath`

Found while working on PR https://github.com/microsoft/vscode-jupyter/pull/9617