### PR TITLE
Fix logging to actually set the globalLoggingLevel

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -57,6 +57,7 @@ env:
   VSIX_NAME_PYTHON: 'ms-python-insiders.vsix'
   VSC_JUPTYER_PYTHON_EXTENSION_VERSION: 'stable'
   VSC_JUPYTER_LOG_KERNEL_OUTPUT: true
+  VSC_PYTHON_LOG_FILE: true
   DOTNET_VERSION: 6.0.x
 
 jobs:
@@ -618,6 +619,7 @@ jobs:
           VSC_JUPYTER_CI_RUN_JAVA_NB_TEST: ${{ matrix.python == 'conda' }}
           VSC_JUPYTER_CI_IS_CONDA: ${{ matrix.python == 'conda' }}
           VSC_JUPYTER_CI_TEST_VSC_CHANNEL: 'insiders'
+          VSC_PYTHON_LOG_FILE: ${{env.VSC_JUPYTER_USER_DATA_DIR}}/logs/python.log
           TEST_FILES_SUFFIX: '+(interrupt|execut)*.vscode.test*'
         id: test_notebook_vscode_windows
         if: matrix.python != 'noPython' && matrix.os == 'windows-latest'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -57,7 +57,6 @@ env:
   VSIX_NAME_PYTHON: 'ms-python-insiders.vsix'
   VSC_JUPTYER_PYTHON_EXTENSION_VERSION: 'stable'
   VSC_JUPYTER_LOG_KERNEL_OUTPUT: true
-  VSC_PYTHON_LOG_FILE: true
   DOTNET_VERSION: 6.0.x
 
 jobs:

--- a/src/platform/logging/index.ts
+++ b/src/platform/logging/index.ts
@@ -35,9 +35,9 @@ const logLevelMap: Map<string | undefined, LogLevel> = new Map([
     [undefined, LogLevel.Error]
 ]);
 
-let globalLoggingLevel: LogLevel;
-export function setLoggingLevel(level?: LoggingLevelSettingType): void {
-    globalLoggingLevel = logLevelMap.get(level) ?? LogLevel.Error;
+let globalLoggingLevel: LogLevel = LogLevel.Debug;
+export function setLoggingLevel(level?: LoggingLevelSettingType | number): void {
+    globalLoggingLevel = typeof level === 'number' ? level : logLevelMap.get(level) ?? LogLevel.Error;
 }
 
 export function setHomeDirectory(homeDir: string) {


### PR DESCRIPTION
Trying to investigate the interpreter perf issue and noticed we weren't logging hardly anything.