### PR TITLE
Revert some changes realted to logging

### DIFF
--- a/src/kernels/kernel.base.ts
+++ b/src/kernels/kernel.base.ts
@@ -239,9 +239,9 @@ export abstract class BaseKernel implements IKernel {
         try {
             // No need to block kernel startup on UI updates.
             traceInfo(
-                `Starting Notebook in kernel.ts id = ${this.kernelConnectionMetadata.id} for ${getDisplayPath(
-                    this.id
-                )} (disableUI=${this.startupUI.disableUI})`
+                `Starting Notebook id = ${this.kernelConnectionMetadata.id} for ${getDisplayPath(this.id)} (disableUI=${
+                    this.startupUI.disableUI
+                })`
             );
             this.createProgressIndicator(disposables);
             this.isKernelDead = false;

--- a/src/platform/common/process/condaService.node.ts
+++ b/src/platform/common/process/condaService.node.ts
@@ -171,7 +171,7 @@ export class CondaService {
             : await this.fs.getFileHash(this._file.fsPath);
         await this.globalState.update(CACHEKEY_FOR_CONDA_INFO, {
             version: this._version.raw,
-            file: this._file,
+            file: this._file.fsPath,
             fileHash
         });
     }
@@ -181,20 +181,20 @@ export class CondaService {
      * Even if not, we'll update this with the latest information.
      */
     private async getCachedInformation(): Promise<{ version: SemVer; file: Uri } | undefined> {
-        const cachedInfo = this.globalState.get<{ version: string; file: Uri; fileHash: string } | undefined>(
+        const cachedInfo = this.globalState.get<{ version: string; file: string; fileHash: string } | undefined>(
             CACHEKEY_FOR_CONDA_INFO,
             undefined
         );
         if (!cachedInfo) {
             return;
         }
-        const fileHash = cachedInfo.file.fsPath.toLowerCase().endsWith('conda')
+        const fileHash = cachedInfo.file.toLowerCase().endsWith('conda')
             ? ''
-            : await this.fs.getFileHash(cachedInfo.file.fsPath);
+            : await this.fs.getFileHash(cachedInfo.file);
         if (cachedInfo.fileHash === fileHash) {
             return {
                 version: new SemVer(cachedInfo.version),
-                file: cachedInfo.file
+                file: Uri.file(cachedInfo.file)
             };
         }
     }

--- a/src/platform/logging/consoleLogger.ts
+++ b/src/platform/logging/consoleLogger.ts
@@ -6,9 +6,7 @@ import { getTimeForLogging } from './util';
 const format = require('format-util') as typeof import('format-util');
 
 function formatMessage(level: string | undefined, message: string, ...data: Arguments): string {
-    return level
-        ? `${level} ${getTimeForLogging()}: ${format(message, ...data)}`
-        : format(message, ...data);
+    return level ? `${level} ${getTimeForLogging()}: ${format(message, ...data)}` : format(message, ...data);
 }
 
 export class ConsoleLogger implements ILogger {

--- a/src/platform/logging/consoleLogger.ts
+++ b/src/platform/logging/consoleLogger.ts
@@ -7,7 +7,7 @@ const format = require('format-util') as typeof import('format-util');
 
 function formatMessage(level: string | undefined, message: string, ...data: Arguments): string {
     return level
-        ? `[${level.toUpperCase()} ${getTimeForLogging()}]: ${format(message, ...data)}`
+        ? `${level} ${getTimeForLogging()}: ${format(message, ...data)}`
         : format(message, ...data);
 }
 

--- a/src/platform/logging/fileLogger.node.ts
+++ b/src/platform/logging/fileLogger.node.ts
@@ -8,9 +8,7 @@ import { Arguments, ILogger } from './types';
 import { getTimeForLogging } from './util';
 
 function formatMessage(level?: string, ...data: Arguments): string {
-    return level
-        ? `${level} ${getTimeForLogging()}: ${util.format(...data)}\r\n`
-        : `${util.format(...data)}\r\n`;
+    return level ? `${level} ${getTimeForLogging()}: ${util.format(...data)}\r\n` : `${util.format(...data)}\r\n`;
 }
 
 export class FileLogger implements ILogger, Disposable {

--- a/src/platform/logging/fileLogger.node.ts
+++ b/src/platform/logging/fileLogger.node.ts
@@ -9,7 +9,7 @@ import { getTimeForLogging } from './util';
 
 function formatMessage(level?: string, ...data: Arguments): string {
     return level
-        ? `[${level.toUpperCase()} ${getTimeForLogging()}]: ${util.format(...data)}\r\n`
+        ? `${level} ${getTimeForLogging()}: ${util.format(...data)}\r\n`
         : `${util.format(...data)}\r\n`;
 }
 

--- a/src/platform/logging/index.ts
+++ b/src/platform/logging/index.ts
@@ -49,25 +49,25 @@ export function traceLog(message: string, ...args: Arguments): void {
 }
 
 export function traceError(message: string, ...args: Arguments): void {
-    if (globalLoggingLevel >= LogLevel.Error) {
+    if (globalLoggingLevel <= LogLevel.Error) {
         loggers.forEach((l) => l.traceError(message, ...args));
     }
 }
 
 export function traceWarning(message: string, ...args: Arguments): void {
-    if (globalLoggingLevel >= LogLevel.Warn) {
+    if (globalLoggingLevel <= LogLevel.Warn) {
         loggers.forEach((l) => l.traceWarn(message, ...args));
     }
 }
 
 export function traceInfo(message: string, ...args: Arguments): void {
-    if (globalLoggingLevel >= LogLevel.Info) {
+    if (globalLoggingLevel <= LogLevel.Info) {
         loggers.forEach((l) => l.traceInfo(message, ...args));
     }
 }
 
 export function traceVerbose(message: string, ...args: Arguments): void {
-    if (globalLoggingLevel <= LogLevel.Debug) {
+    if (globalLoggingLevel <= LogLevel.Trace) {
         loggers.forEach((l) => l.traceVerbose(message, ...args));
     }
 }

--- a/src/platform/logging/outputChannelLogger.ts
+++ b/src/platform/logging/outputChannelLogger.ts
@@ -8,7 +8,7 @@ const format = require('format-util') as typeof import('format-util');
 
 function formatMessage(level: string | undefined, message: string, ...data: Arguments): string {
     return level
-        ? `[${level.toUpperCase()} ${getTimeForLogging()}]: ${format(message, ...data)}`
+        ? `${level} ${getTimeForLogging()}: ${format(message, ...data)}`
         : format(message, ...data);
 }
 

--- a/src/platform/logging/outputChannelLogger.ts
+++ b/src/platform/logging/outputChannelLogger.ts
@@ -7,9 +7,7 @@ import { getTimeForLogging } from './util';
 const format = require('format-util') as typeof import('format-util');
 
 function formatMessage(level: string | undefined, message: string, ...data: Arguments): string {
-    return level
-        ? `${level} ${getTimeForLogging()}: ${format(message, ...data)}`
-        : format(message, ...data);
+    return level ? `${level} ${getTimeForLogging()}: ${format(message, ...data)}` : format(message, ...data);
 }
 
 export class OutputChannelLogger implements ILogger {

--- a/src/platform/logging/util.ts
+++ b/src/platform/logging/util.ts
@@ -49,5 +49,5 @@ export function returnValueToLogString(returnValue: unknown): string {
 }
 export function getTimeForLogging(): string {
     const date = new Date();
-    return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()} ${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}.${date.getMilliseconds()}`;
+    return `${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}.${date.getMilliseconds()}`;
 }


### PR DESCRIPTION
This PR seems to have resulted in some changes that now increases the amout of data being logged https://github.com/microsoft/vscode-jupyter/pull/9545

Ran into this while testing https://github.com/microsoft/vscode-jupyter/issues/9697 & saw that my logs were much larger (basically there was too much in the logs)

E.g. in the past verbose logging would never show up in the logs, now all of the verbose logging shows up as a default.
Also fixed a bug where we were cashing a Uri & caused things to fall over ( as uri cannot be serialized into JSON) 

This is what we used to have
```
Visual Studio Code (1.66.2, undefined, desktop)
Jupyter Extension Version: 2022.3.1000901801.
Python Extension Version: 2022.4.1.
Workspace folder ~/Documents/Notebooks/Project
Info 10:31:53: ZMQ install verified.
Info 10:31:53: Preferred kernel connection found in cache .jvsc74a57bd0e7370f93d1d0cde622a1f8e1c04877d8463912d04d973331ad4851f04de6915a./bin/python./bin/python.-m#ipykernel_launcher
Info 10:31:53: PreferredConnection: .jvsc74a57bd0e7370f93d1d0cde622a1f8e1c04877d8463912d04d973331ad4851f04de6915a./bin/python./bin/python.-m#ipykernel_launcher found for NotebookDocument: ~/Documents/Notebooks/Project/bug.ipynb
Info 10:31:53: Early registration of controller for Kernel connection .jvsc74a57bd0e7370f93d1d0cde622a1f8e1c04877d8463912d04d973331ad4851f04de6915a./bin/python./bin/python.-m#ipykernel_launcher
Info 10:31:53: TargetController found ID: .jvsc74a57bd0e7370f93d1d0cde622a1f8e1c04877d8463912d04d973331ad4851f04de6915a./bin/python./bin/python.-m#ipykernel_launcher for document ~/Documents/Notebooks/Project/bug.ipynb
Info 10:31:53: Setting controller affinity for ~/Documents/Notebooks/Project/bug.ipynb .jvsc74a57bd0e7370f93d1d0cde622a1f8e1c04877d8463912d04d973331ad4851f04de6915a./bin/python./bin/python.-m#ipykernel_launcher
Info 10:31:53: Getting activation commands for /bin/python are not cached. May take a while.
Info 10:31:53: Experiment status for python is {"enabled":true,"optInto":[],"optOutFrom":[]}
Info 10:31:54: Setting setActiveController for ~/Documents/Notebooks/Project/bug.ipynb
```

This is what we have in main
```
Visual Studio Code - Insiders (1.67.0-insider, wsl, desktop)
Jupyter Extension Version: 2022.4.100.
Python Extension Version: 2022.5.11051003.
Workspace folder /home/don/samples/pySamples/crap
[DEBUG 2022-3-19 10:43:34.458]: Experimentation service retrieved: [object Object]
User belongs to experiment group 'jupyterTestcf'
User belongs to experiment group 'jupyterEnhancedDataViewer'
[DEBUG 2022-3-19 10:43:35.212]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venv/bin/python
[DEBUG 2022-3-19 10:43:35.213]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venv/bin/python are cached.
[DEBUG 2022-3-19 10:43:35.216]: Creating controller for jupyter-notebook with interpreter /home/don/samples/pySamples/crap/.venv/bin/python
[DEBUG 2022-3-19 10:43:35.468]: Got activation Env Vars from cache
[DEBUG 2022-3-19 10:43:35.469]: Got env vars ourselves faster /home/don/samples/pySamples/crap/.venv/bin/python
[DEBUG 2022-3-19 10:43:35.469]: Got env vars ourselves /home/don/samples/pySamples/crap/.venv/bin/python in 258ms
> ~/samples/pySamples/crap/.venv/bin/python -m pip list
[DEBUG 2022-3-19 10:43:35.710]: Setting controller affinity for /home/don/samples/pySamples/crap/widgets/matplotlib/widget.ipynb .jvsc74a57bd0785edfce71b7b34600eacc1c40d1f7960d8cad3527bf2998465efd5555859783./home/don/samples/pySamples/crap/.venvWidgets/python./home/don/samples/pySamples/crap/.venvWidgets/python.-m#ipykernel_launcher
[DEBUG 2022-3-19 10:43:35.715]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python
[DEBUG 2022-3-19 10:43:35.717]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python are cached.
[DEBUG 2022-3-19 10:43:35.720]: Cached data exists getEnvironmentVariables, <No Resource>
[DEBUG 2022-3-19 10:43:35.920]: KernelProvider switched kernel to id = .jvsc74a57bd0785edfce71b7b34600eacc1c40d1f7960d8cad3527bf2998465efd5555859783./home/don/samples/pySamples/crap/.venvWidgets/python./home/don/samples/pySamples/crap/.venvWidgets/python.-m#ipykernel_launcher
[DEBUG 2022-3-19 10:43:35.922]: start the kernel, options.disableUI=true
[DEBUG 2022-3-19 10:43:35.924]: Start Notebook in kernel.ts with disableUI = true
[DEBUG 2022-3-19 10:43:35.927]: Getting preferred kernel for /home/don/samples/pySamples/crap/widgets/matplotlib/widget.ipynb
[DEBUG 2022-3-19 10:43:35.931]: Controller selection change completed
[DEBUG 2022-3-19 10:43:35.947]: Got activation Env Vars from cache
[DEBUG 2022-3-19 10:43:35.949]: Got env vars ourselves faster /home/don/samples/pySamples/crap/.venvWidgets/bin/python
[DEBUG 2022-3-19 10:43:35.949]: Got env vars ourselves /home/don/samples/pySamples/crap/.venvWidgets/bin/python in 236ms
> ~/samples/pySamples/crap/.venvWidgets/bin/python -m pip list
[DEBUG 2022-3-19 10:43:36.43]: Connecting to raw session for /home/don/samples/pySamples/crap/widgets/matplotlib/widget.ipynb with connection .jvsc74a57bd0785edfce71b7b34600eacc1c40d1f7960d8cad3527bf2998465efd5555859783./home/don/samples/pySamples/crap/.venvWidgets/python./home/don/samples/pySamples/crap/.venvWidgets/python.-m#ipykernel_launcher
[DEBUG 2022-3-19 10:43:36.46]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python
[DEBUG 2022-3-19 10:43:36.48]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python are cached.
[DEBUG 2022-3-19 10:43:36.51]: Cached data exists getEnvironmentVariables, /home/don/samples/pySamples/crap/widgets/matplotlib/widget.ipynb
[DEBUG 2022-3-19 10:43:36.218]: Loading kernelspec from /usr/share/jupyter/kernels/python3/kernel.json for 
[DEBUG 2022-3-19 10:43:36.220]: Loading kernelspec from /usr/local/share/jupyter/kernels/ocaml-jupyter/kernel.json for 
[DEBUG 2022-3-19 10:43:36.226]: Loading kernelspec from /home/don/.local/share/jupyter/kernels/.venvkernel/kernel.json for 
[DEBUG 2022-3-19 10:43:36.227]: Loading kernelspec from /home/don/.local/share/jupyter/kernels/.venvnokernel/kernel.json for 
[DEBUG 2022-3-19 10:43:36.227]: Loading kernelspec from /home/don/.local/share/jupyter/kernels/ganymede-1.1.0.20210614-java-11/kernel.json for 
[DEBUG 2022-3-19 10:43:36.228]: Loading kernelspec from /home/don/.local/share/jupyter/kernels/ir/kernel.json for 
[DEBUG 2022-3-19 10:43:36.229]: Loading kernelspec from /home/don/.local/share/jupyter/kernels/javascript/kernel.json for 
[DEBUG 2022-3-19 10:43:36.229]: Loading kernelspec from /home/don/.local/share/jupyter/kernels/julia-1.6.4/kernel.json for 
[DEBUG 2022-3-19 10:43:36.230]: Loading kernelspec from /home/don/.local/share/jupyter/kernels/julia-1.6/kernel.json for 
[DEBUG 2022-3-19 10:43:36.231]: Loading kernelspec from /home/don/.local/share/jupyter/kernels/powershell/kernel.json for 
[DEBUG 2022-3-19 10:43:36.231]: Loading kernelspec from /home/don/.local/share/jupyter/kernels/python3/kernel.json for 
[DEBUG 2022-3-19 10:43:36.232]: Loading kernelspec from /home/don/.local/share/jupyter/kernels/venvglobalkernel/kernel.json for 
[DEBUG 2022-3-19 10:43:36.244]: Got activation Env Vars from cache
[DEBUG 2022-3-19 10:43:36.246]: Got env vars ourselves faster /home/don/samples/pySamples/crap/.venvWidgets/bin/python
[DEBUG 2022-3-19 10:43:36.246]: Got env vars ourselves /home/don/samples/pySamples/crap/.venvWidgets/bin/python in 201ms
> ~/samples/pySamples/crap/.venvWidgets/bin/python -c "import ipykernel; print(ipykernel.__version__); print("5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d"); print(ipykernel.__file__)"
[DEBUG 2022-3-19 10:43:36.326]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python
[DEBUG 2022-3-19 10:43:36.327]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python are cached.
[DEBUG 2022-3-19 10:43:36.328]: Cached data exists getEnvironmentVariables, /home/don/samples/pySamples/crap/widgets/matplotlib/widget.ipynb
[DEBUG 2022-3-19 10:43:36.331]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python
[DEBUG 2022-3-19 10:43:36.332]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python are cached.
[DEBUG 2022-3-19 10:43:36.334]: Cached data exists getEnvironmentVariables, /home/don/samples/pySamples/crap/widgets/matplotlib/widget.ipynb
[DEBUG 2022-3-19 10:43:36.335]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python
[DEBUG 2022-3-19 10:43:36.336]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python are cached.
[DEBUG 2022-3-19 10:43:36.360]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venv/bin/python
[DEBUG 2022-3-19 10:43:36.360]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venv/bin/python are cached.
[DEBUG 2022-3-19 10:43:36.362]: Got env vars with python /home/don/samples/pySamples/crap/.venv/bin/python in 1151ms
[DEBUG 2022-3-19 10:43:36.465]: Got activation Env Vars from cache
[DEBUG 2022-3-19 10:43:36.466]: Got activation Env Vars from cache
[DEBUG 2022-3-19 10:43:36.467]: Got env vars ourselves faster /home/don/samples/pySamples/crap/.venvWidgets/bin/python
[DEBUG 2022-3-19 10:43:36.468]: Got env vars ourselves faster /home/don/samples/pySamples/crap/.venvWidgets/bin/python
[DEBUG 2022-3-19 10:43:36.468]: Got env vars ourselves /home/don/samples/pySamples/crap/.venvWidgets/bin/python in 144ms
[DEBUG 2022-3-19 10:43:36.469]: Got env vars ourselves /home/don/samples/pySamples/crap/.venvWidgets/bin/python in 139ms
> ~/samples/pySamples/crap/.venvWidgets/bin/python -m ipykernel_launcher --ip=127.0.0.1 --stdin=9003 --control=9001 --hb=9000 --Session.signature_scheme="hmac-sha256" --Session.key=b"ba3d9c0c-3129-4b2b-8031-244e31d2f905" --shell=9002 --transport="tcp" --iopub=9004 --f=/home/don/.local/share/jupyter/kernel-6690NOdJ1RTjJXcr.json
cwd: ~/samples/pySamples/crap/widgets/matplotlib
[DEBUG 2022-3-19 10:43:36.547]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python
[DEBUG 2022-3-19 10:43:36.548]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python are cached.
[DEBUG 2022-3-19 10:43:36.552]: Got env vars with python /home/don/samples/pySamples/crap/.venvWidgets/bin/python in 838ms
[DEBUG 2022-3-19 10:43:36.833]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python
[DEBUG 2022-3-19 10:43:36.834]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python are cached.
[DEBUG 2022-3-19 10:43:36.835]: Got env vars with python /home/don/samples/pySamples/crap/.venvWidgets/bin/python in 790ms
[DEBUG 2022-3-19 10:43:36.925]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python
[DEBUG 2022-3-19 10:43:36.926]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python are cached.
[DEBUG 2022-3-19 10:43:36.927]: Got env vars with python /home/don/samples/pySamples/crap/.venvWidgets/bin/python in 602ms
[DEBUG 2022-3-19 10:43:36.952]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python
[DEBUG 2022-3-19 10:43:36.952]: Getting activation commands for file:///home/don/samples/pySamples/crap/.venvWidgets/bin/python are cached.
[DEBUG 2022-3-19 10:43:36.953]: Got env vars with python /home/don/samples/pySamples/crap/.venvWidgets/bin/python in 623ms
[DEBUG 2022-3-19 10:43:37.167]: KernelProcess error: /home/don/samples/pySamples/crap/.venvWidgets/lib/python3.8/site-packages/traitlets/traitlets.py:2202: FutureWarning: Supporting extra quotes around strings is deprecated in traitlets 5.0. You can use 'hmac-sha256' instead of '"hmac-sha256"' if you require traitlets >=5.
  warn(
/home/don/samples/pySamples/crap/.venvWidgets/lib/python3.8/site-packages/traitlets/traitlets.py:2157: FutureWarning: Supporting extra quotes around Bytes is deprecated in traitlets 5.0. Use 'ba3d9c0c-3129-4b2b-8031-244e31d2f905' instead of 'b"ba3d9c0c-3129-4b2b-8031-244e31d2f905"'.
  warn(

[DEBUG 2022-3-19 10:43:37.180]: KernelProcess output: NOTE: When using the `ipython kernel` entry point, Ctrl-C will not work.

To exit, you will have to explicitly quit this process, by either sending
"quit" from a client, or using Ctrl-\ in UNIX-like environments.

To read more about this, see https://github.com/ipython/ipython/issues/2049


To connect another client to this kernel, use:
    --existing /home/don/.local/share/jupyter/kernel-6690NOdJ1RTjJXcr.json

[DEBUG 2022-3-19 10:43:37.293]: Waiting for Raw Session to be ready in postStartRawSession
[DEBUG 2022-3-19 10:43:37.294]: Waiting for Raw session to be ready, currently connected
[DEBUG 2022-3-19 10:43:37.294]: Raw session connected
[DEBUG 2022-3-19 10:43:37.295]: Waiting for Raw session to be ready for 30s
[DEBUG 2022-3-19 10:43:37.296]: Waited for Raw session to be ready & got connected
[DEBUG 2022-3-19 10:43:37.296]: Successfully waited for Raw Session to be ready in postStartRawSession
[DEBUG 2022-3-19 10:43:37.297]: Kernel status before requesting kernel info and after ready is unknown
[DEBUG 2022-3-19 10:43:37.297]: Sending request for kernelinfo
[DEBUG 2022-3-19 10:43:38.219]: Got response for requestKernelInfo
[DEBUG 2022-3-19 10:43:38.219]: Successfully compelted postStartRawSession
[DEBUG 2022-3-19 10:43:38.225]: Started running kernel initialization for /home/don/samples/pySamples/crap/widgets/matplotlib/widget.ipynb
[DEBUG 2022-3-19 10:43:38.436]: IKernel Status change to busy
[DEBUG 2022-3-19 10:43:38.472]: IKernel Status change to idle
[DEBUG 2022-3-19 10:43:38.477]: Not executing startup notebook: Object, code: 
[DEBUG 2022-3-19 10:43:38.477]: Requesting Kernel info
[DEBUG 2022-3-19 10:43:38.478]: Got Kernel info
[DEBUG 2022-3-19 10:43:38.478]: End running kernel initialization, now waiting for idle
[DEBUG 2022-3-19 10:43:38.479]: End running kernel initialization, session is idle
[DEBUG 2022-3-19 10:43:46.140]: Loading kernelspec from /home/don/samples/pySamples/crap/.venv/share/jupyter/kernels/mytest/kernel.json for /home/don/samples/pySamples/crap/.venv/bin/python
[DEBUG 2022-3-19 10:43:46.141]: Loading kernelspec from /home/don/samples/pySamples/crap/.venv/share/jupyter/kernels/python-my-env/kernel.json for /home/don/samples/pySamples/crap/.venv/bin/python
[DEBUG 2022-3-19 10:43:46.141]: Loading kernelspec from /home/don/samples/pySamples/crap/.venv/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venv/bin/python
[DEBUG 2022-3-19 10:43:46.142]: Loading kernelspec from /home/don/.pyenv/versions/2.7.18/share/jupyter/kernels/python2/kernel.json for /home/don/.pyenv/versions/2.7.18/bin/python
[DEBUG 2022-3-19 10:43:46.143]: Loading kernelspec from /home/don/samples/pySamples/crap/.venv310/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venv310/bin/python
[DEBUG 2022-3-19 10:43:46.144]: Loading kernelspec from /home/don/samples/pySamples/crap/.venv38_8/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venv38_8/bin/python
[DEBUG 2022-3-19 10:43:46.144]: Loading kernelspec from /home/don/samples/pySamples/crap/.venvClean/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venvClean/bin/python
[DEBUG 2022-3-19 10:43:46.145]: Loading kernelspec from /home/don/samples/pySamples/crap/.venvDump/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venvDump/bin/python
[DEBUG 2022-3-19 10:43:46.146]: Loading kernelspec from /home/don/samples/pySamples/crap/.venvIPython8/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venvIPython8/bin/python
[DEBUG 2022-3-19 10:43:46.146]: Loading kernelspec from /home/don/samples/pySamples/crap/.venvJupyter/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venvJupyter/bin/python
[DEBUG 2022-3-19 10:43:46.147]: Loading kernelspec from /home/don/samples/pySamples/crap/.venvJupyterHub/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venvJupyterHub/bin/python
[DEBUG 2022-3-19 10:43:46.148]: Loading kernelspec from /home/don/samples/pySamples/crap/.venvLab/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venvLab/bin/python
[DEBUG 2022-3-19 10:43:46.149]: Loading kernelspec from /home/don/samples/pySamples/crap/.venvLatest/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venvLatest/bin/python
[DEBUG 2022-3-19 10:43:46.149]: Loading kernelspec from /home/don/samples/pySamples/crap/.venvMito/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venvMito/bin/python
[DEBUG 2022-3-19 10:43:46.150]: Loading kernelspec from /home/don/samples/pySamples/crap/.venvNoIPythonGenUtils/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venvNoIPythonGenUtils/bin/python
[DEBUG 2022-3-19 10:43:46.150]: Loading kernelspec from /home/don/samples/pySamples/crap/.venvOCAML/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venvOCAML/bin/python
[DEBUG 2022-3-19 10:43:46.151]: Loading kernelspec from /home/don/samples/pySamples/crap/.venvPlotlyExpress/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venvPlotlyExpress/bin/python
[DEBUG 2022-3-19 10:43:46.151]: Loading kernelspec from /home/don/samples/pySamples/crap/.venvPowerShell/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venvPowerShell/bin/python
[DEBUG 2022-3-19 10:43:46.151]: Loading kernelspec from /home/don/samples/pySamples/crap/.venvSklearn/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venvSklearn/bin/python
[DEBUG 2022-3-19 10:43:46.152]: Loading kernelspec from /home/don/samples/pySamples/crap/.venvVega/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venvVega/bin/python
[DEBUG 2022-3-19 10:43:46.153]: Loading kernelspec from /home/don/samples/pySamples/crap/.venvWidget80/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venvWidget80/bin/python
[DEBUG 2022-3-19 10:43:46.153]: Loading kernelspec from /home/don/samples/pySamples/crap/.venvWidgets/share/jupyter/kernels/python3/kernel.json for /home/don/samples/pySamples/crap/.venvWidgets/bin/python
[DEBUG 2022-3-19 10:43:46.154]: Loading kernelspec from /home/don/miniconda3/envs/abc/share/jupyter/kernels/python3/kernel.json for /home/don/miniconda3/envs/abc/bin/python
[DEBUG 2022-3-19 10:43:46.154]: Loading kernelspec from /home/don/miniconda3/envs/env1/share/jupyter/kernels/python3/kernel.json for /home/don/miniconda3/envs/env1/bin/python
[DEBUG 2022-3-19 10:43:46.155]: Loading kernelspec from /home/don/miniconda3/envs/envKql/share/jupyter/kernels/python3/kernel.json for /home/don/miniconda3/envs/envKql/bin/python
[DEBUG 2022-3-19 10:43:46.155]: Loading kernelspec from /home/don/miniconda3/envs/envTemp1/share/jupyter/kernels/python3/kernel.json for /home/don/miniconda3/envs/envTemp1/bin/python
[DEBUG 2022-3-19 10:43:46.156]: Loading kernelspec from /home/don/miniconda3/envs/golden_scenario_env/share/jupyter/kernels/python3/kernel.json for /home/don/miniconda3/envs/golden_scenario_env/bin/python
[DEBUG 2022-3-19 10:43:46.157]: Loading kernelspec from /home/don/miniconda3/envs/sage/share/jupyter/kernels/python3/kernel.json for /home/don/miniconda3/envs/sage/bin/python
[DEBUG 2022-3-19 10:43:46.158]: Loading kernelspec from /home/don/miniconda3/envs/sage/share/jupyter/kernels/sagemath/kernel.json for /home/don/miniconda3/envs/sage/bin/python
[DEBUG 2022-3-19 10:43:46.158]: Loading kernelspec from /home/don/miniconda3/envs/tf/share/jupyter/kernels/python3/kernel.json for /home/don/miniconda3/envs/tf/bin/python
[DEBUG 2022-3-19 10:43:46.159]: Loading kernelspec from /home/don/miniconda3/envs/tf_gpu/share/jupyter/kernels/python3/kernel.json for /home/don/miniconda3/envs/tf_gpu/bin/python
[DEBUG 2022-3-19 10:43:46.160]: Loading kernelspec from /home/don/miniconda3/envs/tf_gpu/share/jupyter/kernels/tf-gpu-debug/kernel.json for /home/don/miniconda3/envs/tf_gpu/bin/python
[DEBUG 2022-3-19 10:43:46.296]: Kernel venvglobalkernel matches Python 3.8.12 ('.venv': pipenv) based on path in argv.
[DEBUG 2022-3-19 10:43:46.299]: Kernel venvglobalkernel matches Python 3.8.12 ('.venv': pipenv) based on path in argv.
[DEBUG 2022-3-19 10:43:46.301]: Kernel venvglobalkernel matches Python 3.8.12 ('.venv': pipenv) based on path in argv.
[DEBUG 2022-3-19 10:43:46.302]: Kernel venvglobalkernel matches Python 3.8.12 ('.venv': pipenv) based on path in argv.
[DEBUG 2022-3-19 10:43:46.303]: Kernel venvglobalkernel matches Python 3.8.12 ('.venv': pipenv) based on path in argv.
[DEBUG 2022-3-19 10:43:46.305]: Kernel venvglobalkernel matches Python 3.8.12 ('.venv': pipenv) based on path in argv.
[DEBUG 2022-3-19 10:43:46.378]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae', /python
[DEBUG 2022-3-19 10:43:46.378]: Hiding default kernel spec 'Python 2', 'pythonjvsc74a57bd0d44503299428ac231563c18a7a1548b95bf18d1b1ca72dfa6d84161eb1571ad0', /python
[DEBUG 2022-3-19 10:43:46.379]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3100jvsc74a57bd0634dd5ad51c8428f960320242b892cf18e31e0d7464bf46dc14e5166fe075256', /python
[DEBUG 2022-3-19 10:43:46.379]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd08a3ad01b4a7ad0543281b68be4d6073d648d1872c86b4c26ba1ce2858e740b3d', /python
[DEBUG 2022-3-19 10:43:46.379]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0cdcef8d68626485ce31124094088ea4f663d8f1bee8c8ef5794a8d640d4e412e', /python
[DEBUG 2022-3-19 10:43:46.380]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd09968599c749c7e85ea7552fe093ffe8a75e0a83d973ab7d702bd4595706e78a1', /python
[DEBUG 2022-3-19 10:43:46.380]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd066139348caf7cb051dbb7573416b4597887dec19f7cfa1e941b98d178637bf6d', /python
[DEBUG 2022-3-19 10:43:46.380]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd026362c76df08e6795ec7bb890471fed444ecc20062c61f3ceb3b5071ff785288', /python
[DEBUG 2022-3-19 10:43:46.380]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd00b895896492e2d0bc306a400ebcd3a09c75257ad0cb41d05f1d70eb83fd4e82a', /python
[DEBUG 2022-3-19 10:43:46.381]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0c97f527725ed1b1f21ca875d4303600675e0e432d4444a3b1d85bdf4817170a8', /python
[DEBUG 2022-3-19 10:43:46.381]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0af786047f1c3cd85657f71c1da14fc9c9313edd4f40a16aa4e348599b20d15ca', /python
[DEBUG 2022-3-19 10:43:46.381]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd01da80cdddf70df14db0f39d3c88ee8abad70023faaa222ce11ca69b908c9831c', /python
[DEBUG 2022-3-19 10:43:46.381]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd007e919204236a46e818fb2226c97300c1efb30c8863f618209d46bf66bfd5d1e', /python
[DEBUG 2022-3-19 10:43:46.382]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0742490dfec7a872128fbee14a994c1d8beb1cc7caa54e78ea7ef3c08437e5b36', /python
[DEBUG 2022-3-19 10:43:46.382]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0f34bad3d75b1c33981eb7576ca58c81a8f2635862476211cc7bc1a8083e4d3ff', /python
[DEBUG 2022-3-19 10:43:46.382]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0591ee1787f787333a5664d4ecda002d83bfab239fb6f90d27c26a53219d33ec0', /python
[DEBUG 2022-3-19 10:43:46.382]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0df182e9b2cc56efb974e622c7053d2aacd5f31356a22f8cc8a3843fb62e9328b', ~/miniconda3/envs/abc/bin/python
[DEBUG 2022-3-19 10:43:46.383]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd03a359ff06103a45cf9a18736dbfc74bedc15c4166c925bfce48beb6bf99a86db', ~/miniconda3/envs/env1/bin/python
[DEBUG 2022-3-19 10:43:46.383]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0d0fd6c253a61e46c43db05e2114a862a7f350a39db683163c8240df924e5c9d5', ~/miniconda3/envs/envKql/bin/python
[DEBUG 2022-3-19 10:43:46.383]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0e3967d17aeb7b17e0350cfc9ab4265bf4483171f4665bd7400fff589e080aa02', ~/miniconda3/envs/envTemp1/bin/python
[DEBUG 2022-3-19 10:43:46.383]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0785edfce71b7b34600eacc1c40d1f7960d8cad3527bf2998465efd5555859783', /python
[DEBUG 2022-3-19 10:43:46.384]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3101jvsc74a57bd0dd6644a4d6ce6b3ee9b5983998d2ead42f9e79546c761dcbf88f11aef6cd609f', ~/miniconda3/envs/golden_scenario_env/bin/python
[DEBUG 2022-3-19 10:43:46.384]: Hiding default kernel spec 'Python 3', 'python3812jvsc74a57bd0518d23331377686d4217d3578071560115dca7e98bf3dfe1072fbc00783ff437', ~/miniconda3/envs/sage/bin/python
[DEBUG 2022-3-19 10:43:46.384]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd029da4c255bb988a50219cddcbad97c2227ee8f62c293e2e8122b9e89f9da9265', ~/miniconda3/envs/tf/bin/python
[DEBUG 2022-3-19 10:43:46.384]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd05e18b8d9af2ccffaf7d94da25fcdecff98dcfefd7396abf4f0d66dd2103b5bbc', ~/miniconda3/envs/tf_gpu/bin/python
[DEBUG 2022-3-19 10:43:46.385]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd08a9edc66896c58a694162c26179b2405fabe6508d3f64a3342111512acc6aebd', /python
[DEBUG 2022-3-19 10:43:46.385]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd07ba01d208a896c8c0c774151fc595d82208a92adb97525dad39cabf4eab581b1', /python
[DEBUG 2022-3-19 10:43:46.385]: Kernel python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae matches Python 3.8.12 ('.venv': pipenv) based on interpreter path.
[DEBUG 2022-3-19 10:43:46.386]: Kernel python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae matches Python 3.8.12 ('.venvWidgets': venv) based on path in argv.
[DEBUG 2022-3-19 10:43:46.386]: Kernel python3812jvsc74a57bd04717944c9f6968bf83678f78bd1a822ff4aff18182691a35dd09e1dc45b02eff matches Python 3.8.12 ('.venvLatest': venv) based on interpreter path.
[DEBUG 2022-3-19 10:43:46.387]: Kernel python3812jvsc74a57bd05e18b8d9af2ccffaf7d94da25fcdecff98dcfefd7396abf4f0d66dd2103b5bbc.--debug matches Python 3.8.12 based on path in argv.
[DEBUG 2022-3-19 10:43:46.388]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae', /python
[DEBUG 2022-3-19 10:43:46.388]: Hiding default kernel spec 'Python 2', 'pythonjvsc74a57bd0d44503299428ac231563c18a7a1548b95bf18d1b1ca72dfa6d84161eb1571ad0', /python
[DEBUG 2022-3-19 10:43:46.388]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3100jvsc74a57bd0634dd5ad51c8428f960320242b892cf18e31e0d7464bf46dc14e5166fe075256', /python
[DEBUG 2022-3-19 10:43:46.389]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd08a3ad01b4a7ad0543281b68be4d6073d648d1872c86b4c26ba1ce2858e740b3d', /python
[DEBUG 2022-3-19 10:43:46.389]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0cdcef8d68626485ce31124094088ea4f663d8f1bee8c8ef5794a8d640d4e412e', /python
[DEBUG 2022-3-19 10:43:46.389]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd09968599c749c7e85ea7552fe093ffe8a75e0a83d973ab7d702bd4595706e78a1', /python
[DEBUG 2022-3-19 10:43:46.389]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd066139348caf7cb051dbb7573416b4597887dec19f7cfa1e941b98d178637bf6d', /python
[DEBUG 2022-3-19 10:43:46.390]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd026362c76df08e6795ec7bb890471fed444ecc20062c61f3ceb3b5071ff785288', /python
[DEBUG 2022-3-19 10:43:46.390]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd00b895896492e2d0bc306a400ebcd3a09c75257ad0cb41d05f1d70eb83fd4e82a', /python
[DEBUG 2022-3-19 10:43:46.390]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0c97f527725ed1b1f21ca875d4303600675e0e432d4444a3b1d85bdf4817170a8', /python
[DEBUG 2022-3-19 10:43:46.391]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0af786047f1c3cd85657f71c1da14fc9c9313edd4f40a16aa4e348599b20d15ca', /python
[DEBUG 2022-3-19 10:43:46.391]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd01da80cdddf70df14db0f39d3c88ee8abad70023faaa222ce11ca69b908c9831c', /python
[DEBUG 2022-3-19 10:43:46.391]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd007e919204236a46e818fb2226c97300c1efb30c8863f618209d46bf66bfd5d1e', /python
[DEBUG 2022-3-19 10:43:46.391]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0742490dfec7a872128fbee14a994c1d8beb1cc7caa54e78ea7ef3c08437e5b36', /python
[DEBUG 2022-3-19 10:43:46.392]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0f34bad3d75b1c33981eb7576ca58c81a8f2635862476211cc7bc1a8083e4d3ff', /python
[DEBUG 2022-3-19 10:43:46.392]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0591ee1787f787333a5664d4ecda002d83bfab239fb6f90d27c26a53219d33ec0', /python
[DEBUG 2022-3-19 10:43:46.392]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0df182e9b2cc56efb974e622c7053d2aacd5f31356a22f8cc8a3843fb62e9328b', ~/miniconda3/envs/abc/bin/python
[DEBUG 2022-3-19 10:43:46.392]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd03a359ff06103a45cf9a18736dbfc74bedc15c4166c925bfce48beb6bf99a86db', ~/miniconda3/envs/env1/bin/python
[DEBUG 2022-3-19 10:43:46.393]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0d0fd6c253a61e46c43db05e2114a862a7f350a39db683163c8240df924e5c9d5', ~/miniconda3/envs/envKql/bin/python
[DEBUG 2022-3-19 10:43:46.393]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0e3967d17aeb7b17e0350cfc9ab4265bf4483171f4665bd7400fff589e080aa02', ~/miniconda3/envs/envTemp1/bin/python
[DEBUG 2022-3-19 10:43:46.393]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0785edfce71b7b34600eacc1c40d1f7960d8cad3527bf2998465efd5555859783', /python
[DEBUG 2022-3-19 10:43:46.394]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3101jvsc74a57bd0dd6644a4d6ce6b3ee9b5983998d2ead42f9e79546c761dcbf88f11aef6cd609f', ~/miniconda3/envs/golden_scenario_env/bin/python
[DEBUG 2022-3-19 10:43:46.394]: Hiding default kernel spec 'Python 3', 'python3812jvsc74a57bd0518d23331377686d4217d3578071560115dca7e98bf3dfe1072fbc00783ff437', ~/miniconda3/envs/sage/bin/python
[DEBUG 2022-3-19 10:43:46.394]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd029da4c255bb988a50219cddcbad97c2227ee8f62c293e2e8122b9e89f9da9265', ~/miniconda3/envs/tf/bin/python
[DEBUG 2022-3-19 10:43:46.395]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd05e18b8d9af2ccffaf7d94da25fcdecff98dcfefd7396abf4f0d66dd2103b5bbc', ~/miniconda3/envs/tf_gpu/bin/python
[DEBUG 2022-3-19 10:43:46.395]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd08a9edc66896c58a694162c26179b2405fabe6508d3f64a3342111512acc6aebd', /python
[DEBUG 2022-3-19 10:43:46.395]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd07ba01d208a896c8c0c774151fc595d82208a92adb97525dad39cabf4eab581b1', /python
[DEBUG 2022-3-19 10:43:46.396]: Kernel python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae matches Python 3.8.12 ('.venv': pipenv) based on interpreter path.
[DEBUG 2022-3-19 10:43:46.396]: Kernel python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae matches Python 3.8.12 ('.venvWidgets': venv) based on path in argv.
[DEBUG 2022-3-19 10:43:46.397]: Kernel python3812jvsc74a57bd04717944c9f6968bf83678f78bd1a822ff4aff18182691a35dd09e1dc45b02eff matches Python 3.8.12 ('.venvLatest': venv) based on interpreter path.
[DEBUG 2022-3-19 10:43:46.397]: Kernel python3812jvsc74a57bd05e18b8d9af2ccffaf7d94da25fcdecff98dcfefd7396abf4f0d66dd2103b5bbc.--debug matches Python 3.8.12 based on path in argv.
[DEBUG 2022-3-19 10:43:46.397]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae', /python
[DEBUG 2022-3-19 10:43:46.398]: Hiding default kernel spec 'Python 2', 'pythonjvsc74a57bd0d44503299428ac231563c18a7a1548b95bf18d1b1ca72dfa6d84161eb1571ad0', /python
[DEBUG 2022-3-19 10:43:46.398]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3100jvsc74a57bd0634dd5ad51c8428f960320242b892cf18e31e0d7464bf46dc14e5166fe075256', /python
[DEBUG 2022-3-19 10:43:46.398]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd08a3ad01b4a7ad0543281b68be4d6073d648d1872c86b4c26ba1ce2858e740b3d', /python
[DEBUG 2022-3-19 10:43:46.399]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0cdcef8d68626485ce31124094088ea4f663d8f1bee8c8ef5794a8d640d4e412e', /python
[DEBUG 2022-3-19 10:43:46.399]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd09968599c749c7e85ea7552fe093ffe8a75e0a83d973ab7d702bd4595706e78a1', /python
[DEBUG 2022-3-19 10:43:46.399]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd066139348caf7cb051dbb7573416b4597887dec19f7cfa1e941b98d178637bf6d', /python
[DEBUG 2022-3-19 10:43:46.400]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd026362c76df08e6795ec7bb890471fed444ecc20062c61f3ceb3b5071ff785288', /python
[DEBUG 2022-3-19 10:43:46.400]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd00b895896492e2d0bc306a400ebcd3a09c75257ad0cb41d05f1d70eb83fd4e82a', /python
[DEBUG 2022-3-19 10:43:46.400]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0c97f527725ed1b1f21ca875d4303600675e0e432d4444a3b1d85bdf4817170a8', /python
[DEBUG 2022-3-19 10:43:46.400]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0af786047f1c3cd85657f71c1da14fc9c9313edd4f40a16aa4e348599b20d15ca', /python
[DEBUG 2022-3-19 10:43:46.401]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd01da80cdddf70df14db0f39d3c88ee8abad70023faaa222ce11ca69b908c9831c', /python
[DEBUG 2022-3-19 10:43:46.401]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd007e919204236a46e818fb2226c97300c1efb30c8863f618209d46bf66bfd5d1e', /python
[DEBUG 2022-3-19 10:43:46.401]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0742490dfec7a872128fbee14a994c1d8beb1cc7caa54e78ea7ef3c08437e5b36', /python
[DEBUG 2022-3-19 10:43:46.401]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0f34bad3d75b1c33981eb7576ca58c81a8f2635862476211cc7bc1a8083e4d3ff', /python
[DEBUG 2022-3-19 10:43:46.402]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0591ee1787f787333a5664d4ecda002d83bfab239fb6f90d27c26a53219d33ec0', /python
[DEBUG 2022-3-19 10:43:46.402]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0df182e9b2cc56efb974e622c7053d2aacd5f31356a22f8cc8a3843fb62e9328b', ~/miniconda3/envs/abc/bin/python
[DEBUG 2022-3-19 10:43:46.402]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd03a359ff06103a45cf9a18736dbfc74bedc15c4166c925bfce48beb6bf99a86db', ~/miniconda3/envs/env1/bin/python
[DEBUG 2022-3-19 10:43:46.402]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0d0fd6c253a61e46c43db05e2114a862a7f350a39db683163c8240df924e5c9d5', ~/miniconda3/envs/envKql/bin/python
[DEBUG 2022-3-19 10:43:46.402]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0e3967d17aeb7b17e0350cfc9ab4265bf4483171f4665bd7400fff589e080aa02', ~/miniconda3/envs/envTemp1/bin/python
[DEBUG 2022-3-19 10:43:46.403]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0785edfce71b7b34600eacc1c40d1f7960d8cad3527bf2998465efd5555859783', /python
[DEBUG 2022-3-19 10:43:46.403]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3101jvsc74a57bd0dd6644a4d6ce6b3ee9b5983998d2ead42f9e79546c761dcbf88f11aef6cd609f', ~/miniconda3/envs/golden_scenario_env/bin/python
[DEBUG 2022-3-19 10:43:46.403]: Hiding default kernel spec 'Python 3', 'python3812jvsc74a57bd0518d23331377686d4217d3578071560115dca7e98bf3dfe1072fbc00783ff437', ~/miniconda3/envs/sage/bin/python
[DEBUG 2022-3-19 10:43:46.404]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd029da4c255bb988a50219cddcbad97c2227ee8f62c293e2e8122b9e89f9da9265', ~/miniconda3/envs/tf/bin/python
[DEBUG 2022-3-19 10:43:46.404]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd05e18b8d9af2ccffaf7d94da25fcdecff98dcfefd7396abf4f0d66dd2103b5bbc', ~/miniconda3/envs/tf_gpu/bin/python
[DEBUG 2022-3-19 10:43:46.404]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd08a9edc66896c58a694162c26179b2405fabe6508d3f64a3342111512acc6aebd', /python
[DEBUG 2022-3-19 10:43:46.404]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd07ba01d208a896c8c0c774151fc595d82208a92adb97525dad39cabf4eab581b1', /python
[DEBUG 2022-3-19 10:43:46.405]: Kernel python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae matches Python 3.8.12 ('.venv': pipenv) based on interpreter path.
[DEBUG 2022-3-19 10:43:46.405]: Kernel python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae matches Python 3.8.12 ('.venvWidgets': venv) based on path in argv.
[DEBUG 2022-3-19 10:43:46.405]: Kernel python3812jvsc74a57bd04717944c9f6968bf83678f78bd1a822ff4aff18182691a35dd09e1dc45b02eff matches Python 3.8.12 ('.venvLatest': venv) based on interpreter path.
[DEBUG 2022-3-19 10:43:46.406]: Kernel python3812jvsc74a57bd05e18b8d9af2ccffaf7d94da25fcdecff98dcfefd7396abf4f0d66dd2103b5bbc.--debug matches Python 3.8.12 based on path in argv.
[DEBUG 2022-3-19 10:43:46.407]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae', /python
[DEBUG 2022-3-19 10:43:46.407]: Hiding default kernel spec 'Python 2', 'pythonjvsc74a57bd0d44503299428ac231563c18a7a1548b95bf18d1b1ca72dfa6d84161eb1571ad0', /python
[DEBUG 2022-3-19 10:43:46.407]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3100jvsc74a57bd0634dd5ad51c8428f960320242b892cf18e31e0d7464bf46dc14e5166fe075256', /python
[DEBUG 2022-3-19 10:43:46.407]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd08a3ad01b4a7ad0543281b68be4d6073d648d1872c86b4c26ba1ce2858e740b3d', /python
[DEBUG 2022-3-19 10:43:46.408]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0cdcef8d68626485ce31124094088ea4f663d8f1bee8c8ef5794a8d640d4e412e', /python
[DEBUG 2022-3-19 10:43:46.408]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd09968599c749c7e85ea7552fe093ffe8a75e0a83d973ab7d702bd4595706e78a1', /python
[DEBUG 2022-3-19 10:43:46.408]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd066139348caf7cb051dbb7573416b4597887dec19f7cfa1e941b98d178637bf6d', /python
[DEBUG 2022-3-19 10:43:46.408]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd026362c76df08e6795ec7bb890471fed444ecc20062c61f3ceb3b5071ff785288', /python
[DEBUG 2022-3-19 10:43:46.408]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd00b895896492e2d0bc306a400ebcd3a09c75257ad0cb41d05f1d70eb83fd4e82a', /python
[DEBUG 2022-3-19 10:43:46.409]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0c97f527725ed1b1f21ca875d4303600675e0e432d4444a3b1d85bdf4817170a8', /python
[DEBUG 2022-3-19 10:43:46.409]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0af786047f1c3cd85657f71c1da14fc9c9313edd4f40a16aa4e348599b20d15ca', /python
[DEBUG 2022-3-19 10:43:46.409]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd01da80cdddf70df14db0f39d3c88ee8abad70023faaa222ce11ca69b908c9831c', /python
[DEBUG 2022-3-19 10:43:46.410]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd007e919204236a46e818fb2226c97300c1efb30c8863f618209d46bf66bfd5d1e', /python
[DEBUG 2022-3-19 10:43:46.410]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0742490dfec7a872128fbee14a994c1d8beb1cc7caa54e78ea7ef3c08437e5b36', /python
[DEBUG 2022-3-19 10:43:46.410]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0f34bad3d75b1c33981eb7576ca58c81a8f2635862476211cc7bc1a8083e4d3ff', /python
[DEBUG 2022-3-19 10:43:46.410]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0591ee1787f787333a5664d4ecda002d83bfab239fb6f90d27c26a53219d33ec0', /python
[DEBUG 2022-3-19 10:43:46.410]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0df182e9b2cc56efb974e622c7053d2aacd5f31356a22f8cc8a3843fb62e9328b', ~/miniconda3/envs/abc/bin/python
[DEBUG 2022-3-19 10:43:46.411]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd03a359ff06103a45cf9a18736dbfc74bedc15c4166c925bfce48beb6bf99a86db', ~/miniconda3/envs/env1/bin/python
[DEBUG 2022-3-19 10:43:46.411]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0d0fd6c253a61e46c43db05e2114a862a7f350a39db683163c8240df924e5c9d5', ~/miniconda3/envs/envKql/bin/python
[DEBUG 2022-3-19 10:43:46.411]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0e3967d17aeb7b17e0350cfc9ab4265bf4483171f4665bd7400fff589e080aa02', ~/miniconda3/envs/envTemp1/bin/python
[DEBUG 2022-3-19 10:43:46.412]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0785edfce71b7b34600eacc1c40d1f7960d8cad3527bf2998465efd5555859783', /python
[DEBUG 2022-3-19 10:43:46.412]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3101jvsc74a57bd0dd6644a4d6ce6b3ee9b5983998d2ead42f9e79546c761dcbf88f11aef6cd609f', ~/miniconda3/envs/golden_scenario_env/bin/python
[DEBUG 2022-3-19 10:43:46.412]: Hiding default kernel spec 'Python 3', 'python3812jvsc74a57bd0518d23331377686d4217d3578071560115dca7e98bf3dfe1072fbc00783ff437', ~/miniconda3/envs/sage/bin/python
[DEBUG 2022-3-19 10:43:46.412]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd029da4c255bb988a50219cddcbad97c2227ee8f62c293e2e8122b9e89f9da9265', ~/miniconda3/envs/tf/bin/python
[DEBUG 2022-3-19 10:43:46.412]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd05e18b8d9af2ccffaf7d94da25fcdecff98dcfefd7396abf4f0d66dd2103b5bbc', ~/miniconda3/envs/tf_gpu/bin/python
[DEBUG 2022-3-19 10:43:46.413]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd08a9edc66896c58a694162c26179b2405fabe6508d3f64a3342111512acc6aebd', /python
[DEBUG 2022-3-19 10:43:46.413]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd07ba01d208a896c8c0c774151fc595d82208a92adb97525dad39cabf4eab581b1', /python
[DEBUG 2022-3-19 10:43:46.413]: Kernel python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae matches Python 3.8.12 ('.venv': pipenv) based on interpreter path.
[DEBUG 2022-3-19 10:43:46.414]: Kernel python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae matches Python 3.8.12 ('.venvWidgets': venv) based on path in argv.
[DEBUG 2022-3-19 10:43:46.414]: Kernel python3812jvsc74a57bd04717944c9f6968bf83678f78bd1a822ff4aff18182691a35dd09e1dc45b02eff matches Python 3.8.12 ('.venvLatest': venv) based on interpreter path.
[DEBUG 2022-3-19 10:43:46.415]: Kernel python3812jvsc74a57bd05e18b8d9af2ccffaf7d94da25fcdecff98dcfefd7396abf4f0d66dd2103b5bbc.--debug matches Python 3.8.12 based on path in argv.
[DEBUG 2022-3-19 10:43:46.415]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae', /python
[DEBUG 2022-3-19 10:43:46.415]: Hiding default kernel spec 'Python 2', 'pythonjvsc74a57bd0d44503299428ac231563c18a7a1548b95bf18d1b1ca72dfa6d84161eb1571ad0', /python
[DEBUG 2022-3-19 10:43:46.415]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3100jvsc74a57bd0634dd5ad51c8428f960320242b892cf18e31e0d7464bf46dc14e5166fe075256', /python
[DEBUG 2022-3-19 10:43:46.416]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd08a3ad01b4a7ad0543281b68be4d6073d648d1872c86b4c26ba1ce2858e740b3d', /python
[DEBUG 2022-3-19 10:43:46.416]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0cdcef8d68626485ce31124094088ea4f663d8f1bee8c8ef5794a8d640d4e412e', /python
[DEBUG 2022-3-19 10:43:46.416]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd09968599c749c7e85ea7552fe093ffe8a75e0a83d973ab7d702bd4595706e78a1', /python
[DEBUG 2022-3-19 10:43:46.417]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd066139348caf7cb051dbb7573416b4597887dec19f7cfa1e941b98d178637bf6d', /python
[DEBUG 2022-3-19 10:43:46.417]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd026362c76df08e6795ec7bb890471fed444ecc20062c61f3ceb3b5071ff785288', /python
[DEBUG 2022-3-19 10:43:46.417]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd00b895896492e2d0bc306a400ebcd3a09c75257ad0cb41d05f1d70eb83fd4e82a', /python
[DEBUG 2022-3-19 10:43:46.417]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0c97f527725ed1b1f21ca875d4303600675e0e432d4444a3b1d85bdf4817170a8', /python
[DEBUG 2022-3-19 10:43:46.417]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0af786047f1c3cd85657f71c1da14fc9c9313edd4f40a16aa4e348599b20d15ca', /python
[DEBUG 2022-3-19 10:43:46.418]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd01da80cdddf70df14db0f39d3c88ee8abad70023faaa222ce11ca69b908c9831c', /python
[DEBUG 2022-3-19 10:43:46.418]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd007e919204236a46e818fb2226c97300c1efb30c8863f618209d46bf66bfd5d1e', /python
[DEBUG 2022-3-19 10:43:46.418]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0742490dfec7a872128fbee14a994c1d8beb1cc7caa54e78ea7ef3c08437e5b36', /python
[DEBUG 2022-3-19 10:43:46.418]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0f34bad3d75b1c33981eb7576ca58c81a8f2635862476211cc7bc1a8083e4d3ff', /python
[DEBUG 2022-3-19 10:43:46.418]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0591ee1787f787333a5664d4ecda002d83bfab239fb6f90d27c26a53219d33ec0', /python
[DEBUG 2022-3-19 10:43:46.419]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0df182e9b2cc56efb974e622c7053d2aacd5f31356a22f8cc8a3843fb62e9328b', ~/miniconda3/envs/abc/bin/python
[DEBUG 2022-3-19 10:43:46.419]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd03a359ff06103a45cf9a18736dbfc74bedc15c4166c925bfce48beb6bf99a86db', ~/miniconda3/envs/env1/bin/python
[DEBUG 2022-3-19 10:43:46.419]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0d0fd6c253a61e46c43db05e2114a862a7f350a39db683163c8240df924e5c9d5', ~/miniconda3/envs/envKql/bin/python
[DEBUG 2022-3-19 10:43:46.419]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0e3967d17aeb7b17e0350cfc9ab4265bf4483171f4665bd7400fff589e080aa02', ~/miniconda3/envs/envTemp1/bin/python
[DEBUG 2022-3-19 10:43:46.420]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0785edfce71b7b34600eacc1c40d1f7960d8cad3527bf2998465efd5555859783', /python
[DEBUG 2022-3-19 10:43:46.420]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3101jvsc74a57bd0dd6644a4d6ce6b3ee9b5983998d2ead42f9e79546c761dcbf88f11aef6cd609f', ~/miniconda3/envs/golden_scenario_env/bin/python
[DEBUG 2022-3-19 10:43:46.420]: Hiding default kernel spec 'Python 3', 'python3812jvsc74a57bd0518d23331377686d4217d3578071560115dca7e98bf3dfe1072fbc00783ff437', ~/miniconda3/envs/sage/bin/python
[DEBUG 2022-3-19 10:43:46.420]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd029da4c255bb988a50219cddcbad97c2227ee8f62c293e2e8122b9e89f9da9265', ~/miniconda3/envs/tf/bin/python
[DEBUG 2022-3-19 10:43:46.421]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd05e18b8d9af2ccffaf7d94da25fcdecff98dcfefd7396abf4f0d66dd2103b5bbc', ~/miniconda3/envs/tf_gpu/bin/python
[DEBUG 2022-3-19 10:43:46.421]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd08a9edc66896c58a694162c26179b2405fabe6508d3f64a3342111512acc6aebd', /python
[DEBUG 2022-3-19 10:43:46.421]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd07ba01d208a896c8c0c774151fc595d82208a92adb97525dad39cabf4eab581b1', /python
[DEBUG 2022-3-19 10:43:46.421]: Kernel python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae matches Python 3.8.12 ('.venv': pipenv) based on interpreter path.
[DEBUG 2022-3-19 10:43:46.422]: Kernel python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae matches Python 3.8.12 ('.venvWidgets': venv) based on path in argv.
[DEBUG 2022-3-19 10:43:46.422]: Kernel python3812jvsc74a57bd04717944c9f6968bf83678f78bd1a822ff4aff18182691a35dd09e1dc45b02eff matches Python 3.8.12 ('.venvLatest': venv) based on interpreter path.
[DEBUG 2022-3-19 10:43:46.423]: Kernel python3812jvsc74a57bd05e18b8d9af2ccffaf7d94da25fcdecff98dcfefd7396abf4f0d66dd2103b5bbc.--debug matches Python 3.8.12 based on path in argv.
[DEBUG 2022-3-19 10:43:46.424]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae', /python
[DEBUG 2022-3-19 10:43:46.424]: Hiding default kernel spec 'Python 2', 'pythonjvsc74a57bd0d44503299428ac231563c18a7a1548b95bf18d1b1ca72dfa6d84161eb1571ad0', /python
[DEBUG 2022-3-19 10:43:46.424]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3100jvsc74a57bd0634dd5ad51c8428f960320242b892cf18e31e0d7464bf46dc14e5166fe075256', /python
[DEBUG 2022-3-19 10:43:46.425]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd08a3ad01b4a7ad0543281b68be4d6073d648d1872c86b4c26ba1ce2858e740b3d', /python
[DEBUG 2022-3-19 10:43:46.425]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0cdcef8d68626485ce31124094088ea4f663d8f1bee8c8ef5794a8d640d4e412e', /python
[DEBUG 2022-3-19 10:43:46.425]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd09968599c749c7e85ea7552fe093ffe8a75e0a83d973ab7d702bd4595706e78a1', /python
[DEBUG 2022-3-19 10:43:46.425]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd066139348caf7cb051dbb7573416b4597887dec19f7cfa1e941b98d178637bf6d', /python
[DEBUG 2022-3-19 10:43:46.426]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd026362c76df08e6795ec7bb890471fed444ecc20062c61f3ceb3b5071ff785288', /python
[DEBUG 2022-3-19 10:43:46.426]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd00b895896492e2d0bc306a400ebcd3a09c75257ad0cb41d05f1d70eb83fd4e82a', /python
[DEBUG 2022-3-19 10:43:46.426]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0c97f527725ed1b1f21ca875d4303600675e0e432d4444a3b1d85bdf4817170a8', /python
[DEBUG 2022-3-19 10:43:46.426]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0af786047f1c3cd85657f71c1da14fc9c9313edd4f40a16aa4e348599b20d15ca', /python
[DEBUG 2022-3-19 10:43:46.426]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd01da80cdddf70df14db0f39d3c88ee8abad70023faaa222ce11ca69b908c9831c', /python
[DEBUG 2022-3-19 10:43:46.427]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd007e919204236a46e818fb2226c97300c1efb30c8863f618209d46bf66bfd5d1e', /python
[DEBUG 2022-3-19 10:43:46.427]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0742490dfec7a872128fbee14a994c1d8beb1cc7caa54e78ea7ef3c08437e5b36', /python
[DEBUG 2022-3-19 10:43:46.427]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0f34bad3d75b1c33981eb7576ca58c81a8f2635862476211cc7bc1a8083e4d3ff', /python
[DEBUG 2022-3-19 10:43:46.427]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0591ee1787f787333a5664d4ecda002d83bfab239fb6f90d27c26a53219d33ec0', /python
[DEBUG 2022-3-19 10:43:46.428]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0df182e9b2cc56efb974e622c7053d2aacd5f31356a22f8cc8a3843fb62e9328b', ~/miniconda3/envs/abc/bin/python
[DEBUG 2022-3-19 10:43:46.428]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd03a359ff06103a45cf9a18736dbfc74bedc15c4166c925bfce48beb6bf99a86db', ~/miniconda3/envs/env1/bin/python
[DEBUG 2022-3-19 10:43:46.428]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0d0fd6c253a61e46c43db05e2114a862a7f350a39db683163c8240df924e5c9d5', ~/miniconda3/envs/envKql/bin/python
[DEBUG 2022-3-19 10:43:46.428]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0e3967d17aeb7b17e0350cfc9ab4265bf4483171f4665bd7400fff589e080aa02', ~/miniconda3/envs/envTemp1/bin/python
[DEBUG 2022-3-19 10:43:46.429]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0785edfce71b7b34600eacc1c40d1f7960d8cad3527bf2998465efd5555859783', /python
[DEBUG 2022-3-19 10:43:46.429]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3101jvsc74a57bd0dd6644a4d6ce6b3ee9b5983998d2ead42f9e79546c761dcbf88f11aef6cd609f', ~/miniconda3/envs/golden_scenario_env/bin/python
[DEBUG 2022-3-19 10:43:46.429]: Hiding default kernel spec 'Python 3', 'python3812jvsc74a57bd0518d23331377686d4217d3578071560115dca7e98bf3dfe1072fbc00783ff437', ~/miniconda3/envs/sage/bin/python
[DEBUG 2022-3-19 10:43:46.429]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd029da4c255bb988a50219cddcbad97c2227ee8f62c293e2e8122b9e89f9da9265', ~/miniconda3/envs/tf/bin/python
[DEBUG 2022-3-19 10:43:46.430]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd05e18b8d9af2ccffaf7d94da25fcdecff98dcfefd7396abf4f0d66dd2103b5bbc', ~/miniconda3/envs/tf_gpu/bin/python
[DEBUG 2022-3-19 10:43:46.430]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd08a9edc66896c58a694162c26179b2405fabe6508d3f64a3342111512acc6aebd', /python
[DEBUG 2022-3-19 10:43:46.430]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd07ba01d208a896c8c0c774151fc595d82208a92adb97525dad39cabf4eab581b1', /python
[DEBUG 2022-3-19 10:43:46.430]: Kernel python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae matches Python 3.8.12 ('.venv': pipenv) based on interpreter path.
[DEBUG 2022-3-19 10:43:46.431]: Kernel python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae matches Python 3.8.12 ('.venvWidgets': venv) based on path in argv.
[DEBUG 2022-3-19 10:43:46.431]: Kernel python3812jvsc74a57bd04717944c9f6968bf83678f78bd1a822ff4aff18182691a35dd09e1dc45b02eff matches Python 3.8.12 ('.venvLatest': venv) based on interpreter path.
[DEBUG 2022-3-19 10:43:46.432]: Kernel python3812jvsc74a57bd05e18b8d9af2ccffaf7d94da25fcdecff98dcfefd7396abf4f0d66dd2103b5bbc.--debug matches Python 3.8.12 based on path in argv.
[DEBUG 2022-3-19 10:43:46.968]: Kernel venvglobalkernel matches Python 3.8.12 ('.venv': pipenv) based on path in argv.
[DEBUG 2022-3-19 10:43:46.970]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae', /python
[DEBUG 2022-3-19 10:43:46.970]: Hiding default kernel spec 'Python 2', 'pythonjvsc74a57bd0d44503299428ac231563c18a7a1548b95bf18d1b1ca72dfa6d84161eb1571ad0', /python
[DEBUG 2022-3-19 10:43:46.971]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3100jvsc74a57bd0634dd5ad51c8428f960320242b892cf18e31e0d7464bf46dc14e5166fe075256', /python
[DEBUG 2022-3-19 10:43:46.971]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd08a3ad01b4a7ad0543281b68be4d6073d648d1872c86b4c26ba1ce2858e740b3d', /python
[DEBUG 2022-3-19 10:43:46.972]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0cdcef8d68626485ce31124094088ea4f663d8f1bee8c8ef5794a8d640d4e412e', /python
[DEBUG 2022-3-19 10:43:46.972]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0f34bad3d75b1c33981eb7576ca58c81a8f2635862476211cc7bc1a8083e4d3ff', /python
[DEBUG 2022-3-19 10:43:46.973]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd09968599c749c7e85ea7552fe093ffe8a75e0a83d973ab7d702bd4595706e78a1', /python
[DEBUG 2022-3-19 10:43:46.973]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd066139348caf7cb051dbb7573416b4597887dec19f7cfa1e941b98d178637bf6d', /python
[DEBUG 2022-3-19 10:43:46.973]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd026362c76df08e6795ec7bb890471fed444ecc20062c61f3ceb3b5071ff785288', /python
[DEBUG 2022-3-19 10:43:46.974]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd00b895896492e2d0bc306a400ebcd3a09c75257ad0cb41d05f1d70eb83fd4e82a', /python
[DEBUG 2022-3-19 10:43:46.974]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd08a9edc66896c58a694162c26179b2405fabe6508d3f64a3342111512acc6aebd', /python
[DEBUG 2022-3-19 10:43:46.975]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0c97f527725ed1b1f21ca875d4303600675e0e432d4444a3b1d85bdf4817170a8', /python
[DEBUG 2022-3-19 10:43:46.975]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0af786047f1c3cd85657f71c1da14fc9c9313edd4f40a16aa4e348599b20d15ca', /python
[DEBUG 2022-3-19 10:43:46.976]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd07ba01d208a896c8c0c774151fc595d82208a92adb97525dad39cabf4eab581b1', /python
[DEBUG 2022-3-19 10:43:46.976]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd01da80cdddf70df14db0f39d3c88ee8abad70023faaa222ce11ca69b908c9831c', /python
[DEBUG 2022-3-19 10:43:46.977]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd007e919204236a46e818fb2226c97300c1efb30c8863f618209d46bf66bfd5d1e', /python
[DEBUG 2022-3-19 10:43:46.977]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0742490dfec7a872128fbee14a994c1d8beb1cc7caa54e78ea7ef3c08437e5b36', /python
[DEBUG 2022-3-19 10:43:46.977]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0591ee1787f787333a5664d4ecda002d83bfab239fb6f90d27c26a53219d33ec0', /python
[DEBUG 2022-3-19 10:43:46.978]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0785edfce71b7b34600eacc1c40d1f7960d8cad3527bf2998465efd5555859783', /python
[DEBUG 2022-3-19 10:43:46.978]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0df182e9b2cc56efb974e622c7053d2aacd5f31356a22f8cc8a3843fb62e9328b', ~/miniconda3/envs/abc/bin/python
[DEBUG 2022-3-19 10:43:46.978]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd03a359ff06103a45cf9a18736dbfc74bedc15c4166c925bfce48beb6bf99a86db', ~/miniconda3/envs/env1/bin/python
[DEBUG 2022-3-19 10:43:46.979]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0d0fd6c253a61e46c43db05e2114a862a7f350a39db683163c8240df924e5c9d5', ~/miniconda3/envs/envKql/bin/python
[DEBUG 2022-3-19 10:43:46.979]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0e3967d17aeb7b17e0350cfc9ab4265bf4483171f4665bd7400fff589e080aa02', ~/miniconda3/envs/envTemp1/bin/python
[DEBUG 2022-3-19 10:43:46.979]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3101jvsc74a57bd0dd6644a4d6ce6b3ee9b5983998d2ead42f9e79546c761dcbf88f11aef6cd609f', ~/miniconda3/envs/golden_scenario_env/bin/python
[DEBUG 2022-3-19 10:43:46.980]: Hiding default kernel spec 'Python 3', 'python3812jvsc74a57bd0518d23331377686d4217d3578071560115dca7e98bf3dfe1072fbc00783ff437', ~/miniconda3/envs/sage/bin/python
[DEBUG 2022-3-19 10:43:46.980]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd029da4c255bb988a50219cddcbad97c2227ee8f62c293e2e8122b9e89f9da9265', ~/miniconda3/envs/tf/bin/python
[DEBUG 2022-3-19 10:43:46.980]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd05e18b8d9af2ccffaf7d94da25fcdecff98dcfefd7396abf4f0d66dd2103b5bbc', ~/miniconda3/envs/tf_gpu/bin/python
[DEBUG 2022-3-19 10:43:46.981]: Kernel python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae matches Python 3.8.12 ('.venv': pipenv) based on interpreter path.
[DEBUG 2022-3-19 10:43:46.981]: Kernel python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae matches Python 3.8.12 ('.venvWidgets': venv) based on path in argv.
[DEBUG 2022-3-19 10:43:46.981]: Kernel python3812jvsc74a57bd04717944c9f6968bf83678f78bd1a822ff4aff18182691a35dd09e1dc45b02eff matches Python 3.8.12 ('.venvLatest': venv) based on interpreter path.
[DEBUG 2022-3-19 10:43:46.982]: Kernel python3812jvsc74a57bd05e18b8d9af2ccffaf7d94da25fcdecff98dcfefd7396abf4f0d66dd2103b5bbc.--debug matches Python 3.8.12 based on path in argv.
[DEBUG 2022-3-19 10:43:47.31]: Kernel venvglobalkernel matches Python 3.8.12 ('.venv': pipenv) based on path in argv.
[DEBUG 2022-3-19 10:43:47.35]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae', /python
[DEBUG 2022-3-19 10:43:47.35]: Hiding default kernel spec 'Python 2', 'pythonjvsc74a57bd0d44503299428ac231563c18a7a1548b95bf18d1b1ca72dfa6d84161eb1571ad0', /python
[DEBUG 2022-3-19 10:43:47.36]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3100jvsc74a57bd0634dd5ad51c8428f960320242b892cf18e31e0d7464bf46dc14e5166fe075256', /python
[DEBUG 2022-3-19 10:43:47.36]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd08a3ad01b4a7ad0543281b68be4d6073d648d1872c86b4c26ba1ce2858e740b3d', /python
[DEBUG 2022-3-19 10:43:47.37]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0cdcef8d68626485ce31124094088ea4f663d8f1bee8c8ef5794a8d640d4e412e', /python
[DEBUG 2022-3-19 10:43:47.37]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0f34bad3d75b1c33981eb7576ca58c81a8f2635862476211cc7bc1a8083e4d3ff', /python
[DEBUG 2022-3-19 10:43:47.38]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd09968599c749c7e85ea7552fe093ffe8a75e0a83d973ab7d702bd4595706e78a1', /python
[DEBUG 2022-3-19 10:43:47.38]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd066139348caf7cb051dbb7573416b4597887dec19f7cfa1e941b98d178637bf6d', /python
[DEBUG 2022-3-19 10:43:47.39]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd026362c76df08e6795ec7bb890471fed444ecc20062c61f3ceb3b5071ff785288', /python
[DEBUG 2022-3-19 10:43:47.39]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd00b895896492e2d0bc306a400ebcd3a09c75257ad0cb41d05f1d70eb83fd4e82a', /python
[DEBUG 2022-3-19 10:43:47.40]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd08a9edc66896c58a694162c26179b2405fabe6508d3f64a3342111512acc6aebd', /python
[DEBUG 2022-3-19 10:43:47.40]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0c97f527725ed1b1f21ca875d4303600675e0e432d4444a3b1d85bdf4817170a8', /python
[DEBUG 2022-3-19 10:43:47.41]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0af786047f1c3cd85657f71c1da14fc9c9313edd4f40a16aa4e348599b20d15ca', /python
[DEBUG 2022-3-19 10:43:47.42]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd07ba01d208a896c8c0c774151fc595d82208a92adb97525dad39cabf4eab581b1', /python
[DEBUG 2022-3-19 10:43:47.42]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd01da80cdddf70df14db0f39d3c88ee8abad70023faaa222ce11ca69b908c9831c', /python
[DEBUG 2022-3-19 10:43:47.43]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd007e919204236a46e818fb2226c97300c1efb30c8863f618209d46bf66bfd5d1e', /python
[DEBUG 2022-3-19 10:43:47.43]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0742490dfec7a872128fbee14a994c1d8beb1cc7caa54e78ea7ef3c08437e5b36', /python
[DEBUG 2022-3-19 10:43:47.44]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0591ee1787f787333a5664d4ecda002d83bfab239fb6f90d27c26a53219d33ec0', /python
[DEBUG 2022-3-19 10:43:47.44]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0785edfce71b7b34600eacc1c40d1f7960d8cad3527bf2998465efd5555859783', /python
[DEBUG 2022-3-19 10:43:47.45]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0df182e9b2cc56efb974e622c7053d2aacd5f31356a22f8cc8a3843fb62e9328b', ~/miniconda3/envs/abc/bin/python
[DEBUG 2022-3-19 10:43:47.45]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd03a359ff06103a45cf9a18736dbfc74bedc15c4166c925bfce48beb6bf99a86db', ~/miniconda3/envs/env1/bin/python
[DEBUG 2022-3-19 10:43:47.46]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd0d0fd6c253a61e46c43db05e2114a862a7f350a39db683163c8240df924e5c9d5', ~/miniconda3/envs/envKql/bin/python
[DEBUG 2022-3-19 10:43:47.46]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd0e3967d17aeb7b17e0350cfc9ab4265bf4483171f4665bd7400fff589e080aa02', ~/miniconda3/envs/envTemp1/bin/python
[DEBUG 2022-3-19 10:43:47.46]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3101jvsc74a57bd0dd6644a4d6ce6b3ee9b5983998d2ead42f9e79546c761dcbf88f11aef6cd609f', ~/miniconda3/envs/golden_scenario_env/bin/python
[DEBUG 2022-3-19 10:43:47.47]: Hiding default kernel spec 'Python 3', 'python3812jvsc74a57bd0518d23331377686d4217d3578071560115dca7e98bf3dfe1072fbc00783ff437', ~/miniconda3/envs/sage/bin/python
[DEBUG 2022-3-19 10:43:47.47]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python397jvsc74a57bd029da4c255bb988a50219cddcbad97c2227ee8f62c293e2e8122b9e89f9da9265', ~/miniconda3/envs/tf/bin/python
[DEBUG 2022-3-19 10:43:47.47]: Hiding default kernel spec 'Python 3 (ipykernel)', 'python3812jvsc74a57bd05e18b8d9af2ccffaf7d94da25fcdecff98dcfefd7396abf4f0d66dd2103b5bbc', ~/miniconda3/envs/tf_gpu/bin/python
[DEBUG 2022-3-19 10:43:47.48]: Kernel python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae matches Python 3.8.12 ('.venv': pipenv) based on interpreter path.
[DEBUG 2022-3-19 10:43:47.48]: Kernel python3812jvsc74a57bd070237d3c917722b6244d3f74d89ac09fe6e36440bb186eba92b0edc58ba017ae matches Python 3.8.12 ('.venvWidgets': venv) based on path in argv.
[DEBUG 2022-3-19 10:43:47.49]: Kernel python3812jvsc74a57bd04717944c9f6968bf83678f78bd1a822ff4aff18182691a35dd09e1dc45b02eff matches Python 3.8.12 ('.venvLatest': venv) based on interpreter path.
[DEBUG 2022-3-19 10:43:47.49]: Kernel python3812jvsc74a57bd05e18b8d9af2ccffaf7d94da25fcdecff98dcfefd7396abf4f0d66dd2103b5bbc.--debug matches Python 3.8.12 based on path in argv.
```

Back to what it was after the change
```
Visual Studio Code - Insiders (1.67.0-insider, wsl, desktop)
Jupyter Extension Version: 2022.4.100.
Python Extension Version: 2022.5.11051003.
Workspace folder /home/don/samples/pySamples/crap
info 10:49:31.379: ZMQ install verified.
User belongs to experiment group 'jupyterTestcf'
User belongs to experiment group 'jupyterEnhancedDataViewer'
info 10:49:32.509: Experiment status for python is {"enabled":"true","optInto":[],"optOutFrom":[]}
info 10:49:32.811: Starting Notebook in kernel.ts id = .jvsc74a57bd0785edfce71b7b34600eacc1c40d1f7960d8cad3527bf2998465efd5555859783./home/don/samples/pySamples/crap/.venvWidgets/python./home/don/samples/pySamples/crap/.venvWidgets/python.-m#ipykernel_launcher for /home/don/samples/pySamples/crap/widgets/matplotlib/widget.ipynb (disableUI=true)
info 10:49:32.821: Creating raw notebook for /home/don/samples/pySamples/crap/widgets/matplotlib/widget.ipynb
info 10:49:32.821: Computing working directory /home/don/samples/pySamples/crap/widgets/matplotlib/widget.ipynb
info 10:49:32.858: Starting raw kernel .venvWidgets (Python 3.8.12) for interpreter /home/don/samples/pySamples/crap/.venvWidgets/bin/python
info 10:49:32.868: Kernel launching with ports 9000,9001,9002,9003,9004. Start port is 9000
info 10:49:32.931: API called from ms-toolsai.vscode-jupyter-powertoys
info 10:49:32.956: Process Execution: > ~/samples/pySamples/crap/.venvWidgets/bin/python -m pip list
> ~/samples/pySamples/crap/.venvWidgets/bin/python -m pip list
info 10:49:33.8: Process Execution: > ~/samples/pySamples/crap/.venvWidgets/bin/python -c "import ipykernel; print(ipykernel.__version__); print("5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d"); print(ipykernel.__file__)"
> ~/samples/pySamples/crap/.venvWidgets/bin/python -c "import ipykernel; print(ipykernel.__version__); print("5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d"); print(ipykernel.__file__)"
info 10:49:33.83: Find preferred kernel for /home/don/samples/pySamples/crap/widgets/matplotlib/widget.ipynb with metadata {"interpreter":{"hash":"785edfce71b7b34600eacc1c40d1f7960d8cad3527bf2998465efd5555859783"},"kernelspec":{"display_name":"Python 3.8.12 ('.venvWidgets': venv)","language":"python","name":"python3"},"language_info":{"codemirror_mode":{"name":"ipython","version":3},"file_extension":".py","mimetype":"text/x-python","name":"python","nbconvert_exporter":"python","pygments_lexer":"ipython3","version":"3.8.12"},"orig_nbformat":4} & preferred interpreter /home/don/samples/pySamples/crap/.venv/bin/python
info 10:49:33.98: Preferred Remote kernel for /home/don/samples/pySamples/crap/widgets/matplotlib/widget.ipynb is undefined
info 10:49:33.135: findKernel found .venvWidgets (Python 3.8.12)
info 10:49:33.139: PreferredConnection: .jvsc74a57bd0785edfce71b7b34600eacc1c40d1f7960d8cad3527bf2998465efd5555859783./home/don/samples/pySamples/crap/.venvWidgets/python./home/don/samples/pySamples/crap/.venvWidgets/python.-m#ipykernel_launcher found for NotebookDocument: /home/don/samples/pySamples/crap/widgets/matplotlib/widget.ipynb
info 10:49:33.140: TargetController found ID: .jvsc74a57bd0785edfce71b7b34600eacc1c40d1f7960d8cad3527bf2998465efd5555859783./home/don/samples/pySamples/crap/.venvWidgets/python./home/don/samples/pySamples/crap/.venvWidgets/python.-m#ipykernel_launcher for document /home/don/samples/pySamples/crap/widgets/matplotlib/widget.ipynb
info 10:49:33.264: Process Execution: > ~/samples/pySamples/crap/.venv/bin/python -m pip list
> ~/samples/pySamples/crap/.venv/bin/python -m pip list
info 10:49:33.266: Adding env Variable PYTHONNOUSERSITE to /home/don/samples/pySamples/crap/.venvWidgets/bin/python
info 10:49:33.287: Process Execution: > ~/samples/pySamples/crap/.venvWidgets/bin/python -m ipykernel_launcher --ip=127.0.0.1 --stdin=9003 --control=9001 --hb=9000 --Session.signature_scheme="hmac-sha256" --Session.key=b"c1ccf4b8-b822-463b-b3f1-1b5d8fffaaff" --shell=9002 --transport="tcp" --iopub=9004 --f=/home/don/.local/share/jupyter/kernel-89397sHvFhBP1Lpv.json
> ~/samples/pySamples/crap/.venvWidgets/bin/python -m ipykernel_launcher --ip=127.0.0.1 --stdin=9003 --control=9001 --hb=9000 --Session.signature_scheme="hmac-sha256" --Session.key=b"c1ccf4b8-b822-463b-b3f1-1b5d8fffaaff" --shell=9002 --transport="tcp" --iopub=9004 --f=/home/don/.local/share/jupyter/kernel-89397sHvFhBP1Lpv.json
info 10:49:33.288: Process Execution: cwd: ~/samples/pySamples/crap/widgets/matplotlib
cwd: ~/samples/pySamples/crap/widgets/matplotlib
info 10:49:33.355: ipykernel version 6.4.2 for /home/don/samples/pySamples/crap/.venvWidgets/bin/python
info 10:49:33.355: ipykernel location ~/samples/pySamples/crap/.venvWidgets/lib/python3.8/site-packages/ipykernel/__init__.py for /home/don/samples/pySamples/crap/.venvWidgets/bin/python
info 10:49:33.528: Registering dummy command feature
info 10:49:33.839: Registering dummy command feature
warn 10:49:34.33: StdErr from Kernel Process /home/don/samples/pySamples/crap/.venvWidgets/lib/python3.8/site-packages/traitlets/traitlets.py:2202: FutureWarning: Supporting extra quotes around strings is deprecated in traitlets 5.0. You can use 'hmac-sha256' instead of '"hmac-sha256"' if you require traitlets >=5.
  warn(
/home/don/samples/pySamples/crap/.venvWidgets/lib/python3.8/site-packages/traitlets/traitlets.py:2157: FutureWarning: Supporting extra quotes around Bytes is deprecated in traitlets 5.0. Use 'c1ccf4b8-b822-463b-b3f1-1b5d8fffaaff' instead of 'b"c1ccf4b8-b822-463b-b3f1-1b5d8fffaaff"'.
  warn(

info 10:49:34.35: Kernel Output: NOTE: When using the `ipython kernel` entry point, Ctrl-C will not work.

To exit, you will have to explicitly quit this process, by either sending
"quit" from a client, or using Ctrl-\ in UNIX-like environments.

To read more about this, see https://github.com/ipython/ipython/issues/2049


To connect another client to this kernel, use:
    --existing /home/don/.local/share/jupyter/kernel-89397sHvFhBP1Lpv.json

info 10:49:35.130: Started kernel .venvWidgets (Python 3.8.12), (Raw session started and connected)
info 10:49:35.132: Finished connecting 73492d3b-afb0-4582-99b2-3db4c2daae07
info 10:49:35.457: UpdateWorkingDirectoryAndPath in Kernel
info 10:49:35.466: Executing silently Code (idle) = import os\nimport sys\n%cd "/home/don/samples/pySamples/crap/widgets/matplotlib"\nif os.getcwd() not in
info 10:49:35.488: Executing silently Code (completed) = import os\nimport sys\n%cd "/home/don/samples/pySamples/crap/widgets/matplotlib"\nif os.getcwd() not in
info 10:49:35.489: Waiting for idle on (kernel): c7fd3905-a49c-43e6-a976-58770c85073a -> idle
info 10:49:35.490: Finished waiting for idle on (kernel): c7fd3905-a49c-43e6-a976-58770c85073a -> idle
```