### PR TITLE
Ensure test.only is not allowed

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -174,9 +174,11 @@ module.exports = {
         'eslint-plugin-react',
         '@typescript-eslint',
         '@typescript-eslint/tslint',
-        'eslint-plugin-local-rules'
+        'eslint-plugin-local-rules',
+        'no-only-tests'
     ],
     rules: {
+        'no-only-tests/no-only-tests': 'error',
         // Overriding ESLint rules with Typescript-specific ones
         '@typescript-eslint/ban-ts-comment': [
             'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -201,6 +201,7 @@
                 "eslint-plugin-jsx-a11y": "^6.3.1",
                 "eslint-plugin-local-rules": "file:build/eslint-rules",
                 "eslint-plugin-no-null": "^1.0.2",
+                "eslint-plugin-no-only-tests": "^2.6.0",
                 "eslint-plugin-prefer-arrow": "^1.2.2",
                 "eslint-plugin-prettier": "^3.1.2",
                 "eslint-plugin-react": "^7.22.0",
@@ -9863,6 +9864,15 @@
             },
             "peerDependencies": {
                 "eslint": ">=3.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-no-only-tests": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
+            "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=4.0.0"
             }
         },
         "node_modules/eslint-plugin-prefer-arrow": {
@@ -27845,7 +27855,7 @@
                 "minimist": "~1.2.0",
                 "moment": "^2.24.0",
                 "path-browserify": "^1.0.0",
-                "url-parse": "1.5.8"
+                "url-parse": "~1.5.1"
             }
         },
         "@jupyterlab/nbformat": {
@@ -31380,7 +31390,7 @@
             "requires": {
                 "@mapbox/node-pre-gyp": "^1.0.0",
                 "nan": "^2.15.0",
-                "simple-get": "3.1.1"
+                "simple-get": "^3.0.3"
             }
         },
         "caseless": {
@@ -33911,6 +33921,12 @@
             "integrity": "sha1-EjaoEjkTkKGHetQAfCbnRTQclR8=",
             "dev": true,
             "requires": {}
+        },
+        "eslint-plugin-no-only-tests": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
+            "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
+            "dev": true
         },
         "eslint-plugin-prefer-arrow": {
             "version": "1.2.3",
@@ -45448,7 +45464,8 @@
             }
         },
         "url-parse": {
-            "version": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
             "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
             "requires": {
                 "querystringify": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2328,6 +2328,7 @@
         "eslint-plugin-jsx-a11y": "^6.3.1",
         "eslint-plugin-local-rules": "file:build/eslint-rules",
         "eslint-plugin-no-null": "^1.0.2",
+        "eslint-plugin-no-only-tests": "^2.6.0",
         "eslint-plugin-prefer-arrow": "^1.2.2",
         "eslint-plugin-prettier": "^3.1.2",
         "eslint-plugin-react": "^7.22.0",


### PR DESCRIPTION
Ensures we don't accidentally have `test.only(` in our code.

While testing VSCode issues I realized we could add an eslint.
Easy PR hence submitting now before I start sending PRs with `test.only(`