### PR TITLE
Move connection out of execution

### DIFF
--- a/src/kernels/jupyter/jupyterConnection.ts
+++ b/src/kernels/jupyter/jupyterConnection.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
+import { IExtensionSyncActivationService } from '../../platform/activation/types';
 import { Identifiers } from '../../platform/common/constants';
 import { IDisposableRegistry } from '../../platform/common/types';
 import { IJupyterConnection } from '../types';
@@ -16,7 +17,7 @@ import {
 } from './types';
 
 @injectable()
-export class JupyterConnection {
+export class JupyterConnection implements IExtensionSyncActivationService {
     private uriToJupyterServerUri = new Map<string, IJupyterServerUri>();
     private pendingTimeouts: (NodeJS.Timeout | number)[] = [];
     constructor(

--- a/src/kernels/jupyter/jupyterConnection.ts
+++ b/src/kernels/jupyter/jupyterConnection.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { inject, injectable } from 'inversify';
+import { Identifiers } from '../../platform/common/constants';
+import { IDisposableRegistry } from '../../platform/common/types';
+import { IJupyterConnection } from '../types';
+import { createRemoteConnectionInfo } from './jupyterUtils';
+import { ServerConnectionType } from './launcher/serverConnectionType';
+import {
+    IJupyterServerUri,
+    IJupyterSessionManager,
+    IJupyterSessionManagerFactory,
+    IJupyterUriProviderRegistration,
+    JupyterServerUriHandle
+} from './types';
+
+@injectable()
+export class JupyterConnection {
+    private uriToJupyterServerUri = new Map<string, IJupyterServerUri>();
+    private pendingTimeouts: (NodeJS.Timeout | number)[] = [];
+    constructor(
+        @inject(IJupyterUriProviderRegistration)
+        private readonly jupyterPickerRegistration: IJupyterUriProviderRegistration,
+        @inject(IJupyterSessionManagerFactory)
+        private readonly jupyterSessionManagerFactory: IJupyterSessionManagerFactory,
+        @inject(IDisposableRegistry)
+        private readonly disposables: IDisposableRegistry,
+        @inject(ServerConnectionType) private readonly serverConnectionType: ServerConnectionType
+    ) {
+        disposables.push(this);
+    }
+    public activate() {
+        this.serverConnectionType.onDidChange(
+            () =>
+                // When server URI changes, clear our pending URI timeouts
+                this.clearTimeouts(),
+            this,
+            this.disposables
+        );
+    }
+    public dispose() {
+        this.clearTimeouts();
+    }
+    private clearTimeouts() {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        this.pendingTimeouts.forEach((t) => clearTimeout(t as any));
+        this.pendingTimeouts = [];
+    }
+    public createConnectionInfo(uri: string) {
+        return createRemoteConnectionInfo(uri, this.getServerUri.bind(this));
+    }
+    public async validateRemoteUri(uri: string): Promise<void> {
+        // Prepare our map of server URIs (needed in order to retrieve the uri during the connection)
+        await this.updateServerUri(uri);
+
+        // Create an active connection.
+        return this.validateRemoteConnection(await createRemoteConnectionInfo(uri, this.getServerUri.bind(this)));
+    }
+
+    public async validateRemoteConnection(connection: IJupyterConnection): Promise<void> {
+        let sessionManager: IJupyterSessionManager | undefined = undefined;
+        try {
+            // Attempt to list the running kernels. It will return empty if there are none, but will
+            // throw if can't connect.
+            sessionManager = await this.jupyterSessionManagerFactory.create(connection, false);
+            await sessionManager.getRunningKernels();
+
+            // We should throw an exception if any of that fails.
+        } finally {
+            if (connection) {
+                connection.dispose();
+            }
+            if (sessionManager) {
+                void sessionManager.dispose();
+            }
+        }
+    }
+
+    public async updateServerUri(uri: string): Promise<void> {
+        const idAndHandle = this.extractJupyterServerHandleAndId(uri);
+        if (idAndHandle) {
+            const serverUri = await this.jupyterPickerRegistration.getJupyterServerUri(
+                idAndHandle.id,
+                idAndHandle.handle
+            );
+            this.uriToJupyterServerUri.set(uri, serverUri);
+            // See if there's an expiration date
+            if (serverUri.expiration) {
+                const timeoutInMS = serverUri.expiration.getTime() - Date.now();
+                // Week seems long enough (in case the expiration is ridiculous)
+                if (timeoutInMS > 0 && timeoutInMS < 604800000) {
+                    this.pendingTimeouts.push(setTimeout(() => this.updateServerUri(uri).ignoreErrors(), timeoutInMS));
+                }
+            }
+        }
+    }
+
+    private getServerUri(uri: string): IJupyterServerUri | undefined {
+        const idAndHandle = this.extractJupyterServerHandleAndId(uri);
+        if (idAndHandle) {
+            return this.uriToJupyterServerUri.get(uri);
+        }
+    }
+    private extractJupyterServerHandleAndId(uri: string): { handle: JupyterServerUriHandle; id: string } | undefined {
+        const url: URL = new URL(uri);
+
+        // Id has to be there too.
+        const id = url.searchParams.get(Identifiers.REMOTE_URI_ID_PARAM);
+        const uriHandle = url.searchParams.get(Identifiers.REMOTE_URI_HANDLE_PARAM);
+        return id && uriHandle ? { handle: uriHandle, id } : undefined;
+    }
+}

--- a/src/kernels/jupyter/launcher/liveshare/hostJupyterExecution.ts
+++ b/src/kernels/jupyter/launcher/liveshare/hostJupyterExecution.ts
@@ -23,13 +23,11 @@ import {
     INotebookServerOptions,
     INotebookServer,
     INotebookStarter,
-    IJupyterUriProviderRegistration,
-    IJupyterSessionManagerFactory,
     INotebookServerFactory,
     IJupyterServerUriStorage
 } from '../../types';
 import { IJupyterSubCommandExecutionService } from '../../types.node';
-import { ServerConnectionType } from '../serverConnectionType';
+import { JupyterConnection } from '../../jupyterConnection';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -48,11 +46,9 @@ export class HostJupyterExecution extends JupyterExecutionBase implements IJupyt
         @inject(IJupyterSubCommandExecutionService)
         @optional()
         jupyterInterpreterService: IJupyterSubCommandExecutionService | undefined,
-        @inject(IJupyterUriProviderRegistration) jupyterPickerRegistration: IJupyterUriProviderRegistration,
-        @inject(IJupyterSessionManagerFactory) sessionManagerFactory: IJupyterSessionManagerFactory,
         @inject(INotebookServerFactory) notebookServerFactory: INotebookServerFactory,
         @inject(IJupyterServerUriStorage) private readonly serverUriStorage: IJupyterServerUriStorage,
-        @inject(ServerConnectionType) serverConnectionType: ServerConnectionType
+        @inject(JupyterConnection) jupyterConnection: JupyterConnection
     ) {
         super(
             interpreterService,
@@ -61,10 +57,8 @@ export class HostJupyterExecution extends JupyterExecutionBase implements IJupyt
             configService,
             notebookStarter,
             jupyterInterpreterService,
-            jupyterPickerRegistration,
-            sessionManagerFactory,
             notebookServerFactory,
-            serverConnectionType
+            jupyterConnection
         );
         this.serverCache = new ServerCache();
         this.serverUriStorage.onDidChangeUri(

--- a/src/kernels/jupyter/serverSelector.ts
+++ b/src/kernels/jupyter/serverSelector.ts
@@ -23,12 +23,12 @@ import {
     IJupyterUriProvider,
     IJupyterUriProviderRegistration,
     IJupyterServerUriStorage,
-    JupyterServerUriHandle,
-    IJupyterExecution
+    JupyterServerUriHandle
 } from './types';
 import { IDataScienceErrorHandler, WrappedError } from '../../platform/errors/types';
 import { handleCertsError } from './jupyterUtils';
 import { IConfigurationService } from '../../platform/common/types';
+import { JupyterConnection } from './jupyterConnection';
 
 const defaultUri = 'https://hostname:8080/?token=849d61a414abafab97bc4aab1f3547755ddc232c2b8cb7fe';
 
@@ -55,11 +55,11 @@ export class JupyterServerSelector {
         @inject(IJupyterUriProviderRegistration)
         private extraUriProviders: IJupyterUriProviderRegistration,
         @inject(IJupyterServerUriStorage) private readonly serverUriStorage: IJupyterServerUriStorage,
-        @inject(IJupyterExecution) private readonly execution: IJupyterExecution,
         @inject(IDataScienceErrorHandler)
         private readonly errorHandler: IDataScienceErrorHandler,
         @inject(IApplicationShell) private readonly applicationShell: IApplicationShell,
-        @inject(IConfigurationService) private readonly configService: IConfigurationService
+        @inject(IConfigurationService) private readonly configService: IConfigurationService,
+        @inject(JupyterConnection) private readonly jupyterConnection: JupyterConnection
     ) {}
 
     @captureTelemetry(Telemetry.SelectJupyterURI)
@@ -82,7 +82,7 @@ export class JupyterServerSelector {
     public async setJupyterURIToRemote(userURI: string): Promise<void> {
         // Double check this server can be connected to. Might need a password, might need a allowUnauthorized
         try {
-            await this.execution.validateRemoteUri(userURI);
+            await this.jupyterConnection.validateRemoteUri(userURI);
         } catch (err) {
             if (err.message.indexOf('reason: self signed certificate') >= 0) {
                 sendTelemetryEvent(Telemetry.ConnectRemoteSelfCertFailedJupyter);

--- a/src/kernels/jupyter/serviceRegistry.node.ts
+++ b/src/kernels/jupyter/serviceRegistry.node.ts
@@ -146,4 +146,5 @@ export function registerTypes(serviceManager: IServiceManager, _isDevMode: boole
     serviceManager.addSingleton<IJupyterRequestAgentCreator>(IJupyterRequestAgentCreator, RequestAgentCreator);
     serviceManager.addSingleton<ServerConnectionType>(ServerConnectionType, ServerConnectionType);
     serviceManager.addSingleton<JupyterConnection>(JupyterConnection, JupyterConnection);
+    serviceManager.addBinding(JupyterConnection, IExtensionSingleActivationService);
 }

--- a/src/kernels/jupyter/serviceRegistry.node.ts
+++ b/src/kernels/jupyter/serviceRegistry.node.ts
@@ -23,6 +23,7 @@ import { JupyterInterpreterSubCommandExecutionService } from './interpreter/jupy
 import { NbConvertExportToPythonService } from './interpreter/nbconvertExportToPythonService.node';
 import { NbConvertInterpreterDependencyChecker } from './interpreter/nbconvertInterpreterDependencyChecker.node';
 import { CellOutputMimeTypeTracker } from './jupyterCellOutputMimeTypeTracker.node';
+import { JupyterConnection } from './jupyterConnection';
 import { JupyterKernelService } from './jupyterKernelService.node';
 import { JupyterUriProviderRegistration } from './jupyterUriProviderRegistration';
 import { JupyterCommandLineSelector } from './launcher/commandLineSelector';
@@ -144,4 +145,5 @@ export function registerTypes(serviceManager: IServiceManager, _isDevMode: boole
     serviceManager.addSingleton<IJupyterRequestCreator>(IJupyterRequestCreator, JupyterRequestCreator);
     serviceManager.addSingleton<IJupyterRequestAgentCreator>(IJupyterRequestAgentCreator, RequestAgentCreator);
     serviceManager.addSingleton<ServerConnectionType>(ServerConnectionType, ServerConnectionType);
+    serviceManager.addSingleton<JupyterConnection>(JupyterConnection, JupyterConnection);
 }

--- a/src/kernels/jupyter/serviceRegistry.web.ts
+++ b/src/kernels/jupyter/serviceRegistry.web.ts
@@ -7,6 +7,7 @@ import { INotebookProvider } from '../types';
 import { JupyterCommandLineSelectorCommand } from './commands/commandLineSelector';
 import { CommandRegistry } from './commands/commandRegistry';
 import { JupyterServerSelectorCommand } from './commands/serverSelector';
+import { JupyterConnection } from './jupyterConnection';
 import { JupyterKernelService } from './jupyterKernelService.web';
 import { JupyterUriProviderRegistration } from './jupyterUriProviderRegistration';
 import { JupyterCommandLineSelector } from './launcher/commandLineSelector';
@@ -69,4 +70,5 @@ export function registerTypes(serviceManager: IServiceManager, _isDevMode: boole
     serviceManager.addSingleton<IJupyterServerProvider>(IJupyterServerProvider, NotebookServerProvider);
     serviceManager.addSingleton<IJupyterRequestCreator>(IJupyterRequestCreator, JupyterRequestCreator);
     serviceManager.addSingleton<ServerConnectionType>(ServerConnectionType, ServerConnectionType);
+    serviceManager.addSingleton<JupyterConnection>(JupyterConnection, JupyterConnection);
 }

--- a/src/kernels/jupyter/serviceRegistry.web.ts
+++ b/src/kernels/jupyter/serviceRegistry.web.ts
@@ -71,4 +71,5 @@ export function registerTypes(serviceManager: IServiceManager, _isDevMode: boole
     serviceManager.addSingleton<IJupyterRequestCreator>(IJupyterRequestCreator, JupyterRequestCreator);
     serviceManager.addSingleton<ServerConnectionType>(ServerConnectionType, ServerConnectionType);
     serviceManager.addSingleton<JupyterConnection>(JupyterConnection, JupyterConnection);
+    serviceManager.addBinding(JupyterConnection, IExtensionSingleActivationService);
 }

--- a/src/kernels/jupyter/types.ts
+++ b/src/kernels/jupyter/types.ts
@@ -67,24 +67,24 @@ export interface IJupyterNotebookProvider {
     createNotebook(options: NotebookCreationOptions): Promise<IJupyterSession>;
 }
 
-export type INotebookServerOptions =
-    | {
-          resource: Resource;
-          ui: IDisplayOptions;
-          /**
-           * Whether we're only interested in local Jupyter Servers.
-           */
-          localJupyter: true;
-      }
-    | {
-          uri: string;
-          resource: Resource;
-          ui: IDisplayOptions;
-          /**
-           * Whether we're only interested in local Jupyter Servers.
-           */
-          localJupyter: false;
-      };
+export type INotebookServerLocalOptions = {
+    resource: Resource;
+    ui: IDisplayOptions;
+    /**
+     * Whether we're only interested in local Jupyter Servers.
+     */
+    localJupyter: true;
+};
+export type INotebookServerRemoteOptions = {
+    uri: string;
+    resource: Resource;
+    ui: IDisplayOptions;
+    /**
+     * Whether we're only interested in local Jupyter Servers.
+     */
+    localJupyter: false;
+};
+export type INotebookServerOptions = INotebookServerLocalOptions | INotebookServerRemoteOptions;
 
 export const IJupyterExecution = Symbol('IJupyterExecution');
 export interface IJupyterExecution extends IAsyncDisposable {
@@ -94,7 +94,6 @@ export interface IJupyterExecution extends IAsyncDisposable {
     getServer(options: INotebookServerOptions): Promise<INotebookServer | undefined>;
     getNotebookError(): Promise<string>;
     refreshCommands(): Promise<void>;
-    validateRemoteUri(uri: string): Promise<void>;
 }
 
 export interface IJupyterPasswordConnectInfo {

--- a/src/test/datascience/execution.unit.test.ts
+++ b/src/test/datascience/execution.unit.test.ts
@@ -60,10 +60,8 @@ import { INotebookServerFactory } from '../../kernels/jupyter/types';
 import { IJupyterSubCommandExecutionService } from '../../kernels/jupyter/types.node';
 import { SystemVariables } from '../../platform/common/variables/systemVariables.node';
 import { getOSType, OSType } from '../../platform/common/utils/platform';
-import { JupyterUriProviderRegistration } from '../../kernels/jupyter/jupyterUriProviderRegistration';
-import { JupyterSessionManagerFactory } from '../../kernels/jupyter/session/jupyterSessionManagerFactory';
 import { JupyterServerUriStorage } from '../../kernels/jupyter/launcher/serverUriStorage';
-import { ServerConnectionType } from '../../kernels/jupyter/launcher/serverConnectionType';
+import { JupyterConnection } from '../../kernels/jupyter/jupyterConnection';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, , no-multi-str,  */
 class DisposableRegistry implements IAsyncDisposableRegistry {
@@ -86,7 +84,7 @@ class DisposableRegistry implements IAsyncDisposableRegistry {
     };
 }
 
-suite('Jupyter Execution', async () => {
+suite.only('Jupyter Execution', async () => {
     const interpreterService = mock<IInterpreterService>();
     const jupyterOutputChannel = new MockOutputChannel('');
     const executionFactory = mock(PythonExecutionFactory);
@@ -1000,15 +998,9 @@ suite('Jupyter Execution', async () => {
         when(kernelFinder.listKernels(anything(), anything())).thenResolve([kernelMetadata]);
         when(serviceContainer.get<NotebookStarter>(NotebookStarter)).thenReturn(notebookStarter);
         when(serviceContainer.get<ILocalKernelFinder>(ILocalKernelFinder)).thenReturn(instance(kernelFinder));
-        const sessionManagerFactory = mock(JupyterSessionManagerFactory);
         const serverFactory = mock<INotebookServerFactory>();
-        const provider = mock(JupyterUriProviderRegistration);
         const serverUriStorage = mock(JupyterServerUriStorage);
-        const connectionType = mock<ServerConnectionType>();
-        when(connectionType.isLocalLaunch).thenReturn(true);
-        const onDidChangeEvent = new EventEmitter<void>();
-        disposableRegistry.push(onDidChangeEvent);
-        when(connectionType.onDidChange).thenReturn(onDidChangeEvent.event);
+        const connection = mock<JupyterConnection>();
         return {
             executionService: activeService.object,
             jupyterExecution: new HostJupyterExecution(
@@ -1019,11 +1011,9 @@ suite('Jupyter Execution', async () => {
                 instance(configService),
                 notebookStarter,
                 jupyterCmdExecutionService,
-                instance(provider),
-                instance(sessionManagerFactory),
                 instance(serverFactory),
                 instance(serverUriStorage),
-                instance(connectionType)
+                instance(connection)
             )
         };
     }

--- a/src/test/datascience/execution.unit.test.ts
+++ b/src/test/datascience/execution.unit.test.ts
@@ -84,7 +84,7 @@ class DisposableRegistry implements IAsyncDisposableRegistry {
     };
 }
 
-suite.only('Jupyter Execution', async () => {
+suite('Jupyter Execution', async () => {
     const interpreterService = mock<IInterpreterService>();
     const jupyterOutputChannel = new MockOutputChannel('');
     const executionFactory = mock(PythonExecutionFactory);

--- a/src/test/datascience/jupyter/serverSelector.unit.test.ts
+++ b/src/test/datascience/jupyter/serverSelector.unit.test.ts
@@ -30,7 +30,7 @@ import { ServerConnectionType } from '../../../kernels/jupyter/launcher/serverCo
 import { JupyterConnection } from '../../../kernels/jupyter/jupyterConnection';
 
 /* eslint-disable , @typescript-eslint/no-explicit-any */
-suite.only('DataScience - Jupyter Server URI Selector', () => {
+suite('DataScience - Jupyter Server URI Selector', () => {
     let quickPick: MockQuickPick | undefined;
     let clipboard: IClipboard;
     let connection: JupyterConnection;

--- a/src/test/datascience/jupyter/serverSelector.unit.test.ts
+++ b/src/test/datascience/jupyter/serverSelector.unit.test.ts
@@ -23,18 +23,17 @@ import { JupyterServerUriStorage } from '../../../kernels/jupyter/launcher/serve
 import { JupyterServerSelector } from '../../../kernels/jupyter/serverSelector';
 import { JupyterUriProviderRegistration } from '../../../kernels/jupyter/jupyterUriProviderRegistration';
 import { Settings } from '../../../platform/common/constants';
-import { HostJupyterExecution } from '../../../kernels/jupyter/launcher/liveshare/hostJupyterExecution';
 import { DataScienceErrorHandler } from '../../../platform/errors/errorHandler';
-import { IJupyterExecution } from '../../../kernels/jupyter/types';
 import { IDisposable } from '../../../platform/common/types';
 import { disposeAllDisposables } from '../../../platform/common/helpers';
 import { ServerConnectionType } from '../../../kernels/jupyter/launcher/serverConnectionType';
+import { JupyterConnection } from '../../../kernels/jupyter/jupyterConnection';
 
 /* eslint-disable , @typescript-eslint/no-explicit-any */
-suite('DataScience - Jupyter Server URI Selector', () => {
+suite.only('DataScience - Jupyter Server URI Selector', () => {
     let quickPick: MockQuickPick | undefined;
     let clipboard: IClipboard;
-    let execution: IJupyterExecution;
+    let connection: JupyterConnection;
     let applicationShell: IApplicationShell;
     const disposables: IDisposable[] = [];
     function createDataScienceObject(
@@ -59,7 +58,7 @@ suite('DataScience - Jupyter Server URI Selector', () => {
         when(workspaceService.getWorkspaceFolderIdentifier(anything())).thenReturn('1');
         when(workspaceService.hasWorkspaceFolders).thenReturn(hasFolders);
         const encryptedStorage = new MockEncryptedStorage();
-        execution = mock(HostJupyterExecution);
+        connection = mock<JupyterConnection>();
         const handler = mock(DataScienceErrorHandler);
         const connectionType = mock<ServerConnectionType>();
         when(connectionType.isLocalLaunch).thenReturn(false);
@@ -80,10 +79,10 @@ suite('DataScience - Jupyter Server URI Selector', () => {
             multiStepFactory,
             instance(picker),
             storage,
-            instance(execution),
             instance(handler),
             instance(applicationShell),
-            instance(configService)
+            instance(configService),
+            instance(connection)
         );
         return { selector, storage };
     }
@@ -237,40 +236,40 @@ suite('DataScience - Jupyter Server URI Selector', () => {
         await selector.selectJupyterURI(true);
         const value = await storage.getUri();
         assert.equal(value, 'https://localhost:1111', 'Validation failed');
-        verify(execution.validateRemoteUri('https://localhost:1111')).once();
+        verify(connection.validateRemoteUri('https://localhost:1111')).once();
     });
 
     test('Remote authorization is asked and works', async () => {
         const { selector, storage } = createDataScienceObject('$(server) Existing', 'https://localhost:1111', true);
-        when(execution.validateRemoteUri(anyString())).thenReject(new Error('reason: self signed certificate'));
+        when(connection.validateRemoteUri(anyString())).thenReject(new Error('reason: self signed certificate'));
         when(applicationShell.showErrorMessage(anything(), anything(), anything())).thenCall((_m, c1, _c2) => {
             return Promise.resolve(c1);
         });
         await selector.selectJupyterURI(true);
         const value = await storage.getUri();
         assert.equal(value, 'https://localhost:1111', 'Validation failed');
-        verify(execution.validateRemoteUri('https://localhost:1111')).once();
+        verify(connection.validateRemoteUri('https://localhost:1111')).once();
     });
 
     test('Remote authorization is asked and skipped', async () => {
         const { selector, storage } = createDataScienceObject('$(server) Existing', 'https://localhost:1111', true);
-        when(execution.validateRemoteUri(anyString())).thenReject(new Error('reason: self signed certificate'));
+        when(connection.validateRemoteUri(anyString())).thenReject(new Error('reason: self signed certificate'));
         when(applicationShell.showErrorMessage(anything(), anything(), anything())).thenCall((_m, _c1, c2) => {
             return Promise.resolve(c2);
         });
         await selector.selectJupyterURI(true);
         const value = await storage.getUri();
         assert.equal(value, 'local', 'Should not be a remote URI');
-        verify(execution.validateRemoteUri('https://localhost:1111')).once();
+        verify(connection.validateRemoteUri('https://localhost:1111')).once();
     });
 
     test('Remote authorization is asked and skipped for a different error', async () => {
         const { selector, storage } = createDataScienceObject('$(server) Existing', 'https://localhost:1111', true);
-        when(execution.validateRemoteUri(anyString())).thenReject(new Error('different error'));
+        when(connection.validateRemoteUri(anyString())).thenReject(new Error('different error'));
         await selector.selectJupyterURI(true);
         const value = await storage.getUri();
         assert.equal(value, 'local', 'Should not be a remote URI');
-        verify(execution.validateRemoteUri('https://localhost:1111')).once();
+        verify(connection.validateRemoteUri('https://localhost:1111')).once();
     });
 
     suite('Default Uri when selecting remote uri', () => {


### PR DESCRIPTION
Fixes #8933 

Basically the long term plan is to remove the JupyterExecution.
Creating connection information and validating connections to remote jupyter servers isn't a responsibility of the JupyterExecution. the class is kinda overloaded.

Moved connection related stuff into JupyterConnection class.