### PR TITLE
Fix failures for remote

### DIFF
--- a/news/2 Fixes/9728.md
+++ b/news/2 Fixes/9728.md
@@ -1,0 +1,1 @@
+Fix kernels not showing up at all if remote kernel fetch fails.

--- a/package.json
+++ b/package.json
@@ -2078,7 +2078,6 @@
     "enabledApiProposals": [
         "notebookControllerKind",
         "notebookDebugOptions",
-        "notebookDocumentEvents",
         "notebookDeprecated",
         "notebookEditor",
         "notebookEditorDecorationType",

--- a/src/kernels/kernelFinder.base.ts
+++ b/src/kernels/kernelFinder.base.ts
@@ -138,8 +138,10 @@ export abstract class BaseKernelFinder implements IKernelFinder {
             }),
             this.listRemoteKernels(resource, cancelToken, useCache).catch((ex) => {
                 traceError('Failed to get remote kernels', ex);
-                // When remote kernels fail, turn off remote
-                void this.serverUriStorage.setUri(Settings.JupyterServerLocalLaunch);
+                // When remote kernels fail, turn off remote if we get a ECONNREFUSED error
+                if (ex.toString().toLowerCase().includes('econn')) {
+                    void this.serverUriStorage.setUri(Settings.JupyterServerLocalLaunch);
+                }
                 return [];
             })
         ]);

--- a/src/kernels/kernelFinder.node.ts
+++ b/src/kernels/kernelFinder.node.ts
@@ -24,7 +24,7 @@ export class KernelFinder extends BaseKernelFinder {
         @inject(IConfigurationService) configurationService: IConfigurationService,
         @inject(IMemento) @named(GLOBAL_MEMENTO) globalState: Memento,
         @inject(IFileSystem) private readonly fs: IFileSystem,
-        @inject(IJupyterServerUriStorage) private readonly serverUriStorage: IJupyterServerUriStorage
+        @inject(IJupyterServerUriStorage) serverUriStorage: IJupyterServerUriStorage
     ) {
         super(
             extensionChecker,
@@ -34,7 +34,8 @@ export class KernelFinder extends BaseKernelFinder {
             notebookProvider,
             localKernelFinder,
             remoteKernelFinder,
-            globalState
+            globalState,
+            serverUriStorage
         );
     }
 

--- a/src/kernels/kernelFinder.web.ts
+++ b/src/kernels/kernelFinder.web.ts
@@ -21,7 +21,7 @@ export class KernelFinder extends BaseKernelFinder {
         @inject(INotebookProvider) notebookProvider: INotebookProvider,
         @inject(IConfigurationService) configurationService: IConfigurationService,
         @inject(IMemento) @named(GLOBAL_MEMENTO) globalState: Memento,
-        @inject(IJupyterServerUriStorage) private readonly serverUriStorage: IJupyterServerUriStorage
+        @inject(IJupyterServerUriStorage) serverUriStorage: IJupyterServerUriStorage
     ) {
         super(
             extensionChecker,
@@ -31,7 +31,8 @@ export class KernelFinder extends BaseKernelFinder {
             notebookProvider,
             undefined, // Local not supported in web
             remoteKernelFinder,
-            globalState
+            globalState,
+            serverUriStorage
         );
     }
     protected async isValidCachedKernel(kernel: KernelConnectionMetadata): Promise<boolean> {

--- a/src/test/datascience/kernel-launcher/kernelFinder.vscode.test.node.ts
+++ b/src/test/datascience/kernel-launcher/kernelFinder.vscode.test.node.ts
@@ -118,11 +118,11 @@ suite('DataScience - Kernels Finder', () => {
         ) as LocalKernelConnectionMetadata;
         assert.ok(juliaKernelSpec);
 
-        const kernelSpec = await kernelFinder.findKernel(resourceToUse, {
+        const kernelSpec = (await kernelFinder.findKernel(resourceToUse, {
             kernelspec: juliaKernelSpec?.kernelSpec as any,
             orig_nbformat: 4
-        });
-        assert.ok(kernelSpec);
-        assert.deepEqual(kernelSpec, juliaKernelSpec);
+        })) as LocalKernelConnectionMetadata;
+        assert.ok(kernelSpec.kernelSpec);
+        assert.deepEqual(kernelSpec.kernelSpec.name, juliaKernelSpec.kernelSpec.name);
     });
 });


### PR DESCRIPTION
Fixes #9728 

The kernel refactor meant that if any kernel fetching failed, no kernels are returned.

