### PR TITLE
Fix handling of kernel errors in web extension

### DIFF
--- a/news/2 Fixes/9817.md
+++ b/news/2 Fixes/9817.md
@@ -1,0 +1,1 @@
+Fix handling of kernel errors in web extension.

--- a/package.json
+++ b/package.json
@@ -330,8 +330,7 @@
             {
                 "command": "jupyter.viewOutput",
                 "title": "%jupyter.command.jupyter.viewOutput.title%",
-                "category": "Jupyter",
-                "enablement": "!jupyter.webExtension"
+                "category": "Jupyter"
             },
             {
                 "command": "jupyter.notebookeditor.export",

--- a/src/kernels/kernelConnector.ts
+++ b/src/kernels/kernelConnector.ts
@@ -87,7 +87,7 @@ export class KernelConnector {
         switch (selection) {
             case DataScience.restartKernel(): {
                 // Set our status
-                const status = statusProvider.set(DataScience.restartingKernelStatus());
+                const status = statusProvider?.set(DataScience.restartingKernelStatus());
                 try {
                     await kernel.restart();
                     restartedKernel = true;
@@ -123,7 +123,7 @@ export class KernelConnector {
             clearInstalledIntoInterpreterMemento(memento, Product.ipykernel, metadata.interpreter.uri).ignoreErrors();
         }
 
-        const handleResult = await errorHandler.handleKernelError(
+        const handleResult = await errorHandler?.handleKernelError(
             error,
             errorContext,
             metadata,
@@ -133,7 +133,8 @@ export class KernelConnector {
 
         // Send telemetry for handling the error (if raw)
         const isLocal = isLocalConnection(metadata);
-        const rawLocalKernel = serviceContainer.get<IRawNotebookProvider>(IRawNotebookProvider).isSupported && isLocal;
+        const rawNotebookProvider = serviceContainer.get<IRawNotebookProvider>(IRawNotebookProvider);
+        const rawLocalKernel = rawNotebookProvider?.isSupported && isLocal;
         if (rawLocalKernel && errorContext === 'start') {
             sendKernelTelemetryEvent(resource, Telemetry.RawKernelSessionStartNoIpykernel, {
                 reason: handleResult


### PR DESCRIPTION
Fixes #9817 

Kernel errors were not being handled in web extension because of usage of IRawNotebookProvider (not supported in web)

