### PR TITLE
Fix remote kernel selection

### DIFF
--- a/news/2 Fixes/9809.md
+++ b/news/2 Fixes/9809.md
@@ -1,0 +1,1 @@
+Fix remote kernels not being reselected on reopening a notebook.

--- a/src/kernels/jupyter/session/backingFileCreator.base.ts
+++ b/src/kernels/jupyter/session/backingFileCreator.base.ts
@@ -38,7 +38,7 @@ export class BaseBackingFileCreator implements IJupyterBackingFileCreator {
 
         // Generate a more descriptive name
         const newName = resource
-            ? `${urlPath.basename(resource)}${getRemoteIPynbSuffix()}.ipynb`
+            ? `${urlPath.basename(resource, '.ipynb')}${getRemoteIPynbSuffix()}.ipynb`
             : `${DataScience.defaultNotebookName()}-${uuid()}.ipynb`;
 
         try {

--- a/src/notebooks/controllers/notebookControllerManager.ts
+++ b/src/notebooks/controllers/notebookControllerManager.ts
@@ -312,6 +312,14 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
             traceInfoIfCI(`Disposing controller ${controller.id}`);
             controller.dispose();
         });
+
+        // If any of our non cached controllers were remote, indicate a remote refresh
+        const liveConnections = nonCachedConnections.filter(
+            (n) => n.kind === 'connectToLiveRemoteKernel'
+        ) as LiveRemoteKernelConnectionMetadata[];
+        if (liveConnections.length > 0) {
+            this.remoteRefreshedEmitter.fire(liveConnections);
+        }
     }
 
     private listKernels(

--- a/src/platform/vscode-path/resources.ts
+++ b/src/platform/vscode-path/resources.ts
@@ -209,8 +209,8 @@ export class ExtUri implements IExtUri {
         return basename(resource) || resource.authority;
     }
 
-    basename(resource: URI): string {
-        return paths.posix.basename(resource.path);
+    basename(resource: URI, ext?: string): string {
+        return paths.posix.basename(resource.path, ext);
     }
 
     extname(resource: URI): string {

--- a/src/test/datascience/notebook/remoteNotebookEditor.vscode.common.ts
+++ b/src/test/datascience/notebook/remoteNotebookEditor.vscode.common.ts
@@ -150,11 +150,11 @@ export function sharedRemoteNotebookEditorTests(
         await closeActiveWindows();
 
         // Re-open and execute the second cell.
-        // It should connect to the same live kernel
+        // It should connect to the same live kernel. Don't force it to pick it.
         // Second cell should display the value of existing variable from previous execution.
 
         await openNotebook(ipynbFile);
-        await waitForKernelToGetAutoSelected(PYTHON_LANGUAGE, true);
+        await waitForKernelToGetAutoSelected(PYTHON_LANGUAGE, true, 100_000, true);
         nbEditor = vscodeNotebook.activeNotebookEditor!;
         assert.isOk(nbEditor, 'No active notebook');
 


### PR DESCRIPTION
Fixes #9809 

Root cause was the 'remoteRefreshed' event was never firing, so nothing would indicate to the LiveKernelWatcher that a kernel changed.

Also fixed the test to actually wait for a kernel selection instead of switching itself as should happen in this scenario.

Also fixed a path name problem in the live kernel.