### PR TITLE
Handle when Jupyter server handle is not valid

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -288,6 +288,7 @@
     "DataScience.jupyterSelectPasswordPrompt": "Enter your password",
     "DataScience.removeRemoteJupyterServerEntryInQuickPick": "Remove",
     "DataScience.jupyterNotebookFailure": "Jupyter notebook failed to launch. \r\n{0}",
+    "DataScience.remoteJupyterServerProvidedBy3rdPartyExtensionNoLongerValid": "The remote Jupyter Server contributed by the extension '{0}' is no longer available.",
     "DataScience.remoteJupyterConnectionFailedWithServer": "Failed to connect to the remote Jupyter Server '{0}'. Verify the server is running and reachable.",
     "DataScience.remoteJupyterConnectionFailedWithServerWithError":"Failed to connect to the remote Jupyter Server '{0}'. Verify the server is running and reachable. ({1}).",
     "DataScience.remoteJupyterConnectionFailedWithoutServerWithError": "Connection failure. Verify the server is running and reachable. ({0}).",

--- a/src/extension.node.ts
+++ b/src/extension.node.ts
@@ -127,7 +127,8 @@ export async function activate(context: IExtensionContext): Promise<IExtensionAp
             registerRemoteServerProvider: noop,
             showDataViewer: () => Promise.resolve(),
             getKernelService: () => Promise.resolve(undefined),
-            getSuggestedController: () => Promise.resolve(undefined)
+            getSuggestedController: () => Promise.resolve(undefined),
+            addRemoteJupyterServer: () => Promise.resolve(undefined)
         };
     }
 }

--- a/src/extension.web.ts
+++ b/src/extension.web.ts
@@ -118,7 +118,8 @@ export async function activate(context: IExtensionContext): Promise<IExtensionAp
             registerRemoteServerProvider: noop,
             showDataViewer: () => Promise.resolve(),
             getKernelService: () => Promise.resolve(undefined),
-            getSuggestedController: () => Promise.resolve(undefined)
+            getSuggestedController: () => Promise.resolve(undefined),
+            addRemoteJupyterServer: () => Promise.resolve(undefined)
         };
     }
 }

--- a/src/kernels/jupyter/jupyterConnection.ts
+++ b/src/kernels/jupyter/jupyterConnection.ts
@@ -6,6 +6,7 @@ import { IExtensionSyncActivationService } from '../../platform/activation/types
 import { Identifiers } from '../../platform/common/constants';
 import { IDisposableRegistry } from '../../platform/common/types';
 import { RemoteJupyterServerUriProviderError } from '../../platform/errors/remoteJupyterServerUriProviderError';
+import { BaseError } from '../../platform/errors/types';
 import { IJupyterConnection } from '../types';
 import { computeServerId, createRemoteConnectionInfo } from './jupyterUtils';
 import { ServerConnectionType } from './launcher/serverConnectionType';
@@ -110,6 +111,9 @@ export class JupyterConnection implements IExtensionSyncActivationService {
                     }
                 }
             } catch (ex) {
+                if (ex instanceof BaseError) {
+                    throw ex;
+                }
                 throw new RemoteJupyterServerUriProviderError(idAndHandle.id, idAndHandle.handle, ex);
             }
         }

--- a/src/platform/api.ts
+++ b/src/platform/api.ts
@@ -6,6 +6,7 @@
 import { ExtensionMode, NotebookController, NotebookDocument } from 'vscode';
 import { JupyterConnection } from '../kernels/jupyter/jupyterConnection';
 import { computeServerId, generateUriFromRemoteProvider } from '../kernels/jupyter/jupyterUtils';
+import { JupyterServerSelector } from '../kernels/jupyter/serverSelector';
 import { IJupyterUriProvider, IJupyterUriProviderRegistration, JupyterServerUriHandle } from '../kernels/jupyter/types';
 import { INotebookControllerManager, INotebookEditorProvider } from '../notebooks/types';
 import { IDataViewerDataProvider, IDataViewerFactory } from '../webviews/extension-side/dataviewer/types';
