### PR TITLE
Use serverId (server url) in kernel connection metadata when connecting to remote jupyter server

### DIFF
--- a/src/kernels/jupyter/launcher/jupyterExecution.ts
+++ b/src/kernels/jupyter/launcher/jupyterExecution.ts
@@ -111,7 +111,6 @@ export class JupyterExecutionBase implements IJupyterExecution {
             let result: INotebookServer | undefined;
             let connection: IJupyterConnection | undefined;
             traceInfo(`Connecting to server`);
-            const isLocalConnection = !options || !options.uri;
 
             // Try to connect to our jupyter process. Check our setting for the number of tries
             let tryCount = 1;
@@ -133,7 +132,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
                     traceInfo(`Connection complete server`);
 
                     sendTelemetryEvent(
-                        isLocalConnection ? Telemetry.ConnectLocalJupyter : Telemetry.ConnectRemoteJupyter
+                        options.localJupyter ? Telemetry.ConnectLocalJupyter : Telemetry.ConnectRemoteJupyter
                     );
                     return result;
                 } catch (err) {
@@ -158,7 +157,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
                         }
 
                         // Something else went wrong
-                        if (!isLocalConnection) {
+                        if (!options.localJupyter) {
                             sendTelemetryEvent(Telemetry.ConnectRemoteFailedJupyter, undefined, undefined, err, true);
 
                             // Check for the self signed certs error specifically
@@ -224,7 +223,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
         cancelToken: CancellationToken
     ): Promise<IJupyterConnection> {
         // If our uri is undefined or if it's set to local launch we need to launch a server locally
-        if (!options || !options.uri) {
+        if (options.localJupyter) {
             // If that works, then attempt to start the server
             traceInfo(`Launching server`);
             const useDefaultConfig = !options || options.skipUsingDefaultConfig ? false : true;

--- a/src/kernels/jupyter/launcher/jupyterNotebookProvider.ts
+++ b/src/kernels/jupyter/launcher/jupyterNotebookProvider.ts
@@ -4,7 +4,6 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { SessionDisposedError } from '../../../platform/errors/sessionDisposedError';
 import {
     ConnectNotebookProviderOptions,
     IJupyterConnection,
@@ -51,17 +50,12 @@ export class JupyterNotebookProvider implements IJupyterNotebookProvider {
             localJupyter: isLocalConnection(options.kernelConnection)
         });
         Cancellation.throwIfCanceled(options.token);
-        if (server) {
-            return server.createNotebook(
-                options.resource,
-                options.kernelConnection,
-                options.token,
-                options.ui,
-                options.creator
-            );
-        }
-        // We want createNotebook to always return a notebook promise, so if we don't have a server
-        // here throw our generic server disposed message that we use in server creatio n
-        throw new SessionDisposedError();
+        return server.createNotebook(
+            options.resource,
+            options.kernelConnection,
+            options.token,
+            options.ui,
+            options.creator
+        );
     }
 }

--- a/src/kernels/jupyter/launcher/jupyterNotebookProvider.ts
+++ b/src/kernels/jupyter/launcher/jupyterNotebookProvider.ts
@@ -6,6 +6,7 @@
 import { inject, injectable } from 'inversify';
 import {
     ConnectNotebookProviderOptions,
+    GetServerOptions,
     IJupyterConnection,
     INotebook,
     isLocalConnection,
@@ -23,14 +24,9 @@ export class JupyterNotebookProvider implements IJupyterNotebookProvider {
     ) {}
 
     public async connect(options: ConnectNotebookProviderOptions): Promise<IJupyterConnection> {
-        const server = await this.serverProvider.getOrCreateServer({
-            ui: options.ui,
-            resource: options.resource,
-            token: options.token,
-            localJupyter: options.kind === 'localJupyter'
-        });
+        const server = await this.serverProvider.getOrCreateServer(options);
         const connection = await server.connection;
-        if (options.kind === 'remoteJupyter') {
+        if (!options.localJupyter) {
             // Log this remote URI into our MRU list
             void this.serverStorage.addToUriList(
                 connection.url || connection.displayName,
@@ -42,13 +38,23 @@ export class JupyterNotebookProvider implements IJupyterNotebookProvider {
     }
 
     public async createNotebook(options: NotebookCreationOptions): Promise<INotebook> {
+        const kernelConnection = options.kernelConnection;
         // Make sure we have a server
-        const server = await this.serverProvider.getOrCreateServer({
-            ui: options.ui,
-            resource: options.resource,
-            token: options.token,
-            localJupyter: isLocalConnection(options.kernelConnection)
-        });
+        const serverOptions: GetServerOptions = isLocalConnection(kernelConnection)
+            ? {
+                  ui: options.ui,
+                  resource: options.resource,
+                  token: options.token,
+                  localJupyter: true
+              }
+            : {
+                  ui: options.ui,
+                  resource: options.resource,
+                  token: options.token,
+                  localJupyter: false,
+                  serverId: kernelConnection.serverId
+              };
+        const server = await this.serverProvider.getOrCreateServer(serverOptions);
         Cancellation.throwIfCanceled(options.token);
         return server.createNotebook(
             options.resource,

--- a/src/kernels/jupyter/launcher/liveshare/serverCache.ts
+++ b/src/kernels/jupyter/launcher/liveshare/serverCache.ts
@@ -103,8 +103,20 @@ export class ServerCache implements IAsyncDisposable {
     }
 
     public async generateDefaultOptions(options: INotebookServerOptions): Promise<INotebookServerOptions> {
+        if (options.localJupyter) {
+            return {
+                resource: options?.resource,
+                skipUsingDefaultConfig: options ? options.skipUsingDefaultConfig : false, // Default for this is false
+                workingDir:
+                    options && options.workingDir
+                        ? options.workingDir
+                        : await this.workspace.computeWorkingDirectory(options.resource),
+                ui: options.ui,
+                localJupyter: true
+            };
+        }
         return {
-            uri: options ? options.uri : undefined,
+            uri: options.uri,
             resource: options?.resource,
             skipUsingDefaultConfig: options ? options.skipUsingDefaultConfig : false, // Default for this is false
             workingDir:
@@ -112,13 +124,13 @@ export class ServerCache implements IAsyncDisposable {
                     ? options.workingDir
                     : await this.workspace.computeWorkingDirectory(options.resource),
             ui: options.ui,
-            localJupyter: options.localJupyter
+            localJupyter: false
         };
     }
 
     private generateKey(options: INotebookServerOptions): string {
         // combine all the values together to make a unique key
-        const uri = options.uri ? options.uri.toString() : '';
+        const uri = options.localJupyter ? '' : options.uri.toString();
         const useFlag = options.skipUsingDefaultConfig ? 'true' : 'false';
         return `uri=${uri};useFlag=${useFlag};local=${options.localJupyter};workingDir=${options.workingDir}`;
     }

--- a/src/kernels/jupyter/launcher/notebookServerProvider.ts
+++ b/src/kernels/jupyter/launcher/notebookServerProvider.ts
@@ -189,12 +189,12 @@ export class NotebookServerProvider implements IJupyterServerProvider {
 
     private async getNotebookServerOptions(resource: Resource, forLocal: boolean): Promise<INotebookServerOptions> {
         // Since there's one server per session, don't use a resource to figure out these settings
-        let serverURI: string | undefined = await this.serverUriStorage.getUri();
+        let serverURI: string | undefined = await this.serverUriStorage.getRemoteUri();
         const useDefaultConfig: boolean | undefined =
             this.configuration.getSettings(undefined).useDefaultConfigForJupyter;
 
         // For the local case pass in our URI as undefined, that way connect doesn't have to check the setting
-        if (forLocal || (serverURI && serverURI.toLowerCase() === Settings.JupyterServerLocalLaunch)) {
+        if (forLocal || !serverURI) {
             return {
                 resource,
                 skipUsingDefaultConfig: !useDefaultConfig,
@@ -206,7 +206,11 @@ export class NotebookServerProvider implements IJupyterServerProvider {
         if (serverURI === Settings.JupyterServerRemoteLaunch) {
             await this.serverSelector.selectJupyterURI(true);
             // Should have been saved
-            serverURI = await this.serverUriStorage.getUri();
+            serverURI = await this.serverUriStorage.getRemoteUri();
+
+            if (!serverURI) {
+                throw new Error('Remote Jupyter Server connection not provided');
+            }
         }
 
         return {

--- a/src/kernels/jupyter/launcher/notebookServerProvider.ts
+++ b/src/kernels/jupyter/launcher/notebookServerProvider.ts
@@ -186,7 +186,7 @@ export class NotebookServerProvider implements IJupyterServerProvider {
 
     private async getNotebookServerOptions(options: GetServerOptions): Promise<INotebookServerOptions> {
         const useDefaultConfig: boolean | undefined =
-            this.   configuration.getSettings(undefined).useDefaultConfigForJupyter;
+            this.configuration.getSettings(undefined).useDefaultConfigForJupyter;
         if (options.localJupyter) {
             return {
                 resource: options.resource,

--- a/src/kernels/jupyter/launcher/serverPreload.node.ts
+++ b/src/kernels/jupyter/launcher/serverPreload.node.ts
@@ -92,7 +92,7 @@ export class ServerPreload implements IExtensionSingleActivationService {
                 await this.notebookProvider.connect({
                     resource: undefined,
                     ui,
-                    kind: 'localJupyter',
+                    localJupyter: true,
                     token: source.token
                 });
             }

--- a/src/kernels/jupyter/launcher/serverUriStorage.ts
+++ b/src/kernels/jupyter/launcher/serverUriStorage.ts
@@ -137,6 +137,19 @@ export class JupyterServerUriStorage implements IJupyterServerUriStorage {
 
         return this.currentUriPromise;
     }
+    public async getRemoteUri(): Promise<string | undefined> {
+        const uri = await this.getUri();
+        switch (uri) {
+            case Settings.JupyterServerLocalLaunch:
+                return;
+            case Settings.JupyterServerRemoteLaunch:
+                // In `getUriInternal` its not possible for us to end up with Settings.JupyterServerRemoteLaunch.
+                // If we do, then this means the uri was never saved or not in encrypted store, hence no point returning and invalid entry.
+                return;
+            default:
+                return uri;
+        }
+    }
 
     public async setUri(uri: string) {
         // Set the URI as our current state

--- a/src/kernels/jupyter/remoteKernelFinder.ts
+++ b/src/kernels/jupyter/remoteKernelFinder.ts
@@ -52,14 +52,14 @@ export class RemoteKernelFinder implements IRemoteKernelFinder {
     @captureTelemetry(Telemetry.KernelListingPerf, { kind: 'remote' })
     public async listKernels(
         _resource: Resource,
-        connInfo: INotebookProviderConnection | undefined,
+        connInfo: INotebookProviderConnection,
         _cancelToken: CancellationToken
     ): Promise<KernelConnectionMetadata[]> {
         // Get a jupyter session manager to talk to
         let sessionManager: IJupyterSessionManager | undefined;
 
         // This should only be used when doing remote.
-        if (connInfo && connInfo.type === 'jupyter') {
+        if (connInfo.type === 'jupyter') {
             try {
                 sessionManager = await this.jupyterSessionManagerFactory.create(connInfo);
 

--- a/src/kernels/jupyter/serverSelector.ts
+++ b/src/kernels/jupyter/serverSelector.ts
@@ -100,6 +100,7 @@ export class JupyterServerSelector {
         }
 
         await this.serverUriStorage.setUri(userURI);
+        await this.serverUriStorage.addToUriList(userURI, Date.now(), userURI);
 
         // Indicate setting a jupyter URI to a remote setting. Check if an azure remote or not
         sendTelemetryEvent(Telemetry.SetJupyterURIToUserSpecified, undefined, {

--- a/src/kernels/jupyter/types.ts
+++ b/src/kernels/jupyter/types.ts
@@ -68,20 +68,28 @@ export interface IJupyterNotebookProvider {
     createNotebook(options: NotebookCreationOptions): Promise<INotebook>;
 }
 
-export interface INotebookServerOptions {
-    /**
-     * Undefined when connecting to local Jupyter (in case Raw kernels aren't supported)
-     */
-    uri?: string;
-    resource: Resource;
-    skipUsingDefaultConfig?: boolean;
-    workingDir?: string;
-    ui: IDisplayOptions;
-    /**
-     * Whether we're only interested in local Jupyter Servers.
-     */
-    localJupyter: boolean;
-}
+export type INotebookServerOptions =
+    | {
+          resource: Resource;
+          skipUsingDefaultConfig?: boolean;
+          workingDir?: string;
+          ui: IDisplayOptions;
+          /**
+           * Whether we're only interested in local Jupyter Servers.
+           */
+          localJupyter: true;
+      }
+    | {
+          uri: string;
+          resource: Resource;
+          skipUsingDefaultConfig?: boolean;
+          workingDir?: string;
+          ui: IDisplayOptions;
+          /**
+           * Whether we're only interested in local Jupyter Servers.
+           */
+          localJupyter: false;
+      };
 
 export const IJupyterExecution = Symbol('IJupyterExecution');
 export interface IJupyterExecution extends IAsyncDisposable {

--- a/src/kernels/jupyter/types.ts
+++ b/src/kernels/jupyter/types.ts
@@ -234,6 +234,7 @@ export interface IJupyterServerUriStorage {
     removeUri(uri: string): Promise<void>;
     clearUriList(): Promise<void>;
     getUri(): Promise<string>;
+    getRemoteUri(): Promise<string | undefined>;
     setUri(uri: string): Promise<void>;
 }
 

--- a/src/kernels/kernelFinder.node.ts
+++ b/src/kernels/kernelFinder.node.ts
@@ -44,8 +44,8 @@ export class KernelFinder extends BaseKernelFinder {
             case 'startUsingRemoteKernelSpec':
             case 'connectToLiveRemoteKernel':
                 // If this is a a remote kernel, it's valid if the URI is still active
-                const uri = await this.serverUriStorage.getUri();
-                return uri.includes(kernel.baseUrl);
+                const uri = await this.serverUriStorage.getRemoteUri();
+                return uri && uri.includes(kernel.baseUrl) ? true : false;
 
             case 'startUsingPythonInterpreter':
                 // Interpreters have to still exist

--- a/src/kernels/kernelFinder.web.ts
+++ b/src/kernels/kernelFinder.web.ts
@@ -40,8 +40,8 @@ export class KernelFinder extends BaseKernelFinder {
             case 'startUsingRemoteKernelSpec':
             case 'connectToLiveRemoteKernel':
                 // If this is a a remote kernel, it's valid if the URI is still active
-                const uri = await this.serverUriStorage.getUri();
-                return uri.includes(kernel.baseUrl);
+                const uri = await this.serverUriStorage.getRemoteUri();
+                return uri && uri.includes(kernel.baseUrl) ? true : false;
 
             case 'startUsingPythonInterpreter':
             case 'startUsingLocalKernelSpec':

--- a/src/kernels/types.ts
+++ b/src/kernels/types.ts
@@ -93,11 +93,7 @@ export type PythonKernelConnectionMetadata = Readonly<{
  * This ensure we don't update is somewhere unnecessarily (such updates would be unexpected).
  * Unexpected as connections are defined once & not changed, if we need to change then user needs to create a new connection.
  */
-export type KernelConnectionMetadata =
-    | Readonly<LiveRemoteKernelConnectionMetadata>
-    | Readonly<LocalKernelSpecConnectionMetadata>
-    | Readonly<RemoteKernelSpecConnectionMetadata>
-    | Readonly<PythonKernelConnectionMetadata>;
+export type KernelConnectionMetadata = RemoteKernelConnectionMetadata | LocalKernelConnectionMetadata;
 
 /**
  * Connection metadata for local kernels. Makes it easier to not have to check for the live connection type.
@@ -105,6 +101,13 @@ export type KernelConnectionMetadata =
 export type LocalKernelConnectionMetadata =
     | Readonly<LocalKernelSpecConnectionMetadata>
     | Readonly<PythonKernelConnectionMetadata>;
+
+/**
+ * Connection metadata for remote kernels. Makes it easier to not have to check for the live connection type.
+ */
+export type RemoteKernelConnectionMetadata =
+    | Readonly<LiveRemoteKernelConnectionMetadata>
+    | Readonly<RemoteKernelSpecConnectionMetadata>;
 
 export interface IKernelSpecQuickPickItem<T extends KernelConnectionMetadata = KernelConnectionMetadata>
     extends QuickPickItem {
@@ -254,14 +257,6 @@ export interface INotebook {
     readonly session: IJupyterSession; // Temporary. This just makes it easier to write a notebook that works with VS code types.
 }
 
-// Options for connecting to a notebook provider
-export type ConnectNotebookProviderOptions = {
-    ui: IDisplayOptions;
-    kind: 'localJupyter' | 'remoteJupyter';
-    token: CancellationToken | undefined;
-    resource: Resource;
-};
-
 export const IJupyterSession = Symbol('IJupyterSession');
 /**
  * Closely represents Jupyter Labs Kernel.IKernelConnection.
@@ -388,16 +383,24 @@ export interface IJupyterKernelSpec {
         | 'registeredByNewVersionOfExtForCustomKernelSpec';
 }
 
-export type GetServerOptions = {
-    ui: IDisplayOptions;
-    /**
-     * Whether we're only interested in local Jupyter Servers.
-     */
-    localJupyter: boolean;
-    token: CancellationToken | undefined;
-    resource: Resource;
-};
+export type GetServerOptions =
+    | {
+          ui: IDisplayOptions;
+          localJupyter: true;
+          token: CancellationToken | undefined;
+          resource: Resource;
+          serverId?: undefined;
+      }
+    | {
+          ui: IDisplayOptions;
+          localJupyter: false;
+          token: CancellationToken | undefined;
+          resource: Resource;
+          serverId: string;
+      };
 
+// Options for connecting to a notebook provider
+export type ConnectNotebookProviderOptions = GetServerOptions;
 /**
  * Options for getting a notebook
  */

--- a/src/test/datascience/interactive-common/notebookServerProvider.unit.test.ts
+++ b/src/test/datascience/interactive-common/notebookServerProvider.unit.test.ts
@@ -11,7 +11,6 @@ import { IInterpreterService } from '../../../platform/interpreter/contracts';
 import { PythonEnvironment } from '../../../platform/pythonEnvironments/info';
 import { NotebookServerProvider } from '../../../kernels/jupyter/launcher/notebookServerProvider';
 import { JupyterServerUriStorage } from '../../../kernels/jupyter/launcher/serverUriStorage';
-import { JupyterServerSelector } from '../../../kernels/jupyter/serverSelector';
 import { DisplayOptions } from '../../../kernels/displayOptions';
 import { IJupyterExecution, INotebookServer } from '../../../kernels/jupyter/types';
 
@@ -52,12 +51,10 @@ suite('DataScience - NotebookServerProvider', () => {
         const serverStorage = mock(JupyterServerUriStorage);
         when(serverStorage.getUri()).thenResolve('local');
         when(serverStorage.getRemoteUri()).thenResolve();
-        const serverSelector = mock(JupyterServerSelector);
         const eventEmitter = new EventEmitter<void>();
         disposables.push(eventEmitter);
         when(serverStorage.onDidChangeUri).thenReturn(eventEmitter.event);
         when((jupyterExecution as any).then).thenReturn(undefined);
-        when((serverSelector as any).then).thenReturn(undefined);
         when((serverStorage as any).then).thenReturn(undefined);
 
         // Create the server provider
@@ -66,7 +63,6 @@ suite('DataScience - NotebookServerProvider', () => {
             instance(jupyterExecution),
             instance(interpreterService),
             instance(serverStorage),
-            instance(serverSelector),
             disposables
         );
         source = new CancellationTokenSource();

--- a/src/test/datascience/interactive-common/notebookServerProvider.unit.test.ts
+++ b/src/test/datascience/interactive-common/notebookServerProvider.unit.test.ts
@@ -51,6 +51,7 @@ suite('DataScience - NotebookServerProvider', () => {
         when(configurationService.getSettings(anything())).thenReturn(instance(pythonSettings));
         const serverStorage = mock(JupyterServerUriStorage);
         when(serverStorage.getUri()).thenResolve('local');
+        when(serverStorage.getRemoteUri()).thenResolve();
         const serverSelector = mock(JupyterServerSelector);
         const eventEmitter = new EventEmitter<void>();
         disposables.push(eventEmitter);

--- a/src/test/datascience/kernel-launcher/remoteKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/remoteKernelFinder.unit.test.ts
@@ -153,6 +153,7 @@ suite(`Remote Kernel Finder`, () => {
         when(fs.localFileExists(anything())).thenResolve(true);
         const serverUriStorage = mock(JupyterServerUriStorage);
         when(serverUriStorage.getUri()).thenResolve(connInfo.baseUrl);
+        when(serverUriStorage.getRemoteUri()).thenResolve(connInfo.baseUrl);
         memento = new MockMemento();
         kernelFinder = new KernelFinder(
             instance(localKernelFinder),


### PR DESCRIPTION
Part of #9167 

* Code cleanup
* Basically uses the serverId (url) in the kernel connection metadata to connect to the remote jupyter server.
* Also paves the way for connecting to multiple remotes (without assuming theres only ever one remote)