### PR TITLE
Dispose kernelmanager and other classes

### DIFF
--- a/src/kernels/jupyter/session/jupyterSessionManager.ts
+++ b/src/kernels/jupyter/session/jupyterSessionManager.ts
@@ -101,6 +101,13 @@ export class JupyterSessionManager implements IJupyterSessionManager {
                 this.sessionManager.dispose(); // Note, shutting down all will kill all kernels on the same connection. We don't want that.
                 this.sessionManager = undefined;
             }
+            if (!this.kernelManager?.isDisposed) {
+                this.kernelManager?.dispose();
+            }
+            if (!this.specsManager?.isDisposed) {
+                this.specsManager?.dispose();
+                this.specsManager = undefined;
+            }
         } catch (e) {
             traceError(`Exception on session manager shutdown: `, e);
         } finally {


### PR DESCRIPTION
Fixes #9801
Found out why we sometimes have regular 403 errors logged in the console window.