@@ -59,6 +60,11 @@ export interface IExtensionApi {
         handle: JupyterServerUriHandle,
         notebook: NotebookDocument
     ): Promise<NotebookController | undefined>;
+    /**
+     * Adds a remote Jupyter Server to the list of Remote Jupyter servers.
+     * This will result in the Jupyter extension listing kernels from this server as items in the kernel picker.
+     */
+    addRemoteJupyterServer(id: string, handle: JupyterServerUriHandle): Promise<void>;
 }
 
 export function buildApi(
@@ -112,6 +118,13 @@ export function buildApi(
             const serverId = computeServerId(uri);
             const { controller } = await controllers.computePreferredNotebookController(notebook, serverId);
             return controller?.controller;
+        },
+        addRemoteJupyterServer: async (id: string, handle: JupyterServerUriHandle) => {
+            const connection = serviceContainer.get<JupyterConnection>(JupyterConnection);
+            const selector = serviceContainer.get<JupyterServerSelector>(JupyterServerSelector);
+            const uri = generateUriFromRemoteProvider(id, handle);
+            await connection.updateServerUri(uri);
+            await selector.setJupyterURIToRemote(uri);
         }
     };
 

--- a/src/platform/api.ts
+++ b/src/platform/api.ts
@@ -64,7 +64,7 @@ export interface IExtensionApi {
      * Adds a remote Jupyter Server to the list of Remote Jupyter servers.
      * This will result in the Jupyter extension listing kernels from this server as items in the kernel picker.
      */
-    addRemoteJupyterServer(id: string, handle: JupyterServerUriHandle): Promise<void>;
+    addRemoteJupyterServer(providerId: string, handle: JupyterServerUriHandle): Promise<void>;
 }
 
 export function buildApi(
@@ -119,10 +119,10 @@ export function buildApi(
             const { controller } = await controllers.computePreferredNotebookController(notebook, serverId);
             return controller?.controller;
         },
-        addRemoteJupyterServer: async (id: string, handle: JupyterServerUriHandle) => {
+        addRemoteJupyterServer: async (providerId: string, handle: JupyterServerUriHandle) => {
             const connection = serviceContainer.get<JupyterConnection>(JupyterConnection);
             const selector = serviceContainer.get<JupyterServerSelector>(JupyterServerSelector);
-            const uri = generateUriFromRemoteProvider(id, handle);
+            const uri = generateUriFromRemoteProvider(providerId, handle);
             await connection.updateServerUri(uri);
             await selector.setJupyterURIToRemote(uri);
         }

--- a/src/platform/common/utils/localize.ts
+++ b/src/platform/common/utils/localize.ts
@@ -553,6 +553,10 @@ export namespace DataScience {
         'DataScience.jupyterNotebookFailure',
         'Jupyter notebook failed to launch. \r\n{0}'
     );
+    export const remoteJupyterServerProvidedBy3rdPartyExtensionNoLongerValid = localize(
+        'DataScience.remoteJupyterServerProvidedBy3rdPartyExtensionNoLongerValid',
+        "The remote Jupyter Server contributed by the extension '{0}' is no longer available."
+    );
     export const remoteJupyterConnectionFailedWithServerWithError = localize(
         'DataScience.remoteJupyterConnectionFailedWithServerWithError',
         "Failed to connect to the remote Jupyter Server '{0}'. Verify the server is running and reachable. ({1})."

--- a/src/platform/errors/invalidRemoteJupyterServerUriHandleError.ts
+++ b/src/platform/errors/invalidRemoteJupyterServerUriHandleError.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { computeServerId, generateUriFromRemoteProvider } from '../../kernels/jupyter/jupyterUtils';
+import { BaseError } from './types';
+
+export class InvalidRemoteJupyterServerUriHandleError extends BaseError {
+    public readonly serverId: string;
+    constructor(
+        public readonly providerId: string,
+        public readonly handle: string,
+        public readonly extensionId: string
+    ) {
+        super('invalidremotejupyterserverurihandle', 'Server handle not in list of known handles');
+        this.serverId = computeServerId(generateUriFromRemoteProvider(providerId, handle));
+    }
+}

--- a/src/platform/errors/types.ts
+++ b/src/platform/errors/types.ts
@@ -103,6 +103,7 @@ export type ErrorCategory =
     | 'remotejupyterserverconnection'
     | 'localjupyterserverconnection'
     | 'remotejupyterserveruriprovider'
+    | 'invalidremotejupyterserverurihandle'
     | 'unknown';
 
 // If there are errors, then the are added to the telementry properties.

--- a/src/test/datascience/errorHandler.unit.test.ts
+++ b/src/test/datascience/errorHandler.unit.test.ts
@@ -9,7 +9,7 @@ import { Uri, WorkspaceFolder } from 'vscode';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../../platform/common/application/types';
 import { getDisplayPath } from '../../platform/common/platform/fs-paths';
 import { Common, DataScience } from '../../platform/common/utils/localize';
-import { IBrowserService, IConfigurationService } from '../../platform/common/types';
+import { IBrowserService, IConfigurationService, IExtensions } from '../../platform/common/types';
 import {
     IKernelDependencyService,
     KernelConnectionMetadata,
@@ -46,6 +46,7 @@ suite('DataScience Error Handler Unit Tests', () => {
     let kernelDependencyInstaller: IKernelDependencyService;
     let uriStorage: IJupyterServerUriStorage;
     let cmdManager: ICommandManager;
+    let extensions: IExtensions;
     const jupyterInterpreter: PythonEnvironment = {
         displayName: 'Hello',
         uri: Uri.file('Some Path'),
@@ -65,6 +66,7 @@ suite('DataScience Error Handler Unit Tests', () => {
         when(workspaceService.workspaceFolders).thenReturn([]);
         kernelDependencyInstaller = mock<IKernelDependencyService>();
         when(kernelDependencyInstaller.areDependenciesInstalled(anything(), anything(), anything())).thenResolve(true);
+        when(extensions.getExtension(anything())).thenReturn({ packageJSON: { displayName: '' } } as any);
         dataScienceErrorHandler = new DataScienceErrorHandler(
             instance(applicationShell),
             instance(dependencyManager),
@@ -74,7 +76,8 @@ suite('DataScience Error Handler Unit Tests', () => {
             instance(workspaceService),
             instance(uriStorage),
             instance(cmdManager),
-            false
+            false,
+            instance(extensions)
         );
         when(applicationShell.showErrorMessage(anything())).thenResolve();
         when(applicationShell.showErrorMessage(anything(), anything())).thenResolve();

--- a/src/test/datascience/errorHandler.unit.test.ts
+++ b/src/test/datascience/errorHandler.unit.test.ts
@@ -62,6 +62,7 @@ suite('DataScience Error Handler Unit Tests', () => {
         uriStorage = mock<IJupyterServerUriStorage>();
         cmdManager = mock<ICommandManager>();
         jupyterInterpreterService = mock<JupyterInterpreterService>();
+        extensions = mock<IExtensions>();
         when(dependencyManager.installMissingDependencies(anything())).thenResolve();
         when(workspaceService.workspaceFolders).thenReturn([]);
         kernelDependencyInstaller = mock<IKernelDependencyService>();


### PR DESCRIPTION
Part of #9683

**Fixes**
* If the `handle` we have is no longer valid, then connecting to Juypyter will no longer work as the 3rd party extension doesn't support the old `handle` that was initially returned.
	* We now display a message if the handle is outdated and allow the user to forget that connection (each connection is unique per `providerId+handle`)
* Added a new method to add a remote jupyter server uri instead of using a command (as per suggestion from Peng)
	* Makes sense as thats a more concrete API with types.