### PR TITLE
connectToLiveKernel to connectoToLiveRemoteKernel

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -527,7 +527,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         reason: 'normally' | 'onKernelDisposed' | 'onAnInterrupt' | 'onARestart' | 'withKeybinding';
 
 ## Locations Used
@@ -578,7 +578,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         status: 'installed' | 'notInstalled';
 
 ## Locations Used
@@ -1366,9 +1366,9 @@ No description provided
 
 ## Properties
 
-- 
+-
         ename: string;
-- 
+-
         evalue: string;
 
 ## Locations Used
@@ -1471,9 +1471,9 @@ No description provided
 
 ## Properties
 
-- 
+-
         where: 'activeInterpreter' | 'otherInterpreter' | 'path' | 'nowhere';
-- 
+-
         command: JupyterCommands;
 
 ## Locations Used
@@ -1491,9 +1491,9 @@ No description provided
 
 ## Properties
 
-- 
+-
         extensionId: string;
-- 
+-
         allowed: 'yes' | 'no';
 
 ## Locations Used
@@ -1532,9 +1532,9 @@ No description provided
 
 ## Properties
 
-- 
+-
         extensionId: string;
-- 
+-
         pemUsed: keyof IExportedKernelService;
 
 ## Locations Used
@@ -1661,9 +1661,9 @@ No description provided
 
 ## Properties
 
-- 
+-
         ename: string;
-- 
+-
         evalue: string;
 
 ## Locations Used
@@ -2393,7 +2393,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * The id of the extension registering with us to be displayed the dropdown list for notebook creation.
          */
@@ -2710,9 +2710,9 @@ No description provided
 
 ## Properties
 
-- 
+-
         ename: string;
-- 
+-
         evalue: string;
 
 ## Locations Used
@@ -2788,12 +2788,12 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * Extension we recommended the user to install.
          */
         extensionId: string;
-- 
+-
         /**
          * `displayed` - If prompt was displayed
          * `dismissed` - If prompt was displayed & dismissed by the user
@@ -4027,7 +4027,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         azure: boolean;
 
 ## Locations Used
@@ -4319,9 +4319,9 @@ No description provided
 
 ## Properties
 
-- 
+-
         ename: string;
-- 
+-
         evalue: string;
 
 ## Locations Used
@@ -4462,7 +4462,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * Whether this is the first time in the session.
          * (fetching kernels first time in the session is slower, later its cached).
@@ -4836,7 +4836,7 @@ No properties for event
 
 ## Properties
 
-- 
+-
         /**
          * Indicates whether the python extension is installed.
          * If we send telemetry fro this & this is `true`, then we have a bug.
@@ -5256,38 +5256,38 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * Hash of the cell output mimetype
          *
          * @type {string}
          */
         hashedName: string;
-- 
+-
         hasText: boolean;
-- 
+-
         hasLatex: boolean;
-- 
+-
         hasHtml: boolean;
-- 
+-
         hasSvg: boolean;
-- 
+-
         hasXml: boolean;
-- 
+-
         hasJson: boolean;
-- 
+-
         hasImage: boolean;
-- 
+-
         hasGeo: boolean;
-- 
+-
         hasPlotly: boolean;
-- 
+-
         hasVega: boolean;
-- 
+-
         hasWidget: boolean;
-- 
+-
         hasJupyter: boolean;
-- 
+-
         hasVnd: boolean;
 
 ## Locations Used
@@ -5362,7 +5362,7 @@ Event can be removed. Not referenced anywhere
 
 ## Properties
 
-- 
+-
         // Result is null if user signalled cancellation or if we timed out
         isResultNull: boolean;
 
@@ -6060,7 +6060,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * Total time spent in attempting to start and connect to jupyter before giving up.
          *
@@ -6236,14 +6236,14 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * Whether this is the first time in the session.
          * (fetching kernels first time in the session is slower, later its cached).
          * This is a generic property supported for all telemetry (sent by decorators).
          */
         firstTime?: boolean;
-- 
+-
         /**
          * Whether this telemetry is for listing of all kernels or just python or just non-python.
          * (fetching kernels first time in the session is slower, later its cached).
@@ -6310,7 +6310,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         action: 'displayed';
 -  // Message displayed.
         /**
@@ -6411,7 +6411,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * Number of kernel specs.
          */
@@ -6741,7 +6741,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         action:
             | 'displayed' // Message displayed.
             | 'dismissed' // user dismissed the message.
@@ -6875,15 +6875,15 @@ No description provided
 
 ## Properties
 
-- 
+-
         moduleName: string;
-- 
+-
         /**
          * Whether the module was already (once before) installed into the python environment or
          * whether this already exists (detected via `pip list`)
          */
         isModulePresent?: 'true' | undefined;
-- 
+-
         action:
             | 'cancelled' // User cancelled the installation or closed the notebook or the like.
             | 'displayed' // Install prompt may have been displayed.
@@ -6901,13 +6901,13 @@ No description provided
             | 'dismissed';
 -  // User chose to dismiss the prompt.
         resourceType?: 'notebook' | 'interactive';
-- 
+-
         /**
          * Hash of the resource (notebook.uri or pythonfile.uri associated with this).
          * If we run the same notebook tomorrow, the hash will be the same.
          */
         resourceHash?: string;
-- 
+-
         pythonEnvType?: EnvironmentType;
 
 ## Locations Used
@@ -7066,7 +7066,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         action:
             | 'displayed' // Message displayed.
             | 'dismissed' // user dismissed the message.
