### PR TITLE
Select active env as fallback, disable remote dbg

### DIFF
--- a/src/interactive-window/interactiveWindowProvider.node.ts
+++ b/src/interactive-window/interactiveWindowProvider.node.ts
@@ -168,7 +168,8 @@ export class InteractiveWindowProvider implements IInteractiveWindowProvider, IA
                 this.serviceContainer.get<IDataScienceErrorHandler>(IDataScienceErrorHandler),
                 preferredController,
                 editor,
-                inputUri
+                inputUri,
+                this.appShell
             );
             this._windows.push(result);
 

--- a/src/notebooks/controllers/notebookControllerManager.ts
+++ b/src/notebooks/controllers/notebookControllerManager.ts
@@ -200,7 +200,12 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
             return this.createActiveInterpreterController(notebookType, resource);
         } else {
             traceInfoIfCI('CreateDefaultRemoteController');
-            return this.createDefaultRemoteController(notebookType);
+            const controller = await this.createDefaultRemoteController(notebookType);
+            if (controller) {
+                return controller;
+            }
+            traceVerbose('No default remote controller, hence returning the active interpreter');
+            return this.createActiveInterpreterController(notebookType, resource);
         }
     }
 
@@ -423,7 +428,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
             }
         });
 
-        return defaultPython3Kernel || defaultPythonKernel || defaultPythonLanguageKernel || controllers[0];
+        return defaultPython3Kernel || defaultPythonKernel || defaultPythonLanguageKernel;
     }
     private removeNoPythonControllers() {
         this.notebookNoPythonController?.dispose();


### PR DESCRIPTION
* If we don't have a default remote controller, then fallback to the active interpreter instead of falling back to a random controller
* When debugging against remote kernel, notify user this isn't possible

This partially fixes the issue where you shutdown your remote jupyter server while VS Code is opened & launch IW.
`partially` because there are some more fixes to come