### PR TITLE
Make IHttpClient not being there not break stuff

### DIFF
--- a/src/kernels/ipywidgets-message-coordination/commonMessageCoordinator.ts
+++ b/src/kernels/ipywidgets-message-coordination/commonMessageCoordinator.ts
@@ -222,7 +222,7 @@ export class CommonMessageCoordinator {
                 this.serviceContainer.get<IKernelProvider>(IKernelProvider),
                 this.serviceContainer.get<IDisposableRegistry>(IDisposableRegistry),
                 this.serviceContainer.get<IConfigurationService>(IConfigurationService),
-                this.serviceContainer.get<IHttpClient>(IHttpClient),
+                this.serviceContainer.tryGet<IHttpClient>(IHttpClient),
                 this.serviceContainer.get<IApplicationShell>(IApplicationShell),
                 this.serviceContainer.get<IWorkspaceService>(IWorkspaceService),
                 this.serviceContainer.get<IPersistentStateFactory>(IPersistentStateFactory),

--- a/src/kernels/ipywidgets-message-coordination/ipyWidgetScriptSource.ts
+++ b/src/kernels/ipywidgets-message-coordination/ipyWidgetScriptSource.ts
@@ -45,7 +45,7 @@ export class IPyWidgetScriptSource {
         private readonly kernelProvider: IKernelProvider,
         disposables: IDisposableRegistry,
         private readonly configurationSettings: IConfigurationService,
-        private readonly httpClient: IHttpClient,
+        private readonly httpClient: IHttpClient | undefined,
         private readonly appShell: IApplicationShell,
         private readonly workspaceService: IWorkspaceService,
         private readonly stateFactory: IPersistentStateFactory,

--- a/src/kernels/ipywidgets-message-coordination/ipyWidgetScriptSourceProvider.ts
+++ b/src/kernels/ipywidgets-message-coordination/ipyWidgetScriptSourceProvider.ts
@@ -54,7 +54,7 @@ export class IPyWidgetScriptSourceProvider implements IWidgetScriptSourceProvide
         private readonly configurationSettings: IConfigurationService,
         private readonly workspaceService: IWorkspaceService,
         private readonly stateFactory: IPersistentStateFactory,
-        private readonly httpClient: IHttpClient,
+        private readonly httpClient: IHttpClient | undefined,
         private readonly sourceProviderFactory: IWidgetScriptSourceProviderFactory
     ) {
         this.userConfiguredCDNAtLeastOnce = this.stateFactory.createGlobalPersistentState<boolean>(

--- a/src/kernels/ipywidgets-message-coordination/scriptSourceProviderFactory.node.ts
+++ b/src/kernels/ipywidgets-message-coordination/scriptSourceProviderFactory.node.ts
@@ -26,7 +26,11 @@ export class ScriptSourceProviderFactory implements IWidgetScriptSourceProviderF
         @inject(IPythonExecutionFactory) private readonly factory: IPythonExecutionFactory
     ) {}
 
-    public getProviders(kernel: IKernel, uriConverter: ILocalResourceUriConverter, httpClient: IHttpClient) {
+    public getProviders(
+        kernel: IKernel,
+        uriConverter: ILocalResourceUriConverter,
+        httpClient: IHttpClient | undefined
+    ) {
         const scriptProviders: IWidgetScriptSourceProvider[] = [];
 
         // If we're allowed to use CDN providers, then use them, and use in order of preference.
@@ -36,9 +40,11 @@ export class ScriptSourceProviderFactory implements IWidgetScriptSourceProviderF
         switch (kernel.kernelConnectionMetadata.kind) {
             case 'connectToLiveRemoteKernel':
             case 'startUsingRemoteKernelSpec':
-                scriptProviders.push(
-                    new RemoteWidgetScriptSourceProvider(kernel.kernelConnectionMetadata.baseUrl, httpClient)
-                );
+                if (httpClient) {
+                    scriptProviders.push(
+                        new RemoteWidgetScriptSourceProvider(kernel.kernelConnectionMetadata.baseUrl, httpClient)
+                    );
+                }
                 break;
 
             default:

--- a/src/kernels/ipywidgets-message-coordination/scriptSourceProviderFactory.web.ts
+++ b/src/kernels/ipywidgets-message-coordination/scriptSourceProviderFactory.web.ts
@@ -9,16 +9,22 @@ import { ILocalResourceUriConverter, IWidgetScriptSourceProvider, IWidgetScriptS
 
 @injectable()
 export class ScriptSourceProviderFactory implements IWidgetScriptSourceProviderFactory {
-    public getProviders(kernel: IKernel, _uriConverter: ILocalResourceUriConverter, httpClient: IHttpClient) {
+    public getProviders(
+        kernel: IKernel,
+        _uriConverter: ILocalResourceUriConverter,
+        httpClient: IHttpClient | undefined
+    ) {
         const scriptProviders: IWidgetScriptSourceProvider[] = [];
 
         // Only remote is supported at the moment
         switch (kernel.kernelConnectionMetadata.kind) {
             case 'connectToLiveRemoteKernel':
             case 'startUsingRemoteKernelSpec':
-                scriptProviders.push(
-                    new RemoteWidgetScriptSourceProvider(kernel.kernelConnectionMetadata.baseUrl, httpClient)
-                );
+                if (httpClient) {
+                    scriptProviders.push(
+                        new RemoteWidgetScriptSourceProvider(kernel.kernelConnectionMetadata.baseUrl, httpClient)
+                    );
+                }
                 break;
         }
 

--- a/src/kernels/ipywidgets-message-coordination/types.ts
+++ b/src/kernels/ipywidgets-message-coordination/types.ts
@@ -57,7 +57,7 @@ export interface IWidgetScriptSourceProviderFactory {
     getProviders(
         kernel: IKernel,
         uriConverter: ILocalResourceUriConverter,
-        httpClient: IHttpClient
+        httpClient: IHttpClient | undefined
     ): IWidgetScriptSourceProvider[];
 }
 

--- a/src/platform/errors/index.ts
+++ b/src/platform/errors/index.ts
@@ -6,7 +6,7 @@ import * as stackTrace from 'stack-trace';
 import { getTelemetrySafeHashedString } from '../../telemetry/helpers';
 import { getErrorTags } from './errors';
 import { getLastFrameFromPythonTraceback } from './errorUtils';
-import { getErrorCategory, TelemetryErrorProperties, WrappedError } from './types';
+import { getErrorCategory, TelemetryErrorProperties, BaseError, WrappedError } from './types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function populateTelemetryWithErrorInfo(props: Partial<TelemetryErrorProperties>, error: Error) {
@@ -22,7 +22,7 @@ export function populateTelemetryWithErrorInfo(props: Partial<TelemetryErrorProp
         props.failureSubCategory = 'errorisstring';
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const stdErr = (error as BaseError ).stdErr ? (error as BaseError ).stdErr : error.stack || '';
+    const stdErr = (error as BaseError).stdErr ? (error as BaseError).stdErr : error.stack || '';
     if (!stdErr) {
         return;
     }

--- a/src/platform/errors/index.ts
+++ b/src/platform/errors/index.ts
@@ -22,7 +22,7 @@ export function populateTelemetryWithErrorInfo(props: Partial<TelemetryErrorProp
         props.failureSubCategory = 'errorisstring';
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const stdErr = (error as any).stdErr ? (error as any).stdErr : error.stack || '';
+    const stdErr = (error as BaseError ).stdErr ? (error as BaseError ).stdErr : error.stack || '';
     if (!stdErr) {
         return;
     }

--- a/src/platform/errors/index.ts
+++ b/src/platform/errors/index.ts
@@ -6,7 +6,7 @@ import * as stackTrace from 'stack-trace';
 import { getTelemetrySafeHashedString } from '../../telemetry/helpers';
 import { getErrorTags } from './errors';
 import { getLastFrameFromPythonTraceback } from './errorUtils';
-import { BaseError, getErrorCategory, TelemetryErrorProperties, WrappedError } from './types';
+import { getErrorCategory, TelemetryErrorProperties, WrappedError } from './types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function populateTelemetryWithErrorInfo(props: Partial<TelemetryErrorProperties>, error: Error) {
@@ -21,7 +21,8 @@ export function populateTelemetryWithErrorInfo(props: Partial<TelemetryErrorProp
         // Helps us determine that we are rejecting with errors in some places, in which case we aren't getting meaningful errors/data.
         props.failureSubCategory = 'errorisstring';
     }
-    const stdErr = (error instanceof BaseError ? error.stdErr : error.stack) || '';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const stdErr = (error as any).stdErr ? (error as any).stdErr : error.stack || '';
     if (!stdErr) {
         return;
     }


### PR DESCRIPTION
For #9799 

Also had an error like so show up:

```
extension.web.bundle.js:4 
        
       Uncaught (in promise) TypeError: Right-hand side of 'instanceof' is not an object
    at eval (extension.web.bundle.js:4:1453946)
    at t.populateTelemetryWithErrorInfo (extension.web.bundle.js:4:1454022)
    at f (extension.web.bundle.js:4:1591407)
    at h (extension.web.bundle.js:4:1590568)
    at eval (extension.web.bundle.js:4:1592187)
```

So fixing that too. Don't need to use instanceof.

