### PR TITLE
Fix problem where validation happens on acceptance but failure is ignored

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -119,7 +119,6 @@ module.exports = {
         'src/test/performance/load.perf.test.ts',
         'src/test/datascience/mockLanguageServerCache.ts',
         'src/test/datascience/data-viewing/dataViewerPDependencyService.unit.test.ts',
-        'src/test/datascience/mockInputBox.ts',
         'src/test/datascience/crossProcessLock.unit.test.ts',
         'src/test/datascience/mockLanguageServerAnalysisOptions.ts',
         'src/test/datascience/mockLanguageServerProxy.ts',

--- a/src/platform/common/utils/multiStepInput.ts
+++ b/src/platform/common/utils/multiStepInput.ts
@@ -196,7 +196,6 @@ export class MultiStepInput<S> implements IMultiStepInput<S> {
                 input.prompt = prompt;
                 input.ignoreFocusOut = true;
                 input.buttons = [...(this.steps.length > 1 ? [QuickInputButtons.Back] : []), ...(buttons || [])];
-                let validating = validate('');
                 disposables.push(
                     input.onDidTriggerButton((item) => {
                         if (item === QuickInputButtons.Back) {
@@ -209,19 +208,19 @@ export class MultiStepInput<S> implements IMultiStepInput<S> {
                         const inputValue = input.value;
                         input.enabled = false;
                         input.busy = true;
-                        if (!(await validate(inputValue))) {
+                        const validationMessage = await validate(inputValue);
+                        if (!validationMessage) {
+                            input.validationMessage = '';
                             resolve(inputValue);
+                        } else {
+                            input.validationMessage = validationMessage;
                         }
                         input.enabled = true;
                         input.busy = false;
                     }),
-                    input.onDidChangeValue(async (text) => {
-                        const current = validate(text);
-                        validating = current;
-                        const validationMessage = await current;
-                        if (current === validating) {
-                            input.validationMessage = validationMessage;
-                        }
+                    input.onDidChangeValue(async () => {
+                        // Validation happens on acceptance. Just clear as the user types
+                        input.validationMessage = '';
                     }),
                     input.onDidHide(() => {
                         (async () => {

--- a/src/test/datascience/jupyter/serverSelector.unit.test.ts
+++ b/src/test/datascience/jupyter/serverSelector.unit.test.ts
@@ -62,6 +62,7 @@ suite('DataScience - Jupyter Server URI Selector', () => {
         const handler = mock(DataScienceErrorHandler);
         const connectionType = mock<ServerConnectionType>();
         when(connectionType.isLocalLaunch).thenReturn(false);
+        when(connection.validateRemoteUri(anything())).thenResolve();
         const onDidChangeEvent = new EventEmitter<void>();
         disposables.push(onDidChangeEvent);
         when(connectionType.onDidChange).thenReturn(onDidChangeEvent.event);

--- a/src/test/datascience/mockInputBox.ts
+++ b/src/test/datascience/mockInputBox.ts
@@ -59,7 +59,9 @@ export class MockInputBox implements InputBox {
             }, 10);
         }, 10);
     }
-    public hide(): void {}
+    public hide(): void {
+        // Do nothing
+    }
     public dispose(): void {
         // Do nothing
     }

--- a/src/test/datascience/mockInputBox.ts
+++ b/src/test/datascience/mockInputBox.ts
@@ -47,13 +47,19 @@ export class MockInputBox implements InputBox {
                     this.didHideEmitter.fire();
                 } else {
                     this.didAcceptEmitter.fire();
+
+                    // Accept may cause validation failure. Check for that
+                    setTimeout(() => {
+                        if (this.validationMessage) {
+                            this.value = this.validationMessage;
+                            this.didHideEmitter.fire();
+                        }
+                    }, 100);
                 }
             }, 10);
         }, 10);
     }
-    public hide(): void {
-        // Do nothing
-    }
+    public hide(): void {}
     public dispose(): void {
         // Do nothing
     }


### PR DESCRIPTION
Started work on ipywidgets and I was getting a cert error for my jupyter server. 

But it wasn't displayed anywhere. 

Recent changes made the validate async, but not sure how the 'change' event doesn't catch the error. Maybe because validate takes longer now. 

This logic seems better to me. Validate on enter, not while typing, especially if validate is actually going to the server.