### PR TITLE
Fix up restart session (remove dead code)

### DIFF
--- a/src/kernels/jupyter/session/jupyterSessionManager.ts
+++ b/src/kernels/jupyter/session/jupyterSessionManager.ts
@@ -3,7 +3,6 @@
 'use strict';
 import type {
     ContentsManager,
-    Kernel,
     KernelSpecManager,
     KernelManager,
     ServerConnection,
@@ -11,7 +10,7 @@ import type {
     SessionManager
 } from '@jupyterlab/services';
 import { JSONObject } from '@lumino/coreutils';
-import { CancellationToken, EventEmitter, Uri } from 'vscode';
+import { CancellationToken, Uri } from 'vscode';
 import { IApplicationShell } from '../../../platform/common/application/types';
 import { traceInfo, traceError, traceVerbose } from '../../../platform/logging';
 import {
@@ -54,8 +53,6 @@ export class JupyterSessionManager implements IJupyterSessionManager {
     private serverSettings: ServerConnection.ISettings | undefined;
     private _jupyterlab?: typeof import('@jupyterlab/services');
     private readonly userAllowsInsecureConnections: IPersistentState<boolean>;
-    private restartSessionCreatedEvent = new EventEmitter<Kernel.IKernelConnection>();
-    private restartSessionUsedEvent = new EventEmitter<Kernel.IKernelConnection>();
     private disposed?: boolean;
     private get jupyterlab(): typeof import('@jupyterlab/services') {
         if (!this._jupyterlab) {
@@ -83,13 +80,6 @@ export class JupyterSessionManager implements IJupyterSessionManager {
         );
     }
 
-    public get onRestartSessionCreated() {
-        return this.restartSessionCreatedEvent.event;
-    }
-
-    public get onRestartSessionUsed() {
-        return this.restartSessionUsedEvent.event;
-    }
     public async dispose() {
         if (this.disposed) {
             return;
@@ -200,8 +190,6 @@ export class JupyterSessionManager implements IJupyterSessionManager {
             this.sessionManager,
             this.contentsManager,
             this.outputChannel,
-            this.restartSessionCreatedEvent.fire.bind(this.restartSessionCreatedEvent),
-            this.restartSessionUsedEvent.fire.bind(this.restartSessionUsedEvent),
             workingDirectory,
             this.configService.getSettings(resource).jupyterLaunchTimeout,
             this.kernelService,

--- a/src/kernels/jupyter/session/jupyterSessionManagerFactory.ts
+++ b/src/kernels/jupyter/session/jupyterSessionManagerFactory.ts
@@ -4,10 +4,7 @@
 import { inject, injectable, named, optional } from 'inversify';
 import { JupyterSessionManager } from './jupyterSessionManager';
 import { IApplicationShell } from '../../../platform/common/application/types';
-import {
-    IConfigurationService,
-    IOutputChannel,
-    IPersistentStateFactory} from '../../../platform/common/types';
+import { IConfigurationService, IOutputChannel, IPersistentStateFactory } from '../../../platform/common/types';
 import { JUPYTER_OUTPUT_CHANNEL } from '../../../webviews/webview-side/common/constants';
 import { IJupyterConnection } from '../../types';
 import {
@@ -58,5 +55,4 @@ export class JupyterSessionManagerFactory implements IJupyterSessionManagerFacto
         await result.initialize(connInfo);
         return result;
     }
-
 }

--- a/src/kernels/jupyter/session/jupyterSessionManagerFactory.ts
+++ b/src/kernels/jupyter/session/jupyterSessionManagerFactory.ts
@@ -2,16 +2,12 @@
 // Licensed under the MIT License.
 'use strict';
 import { inject, injectable, named, optional } from 'inversify';
-import type { Kernel } from '@jupyterlab/services';
-import { EventEmitter } from 'vscode';
 import { JupyterSessionManager } from './jupyterSessionManager';
 import { IApplicationShell } from '../../../platform/common/application/types';
 import {
     IConfigurationService,
     IOutputChannel,
-    IPersistentStateFactory,
-    IDisposableRegistry
-} from '../../../platform/common/types';
+    IPersistentStateFactory} from '../../../platform/common/types';
 import { JUPYTER_OUTPUT_CHANNEL } from '../../../webviews/webview-side/common/constants';
 import { IJupyterConnection } from '../../types';
 import {
@@ -26,15 +22,12 @@ import {
 
 @injectable()
 export class JupyterSessionManagerFactory implements IJupyterSessionManagerFactory {
-    private restartSessionCreatedEvent = new EventEmitter<Kernel.IKernelConnection>();
-    private restartSessionUsedEvent = new EventEmitter<Kernel.IKernelConnection>();
     constructor(
         @inject(IJupyterPasswordConnect) private jupyterPasswordConnect: IJupyterPasswordConnect,
         @inject(IConfigurationService) private config: IConfigurationService,
         @inject(IOutputChannel) @named(JUPYTER_OUTPUT_CHANNEL) private jupyterOutput: IOutputChannel,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(IPersistentStateFactory) private readonly stateFactory: IPersistentStateFactory,
-        @inject(IDisposableRegistry) private readonly disposableRegistry: IDisposableRegistry,
         @inject(IJupyterKernelService) @optional() private readonly kernelService: IJupyterKernelService | undefined,
         @inject(IJupyterBackingFileCreator) private readonly backingFileCreator: IJupyterBackingFileCreator,
         @inject(IJupyterRequestAgentCreator)
@@ -63,20 +56,7 @@ export class JupyterSessionManagerFactory implements IJupyterSessionManagerFacto
             this.requestCreator
         );
         await result.initialize(connInfo);
-        this.disposableRegistry.push(
-            result.onRestartSessionCreated(this.restartSessionCreatedEvent.fire.bind(this.restartSessionCreatedEvent))
-        );
-        this.disposableRegistry.push(
-            result.onRestartSessionUsed(this.restartSessionUsedEvent.fire.bind(this.restartSessionUsedEvent))
-        );
         return result;
     }
 
-    public get onRestartSessionCreated() {
-        return this.restartSessionCreatedEvent.event;
-    }
-
-    public get onRestartSessionUsed() {
-        return this.restartSessionUsedEvent.event;
-    }
 }

--- a/src/kernels/jupyter/types.ts
+++ b/src/kernels/jupyter/types.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 'use strict';
 import type * as nbformat from '@jupyterlab/nbformat';
-import type { Kernel, Session, ContentsManager } from '@jupyterlab/services';
+import type { Session, ContentsManager } from '@jupyterlab/services';
 import { Event } from 'vscode';
 import { SemVer } from 'semver';
 import { Uri, QuickPickItem } from 'vscode';
@@ -110,14 +110,10 @@ export interface IJupyterPasswordConnect {
 
 export const IJupyterSessionManagerFactory = Symbol('IJupyterSessionManagerFactory');
 export interface IJupyterSessionManagerFactory {
-    readonly onRestartSessionCreated: Event<Kernel.IKernelConnection>;
-    readonly onRestartSessionUsed: Event<Kernel.IKernelConnection>;
     create(connInfo: IJupyterConnection, failOnPassword?: boolean): Promise<IJupyterSessionManager>;
 }
 
 export interface IJupyterSessionManager extends IAsyncDisposable {
-    readonly onRestartSessionCreated: Event<Kernel.IKernelConnection>;
-    readonly onRestartSessionUsed: Event<Kernel.IKernelConnection>;
     startNew(
         resource: Resource,
         kernelConnection: KernelConnectionMetadata,

--- a/src/kernels/raw/session/hostRawNotebookProvider.node.ts
+++ b/src/kernels/raw/session/hostRawNotebookProvider.node.ts
@@ -26,7 +26,6 @@ import { isPythonKernelConnection } from '../../helpers';
 import { ConnectNotebookProviderOptions, IJupyterSession, IRawConnection, KernelConnectionMetadata } from '../../types';
 import { IKernelLauncher, IRawNotebookProvider, IRawNotebookSupportedService } from '../types';
 import { RawJupyterSession } from './rawJupyterSession.node';
-import { noop } from '../../../platform/common/utils/misc';
 import { Cancellation } from '../../../platform/common/cancellation';
 import { RawConnection } from './connection';
 
@@ -107,7 +106,6 @@ export class HostRawNotebookProvider implements IRawNotebookProvider {
             rawSession = new RawJupyterSession(
                 this.kernelLauncher,
                 resource,
-                noop,
                 vscode.Uri.file(workingDirectory),
                 interruptTimeout,
                 kernelConnection,

--- a/src/kernels/raw/session/rawJupyterSession.node.ts
+++ b/src/kernels/raw/session/rawJupyterSession.node.ts
@@ -211,16 +211,16 @@ export class RawJupyterSession extends BaseJupyterSession {
     }
 
     protected startRestartSession(disableUI: boolean) {
-            const token = new CancellationTokenSource();
-            const promise = this.createRestartSession(disableUI, token.token);
-            this.restartSessionPromise = { token, promise };
-            promise.finally(() => {
-                token.dispose();
-                if (this.restartSessionPromise?.promise === promise){
-                    this.restartSessionPromise = undefined;
-                };
-            });
-            return promise;
+        const token = new CancellationTokenSource();
+        const promise = this.createRestartSession(disableUI, token.token);
+        this.restartSessionPromise = { token, promise };
+        promise.finally(() => {
+            token.dispose();
+            if (this.restartSessionPromise?.promise === promise) {
+                this.restartSessionPromise = undefined;
+            }
+        });
+        return promise;
     }
     protected async createRestartSession(
         disableUI: boolean,

--- a/src/kernels/raw/session/rawJupyterSession.node.ts
+++ b/src/kernels/raw/session/rawJupyterSession.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
-import type { Kernel, KernelMessage } from '@jupyterlab/services';
+import type { KernelMessage } from '@jupyterlab/services';
 import type { Slot } from '@lumino/signaling';
 import { CancellationError, CancellationTokenSource, Uri } from 'vscode';
 import { CancellationToken } from 'vscode-jsonrpc';
@@ -52,13 +52,12 @@ export class RawJupyterSession extends BaseJupyterSession {
     constructor(
         private readonly kernelLauncher: IKernelLauncher,
         resource: Resource,
-        restartSessionUsed: (id: Kernel.IKernelConnection) => void,
         workingDirectory: Uri,
         interruptTimeout: number,
         kernelConnection: KernelConnectionMetadata,
         private readonly launchTimeout: number
     ) {
-        super('localRaw', resource, kernelConnection, restartSessionUsed, workingDirectory, interruptTimeout);
+        super('localRaw', resource, kernelConnection, workingDirectory, interruptTimeout);
     }
 
     public async waitForIdle(timeout: number): Promise<void> {
@@ -212,12 +211,16 @@ export class RawJupyterSession extends BaseJupyterSession {
     }
 
     protected startRestartSession(disableUI: boolean) {
-        if (!this.restartSessionPromise) {
             const token = new CancellationTokenSource();
             const promise = this.createRestartSession(disableUI, token.token);
             this.restartSessionPromise = { token, promise };
-            promise.finally(() => token.dispose());
-        }
+            promise.finally(() => {
+                token.dispose();
+                if (this.restartSessionPromise?.promise === promise){
+                    this.restartSessionPromise = undefined;
+                };
+            });
+            return promise;
     }
     protected async createRestartSession(
         disableUI: boolean,

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -41,8 +41,6 @@ import { JupyterRequestCreator } from '../../../kernels/jupyter/session/jupyterR
 suite('DataScience - JupyterSession', () => {
     type IKernelChangedArgs = IChangedArgs<Kernel.IKernelConnection | null, Kernel.IKernelConnection | null, 'kernel'>;
     let jupyterSession: JupyterSession;
-    let restartSessionCreatedEvent: Deferred<void>;
-    let restartSessionUsedEvent: Deferred<void>;
     let connection: IJupyterConnection;
     let mockKernelSpec: ReadWrite<KernelConnectionMetadata>;
     let sessionManager: SessionManager;
@@ -90,8 +88,6 @@ suite('DataScience - JupyterSession', () => {
         id: 'liveKernel'
     };
     function createJupyterSession(resource: Resource = undefined) {
-        restartSessionCreatedEvent = createDeferred();
-        restartSessionUsedEvent = createDeferred();
         connection = mock<IJupyterConnection>();
         mockKernelSpec = {
             id: 'xyz',
@@ -144,12 +140,6 @@ suite('DataScience - JupyterSession', () => {
             instance(sessionManager),
             instance(contentsManager),
             channel,
-            () => {
-                restartSessionCreatedEvent.resolve();
-            },
-            () => {
-                restartSessionUsedEvent.resolve();
-            },
             Uri.file(''),
             1,
             instance(kernelService),
@@ -347,8 +337,6 @@ suite('DataScience - JupyterSession', () => {
                     mock<
                         ISignal<Session.ISessionConnection, KernelMessage.IIOPubMessage<KernelMessage.IOPubMessageType>>
                     >();
-                restartSessionCreatedEvent = createDeferred();
-                restartSessionUsedEvent = createDeferred();
                 when(newSession.statusChanged).thenReturn(instance(newStatusChangedSignal));
                 when(newSession.kernelChanged).thenReturn(instance(newKernelChangedSignal));
                 when(newSession.iopubMessage).thenReturn(instance(newIoPubSignal));
@@ -405,7 +393,6 @@ suite('DataScience - JupyterSession', () => {
                     await jupyterSession.restart();
 
                     // We should kill session and switch to new session, startig a new restart session.
-                    await restartSessionCreatedEvent.promise;
                     await oldSessionShutDown.promise;
                     verify(session.shutdown()).once();
                     verify(session.dispose()).once();

--- a/src/test/datascience/kernel-launcher/remoteKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/remoteKernelFinder.unit.test.ts
@@ -125,8 +125,6 @@ suite(`Remote Kernel Finder`, () => {
         when(jupyterSessionManagerFactory.create(anything())).thenResolve(instance(jupyterSessionManager));
         sessionCreatedEvent = new EventEmitter<Kernel.IKernelConnection>();
         sessionUsedEvent = new EventEmitter<Kernel.IKernelConnection>();
-        when(jupyterSessionManagerFactory.onRestartSessionCreated).thenReturn(sessionCreatedEvent.event);
-        when(jupyterSessionManagerFactory.onRestartSessionUsed).thenReturn(sessionUsedEvent.event);
         interpreterService = mock<IInterpreterService>();
         localKernelFinder = mock(LocalKernelFinder);
         when(localKernelFinder.listKernels(anything(), anything())).thenResolve([]);
@@ -134,7 +132,6 @@ suite(`Remote Kernel Finder`, () => {
         when(extensionChecker.isPythonExtensionInstalled).thenReturn(true);
 
         remoteKernelFinder = new RemoteKernelFinder(
-            disposables,
             instance(jupyterSessionManagerFactory),
             instance(interpreterService),
             instance(extensionChecker),


### PR DESCRIPTION
We no longer start restart sessions everytime, in the past we'd start a session for use as the restart session.
Now that we don't have that functionality we don't need to hide those kernels from the kernel filter & the like.