### PR TITLE
Remove unnecessary caching

### DIFF
--- a/src/kernels/raw/finder/jupyterPaths.node.ts
+++ b/src/kernels/raw/finder/jupyterPaths.node.ts
@@ -128,7 +128,6 @@ export class JupyterPaths {
      * https://jupyter-client.readthedocs.io/en/stable/kernels.html#kernel-specs
      */
     @traceDecoratorVerbose('Get KernelSpec root path')
-    @cache(10 * 60_000)
     public async getKernelSpecRootPaths(cancelToken?: CancellationToken): Promise<Uri[]> {
         // Paths specified in JUPYTER_PATH are supposed to come first in searching
         const paths = new ResourceSet(await this.getJupyterPathPaths(cancelToken));

--- a/src/kernels/raw/finder/jupyterPaths.node.ts
+++ b/src/kernels/raw/finder/jupyterPaths.node.ts
@@ -16,7 +16,6 @@ import { traceDecoratorVerbose } from '../../../platform/logging';
 import { getUserHomeDir } from '../../../platform/common/utils/platform.node';
 import { fsPathToUri } from '../../../platform/vscode-path/utils';
 import { ResourceSet } from '../../../platform/vscode-path/map';
-import { cache } from '../../../platform/common/utils/decorators';
 
 const winJupyterPath = path.join('AppData', 'Roaming', 'jupyter', 'kernels');
 const linuxJupyterPath = path.join('.local', 'share', 'jupyter', 'kernels');


### PR DESCRIPTION
The use of cache decorator was unnecessary and was breaking local dev.
Because the return value was a uri and that cannot be JSON serialized. 

Unnecessary as everything used in this method is already cached, hence the caching on top was unnecessary.
