### PR TITLE
Add new message for failures in the web.

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -292,6 +292,7 @@
     "DataScience.remoteJupyterConnectionFailedWithServer": "Failed to connect to the remote Jupyter Server '{0}'. Verify the server is running and reachable.",
     "DataScience.remoteJupyterConnectionFailedWithServerWithError":"Failed to connect to the remote Jupyter Server '{0}'. Verify the server is running and reachable. ({1}).",
     "DataScience.remoteJupyterConnectionFailedWithoutServerWithError": "Connection failure. Verify the server is running and reachable. ({0}).",
+    "DataScience.remoteJupyterConnectionFailedWithoutServerWithErrorWeb": "Connection failure. Verify the server is running and reachable from a browser. See 'https://aka.ms/vscjremoteweb' for more information.",
     "DataScience.jupyterNotebookRemoteConnectFailedWeb": "Failed to connect to remote Jupyter server.\r\nCheck that the Jupyter Server URI can be reached from a browser.\r\n{0}. Click [here](https://aka.ms/vscjremoteweb) for more information.",
     "DataScience.jupyterNotebookRemoteConnectSelfCertsFailed": "Failed to connect to remote Jupyter notebook.\r\nSpecified server is using self signed certs. Enable Allow Unauthorized Remote Connection setting to connect anyways\r\n{0}\r\n{1}",
     "DataScience.changeJupyterRemoteConnection": "Change Jupyter Server connection.",

--- a/src/kernels/jupyter/serverSelector.ts
+++ b/src/kernels/jupyter/serverSelector.ts
@@ -279,10 +279,12 @@ export class JupyterServerSelector {
                 if (!handled) {
                     return DataScience.jupyterSelfCertExpiredErrorMessageOnly();
                 }
-            } else {
+            } else if (!this.isWebExtension) {
                 return DataScience.remoteJupyterConnectionFailedWithoutServerWithError().format(
                     err.message || err.toString()
                 );
+            } else {
+                return DataScience.remoteJupyterConnectionFailedWithoutServerWithErrorWeb();
             }
         }
     };

--- a/src/platform/common/utils/localize.ts
+++ b/src/platform/common/utils/localize.ts
@@ -569,6 +569,10 @@ export namespace DataScience {
         'DataScience.remoteJupyterConnectionFailedWithoutServerWithError',
         'Connection failure. Verify the server is running and reachable. ({0}).'
     );
+    export const remoteJupyterConnectionFailedWithoutServerWithErrorWeb = localize(
+        'DataScience.remoteJupyterConnectionFailedWithoutServerWithErrorWeb',
+        'Connection failure. Verify the server is running and reachable from a browser. See https://aka.ms/vscjremoteweb for more information.'
+    );
     export const removeRemoteJupyterConnectionButtonText = localize(
         'DataScience.removeRemoteJupyterConnectionButtonText',
         'Forget Connection'


### PR DESCRIPTION
I noticed this yesterday and forgot to fix it. The validation message isn't very helpful for web failures. It just says 'TypeError: Failed to fetch'.

This message gives more information.