### PR TITLE
Fix URI to file path conversion

### DIFF
--- a/news/2 Fixes/9928.md
+++ b/news/2 Fixes/9928.md
@@ -1,0 +1,1 @@
+Fix regression in finding the python interpreter for viewing values in the debugger.

--- a/src/interactive-window/commands/commandRegistry.node.ts
+++ b/src/interactive-window/commands/commandRegistry.node.ts
@@ -555,7 +555,7 @@ export class CommandRegistry implements IDisposable, IExtensionSingleActivationS
                     this.interpreterService
                 ) {
                     const pythonEnv = await this.interpreterService.getInterpreterDetails(
-                        this.debugService.activeDebugSession.configuration.python
+                        Uri.file(this.debugService.activeDebugSession.configuration.python)
                     );
                     // Check that we have dependencies installed for data viewer
                     pythonEnv && (await this.dataViewerDependencyService.checkAndInstallMissingDependencies(pythonEnv));


### PR DESCRIPTION
Fixes #9928

Root cause of the regression was turning everything into URIs instead of strings. Data from the debugger was marked as 'any' so never found in conversion.