### PR TITLE
Revert backing file change for local connections

### DIFF
--- a/src/kernels/jupyter/session/jupyterSession.node.ts
+++ b/src/kernels/jupyter/session/jupyterSession.node.ts
@@ -28,7 +28,6 @@ import { KernelConnectionMetadata, isLocalConnection, IJupyterConnection, ISessi
 import { JupyterKernelService } from '../jupyterKernelService.node';
 import { JupyterWebSockets } from './jupyterWebSocket.node';
 import { DisplayOptions } from '../../displayOptions';
-import { noop } from '../../../platform/common/utils/misc';
 
 function getRemoteIPynbSuffix(): string {
     return `${jvscIdentifier}${uuid()}`;

--- a/src/kernels/jupyter/session/jupyterSession.node.ts
+++ b/src/kernels/jupyter/session/jupyterSession.node.ts
@@ -28,7 +28,6 @@ import { KernelConnectionMetadata, isLocalConnection, IJupyterConnection, ISessi
 import { JupyterKernelService } from '../jupyterKernelService.node';
 import { JupyterWebSockets } from './jupyterWebSocket.node';
 import { DisplayOptions } from '../../displayOptions';
-import { IFileSystem } from '../../../platform/common/platform/types.node';
 import { noop } from '../../../platform/common/utils/misc';
 
 function getRemoteIPynbSuffix(): string {
@@ -50,8 +49,7 @@ export class JupyterSession extends BaseJupyterSession {
         override readonly workingDirectory: string,
         private readonly idleTimeout: number,
         private readonly kernelService: JupyterKernelService,
-        interruptTimeout: number,
-        private readonly fs: IFileSystem
+        interruptTimeout: number
     ) {
         super(
             connInfo.localLaunch ? 'localJupyter' : 'remoteJupyter',
@@ -194,27 +192,7 @@ export class JupyterSession extends BaseJupyterSession {
         }
     }
 
-    private async createBackingFile(): Promise<{ dispose: () => Promise<unknown>; filePath: string } | undefined> {
-        if (this.connInfo.localLaunch) {
-            const tempFile = await this.fs.createTemporaryLocalFile('.ipynb');
-            const tempDirectory = path.join(
-                path.dirname(tempFile.filePath),
-                path.basename(tempFile.filePath, '.ipynb')
-            );
-            await tempFile.dispose();
-            // This way we ensure all checkpoints are in a unique directory and will not conflict.
-            await this.fs.ensureLocalDir(tempDirectory);
-
-            const newName = this.resource
-                ? `${path.basename(this.resource.fsPath, '.ipynb')}.ipynb`
-                : `${DataScience.defaultNotebookName()}-${uuid()}.ipynb`;
-
-            const filePath = path.join(tempDirectory, newName);
-            return {
-                filePath,
-                dispose: () => this.fs.deleteLocalFile(filePath)
-            };
-        }
+    private async createBackingFile(): Promise<Contents.IModel | undefined> {
         let backingFile: Contents.IModel | undefined = undefined;
 
         // First make sure the notebook is in the right relative path (jupyter expects a relative path with unix delimiters)
@@ -256,11 +234,7 @@ export class JupyterSession extends BaseJupyterSession {
         }
 
         if (backingFile) {
-            const filePath = backingFile.path;
-            return {
-                filePath,
-                dispose: () => this.contentsManager.delete(filePath)
-            };
+            return backingFile;
         }
     }
 
@@ -283,7 +257,9 @@ export class JupyterSession extends BaseJupyterSession {
                 );
             } catch (ex) {
                 // If we failed to create the kernel, we need to clean up the file.
-                backingFile?.dispose().catch(noop);
+                if (this.connInfo && backingFile) {
+                    this.contentsManager.delete(backingFile.path).ignoreErrors();
+                }
                 throw ex;
             }
         }
@@ -296,7 +272,7 @@ export class JupyterSession extends BaseJupyterSession {
 
         // Create our session options using this temporary notebook and our connection info
         const sessionOptions: Session.ISessionOptions = {
-            path: backingFile?.filePath || `${uuid()}.ipynb`, // Name has to be unique
+            path: backingFile?.path || `${uuid()}.ipynb`, // Name has to be unique
             kernel: {
                 name: kernelName
             },
@@ -343,7 +319,9 @@ export class JupyterSession extends BaseJupyterSession {
                     })
                     .catch((ex) => Promise.reject(new JupyterSessionStartError(ex)))
                     .finally(() => {
-                        backingFile?.dispose().catch(noop);
+                        if (this.connInfo && backingFile) {
+                            this.contentsManager.delete(backingFile.path).ignoreErrors();
+                        }
                     }),
             options.token
         );

--- a/src/kernels/jupyter/session/jupyterSessionManager.node.ts
+++ b/src/kernels/jupyter/session/jupyterSessionManager.node.ts
@@ -35,7 +35,6 @@ import { JupyterSession } from './jupyterSession.node';
 import { createJupyterWebSocket } from './jupyterWebSocket.node';
 import { sleep } from '../../../platform/common/utils/async';
 import { IJupyterSessionManager, IJupyterPasswordConnect, IJupyterKernel } from '../types';
-import { IFileSystem } from '../../../platform/common/platform/types.node';
 
 // Key for our insecure connection global state
 const GlobalStateUserAllowsInsecureConnections = 'DataScienceAllowInsecureConnections';
@@ -69,8 +68,7 @@ export class JupyterSessionManager implements IJupyterSessionManager {
         private configService: IConfigurationService,
         private readonly appShell: IApplicationShell,
         private readonly stateFactory: IPersistentStateFactory,
-        private readonly kernelService: JupyterKernelService,
-        private readonly fs: IFileSystem
+        private readonly kernelService: JupyterKernelService
     ) {
         this.userAllowsInsecureConnections = this.stateFactory.createGlobalPersistentState<boolean>(
             GlobalStateUserAllowsInsecureConnections,
@@ -195,8 +193,7 @@ export class JupyterSessionManager implements IJupyterSessionManager {
             workingDirectory,
             this.configService.getSettings(resource).jupyterLaunchTimeout,
             this.kernelService,
-            this.configService.getSettings(resource).jupyterInterruptTimeout,
-            this.fs
+            this.configService.getSettings(resource).jupyterInterruptTimeout
         );
         try {
             await session.connect({ token: cancelToken, ui });

--- a/src/kernels/jupyter/session/jupyterSessionManagerFactory.node.ts
+++ b/src/kernels/jupyter/session/jupyterSessionManagerFactory.node.ts
@@ -16,7 +16,6 @@ import { JUPYTER_OUTPUT_CHANNEL } from '../../../webviews/webview-side/common/co
 import { JupyterKernelService } from '../jupyterKernelService.node';
 import { IJupyterConnection } from '../../types';
 import { IJupyterSessionManagerFactory, IJupyterPasswordConnect, IJupyterSessionManager } from '../types';
-import { IFileSystem } from '../../../platform/common/platform/types.node';
 
 @injectable()
 export class JupyterSessionManagerFactory implements IJupyterSessionManagerFactory {
@@ -29,8 +28,7 @@ export class JupyterSessionManagerFactory implements IJupyterSessionManagerFacto
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(IPersistentStateFactory) private readonly stateFactory: IPersistentStateFactory,
         @inject(IDisposableRegistry) private readonly disposableRegistry: IDisposableRegistry,
-        @inject(JupyterKernelService) private readonly kernelService: JupyterKernelService,
-        @inject(IFileSystem) private readonly fs: IFileSystem
+        @inject(JupyterKernelService) private readonly kernelService: JupyterKernelService
     ) {}
 
     /**
@@ -47,8 +45,7 @@ export class JupyterSessionManagerFactory implements IJupyterSessionManagerFacto
             this.config,
             this.appShell,
             this.stateFactory,
-            this.kernelService,
-            this.fs
+            this.kernelService
         );
         await result.initialize(connInfo);
         this.disposableRegistry.push(

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -18,7 +18,6 @@ import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { CancellationTokenSource, Uri } from 'vscode';
 
 import { traceInfo } from '../../../platform/logging';
-import * as path from '../../../platform/vscode-path/path';
 import { ReadWrite, Resource } from '../../../platform/common/types';
 import { createDeferred, Deferred } from '../../../platform/common/utils/async';
 import { DataScience } from '../../../platform/common/utils/localize';
@@ -33,7 +32,6 @@ import { MockOutputChannel } from '../../mockClasses';
 import { JupyterKernelService } from '../../../kernels/jupyter/jupyterKernelService.node';
 import { JupyterSession } from '../../../kernels/jupyter/session/jupyterSession.node';
 import { DisplayOptions } from '../../../kernels/displayOptions';
-import { IFileSystem } from '../../../platform/common/platform/types.node';
 
 /* eslint-disable , @typescript-eslint/no-explicit-any */
 suite('DataScience - JupyterSession', () => {
@@ -116,7 +114,6 @@ suite('DataScience - JupyterSession', () => {
         when(session.isDisposed).thenReturn(false);
         when(kernel.status).thenReturn('idle');
         when(connection.rootDirectory).thenReturn('');
-        when(connection.localLaunch).thenReturn(false);
         const channel = new MockOutputChannel('JUPYTER');
         const kernelService = mock(JupyterKernelService);
         when(kernelService.ensureKernelIsUsable(anything(), anything(), anything(), anything())).thenResolve();
@@ -127,11 +124,7 @@ suite('DataScience - JupyterSession', () => {
         specManager = mock(KernelSpecManager);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         when(sessionManager.connectTo(anything())).thenReturn(newActiveRemoteKernel.model as any);
-        const fs = mock<IFileSystem>();
-        const tmpFile = path.join('tmp', 'tempfile.json');
-        when(fs.createTemporaryLocalFile(anything())).thenResolve({ dispose: noop, filePath: tmpFile });
-        when(fs.deleteLocalFile(anything())).thenResolve();
-        when(fs.ensureLocalDir(anything())).thenResolve();
+
         jupyterSession = new JupyterSession(
             resource,
             instance(connection),
@@ -149,8 +142,7 @@ suite('DataScience - JupyterSession', () => {
             '',
             1,
             instance(kernelService),
-            1,
-            instance(fs)
+            1
         );
     }
     setup(() => createJupyterSession());
@@ -178,31 +170,19 @@ suite('DataScience - JupyterSession', () => {
     }
     teardown(async () => jupyterSession.dispose().catch(noop));
 
-    test('Start a remote session when connecting', async () => {
-        when(connection.localLaunch).thenReturn(false);
-
+    test('Start a session when connecting', async () => {
         await connect();
 
         assert.isTrue(jupyterSession.isConnected);
         verify(sessionManager.startNew(anything(), anything())).once();
         verify(contentsManager.newUntitled(anything())).once();
     });
-    test('Start a local session when connecting', async () => {
-        when(connection.localLaunch).thenReturn(true);
-
-        await connect();
-
-        assert.isTrue(jupyterSession.isConnected);
-        verify(sessionManager.startNew(anything(), anything())).once();
-        verify(contentsManager.newUntitled(anything())).never();
-    });
 
     suite('After connecting', () => {
-        // setup(connect);
+        setup(connect);
         test('Interrupting will result in kernel being interrupted', async () => {
             when(kernel.interrupt()).thenResolve();
 
-            await connect();
             await jupyterSession.interrupt();
 
             verify(kernel.interrupt()).once();
@@ -260,9 +240,9 @@ suite('DataScience - JupyterSession', () => {
             test('Remote session with Notebook and starting a new session', async () => {
                 // Create jupyter session for Notebooks
                 createJupyterSession(Uri.file('test.ipynb'));
-                when(connection.localLaunch).thenReturn(false);
                 await connect();
 
+                when(connection.localLaunch).thenReturn(false);
                 when(sessionManager.refreshRunning()).thenResolve();
                 when(session.isRemoteSession).thenReturn(true);
                 when(session.kernelConnectionMetadata).thenReturn({
@@ -307,17 +287,14 @@ suite('DataScience - JupyterSession', () => {
                 verify(session.dispose()).once();
             });
             test('Local session', async () => {
-                console.error('Start test');
                 when(connection.localLaunch).thenReturn(true);
                 when(session.isRemoteSession).thenReturn(false);
                 when(session.shutdown()).thenResolve();
                 when(session.dispose()).thenReturn();
-
-                await connect();
                 await jupyterSession.dispose();
 
                 verify(sessionManager.refreshRunning()).never();
-                verify(contentsManager.delete(anything())).never();
+                verify(contentsManager.delete(anything())).once();
                 // always kill the sessions.
                 verify(session.shutdown()).once();
                 verify(session.dispose()).once();
@@ -325,17 +302,13 @@ suite('DataScience - JupyterSession', () => {
         });
         suite('Wait for session idle', () => {
             test('Will timeout', async () => {
-                await connect();
-
                 when(kernel.status).thenReturn('unknown');
-                when(connection.localLaunch).thenReturn(true);
 
                 const promise = jupyterSession.waitForIdle(100);
 
                 await assert.isRejected(promise, DataScience.jupyterLaunchTimedOut());
             });
             test('Will succeed', async () => {
-                await connect();
                 when(kernel.status).thenReturn('idle');
 
                 await jupyterSession.waitForIdle(100);
@@ -376,7 +349,6 @@ suite('DataScience - JupyterSession', () => {
                     newSessionCreated.resolve();
                     return Promise.resolve(instance(newSession));
                 });
-                await connect();
             });
             teardown(() => {
                 verify(sessionManager.connectTo(anything())).never();


### PR DESCRIPTION
Fixes #9709

The fix for #6510 caused a regression when not using ZMQ (at least on windows).

I'll reopen 6510 after this goes through.