### PR TITLE
Add support for returning a preferred controller from the 'jupyter.selectjupyteruri' command

### DIFF
--- a/src/notebooks/types.ts
+++ b/src/notebooks/types.ts
@@ -31,6 +31,7 @@ export interface INotebookControllerManager {
         notebookType: typeof JupyterNotebookView | typeof InteractiveWindowView
     ): IVSCodeNotebookController | undefined;
     getPreferredNotebookController(document: NotebookDocument): IVSCodeNotebookController | undefined;
+    computePreferredNotebookController(document: NotebookDocument): Promise<IVSCodeNotebookController | undefined>;
 }
 export enum CellOutputMimeTypes {
     error = 'application/vnd.code.notebook.error',

--- a/src/platform/commands/serverSelector.node.ts
+++ b/src/platform/commands/serverSelector.node.ts
@@ -6,30 +6,47 @@
 import { inject, injectable } from 'inversify';
 import { ICommandManager } from '../../platform/common/application/types';
 import { IDisposable } from '../../platform/common/types';
-import { Uri } from 'vscode';
+import { NotebookDocument, Uri } from 'vscode';
 import { JupyterServerSelector } from '../../kernels/jupyter/serverSelector.node';
 import { Commands } from '../common/constants';
 import { traceInfo } from '../logging';
+import { INotebookControllerManager } from '../../notebooks/types';
 
 @injectable()
 export class JupyterServerSelectorCommand implements IDisposable {
     private readonly disposables: IDisposable[] = [];
     constructor(
         @inject(ICommandManager) private readonly commandManager: ICommandManager,
-        @inject(JupyterServerSelector) private readonly serverSelector: JupyterServerSelector
+        @inject(JupyterServerSelector) private readonly serverSelector: JupyterServerSelector,
+        @inject(INotebookControllerManager) private readonly controllerManager: INotebookControllerManager
     ) {}
     public register() {
         this.disposables.push(
             this.commandManager.registerCommand(
                 Commands.SelectJupyterURI,
-                (
+                async (
                     local: boolean = true,
-                    source: Uri | 'nativeNotebookStatusBar' | 'commandPalette' | 'toolbar' = 'commandPalette'
+                    source: Uri | 'nativeNotebookStatusBar' | 'commandPalette' | 'toolbar' = 'commandPalette',
+                    notebook: NotebookDocument | undefined
                 ) => {
                     if (source instanceof Uri) {
                         traceInfo(`Setting Jupyter Server URI to remote: ${source}`);
-                        void this.serverSelector.setJupyterURIToRemote(source.toString(true));
-                        return;
+
+                        // Set the uri directly
+                        await this.serverSelector.setJupyterURIToRemote(source.toString(true));
+
+                        // Find one that is the default for this remote
+                        if (notebook) {
+                            // Recompute the preferred controller
+                            await this.controllerManager.computePreferredNotebookController(notebook);
+
+                            // That should have picked a preferred
+                            const preferred = this.controllerManager.getPreferredNotebookController(notebook);
+                            if (preferred) {
+                                return preferred.id;
+                            }
+                        }
+                        return undefined;
                     }
 
                     // Activate UI Selector

--- a/src/platform/common/application/commands.ts
+++ b/src/platform/common/application/commands.ts
@@ -180,7 +180,11 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [DSCommands.ShowDataViewer]: [IShowDataViewerFromVariablePanel];
     [DSCommands.RefreshDataViewer]: [];
     [DSCommands.ClearSavedJupyterUris]: [];
-    [DSCommands.SelectJupyterURI]: [boolean | undefined, Uri | 'toolbar' | 'nativeNotebookStatusBar' | undefined];
+    [DSCommands.SelectJupyterURI]: [
+        boolean | undefined,
+        Uri | 'toolbar' | 'nativeNotebookStatusBar' | undefined,
+        NotebookDocument | undefined
+    ];
     [DSCommands.SelectNativeJupyterUriFromToolBar]: [];
     [DSCommands.DebugNotebook]: [];
     [DSCommands.RunByLine]: [NotebookCell];

--- a/src/test/datascience/.vscode/settings.json
+++ b/src/test/datascience/.vscode/settings.json
@@ -31,5 +31,5 @@
     "python.experiments.enabled": true,
     "python.defaultInterpreterPath": "python",
     "jupyter.generateSVGPlots": "false",
-    "jupyter.jupyterServerType": "remote"
+    "jupyter.jupyterServerType": "local"
 }

--- a/src/test/datascience/.vscode/settings.json
+++ b/src/test/datascience/.vscode/settings.json
@@ -30,5 +30,6 @@
     // Python experiments have to be on for insiders to work
     "python.experiments.enabled": true,
     "python.defaultInterpreterPath": "python",
-    "jupyter.generateSVGPlots": "false"
+    "jupyter.generateSVGPlots": "false",
+    "jupyter.jupyterServerType": "remote"
 }

--- a/src/test/datascience/commands/serverSelector.unit.test.ts
+++ b/src/test/datascience/commands/serverSelector.unit.test.ts
@@ -7,18 +7,25 @@ import { ICommandManager } from '../../../platform/common/application/types';
 import { JupyterServerSelectorCommand } from '../../../platform/commands/serverSelector.node';
 import { JupyterServerSelector } from '../../../kernels/jupyter/serverSelector.node';
 import { Commands } from '../../../platform/common/constants';
+import { INotebookControllerManager } from '../../../notebooks/types';
 
 /* eslint-disable  */
 suite('DataScience - Server Selector Command', () => {
     let serverSelectorCommand: JupyterServerSelectorCommand;
     let commandManager: ICommandManager;
     let serverSelector: JupyterServerSelector;
+    let controllerManager: INotebookControllerManager;
 
     setup(() => {
         commandManager = mock(CommandManager);
         serverSelector = mock(JupyterServerSelector);
+        controllerManager = mock(controllerManager);
 
-        serverSelectorCommand = new JupyterServerSelectorCommand(instance(commandManager), instance(serverSelector));
+        serverSelectorCommand = new JupyterServerSelectorCommand(
+            instance(commandManager),
+            instance(serverSelector),
+            instance(controllerManager)
+        );
     });
 
     test('Register Command', () => {

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -40,7 +40,7 @@ import { GLOBAL_MEMENTO, IDisposable, IMemento } from '../../../platform/common/
 import { createDeferred } from '../../../platform/common/utils/async';
 import { swallowExceptions } from '../../../platform/common/utils/misc';
 import { IKernelProvider } from '../../../platform/../kernels/types';
-import { IExtensionTestApi, sleep, waitForCondition } from '../../common.node';
+import { sleep, waitForCondition } from '../../common.node';
 import { EXTENSION_ROOT_DIR_FOR_TESTS, IS_REMOTE_NATIVE_TEST, IS_SMOKE_TEST } from '../../constants.node';
 import { noop } from '../../core';
 import { closeActiveWindows, initialize, isInsiders } from '../../initialize.node';
@@ -48,7 +48,6 @@ import { JupyterServer } from '../jupyterServer.node';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { IDebuggingManager, IKernelDebugAdapter } from '../../../platform/debugger/types';
 import { DataScience } from '../../../platform/common/utils/localize';
-import { JupyterServerSelector } from '../../../kernels/jupyter/serverSelector.node';
 import { LastSavedNotebookCellLanguage } from '../../../intellisense/cellLanguageService.node';
 import { VSCodeNotebookController } from '../../../notebooks/controllers/vscodeNotebookController.node';
 import { chainWithPendingUpdates } from '../../../notebooks/execution/notebookUpdater.node';
@@ -383,14 +382,12 @@ export async function waitForKernelToGetAutoSelected(expectedLanguage?: string, 
     return waitForKernelToChange(criteria, timeout);
 }
 
-export async function startJupyterServer(api?: IExtensionTestApi) {
-    const { serviceContainer } = api ? { serviceContainer: api.serviceContainer } : await getServices();
+export async function startJupyterServer(notebook?: NotebookDocument) {
     if (IS_REMOTE_NATIVE_TEST) {
-        const selector = serviceContainer.get<JupyterServerSelector>(JupyterServerSelector);
         const uri = await JupyterServer.instance.startJupyterWithToken();
         const uriString = decodeURIComponent(uri.toString());
         traceInfo(`Jupyter started and listening at ${uriString}`);
-        await selector.setJupyterURIToRemote(uriString);
+        return commands.executeCommand('jupyter.selectjupyteruri', false, uri, notebook);
     } else {
         traceInfo(`Jupyter not started and set to local`); // This is the default
     }

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -55,7 +55,6 @@ import { NotebookCellStateTracker, hasErrorOutput, getTextOutputValue } from '..
 import { INotebookControllerManager, CellOutputMimeTypes, INotebookEditorProvider } from '../../../notebooks/types';
 import { InteractiveControllerIdSuffix } from '../../../notebooks/controllers/notebookControllerManager.node';
 import { IVSCodeNotebookController } from '../../../notebooks/controllers/types';
-import { JupyterServerSelector } from '../../../kernels/jupyter/serverSelector.node';
 
 // Running in Conda environments, things can be a little slower.
 export const defaultNotebookTestTimeout = 60_000;

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -391,9 +391,6 @@ export async function startJupyterServer(notebook?: NotebookDocument) {
         return commands.executeCommand('jupyter.selectjupyteruri', false, uri, notebook);
     } else {
         traceInfo(`Jupyter not started and set to local`); // This is the default
-        const { serviceContainer } = await getServices();
-        const selector = serviceContainer.get<JupyterServerSelector>(JupyterServerSelector);
-        return selector.setJupyterURIToLocal();
     }
 }
 /**

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -55,6 +55,7 @@ import { NotebookCellStateTracker, hasErrorOutput, getTextOutputValue } from '..
 import { INotebookControllerManager, CellOutputMimeTypes, INotebookEditorProvider } from '../../../notebooks/types';
 import { InteractiveControllerIdSuffix } from '../../../notebooks/controllers/notebookControllerManager.node';
 import { IVSCodeNotebookController } from '../../../notebooks/controllers/types';
+import { JupyterServerSelector } from '../../../kernels/jupyter/serverSelector.node';
 
 // Running in Conda environments, things can be a little slower.
 export const defaultNotebookTestTimeout = 60_000;
@@ -390,6 +391,9 @@ export async function startJupyterServer(notebook?: NotebookDocument) {
         return commands.executeCommand('jupyter.selectjupyteruri', false, uri, notebook);
     } else {
         traceInfo(`Jupyter not started and set to local`); // This is the default
+        const { serviceContainer } = await getServices();
+        const selector = serviceContainer.get<JupyterServerSelector>(JupyterServerSelector);
+        return selector.setJupyterURIToLocal();
     }
 }
 /**

--- a/src/test/initialize.node.ts
+++ b/src/test/initialize.node.ts
@@ -40,7 +40,7 @@ export async function initialize(): Promise<IExtensionTestApi> {
     // Ensure we start jupyter server before opening any notebooks or the like.
     if (!jupyterServerStarted) {
         jupyterServerStarted = true;
-        await startJupyterServer(api as unknown as IExtensionTestApi);
+        await startJupyterServer();
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return api as any as IExtensionTestApi;


### PR DESCRIPTION
Based on what @rebornix was talking about, this should make it possible to get the 'preferred' controller after setting a remote server URI

