### PR TITLE
Dont skip completions when testing

### DIFF
--- a/news/3 Code Health/9797.md
+++ b/news/3 Code Health/9797.md
@@ -1,0 +1,1 @@
+Don't skip code completions when the server is busy. Instead let it timeout if the server doesn't come back.

--- a/src/intellisense/pythonKernelCompletionProvider.node.ts
+++ b/src/intellisense/pythonKernelCompletionProvider.node.ts
@@ -27,7 +27,7 @@ import { findAssociatedNotebookDocument, getAssociatedJupyterNotebook } from '..
 import { INotebookLanguageClientProvider } from '../notebooks/types';
 import { mapJupyterKind } from './conversion.node';
 import { IInteractiveWindowProvider } from '../interactive-window/types';
-import { Settings } from '../platform/common/constants';
+import { isTestExecution, Settings } from '../platform/common/constants';
 import { INotebookCompletion } from './types';
 
 let IntellisenseTimeout = Settings.IntellisenseTimeout;
@@ -169,8 +169,10 @@ export class PythonKernelCompletionProvider implements CompletionItemProvider {
         cancelToken?: CancellationToken
     ): Promise<INotebookCompletion> {
         const stopWatch = new StopWatch();
-        // If server is busy, then don't delay code completion.
-        if (session.status === 'busy') {
+        // If server is busy, then don't send code completions. Otherwise
+        // they can stack up and slow down the server significantly.
+        // However during testing we'll just wait.
+        if (session.status === 'busy' && !isTestExecution()) {
             return {
                 matches: [],
                 cursor: { start: 0, end: 0 },


### PR DESCRIPTION
Fixes #9797 

Was going to always not skip when busy, but found during manual testing that this can significantly slow down execution (completion requests get queued up).

So for now, just skipping busy check when testing.
