### PR TITLE
Support storing multiple Uris in uri storage

### DIFF
--- a/src/kernels/jupyter/commands/serverSelector.ts
+++ b/src/kernels/jupyter/commands/serverSelector.ts
@@ -43,7 +43,7 @@ export class JupyterServerSelectorCommand implements IDisposable {
             traceInfo(`Setting Jupyter Server URI to remote: ${source}`);
 
             // Set the uri directly
-            await this.serverSelector.setJupyterURIToRemote(source.toString(true));
+            await this.serverSelector.addRemoteJupyterUri(source.toString(true));
 
             // Find one that is the default for this remote
             if (notebook) {

--- a/src/kernels/jupyter/launcher/serverUriStorage.ts
+++ b/src/kernels/jupyter/launcher/serverUriStorage.ts
@@ -18,7 +18,8 @@ import { ServerConnectionType } from './serverConnectionType';
  */
 @injectable()
 export class JupyterServerUriStorage implements IJupyterServerUriStorage {
-    private currentUriPromise: Promise<string> | undefined;
+    private remoteUris: string[] = [];
+    private currentUriPromise: Promise<string[]> | undefined;
     private _onDidChangeUri = new EventEmitter<void>();
     public get onDidChangeUri() {
         return this._onDidChangeUri.event;
@@ -36,7 +37,7 @@ export class JupyterServerUriStorage implements IJupyterServerUriStorage {
         @inject(ServerConnectionType) private readonly serverConnectionType: ServerConnectionType
     ) {
         // Cache our current state so we don't keep asking for it from the encrypted storage
-        this.getUri().ignoreErrors();
+        this.getUris().ignoreErrors();
     }
     public async addToUriList(uri: string, time: number, displayName: string) {
         // Uri list is saved partially in the global memento and partially in encrypted storage
@@ -55,14 +56,15 @@ export class JupyterServerUriStorage implements IJupyterServerUriStorage {
         return this.updateMemento(editedList);
     }
     public async removeUri(uri: string) {
-        const activeUri = await this.getUri();
+        const activeUris = await this.getUris();
         // Start with saved list.
         const uriList = await this.getSavedUriList();
 
         // Remove this uri if already found (going to add again with a new time)
         const editedList = uriList.filter((f) => f.uri !== uri);
         await this.updateMemento(editedList);
-        if (activeUri === uri) {
+        activeUris.splice(activeUris.indexOf(uri), 1);
+        if (activeUris.length === 0) {
             await this.setUriToLocal();
         }
         this._onDidRemoveUri.fire(uri);
@@ -140,58 +142,56 @@ export class JupyterServerUriStorage implements IJupyterServerUriStorage {
             undefined
         );
     }
-    public getUri(): Promise<string> {
+    private getUris(): Promise<string[]> {
         if (!this.currentUriPromise) {
             this.currentUriPromise = this.getUriInternal();
         }
 
         return this.currentUriPromise;
     }
-    public async getRemoteUri(): Promise<string | undefined> {
-        const uri = await this.getUri();
-        switch (uri) {
-            case Settings.JupyterServerLocalLaunch:
-                return;
-            case Settings.JupyterServerRemoteLaunch:
-                // In `getUriInternal` its not possible for us to end up with Settings.JupyterServerRemoteLaunch.
-                // If we do, then this means the uri was never saved or not in encrypted store, hence no point returning and invalid entry.
-                return;
-            default:
-                return uri;
-        }
+    public async getRemoteUris(): Promise<string[]> {
+        return this.getUris();
     }
     public async setUriToLocal(): Promise<void> {
-        await this.setUri(Settings.JupyterServerLocalLaunch);
-    }
-    public async setUriToRemote(uri: string, displayName: string): Promise<void> {
-        await this.setUri(uri);
-        await this.addToUriList(uri, Date.now(), displayName);
-    }
-
-    public async setUri(uri: string) {
-        // Set the URI as our current state
-        this.currentUriPromise = Promise.resolve(uri);
-        if (uri === Settings.JupyterServerLocalLaunch) {
-            await this.serverConnectionType.setIsLocalLaunch(true);
-        } else {
-            await this.addToUriList(uri, Date.now(), uri);
-            await this.serverConnectionType.setIsLocalLaunch(false);
-
-            // Save in the storage (unique account per workspace)
-            const key = this.getUriAccountKey();
-            await this.encryptedStorage.store(Settings.JupyterServerRemoteLaunchService, key, uri);
-        }
+        this.remoteUris = [];
+        this.currentUriPromise = Promise.resolve(this.remoteUris);
+        await this.serverConnectionType.setIsLocalLaunch(true);
         this._onDidChangeUri.fire();
     }
-    private async getUriInternal(): Promise<string> {
+    public async addRemoteUri(uri: string, displayName: string): Promise<void> {
+        this.remoteUris.push(uri);
+        // Set the URI as our current state
+        this.currentUriPromise = Promise.resolve(this.remoteUris);
+        await this.addToUriList(uri, Date.now(), displayName);
+        await this.serverConnectionType.setIsLocalLaunch(false);
+
+        // Save in the storage (unique account per workspace)
+        await this.encryptedStorage.store(
+            Settings.JupyterServerRemoteLaunchService,
+            this.getUrisAccountKey(),
+            JSON.stringify(this.remoteUris)
+        );
+        this._onDidChangeUri.fire();
+    }
+
+    private async getUriInternal(): Promise<string[]> {
         if (this.serverConnectionType.isLocalLaunch) {
-            return Settings.JupyterServerLocalLaunch;
+            return [];
         } else {
             // Should be stored in encrypted storage based on the workspace
-            const key = this.getUriAccountKey();
-            const storedUri = await this.encryptedStorage.retrieve(Settings.JupyterServerRemoteLaunchService, key);
-
-            return storedUri || Settings.JupyterServerLocalLaunch;
+            const [storedUri, storedUrisStr] = await Promise.all([
+                // Old keys when we only supported one Uri.
+                this.encryptedStorage.retrieve(Settings.JupyterServerRemoteLaunchService, this.getUriAccountKey()),
+                this.encryptedStorage.retrieve(Settings.JupyterServerRemoteLaunchService, this.getUrisAccountKey())
+            ]);
+            let storedUris: string[] | undefined;
+            try {
+                storedUris = storedUrisStr ? JSON.parse(storedUrisStr) : undefined;
+            } catch {
+                //
+            }
+            this.remoteUris = Array.isArray(storedUris) ? storedUris : storedUri ? [storedUri] : [];
+            return this.remoteUris;
         }
     }
 
@@ -207,5 +207,8 @@ export class JupyterServerUriStorage implements IJupyterServerUriStorage {
             return this.crypto.createHash(getFilePath(this.workspaceService.workspaceFile), 'string', 'SHA512');
         }
         return this.appEnv.machineId; // Global key when no folder or workspace file
+    }
+    private getUrisAccountKey() {
+        return `${this.getUriAccountKey()}_MULTIPLE`;
     }
 }

--- a/src/kernels/jupyter/launcher/serverUriStorage.ts
+++ b/src/kernels/jupyter/launcher/serverUriStorage.ts
@@ -159,6 +159,7 @@ export class JupyterServerUriStorage implements IJupyterServerUriStorage {
         this._onDidChangeUri.fire();
     }
     public async addRemoteUri(uri: string, displayName: string): Promise<void> {
+        await this.getUris();
         this.remoteUris.push(uri);
         // Set the URI as our current state
         this.currentUriPromise = Promise.resolve(this.remoteUris);

--- a/src/kernels/jupyter/launcher/serverUriStorage.ts
+++ b/src/kernels/jupyter/launcher/serverUriStorage.ts
@@ -144,7 +144,7 @@ export class JupyterServerUriStorage implements IJupyterServerUriStorage {
     }
     private getUris(): Promise<string[]> {
         if (!this.currentUriPromise) {
-            this.currentUriPromise = this.getUriInternal();
+            this.currentUriPromise = this.getUrisInternal();
         }
 
         return this.currentUriPromise;
@@ -175,7 +175,7 @@ export class JupyterServerUriStorage implements IJupyterServerUriStorage {
         this._onDidChangeUri.fire();
     }
 
-    private async getUriInternal(): Promise<string[]> {
+    private async getUrisInternal(): Promise<string[]> {
         if (this.serverConnectionType.isLocalLaunch) {
             return [];
         } else {

--- a/src/kernels/jupyter/types.ts
+++ b/src/kernels/jupyter/types.ts
@@ -236,9 +236,9 @@ export interface IJupyterServerUriStorage {
     getSavedUriList(): Promise<{ uri: string; time: number; displayName?: string }[]>;
     removeUri(uri: string): Promise<void>;
     clearUriList(): Promise<void>;
-    getRemoteUri(): Promise<string | undefined>;
+    getRemoteUris(): Promise<string[]>;
     setUriToLocal(): Promise<void>;
-    setUriToRemote(uri: string, displayName: string): Promise<void>;
+    addRemoteUri(uri: string, displayName: string): Promise<void>;
 }
 
 export const IJupyterBackingFileCreator = Symbol('IJupyterBackingFileCreator');

--- a/src/kernels/kernelFinder.base.ts
+++ b/src/kernels/kernelFinder.base.ts
@@ -247,8 +247,8 @@ export abstract class BaseKernelFinder implements IKernelFinder {
         cancelToken?: CancellationToken
     ): Promise<INotebookProviderConnection | undefined> {
         const ui = new DisplayOptions(false);
-        const uri = await this.serverUriStorage.getRemoteUri();
-        if (!uri) {
+        const uris = await this.serverUriStorage.getRemoteUris();
+        if (uris.length === 0) {
             return;
         }
         return this.notebookProvider.connect({
@@ -256,7 +256,7 @@ export abstract class BaseKernelFinder implements IKernelFinder {
             ui,
             localJupyter: false,
             token: cancelToken,
-            serverId: computeServerId(uri)
+            serverId: computeServerId(uris[0])
         });
     }
 

--- a/src/notebooks/controllers/remoteSwitcher.ts
+++ b/src/notebooks/controllers/remoteSwitcher.ts
@@ -18,7 +18,6 @@ import { JupyterServerSelector } from '../../kernels/jupyter/serverSelector';
 import { isJupyterNotebook } from '../helpers';
 import { INotebookControllerManager } from '../types';
 import { IJupyterServerUriStorage } from '../../kernels/jupyter/types';
-import { Settings } from '../../platform/common/constants';
 
 @injectable()
 export class RemoteSwitcher implements IExtensionSingleActivationService {
@@ -65,11 +64,11 @@ export class RemoteSwitcher implements IExtensionSingleActivationService {
             return;
         }
         this.statusBarItem.show();
-        const uri = await this.serverUriStorage.getRemoteUri();
+        const uri = await this.serverUriStorage.getRemoteUris();
         const label = !uri
             ? DataScience.jupyterNativeNotebookUriStatusLabelForLocal()
             : DataScience.jupyterNativeNotebookUriStatusLabelForRemote();
-        const tooltipSuffix = uri === Settings.JupyterServerLocalLaunch ? '' : ` (${uri})`;
+        const tooltipSuffix = uri.length === 0 ? '' : ` (${uri.join(',')})`;
         const tooltip = `${DataScience.specifyLocalOrRemoteJupyterServerForConnections()}${tooltipSuffix}`;
         this.statusBarItem.text = `$(debug-disconnect) ${label}`;
         this.statusBarItem.tooltip = tooltip;

--- a/src/platform/api.ts
+++ b/src/platform/api.ts
@@ -124,7 +124,7 @@ export function buildApi(
             const selector = serviceContainer.get<JupyterServerSelector>(JupyterServerSelector);
             const uri = generateUriFromRemoteProvider(providerId, handle);
             await connection.updateServerUri(uri);
-            await selector.setJupyterURIToRemote(uri);
+            await selector.addRemoteJupyterUri(uri);
         }
     };
 

--- a/src/test/datascience/commands/serverSelector.unit.test.ts
+++ b/src/test/datascience/commands/serverSelector.unit.test.ts
@@ -62,6 +62,6 @@ suite('DataScience - Server Selector Command', () => {
 
         handler();
 
-        verify(serverSelector.setJupyterURIToRemote('http://localhost:1234/')).once();
+        verify(serverSelector.addRemoteJupyterUri('http://localhost:1234/')).once();
     });
 });

--- a/src/test/datascience/interactive-common/notebookServerProvider.unit.test.ts
+++ b/src/test/datascience/interactive-common/notebookServerProvider.unit.test.ts
@@ -41,8 +41,7 @@ suite('DataScience - NotebookServerProvider', () => {
         interpreterService = mock<IInterpreterService>();
 
         const serverStorage = mock(JupyterServerUriStorage);
-        when(serverStorage.getUri()).thenResolve('local');
-        when(serverStorage.getRemoteUri()).thenResolve();
+        when(serverStorage.getRemoteUris()).thenResolve();
         const eventEmitter = new EventEmitter<void>();
         disposables.push(eventEmitter);
         when(serverStorage.onDidChangeUri).thenReturn(eventEmitter.event);

--- a/src/test/datascience/jupyter/serverSelector.unit.test.ts
+++ b/src/test/datascience/jupyter/serverSelector.unit.test.ts
@@ -98,13 +98,13 @@ suite('DataScience - Jupyter Server URI Selector', () => {
     test('Local pick server uri', async () => {
         const { selector, storage } = createDataScienceObject('$(zap) Default', '', true);
         await selector.selectJupyterURI(true);
-        let value = await storage.getUri();
-        assert.equal(value, Settings.JupyterServerLocalLaunch, 'Default should pick local launch');
+        let value = await storage.getRemoteUris();
+        assert.isEmpty(value);
 
         // Try a second time.
         await selector.selectJupyterURI(true);
-        value = await storage.getUri();
-        assert.equal(value, Settings.JupyterServerLocalLaunch, 'Default should pick local launch');
+        value = await storage.getRemoteUris();
+        assert.isEmpty(value);
 
         // Verify active items
         assert.equal(quickPick?.items.length, 2, 'Wrong number of items in the quick pick');
@@ -113,13 +113,13 @@ suite('DataScience - Jupyter Server URI Selector', () => {
     test('Local pick server uri with no workspace', async () => {
         const { selector, storage } = createDataScienceObject('$(zap) Default', '', false);
         await selector.selectJupyterURI(true);
-        let value = await storage.getUri();
-        assert.equal(value, Settings.JupyterServerLocalLaunch, 'Default should pick local launch');
+        let value = await storage.getRemoteUris();
+        assert.isEmpty(value);
 
         // Try a second time.
         await selector.selectJupyterURI(true);
-        value = await storage.getUri();
-        assert.equal(value, Settings.JupyterServerLocalLaunch, 'Default should pick local launch');
+        value = await storage.getRemoteUris();
+        assert.isEmpty(value);
 
         // Verify active items
         assert.equal(quickPick?.items.length, 2, 'Wrong number of items in the quick pick');
@@ -193,52 +193,51 @@ suite('DataScience - Jupyter Server URI Selector', () => {
     test('Remote server uri', async () => {
         const { selector, storage } = createDataScienceObject('$(server) Existing', 'http://localhost:1111', true);
         await selector.selectJupyterURI(true);
-        const value = await storage.getUri();
-        assert.equal(value, 'http://localhost:1111', 'Already running should end up with the user inputed value');
+        const value = await storage.getRemoteUris();
+        assert.equal(value[0], 'http://localhost:1111', 'Already running should end up with the user inputed value');
     });
     test('Remote server uri no workspace', async () => {
         const { selector, storage } = createDataScienceObject('$(server) Existing', 'http://localhost:1111', false);
         await selector.selectJupyterURI(true);
-        const value = await storage.getUri();
-        assert.equal(value, 'http://localhost:1111', 'Already running should end up with the user inputed value');
+        const value = await storage.getRemoteUris();
+        assert.equal(value[0], 'http://localhost:1111', 'Already running should end up with the user inputed value');
     });
 
     test('Remote server uri no local', async () => {
         const { selector, storage } = createDataScienceObject('$(server) Existing', 'http://localhost:1111', true);
         await selector.selectJupyterURI(false);
-        const value = await storage.getUri();
-        assert.equal(value, 'http://localhost:1111', 'Already running should end up with the user inputed value');
+        const value = await storage.getRemoteUris();
+        assert.equal(value[0], 'http://localhost:1111', 'Already running should end up with the user inputed value');
     });
 
     test('Remote server uri (reload VSCode if there is a change in settings)', async () => {
         const { selector, storage } = createDataScienceObject('$(server) Existing', 'http://localhost:1111', true);
         await selector.selectJupyterURI(true);
-        const value = await storage.getUri();
-        assert.equal(value, 'http://localhost:1111', 'Already running should end up with the user inputed value');
+        const value = await storage.getRemoteUris();
+        assert.equal(value[0], 'http://localhost:1111', 'Already running should end up with the user inputed value');
     });
 
     test('Remote server uri (do not reload VSCode if there is no change in settings)', async () => {
         const { selector, storage } = createDataScienceObject('$(server) Existing', 'http://localhost:1111', true);
-        await storage.setUri('http://localhost:1111');
+        await storage.addRemoteUri('http://localhost:1111', 'http://localhost:1111');
 
         await selector.selectJupyterURI(true);
-        const value = await storage.getUri();
-        assert.equal(value, 'http://localhost:1111', 'Already running should end up with the user inputed value');
+        const value = await storage.getRemoteUris();
+        assert.equal(value[0], 'http://localhost:1111', 'Already running should end up with the user inputed value');
     });
 
     test('Invalid server uri', async () => {
         const { selector, storage } = createDataScienceObject('$(server) Existing', 'httx://localhost:1111', true);
         await selector.selectJupyterURI(true);
-        const value = await storage.getUri();
-        assert.notEqual(value, 'httx://localhost:1111', 'Already running should validate');
-        assert.equal(value, 'local', 'Validation failed');
+        const value = await storage.getRemoteUris();
+        assert.isEmpty(value);
     });
 
     test('Server is validated', async () => {
         const { selector, storage } = createDataScienceObject('$(server) Existing', 'https://localhost:1111', true);
         await selector.selectJupyterURI(true);
-        const value = await storage.getUri();
-        assert.equal(value, 'https://localhost:1111', 'Validation failed');
+        const value = await storage.getRemoteUris();
+        assert.equal(value[0], 'https://localhost:1111', 'Validation failed');
         verify(connection.validateRemoteUri('https://localhost:1111')).atLeast(1);
     });
 
@@ -251,8 +250,8 @@ suite('DataScience - Jupyter Server URI Selector', () => {
             return Promise.resolve(c1);
         });
         await selector.selectJupyterURI(true);
-        const value = await storage.getUri();
-        assert.equal(value, 'https://localhost:1111', 'Validation failed');
+        const value = await storage.getRemoteUris();
+        assert.equal(value[0], 'https://localhost:1111', 'Validation failed');
         verify(connection.validateRemoteUri('https://localhost:1111')).atLeast(1);
     });
     test('Remote authorization is asked when ssl cert has expired is invalid and works', async () => {
@@ -264,8 +263,8 @@ suite('DataScience - Jupyter Server URI Selector', () => {
             return Promise.resolve(c1);
         });
         await selector.selectJupyterURI(true);
-        const value = await storage.getUri();
-        assert.equal(value, 'https://localhost:1111', 'Validation failed');
+        const value = await storage.getRemoteUris();
+        assert.equal(value[0], 'https://localhost:1111', 'Validation failed');
         verify(connection.validateRemoteUri('https://localhost:1111')).atLeast(1);
     });
 
@@ -276,8 +275,8 @@ suite('DataScience - Jupyter Server URI Selector', () => {
             return Promise.resolve(c2);
         });
         await selector.selectJupyterURI(true);
-        const value = await storage.getUri();
-        assert.equal(value, 'local', 'Should not be a remote URI');
+        const value = await storage.getRemoteUris();
+        assert.isEmpty(value);
         verify(connection.validateRemoteUri('https://localhost:1111')).once();
     });
 
@@ -285,8 +284,8 @@ suite('DataScience - Jupyter Server URI Selector', () => {
         const { selector, storage } = createDataScienceObject('$(server) Existing', 'https://localhost:1111', true);
         when(connection.validateRemoteUri(anyString())).thenReject(new Error('Failed to connect to remote server'));
         await selector.selectJupyterURI(true);
-        const value = await storage.getUri();
-        assert.equal(value, 'local', 'Should not be a remote URI');
+        const value = await storage.getRemoteUris();
+        assert.isEmpty(value);
         verify(connection.validateRemoteUri('https://localhost:1111')).once();
     });
 
@@ -294,8 +293,8 @@ suite('DataScience - Jupyter Server URI Selector', () => {
         const { selector, storage } = createDataScienceObject('$(server) Existing', 'https://localhost:1111', true);
         when(connection.validateRemoteUri(anyString())).thenReject(new Error('different error'));
         await selector.selectJupyterURI(true);
-        const value = await storage.getUri();
-        assert.equal(value, 'local', 'Should not be a remote URI');
+        const value = await storage.getRemoteUris();
+        assert.isEmpty(value);
         verify(connection.validateRemoteUri('https://localhost:1111')).once();
     });
 

--- a/src/test/datascience/kernel-launcher/remoteKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/remoteKernelFinder.unit.test.ts
@@ -148,8 +148,7 @@ suite(`Remote Kernel Finder`, () => {
         when(fs.deleteLocalFile(anything())).thenResolve();
         when(fs.localFileExists(anything())).thenResolve(true);
         const serverUriStorage = mock(JupyterServerUriStorage);
-        when(serverUriStorage.getUri()).thenResolve(connInfo.baseUrl);
-        when(serverUriStorage.getRemoteUri()).thenResolve(connInfo.baseUrl);
+        when(serverUriStorage.getRemoteUris()).thenResolve([connInfo.baseUrl]);
         const connectionType = mock<ServerConnectionType>();
         when(connectionType.isLocalLaunch).thenReturn(false);
         when(connectionType.setIsLocalLaunch(anything())).thenResolve();

--- a/src/test/datascience/notebook/remoteNotebookEditor.vscode.test.ts
+++ b/src/test/datascience/notebook/remoteNotebookEditor.vscode.test.ts
@@ -122,7 +122,7 @@ suite('DataScience - VSCode Notebook - (Remote) (Execution) (slow)', function ()
         const uriString = decodeURIComponent(uri.toString());
         traceInfo(`Another Jupyter started and listening at ${uriString}`);
         await jupyterServerSelector.setJupyterURIToLocal();
-        await jupyterServerSelector.setJupyterURIToRemote(uriString);
+        await jupyterServerSelector.addRemoteJupyterUri(uriString);
 
         // Opening a notebook will trigger the refresh of the kernel list.
         nbUri = await createTemporaryNotebook([], disposables);


### PR DESCRIPTION
Part of #9683 and #9684

Simple change that merely supports storing multiple Uris instead of just one.