@@ -7616,7 +7616,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * Number of kernel specs.
          */
@@ -7693,7 +7693,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * The result of the selection.
          * notSelected - No interpreter was selected.
@@ -8078,7 +8078,7 @@ export function sendNotebookOrKernelLanguageTelemetry(
             case 'startUsingPythonInterpreter':
                 sendNotebookOrKernelLanguageTelemetry(Telemetry.SwitchToExistingKernel, PYTHON_LANGUAGE);
                 break;
-            case 'connectToLiveKernel':
+            case 'connectToLiveRemoteKernel':
                 sendNotebookOrKernelLanguageTelemetry(
 ```
 
@@ -8086,7 +8086,7 @@ export function sendNotebookOrKernelLanguageTelemetry(
 [src/notebooks/controllers/vscodeNotebookController.node.ts#L587](https://github.com/microsoft/vscode-jupyter/tree/main/src/notebooks/controllers/vscodeNotebookController.node.ts#L587)
 ```typescript
                 break;
-            case 'connectToLiveKernel':
+            case 'connectToLiveRemoteKernel':
                 sendNotebookOrKernelLanguageTelemetry(
                     Telemetry.SwitchToExistingKernel,
                     this.connection.kernelModel.language
@@ -8267,7 +8267,7 @@ No description provided
 
 ## Properties
 
-- 
+-
         isErrorOutput: boolean;
 
 ## Locations Used
@@ -8860,28 +8860,28 @@ No description provided
 
 ## Properties
 
-- 
+-
         /**
          * Carries `true` if environment variables are present, `false` otherwise
          *
          * @type {boolean}
          */
         hasEnvVars?: boolean;
-- 
+-
         /**
          * Carries `true` if fetching environment variables failed, `false` otherwise
          *
          * @type {boolean}
          */
         failed?: boolean;
-- 
+-
         /**
          * Whether the environment was activated within a terminal or not.
          *
          * @type {boolean}
          */
         activatedInTerminal?: boolean;
-- 
+-
         /**
          * Whether the environment was activated by the wrapper class.
          * If `true`, this telemetry is sent by the class that wraps the two activation providers   .

--- a/src/intellisense/emptyNotebookCellLanguageService.node.ts
+++ b/src/intellisense/emptyNotebookCellLanguageService.node.ts
@@ -63,7 +63,7 @@ export class EmptyNotebookCellLanguageService implements IExtensionSingleActivat
         let language: string | undefined;
         const kernelKind = connection.kind;
         switch (connection.kind) {
-            case 'connectToLiveKernel': {
+            case 'connectToLiveRemoteKernel': {
                 language = connection.kernelModel.language;
                 break;
             }

--- a/src/intellisense/intellisenseProvider.node.ts
+++ b/src/intellisense/intellisenseProvider.node.ts
@@ -179,7 +179,7 @@ export class IntellisenseProvider implements INotebookLanguageClientProvider, IE
         if (
             interpreterId !== notebookId &&
             (controller?.connection.kind === 'startUsingRemoteKernelSpec' ||
-                controller?.connection.kind === 'connectToLiveKernel')
+                controller?.connection.kind === 'connectToLiveRemoteKernel')
         ) {
             const activeInterpreter = this.getActiveInterpreterSync(uri.fsPath);
             notebookId = activeInterpreter ? this.getInterpreterIdFromCache(activeInterpreter) : undefined;

--- a/src/kernels/common/baseJupyterSession.node.ts
+++ b/src/kernels/common/baseJupyterSession.node.ts
@@ -432,7 +432,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
         shutdownEvenIfRemote?: boolean
     ): boolean {
         // We can never shut down existing (live) kernels.
-        if (session.kernelConnectionMetadata?.kind === 'connectToLiveKernel' && !shutdownEvenIfRemote) {
+        if (session.kernelConnectionMetadata?.kind === 'connectToLiveRemoteKernel' && !shutdownEvenIfRemote) {
             return false;
         }
         // We can always shutdown restart sessions.

--- a/src/kernels/ipywidgets-message-coordination/ipyWidgetScriptSourceProvider.node.ts
+++ b/src/kernels/ipywidgets-message-coordination/ipyWidgetScriptSourceProvider.node.ts
@@ -172,7 +172,7 @@ export class IPyWidgetScriptSourceProvider implements IWidgetScriptSourceProvide
             );
         }
         switch (this.kernel.kernelConnectionMetadata.kind) {
-            case 'connectToLiveKernel':
+            case 'connectToLiveRemoteKernel':
             case 'startUsingRemoteKernelSpec':
                 scriptProviders.push(
                     new RemoteWidgetScriptSourceProvider(this.kernel.kernelConnectionMetadata.baseUrl, this.httpClient)

--- a/src/kernels/jupyter/jupyterKernelService.node.ts
+++ b/src/kernels/jupyter/jupyterKernelService.node.ts
@@ -69,7 +69,7 @@ export class JupyterKernelService {
         traceVerbose('Check if a kernel is usable');
         // If we have an interpreter, make sure it has the correct dependencies installed
         if (
-            kernel.kind !== 'connectToLiveKernel' &&
+            kernel.kind !== 'connectToLiveRemoteKernel' &&
             kernel.interpreter &&
             kernel.kind !== 'startUsingRemoteKernelSpec'
         ) {
@@ -95,7 +95,7 @@ export class JupyterKernelService {
 
         // If the spec file doesn't exist or is not defined, we need to register this kernel
         if (
-            kernel.kind !== 'connectToLiveKernel' &&
+            kernel.kind !== 'connectToLiveRemoteKernel' &&
             kernel.kind !== 'startUsingRemoteKernelSpec' &&
             kernel.kernelSpec &&
             kernel.interpreter
@@ -120,7 +120,7 @@ export class JupyterKernelService {
 
         // Update the kernel environment to use the interpreter's latest
         if (
-            kernel.kind !== 'connectToLiveKernel' &&
+            kernel.kind !== 'connectToLiveRemoteKernel' &&
             kernel.kind !== 'startUsingRemoteKernelSpec' &&
             kernel.kernelSpec &&
             kernel.interpreter &&

--- a/src/kernels/jupyter/session/jupyterSession.node.ts
+++ b/src/kernels/jupyter/session/jupyterSession.node.ts
@@ -117,7 +117,7 @@ export class JupyterSession extends BaseJupyterSession {
             // Don't immediately assume this kernel is valid. Try creating a session with it first.
             if (
                 this.kernelConnectionMetadata &&
-                this.kernelConnectionMetadata.kind === 'connectToLiveKernel' &&
+                this.kernelConnectionMetadata.kind === 'connectToLiveRemoteKernel' &&
                 this.kernelConnectionMetadata.kernelModel.id &&
                 this.kernelConnectionMetadata.kernelModel.model
             ) {

--- a/src/kernels/kernel.node.ts
+++ b/src/kernels/kernel.node.ts
@@ -533,7 +533,7 @@ export class Kernel implements IKernel {
         }
 
         // If this is a live kernel, we shouldn't be changing anything by running startup code.
-        if (this.kernelConnectionMetadata.kind !== 'connectToLiveKernel') {
+        if (this.kernelConnectionMetadata.kind !== 'connectToLiveRemoteKernel') {
             // Gather all of the startup code at one time and execute as one cell
             const startupCode = await this.gatherInternalStartupCode();
             await this.executeSilently(notebook, startupCode, {
@@ -572,7 +572,7 @@ export class Kernel implements IKernel {
             };
             promises.push(notebook.session.requestKernelInfo().then((item) => item?.content));
             // If this doesn't complete in 5 seconds for remote kernels, assume the kernel is busy & provide some default content.
-            if (this.kernelConnectionMetadata.kind === 'connectToLiveKernel') {
+            if (this.kernelConnectionMetadata.kind === 'connectToLiveRemoteKernel') {
                 promises.push(sleep(5_000).then(() => defaultResponse));
             }
             const content = await Promise.race(promises);
@@ -585,7 +585,7 @@ export class Kernel implements IKernel {
         } catch (ex) {
             traceWarning('Failed to request KernelInfo', ex);
         }
-        if (this.kernelConnectionMetadata.kind !== 'connectToLiveKernel') {
+        if (this.kernelConnectionMetadata.kind !== 'connectToLiveRemoteKernel') {
             traceVerbose('End running kernel initialization, now waiting for idle');
             await notebook.session.waitForIdle(this.launchTimeout);
             traceVerbose('End running kernel initialization, session is idle');
@@ -716,7 +716,7 @@ export class Kernel implements IKernel {
         if (
             (isLocalConnection(this.kernelConnectionMetadata) ||
                 isLocalHostConnection(this.kernelConnectionMetadata)) &&
-            this.kernelConnectionMetadata.kind !== 'connectToLiveKernel' // Skip for live kernel. Don't change current directory on a kernel that's already running
+            this.kernelConnectionMetadata.kind !== 'connectToLiveRemoteKernel' // Skip for live kernel. Don't change current directory on a kernel that's already running
         ) {
             let suggestedDir = await calculateWorkingDirectory(
                 this.configService,

--- a/src/kernels/kernelConnectionWrapper.node.ts
+++ b/src/kernels/kernelConnectionWrapper.node.ts
@@ -235,7 +235,7 @@ export class KernelConnectionWrapper implements Kernel.IKernelConnection {
     async shutdown(): Promise<void> {
         if (
             this.kernel.kernelConnectionMetadata.kind === 'startUsingRemoteKernelSpec' ||
-            this.kernel.kernelConnectionMetadata.kind === 'connectToLiveKernel'
+            this.kernel.kernelConnectionMetadata.kind === 'connectToLiveRemoteKernel'
         ) {
             await this.kernel.session?.shutdown();
         }

--- a/src/kernels/kernelDependencyService.node.ts
+++ b/src/kernels/kernelDependencyService.node.ts
@@ -69,7 +69,7 @@ export class KernelDependencyService implements IKernelDependencyService {
             } for resource ${getDisplayPath(resource)}`
         );
         if (
-            kernelConnection.kind === 'connectToLiveKernel' ||
+            kernelConnection.kind === 'connectToLiveRemoteKernel' ||
             kernelConnection.kind === 'startUsingRemoteKernelSpec' ||
             kernelConnection.interpreter === undefined
         ) {
@@ -135,7 +135,7 @@ export class KernelDependencyService implements IKernelDependencyService {
         ignoreCache?: boolean
     ): Promise<boolean> {
         if (
-            kernelConnection.kind === 'connectToLiveKernel' ||
+            kernelConnection.kind === 'connectToLiveRemoteKernel' ||
             kernelConnection.kind === 'startUsingRemoteKernelSpec' ||
             kernelConnection.interpreter === undefined
         ) {

--- a/src/kernels/raw/finder/remoteKernelFinder.node.ts
+++ b/src/kernels/raw/finder/remoteKernelFinder.node.ts
@@ -12,7 +12,7 @@ import {
     IJupyterKernelSpec,
     INotebookProviderConnection,
     KernelConnectionMetadata,
-    LiveKernelConnectionMetadata,
+    LiveRemoteKernelConnectionMetadata,
     RemoteKernelSpecConnectionMetadata
 } from '../../../kernels/types';
 import { PYTHON_LANGUAGE } from '../../../platform/common/constants';
@@ -142,8 +142,8 @@ export class RemoteKernelFinder implements IRemoteKernelFinder {
                     const matchingSpec: Partial<IJupyterKernelSpec> =
                         specs.find((spec) => spec.name === s.kernel?.name) || {};
 
-                    const kernel: LiveKernelConnectionMetadata = {
-                        kind: 'connectToLiveKernel',
+                    const kernel: LiveRemoteKernelConnectionMetadata = {
+                        kind: 'connectToLiveRemoteKernel',
                         kernelModel: {
                             ...s.kernel,
                             ...matchingSpec,

--- a/src/kernels/raw/session/rawJupyterSession.node.ts
+++ b/src/kernels/raw/session/rawJupyterSession.node.ts
@@ -226,7 +226,7 @@ export class RawJupyterSession extends BaseJupyterSession {
         disableUI: boolean,
         cancelToken: CancellationToken
     ): Promise<ISessionWithSocket> {
-        if (!this.kernelConnectionMetadata || this.kernelConnectionMetadata.kind === 'connectToLiveKernel') {
+        if (!this.kernelConnectionMetadata || this.kernelConnectionMetadata.kind === 'connectToLiveRemoteKernel') {
             throw new Error('Unsupported - unable to restart live kernel sessions using raw kernel.');
         }
         return this.startRawSession({ token: cancelToken, ui: new DisplayOptions(disableUI) });

--- a/src/kernels/types.ts
+++ b/src/kernels/types.ts
@@ -33,14 +33,14 @@ export enum NotebookCellRunState {
  * Connection metadata for Live Kernels.
  * With this we are able connect to an existing kernel (instead of starting a new session).
  */
-export type LiveKernelConnectionMetadata = Readonly<{
+export type LiveRemoteKernelConnectionMetadata = Readonly<{
     kernelModel: LiveKernelModel;
     /**
      * Python interpreter will be used for intellisense & the like.
      */
     interpreter?: PythonEnvironment;
     baseUrl: string;
-    kind: 'connectToLiveKernel';
+    kind: 'connectToLiveRemoteKernel';
     id: string;
 }>;
 /**
@@ -91,7 +91,7 @@ export type PythonKernelConnectionMetadata = Readonly<{
  * Unexpected as connections are defined once & not changed, if we need to change then user needs to create a new connection.
  */
 export type KernelConnectionMetadata =
-    | Readonly<LiveKernelConnectionMetadata>
+    | Readonly<LiveRemoteKernelConnectionMetadata>
     | Readonly<LocalKernelSpecConnectionMetadata>
     | Readonly<RemoteKernelSpecConnectionMetadata>
     | Readonly<PythonKernelConnectionMetadata>;

--- a/src/notebooks/controllers/kernelFilter/kernelFilterService.node.ts
+++ b/src/notebooks/controllers/kernelFilter/kernelFilterService.node.ts
@@ -31,7 +31,10 @@ export class KernelFilterService implements IDisposable {
     }
     public isKernelHidden(kernelConnection: KernelConnectionMetadata): boolean {
         const hiddenList = this.getFilters();
-        if (kernelConnection.kind === 'connectToLiveKernel' || kernelConnection.kind === 'startUsingRemoteKernelSpec') {
+        if (
+            kernelConnection.kind === 'connectToLiveRemoteKernel' ||
+            kernelConnection.kind === 'startUsingRemoteKernelSpec'
+        ) {
             return false;
         }
         const hidden = hiddenList.some((item) => {
@@ -100,7 +103,7 @@ export class KernelFilterService implements IDisposable {
         this._onDidChange.fire();
     }
     private translateConnectionToFilter(connection: KernelConnectionMetadata): KernelFilter | undefined {
-        if (connection.kind === 'connectToLiveKernel') {
+        if (connection.kind === 'connectToLiveRemoteKernel') {
             traceVerbose('Hiding default or live kernels via filter is not supported');
             return;
         }

--- a/src/notebooks/controllers/kernelFilter/kernelFilterUI.node.ts
+++ b/src/notebooks/controllers/kernelFilter/kernelFilterUI.node.ts
@@ -67,7 +67,10 @@ export class KernelFilterUI implements IExtensionSyncActivationService, IDisposa
                             label: getDisplayNameOrNameOfKernelConnection(item),
                             picked: !this.kernelFilter.isKernelHidden(item),
                             description: getKernelConnectionPath(item, this.pathUtils, this.workspace),
-                            detail: item.kind === 'connectToLiveKernel' ? getRemoteKernelSessionInformation(item) : '',
+                            detail:
+                                item.kind === 'connectToLiveRemoteKernel'
+                                    ? getRemoteKernelSessionInformation(item)
+                                    : '',
                             connection: item
                         };
                     });

--- a/src/notebooks/controllers/liveKernelSwitcher.node.ts
+++ b/src/notebooks/controllers/liveKernelSwitcher.node.ts
@@ -7,7 +7,7 @@ import { IExtensionSingleActivationService } from '../../platform/activation/typ
 import { IVSCodeNotebook, ICommandManager } from '../../platform/common/application/types';
 import { traceError } from '../../platform/logging';
 import { IDisposableRegistry, IMemento, WORKSPACE_MEMENTO } from '../../platform/common/types';
-import { IKernelProvider, LiveKernelConnectionMetadata } from '../../kernels/types';
+import { IKernelProvider, LiveRemoteKernelConnectionMetadata } from '../../kernels/types';
 import { INotebookControllerManager } from '../types';
 import { switchKernel } from './kernelSelector.node';
 
@@ -61,7 +61,7 @@ export class LiveKernelSwitcher implements IExtensionSingleActivationService {
         }
     }
 
-    private onLiveRefresh(liveConnections: LiveKernelConnectionMetadata[]) {
+    private onLiveRefresh(liveConnections: LiveRemoteKernelConnectionMetadata[]) {
         // When a refresh happens, remember the live connection id for all notebooks
         this.vscNotebook.notebookDocuments.forEach(async (n) => {
             const kernel = this.kernelProvider.get(n.uri);

--- a/src/notebooks/controllers/notebookControllerManager.node.ts
+++ b/src/notebooks/controllers/notebookControllerManager.node.ts
@@ -51,7 +51,7 @@ import { JupyterServerSelector } from '../../kernels/jupyter/serverSelector.node
 import { PreferredRemoteKernelIdProvider } from '../../kernels/raw/finder/preferredRemoteKernelIdProvider.node';
 import { ILocalKernelFinder, IRemoteKernelFinder } from '../../kernels/raw/types';
 import {
-    LiveKernelConnectionMetadata,
+    LiveRemoteKernelConnectionMetadata,
     IKernelProvider,
     KernelConnectionMetadata,
     PythonKernelConnectionMetadata,
@@ -122,7 +122,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
     private interactiveNoPythonController?: NoPythonKernelsNotebookController;
     private notebookNoPythonController?: NoPythonKernelsNotebookController;
     private handlerAddedForChangesToRemoteKernelUri?: boolean;
-    private remoteRefreshedEmitter = new EventEmitter<LiveKernelConnectionMetadata[]>();
+    private remoteRefreshedEmitter = new EventEmitter<LiveRemoteKernelConnectionMetadata[]>();
     constructor(
         @inject(IVSCodeNotebook) private readonly notebook: IVSCodeNotebook,
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
@@ -542,9 +542,9 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
 
             // Indicate a refresh of the remote connections
             const allLiveKernelConnections = this.allKernelConnections.filter(
-                (item) => item.kind === 'connectToLiveKernel'
+                (item) => item.kind === 'connectToLiveRemoteKernel'
             );
-            this.remoteRefreshedEmitter.fire(allLiveKernelConnections as LiveKernelConnectionMetadata[]);
+            this.remoteRefreshedEmitter.fire(allLiveKernelConnections as LiveRemoteKernelConnectionMetadata[]);
         };
         this.serverUriStorage.onDidChangeUri(refreshRemoteKernels, this, this.disposables);
         this.kernelProvider.onDidStartKernel(refreshRemoteKernels, this, this.disposables);
@@ -793,7 +793,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
                 })
                 .forEach(([id, viewType]) => {
                     let hideController = false;
-                    if (kernelConnection.kind === 'connectToLiveKernel') {
+                    if (kernelConnection.kind === 'connectToLiveRemoteKernel') {
                         if (viewType === InteractiveWindowView && doNotHideInteractiveKernel) {
                             hideController = false;
                         } else {
@@ -912,11 +912,11 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
         // Update total number of connection & the like for existing controllers.
         connections.forEach((connection) => {
             const controller = this.registeredControllers.get(connection.id);
-            if (controller && connection.kind === 'connectToLiveKernel') {
+            if (controller && connection.kind === 'connectToLiveRemoteKernel') {
                 controller.updateRemoteKernelDetails(connection);
             }
             const iwController = this.registeredControllers.get(`${connection.id}${InteractiveControllerIdSuffix}`);
-            if (iwController && connection.kind === 'connectToLiveKernel') {
+            if (iwController && connection.kind === 'connectToLiveRemoteKernel') {
                 iwController.updateRemoteKernelDetails(connection);
             }
         });

--- a/src/notebooks/controllers/vscodeNotebookController.node.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.node.ts
@@ -78,7 +78,7 @@ import {
     isLocalConnection,
     KernelConnectionMetadata,
     KernelSocketInformation,
-    LiveKernelConnectionMetadata,
+    LiveRemoteKernelConnectionMetadata,
     LocalKernelSpecConnectionMetadata,
     PythonKernelConnectionMetadata
 } from '../../kernels/types';
@@ -175,14 +175,16 @@ export class VSCodeNotebookController implements Disposable {
         this.controller.interruptHandler = this.handleInterrupt.bind(this);
         this.controller.description = getKernelConnectionPath(kernelConnection, this.pathUtils, this.workspace);
         this.controller.detail =
-            kernelConnection.kind === 'connectToLiveKernel' ? getRemoteKernelSessionInformation(kernelConnection) : '';
+            kernelConnection.kind === 'connectToLiveRemoteKernel'
+                ? getRemoteKernelSessionInformation(kernelConnection)
+                : '';
         this.controller.kind = getKernelConnectionCategory(kernelConnection);
         this.controller.supportsExecutionOrder = true;
         this.controller.supportedLanguages = this.languageService.getSupportedLanguages(kernelConnection);
         // Hook up to see when this NotebookController is selected by the UI
         this.controller.onDidChangeSelectedNotebooks(this.onDidChangeSelectedNotebooks, this, this.disposables);
     }
-    public updateRemoteKernelDetails(kernelConnection: LiveKernelConnectionMetadata) {
+    public updateRemoteKernelDetails(kernelConnection: LiveRemoteKernelConnectionMetadata) {
         this.controller.detail = getRemoteKernelSessionInformation(kernelConnection);
     }
     public updateInterpreterDetails(
@@ -216,7 +218,7 @@ export class VSCodeNotebookController implements Disposable {
         if (kernelConnectionMetadata.id === this.kernelConnection.id) {
             this.kernelConnection = kernelConnectionMetadata;
             this.controller.detail =
-                this.kernelConnection.kind === 'connectToLiveKernel'
+                this.kernelConnection.kind === 'connectToLiveRemoteKernel'
                     ? getRemoteKernelSessionInformation(this.kernelConnection)
                     : '';
         }
@@ -585,7 +587,7 @@ export class VSCodeNotebookController implements Disposable {
             case 'startUsingPythonInterpreter':
                 sendNotebookOrKernelLanguageTelemetry(Telemetry.SwitchToExistingKernel, PYTHON_LANGUAGE);
                 break;
-            case 'connectToLiveKernel':
+            case 'connectToLiveRemoteKernel':
                 sendNotebookOrKernelLanguageTelemetry(
                     Telemetry.SwitchToExistingKernel,
                     this.connection.kernelModel.language
@@ -655,7 +657,7 @@ export class VSCodeNotebookController implements Disposable {
 
 function getKernelConnectionCategory(kernelConnection: KernelConnectionMetadata) {
     switch (kernelConnection.kind) {
-        case 'connectToLiveKernel':
+        case 'connectToLiveRemoteKernel':
             return DataScience.kernelCategoryForJupyterSession();
         case 'startUsingRemoteKernelSpec':
             return DataScience.kernelCategoryForRemoteJupyterKernel();

--- a/src/notebooks/execution/kernelExecution.node.ts
+++ b/src/notebooks/execution/kernelExecution.node.ts
@@ -106,7 +106,7 @@ export class KernelExecution implements IDisposable {
         trackKernelResourceInformation(this.kernel.resourceUri, { interruptKernel: true });
         const notebook = getAssociatedNotebookDocument(this.kernel);
         const executionQueue = notebook ? this.documentExecutions.get(notebook) : undefined;
-        if (notebook && !executionQueue && this.kernel.kernelConnectionMetadata.kind !== 'connectToLiveKernel') {
+        if (notebook && !executionQueue && this.kernel.kernelConnectionMetadata.kind !== 'connectToLiveRemoteKernel') {
             return InterruptResult.Success;
         }
         // Possible we don't have a notebook.

--- a/src/notebooks/helpers.node.ts
+++ b/src/notebooks/helpers.node.ts
@@ -854,7 +854,7 @@ export function updateNotebookMetadata(
 
     let language: string | undefined;
     switch (kernelConnection?.kind) {
-        case 'connectToLiveKernel':
+        case 'connectToLiveRemoteKernel':
             language = kernelConnection.kernelModel.language;
             break;
         case 'startUsingRemoteKernelSpec':

--- a/src/notebooks/types.ts
+++ b/src/notebooks/types.ts
@@ -3,7 +3,7 @@
 import { Event, NotebookDocument, NotebookEditor, Uri } from 'vscode';
 import type * as vsc from 'vscode-languageclient/node';
 import { Resource } from '../platform/common/types';
-import { KernelConnectionMetadata, LiveKernelConnectionMetadata } from '../kernels/types';
+import { KernelConnectionMetadata, LiveRemoteKernelConnectionMetadata } from '../kernels/types';
 import { IVSCodeNotebookController } from './controllers/types';
 import { InteractiveWindowView, JupyterNotebookView } from './constants';
 
@@ -14,7 +14,7 @@ export interface INotebookControllerManager {
     readonly onNotebookControllerSelected: Event<{ notebook: NotebookDocument; controller: IVSCodeNotebookController }>;
     readonly onNotebookControllerSelectionChanged: Event<void>;
     readonly kernelConnections: Promise<Readonly<KernelConnectionMetadata>[]>;
-    readonly remoteRefreshed: Event<LiveKernelConnectionMetadata[]>;
+    readonly remoteRefreshed: Event<LiveRemoteKernelConnectionMetadata[]>;
     /**
      * @param {boolean} [refresh] Optionally forces a refresh of all local/remote kernels.
      */

--- a/src/platform/api/extension.d.ts
+++ b/src/platform/api/extension.d.ts
@@ -177,14 +177,14 @@ export type LiveKernelModel = IJupyterKernel &
  * Connection metadata for Live Kernels.
  * With this we are able connect to an existing kernel (instead of starting a new session).
  */
-export type LiveKernelConnectionMetadata = Readonly<{
+export type LiveRemoteKernelConnectionMetadata = Readonly<{
     kernelModel: LiveKernelModel;
     /**
      * Python interpreter will be used for intellisense & the like.
      */
     interpreter?: PythonEnvironment;
     baseUrl: string;
-    kind: 'connectToLiveKernel';
+    kind: 'connectToLiveRemoteKernel';
     id: string;
 }>;
 
@@ -193,9 +193,7 @@ export type KernelConnectionMetadata =
     | RemoteKernelSpecConnectionMetadata
     | PythonKernelConnectionMetadata
     | LiveRemoteKernelConnectionMetadata;
-
-export type LiveRemoteKernelConnectionMetadata = LiveKernelConnectionMetadata;
-export type ActiveKernel = LiveKernelConnectionMetadata;
+export type ActiveKernel = LiveRemoteKernelConnectionMetadata;
 
 export interface IKernelSocket {
     /**

--- a/src/platform/errors/errorHandler.node.ts
+++ b/src/platform/errors/errorHandler.node.ts
@@ -289,7 +289,7 @@ function getCombinedErrorMessage(prefix?: string, message?: string) {
 }
 function getIPyKernelMissingErrorMessageForCell(kernelConnection: KernelConnectionMetadata) {
     if (
-        kernelConnection.kind === 'connectToLiveKernel' ||
+        kernelConnection.kind === 'connectToLiveRemoteKernel' ||
         kernelConnection.kind === 'startUsingRemoteKernelSpec' ||
         !kernelConnection.interpreter
     ) {

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1475,7 +1475,7 @@ export interface IEventNamePropertyMapping {
             | 'startUsingDefaultKernel'
             | 'startUsingLocalKernelSpec'
             | 'startUsingRemoteKernelSpec'
-            | 'connectToLiveKernel';
+            | 'connectToLiveRemoteKernel';
     } & Partial<TelemetryErrorProperties>;
     /*
      * Telemetry sent when we recommend installing an extension.

--- a/src/telemetry/kernelTelemetry.node.ts
+++ b/src/telemetry/kernelTelemetry.node.ts
@@ -22,7 +22,7 @@ export function sendKernelListTelemetry(
     const uniqueCondaInterpreterPaths = new Set<string>();
     kernels.forEach((item) => {
         switch (item.kind) {
-            case 'connectToLiveKernel':
+            case 'connectToLiveRemoteKernel':
                 counters.kernelLiveCount += 1;
                 break;
             case 'startUsingRemoteKernelSpec':

--- a/src/telemetry/telemetry.node.ts
+++ b/src/telemetry/telemetry.node.ts
@@ -209,7 +209,7 @@ export function trackKernelResourceInformation(resource: Resource, information: 
         }
         let language: string | undefined;
         switch (kernelConnection.kind) {
-            case 'connectToLiveKernel':
+            case 'connectToLiveRemoteKernel':
                 language = kernelConnection.kernelModel.language;
                 break;
             case 'startUsingRemoteKernelSpec':

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -154,7 +154,9 @@ suite('DataScience - JupyterSession', () => {
         );
     }
     setup(() => createJupyterSession());
-    async function connect(kind: 'startUsingLocalKernelSpec' | 'connectToLiveKernel' = 'startUsingLocalKernelSpec') {
+    async function connect(
+        kind: 'startUsingLocalKernelSpec' | 'connectToLiveRemoteKernel' = 'startUsingLocalKernelSpec'
+    ) {
         const nbFile = 'file path';
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         when(contentsManager.newUntitled(anything())).thenResolve({ path: nbFile } as any);
@@ -240,7 +242,7 @@ suite('DataScience - JupyterSession', () => {
                 when(session.isRemoteSession).thenReturn(true);
                 when(session.kernelConnectionMetadata).thenReturn({
                     id: '',
-                    kind: 'connectToLiveKernel',
+                    kind: 'connectToLiveRemoteKernel',
                     kernelModel: {} as any,
                     baseUrl: ''
                 });
@@ -289,7 +291,7 @@ suite('DataScience - JupyterSession', () => {
                 when(session.isRemoteSession).thenReturn(true);
                 when(session.kernelConnectionMetadata).thenReturn({
                     id: '',
-                    kind: 'connectToLiveKernel',
+                    kind: 'connectToLiveRemoteKernel',
                     kernelModel: {} as any,
                     baseUrl: ''
                 });
@@ -453,7 +455,7 @@ suite('DataScience - JupyterSession', () => {
                     )
                 );
 
-                await connect('connectToLiveKernel');
+                await connect('connectToLiveRemoteKernel');
             });
             test('Restart should restart the new remote kernel', async () => {
                 when(remoteKernel.restart()).thenResolve();

--- a/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
@@ -641,7 +641,7 @@ import { IFileSystem } from '../../../platform/common/platform/types.node';
         });
         function verifyGlobalKernelSpec(actual: KernelConnectionMetadata | undefined, expected: KernelSpec.ISpecModel) {
             assert.ok(actual, `${expected.display_name} Kernelspec not found`);
-            if (actual?.kind === 'connectToLiveKernel') {
+            if (actual?.kind === 'connectToLiveRemoteKernel') {
                 throw new Error('Incorrect value');
             }
             assert.strictEqual(actual?.kind, 'startUsingLocalKernelSpec');

--- a/src/test/datascience/kernel-launcher/remoteKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/remoteKernelFinder.unit.test.ts
@@ -12,7 +12,7 @@ import { Disposable, EventEmitter, Uri } from 'vscode';
 import { MockMemento } from '../../mocks/mementos';
 import { CryptoUtils } from '../../../platform/common/crypto.node';
 import { noop } from '../../core';
-import { IJupyterConnection, IJupyterKernelSpec, LiveKernelConnectionMetadata } from '../../../kernels/types';
+import { IJupyterConnection, IJupyterKernelSpec, LiveRemoteKernelConnectionMetadata } from '../../../kernels/types';
 import { IInterpreterService } from '../../../platform/interpreter/contracts.node';
 import { JupyterSessionManager } from '../../../kernels/jupyter/session/jupyterSessionManager.node';
 import { JupyterSessionManagerFactory } from '../../../kernels/jupyter/session/jupyterSessionManagerFactory.node';
@@ -154,7 +154,7 @@ suite(`Remote Kernel Finder`, () => {
             interpreterSpec
         ]);
         const kernels = await kernelFinder.listKernels(undefined, connInfo);
-        const liveKernels = kernels.filter((k) => k.kind === 'connectToLiveKernel');
+        const liveKernels = kernels.filter((k) => k.kind === 'connectToLiveRemoteKernel');
         assert.equal(liveKernels.length, 3, 'Live kernels not found');
     });
 
@@ -169,7 +169,7 @@ suite(`Remote Kernel Finder`, () => {
         ]);
         sessionCreatedEvent.fire({ id: python3Kernels[0].id, clientId: python3Kernels[0].id } as any);
         let kernels = await kernelFinder.listKernels(undefined, connInfo);
-        let liveKernels = kernels.filter((k) => k.kind === 'connectToLiveKernel');
+        let liveKernels = kernels.filter((k) => k.kind === 'connectToLiveRemoteKernel');
 
         // Should skip one
         assert.equal(liveKernels.length, 2, 'Restart session was included');
@@ -177,7 +177,7 @@ suite(`Remote Kernel Finder`, () => {
         // Mark it as used
         sessionUsedEvent.fire({ id: python3Kernels[0].id, clientId: python3Kernels[0].id } as any);
         kernels = await kernelFinder.listKernels(undefined, connInfo);
-        liveKernels = kernels.filter((k) => k.kind === 'connectToLiveKernel');
+        liveKernels = kernels.filter((k) => k.kind === 'connectToLiveRemoteKernel');
         assert.equal(liveKernels.length, 3, 'Restart session was not included');
     });
 
@@ -230,9 +230,9 @@ suite(`Remote Kernel Finder`, () => {
 
         const kernel = await kernelFinder.findKernel(uri, connInfo);
         assert.ok(kernel, 'Kernel not found for uri');
-        assert.equal(kernel?.kind, 'connectToLiveKernel', 'Live kernel not found');
+        assert.equal(kernel?.kind, 'connectToLiveRemoteKernel', 'Live kernel not found');
         assert.equal(
-            (kernel as LiveKernelConnectionMetadata).kernelModel.name,
+            (kernel as LiveRemoteKernelConnectionMetadata).kernelModel.name,
             python3Kernels[1].name,
             'Wrong live kernel returned'
         );

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -508,15 +508,15 @@ suite('Dummy8', () => {
 //                         async (o: IKernelSpecQuickPickItem[]) => {
 //                             const existing = o.filter(
 //                                 (s) =>
-//                                     s.selection.kind === 'connectToLiveKernel' &&
+//                                     s.selection.kind === 'connectToLiveRemoteKernel' &&
 //                                     s.selection.kernelModel.numberOfConnections
 //                             );
 
 //                             // Might be more than one. Get the oldest one. It has the actual activity.
 //                             const sorted = existing.sort((a, b) => {
 //                                 if (
-//                                     a.selection.kind !== 'connectToLiveKernel' ||
-//                                     b.selection.kind !== 'connectToLiveKernel'
+//                                     a.selection.kind !== 'connectToLiveRemoteKernel' ||
+//                                     b.selection.kind !== 'connectToLiveRemoteKernel'
 //                                 ) {
 //                                     return 0;
 //                                 }

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -363,13 +363,13 @@ export async function waitForKernelToGetAutoSelected(expectedLanguage?: string, 
     const language = expectedLower || 'python';
     const match =
         (preferred &&
-            preferred.connection.kind !== 'connectToLiveKernel' &&
+            preferred.connection.kind !== 'connectToLiveRemoteKernel' &&
             (!expectedLanguage || preferred.connection.kernelSpec?.language?.toLowerCase() === expectedLower)) ||
-        preferred?.connection.kind === 'connectToLiveKernel'
+        preferred?.connection.kind === 'connectToLiveRemoteKernel'
             ? preferred
             : notebookControllers.find(
                   (d) =>
-                      d.connection.kind != 'connectToLiveKernel' &&
+                      d.connection.kind != 'connectToLiveRemoteKernel' &&
                       language === d.connection.kernelSpec?.language?.toLowerCase()
               );
 

--- a/src/test/datascience/notebook/notebookControllerManager.unit.test.ts
+++ b/src/test/datascience/notebook/notebookControllerManager.unit.test.ts
@@ -11,7 +11,7 @@ suite('Notebook Controller Manager', () => {
     test('Live kernels should display the name`', () => {
         const name = getDisplayNameOrNameOfKernelConnection({
             id: '',
-            kind: 'connectToLiveKernel',
+            kind: 'connectToLiveRemoteKernel',
             interpreter: undefined,
             kernelModel: {
                 model: undefined,


### PR DESCRIPTION
## Work done on personal time

Basically step 1 to ensure we can connect to live local kernels.
This merely renames connectToLiveKernel to connectToLiveRemoteKernel 