### PR TITLE
Remove invalid kernel connections

### DIFF
--- a/src/kernels/helpers.ts
+++ b/src/kernels/helpers.ts
@@ -1025,7 +1025,7 @@ export function kernelConnectionMetadataHasKernelModel(
 ): connectionMetadata is LiveRemoteKernelConnectionMetadata {
     return connectionMetadata.kind === 'connectToLiveRemoteKernel';
 }
-export function getKernelId(spec: IJupyterKernelSpec, interpreter?: PythonEnvironment, remoteBaseUrl?: string) {
+export function getKernelId(spec: IJupyterKernelSpec, interpreter?: PythonEnvironment, serverId?: string) {
     // Non-Python kernels cannot contain an interpreter (even in their id).
     interpreter = isPythonKernelSpec(spec) ? interpreter : undefined;
     // Do not include things like display names, as they aren't unique & can change over time.
@@ -1062,7 +1062,7 @@ export function getKernelId(spec: IJupyterKernelSpec, interpreter?: PythonEnviro
         // Lets not assume that non-python kernels cannot have such issues
         argsForGenerationOfId = spec.argv.join('#').toLowerCase();
     }
-    const prefixForRemoteKernels = remoteBaseUrl ? `${remoteBaseUrl}.` : '';
+    const prefixForRemoteKernels = serverId ? `${serverId}.` : '';
     const specPath = getFilePath(getNormalizedInterpreterPath(fsPathToUri(spec.interpreterPath) || spec.uri));
     const interpreterPath = getFilePath(getNormalizedInterpreterPath(interpreter?.uri)) || '';
     return `${prefixForRemoteKernels}${

--- a/src/kernels/jupyter/remoteKernelFinder.ts
+++ b/src/kernels/jupyter/remoteKernelFinder.ts
@@ -68,7 +68,7 @@ export class RemoteKernelFinder implements IRemoteKernelFinder {
                             kind: 'startUsingRemoteKernelSpec',
                             interpreter: await this.getInterpreter(s, connInfo.baseUrl),
                             kernelSpec: s,
-                            id: getKernelId(s, undefined, connInfo.baseUrl),
+                            id: getKernelId(s, undefined, computeUriHash(connInfo.url)),
                             baseUrl: connInfo.baseUrl,
                             serverId: computeUriHash(connInfo.url)
                         };


### PR DESCRIPTION
**Ran into the following scenario (during demo in standup):**

* Open notebook and connect to remote jupyter http://localhost:8888/?token=A
* Run a cell,
* Now we have a kernel connection with id = `localhost:8888,python,.....`
	* Note: The kernel connection id contains the baseUrl of the jupyter server.
* Shutdown the Jupyter server and start a new jupyter server, this time http://localhost:8888/?token=B
* The kernel connection id generated id the same, as the baseUrl hasn't changed.
* However the server url is different.
* Thus when we select the kernel, things fall over.

Solution: Ensure the hash of the url is stored in the kernel id instead of the base url.
This only applies to kernel specifications of remote kernels (live remote kernels have a different id alltogether - its the id of the kernel model)