### PR TITLE
use name instead of display_name in kernel comparison

### DIFF
--- a/news/2 Fixes/9704.md
+++ b/news/2 Fixes/9704.md
@@ -1,0 +1,1 @@
+Use kernel name in preferred kernel sorting algorithm.

--- a/src/kernels/helpers.ts
+++ b/src/kernels/helpers.ts
@@ -294,10 +294,10 @@ export function compareKernels(
         b.kernelSpec.metadata?.vscode?.originalDisplayName || b.kernelSpec?.display_name || '';
     const kernelSpecNameOfA = originalSpecFileA
         ? path.basename(path.dirname(originalSpecFileA))
-        : a.kernelSpec?.display_name || '';
+        : a.kernelSpec?.name || '';
     const kernelSpecNameOfB = originalSpecFileB
         ? path.basename(path.dirname(originalSpecFileB))
-        : b.kernelSpec?.display_name || '';
+        : b.kernelSpec?.name || '';
 
     // Special simple comparison algorithm for Non-Python notebooks.
     if (possibleNbMetadataLanguage && possibleNbMetadataLanguage !== PYTHON_LANGUAGE) {

--- a/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
@@ -1130,6 +1130,11 @@ import { JupyterServerUriStorage } from '../../../kernels/jupyter/launcher/serve
                                 {
                                     interpreter: python2Global
                                 }
+                                // },
+                                // {
+                                // interpreter: python38VenvEnv,
+                                // kernelSpecs: [fullyQualifiedPythonKernelSpec]
+                                // }
                             ]
                         };
                         await initialize(testData, activePythonEnv);
@@ -1329,6 +1334,18 @@ import { JupyterServerUriStorage } from '../../../kernels/jupyter/launcher/serve
                             orig_nbformat: 4
                         });
                         await verifyKernel(kernel, { expectedInterpreter: condaEnv1 });
+
+                        // Match based on custom kernelspec name
+                        kernel = (await kernelFinder.findKernel(nbUri, {
+                            kernelspec: {
+                                display_name: 'Junk Display Name',
+                                name: python2spec.name
+                            },
+                            language_info: { name: PYTHON_LANGUAGE },
+                            orig_nbformat: 4
+                        })) as LocalKernelConnectionMetadata;
+                        assert.equal(kernel?.kind, 'startUsingLocalKernelSpec');
+                        assert.equal(kernel?.kernelSpec.name, 'python2Custom');
 
                         // Unknown kernel language
                         kernel = await kernelFinder.findKernel(nbUri, {


### PR DESCRIPTION
Fixes #9704

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
