### PR TITLE
Removing path-browserify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27864,7 +27864,7 @@
                 "minimist": "~1.2.0",
                 "moment": "^2.24.0",
                 "path-browserify": "^1.0.0",
-                "url-parse": "1.5.8"
+                "url-parse": "~1.5.1"
             }
         },
         "@jupyterlab/nbformat": {
@@ -31393,7 +31393,7 @@
             "requires": {
                 "@mapbox/node-pre-gyp": "^1.0.0",
                 "nan": "^2.15.0",
-                "simple-get": "3.1.1"
+                "simple-get": "^3.0.3"
             }
         },
         "caseless": {
@@ -45473,7 +45473,8 @@
             }
         },
         "url-parse": {
-            "version": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
             "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
             "requires": {
                 "querystringify": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,7 +139,6 @@
                 "@types/nock": "^10.0.3",
                 "@types/node": "^14.17.4",
                 "@types/node-fetch": "^2.5.7",
-                "@types/path-browserify": "^1.0.0",
                 "@types/pdfkit": "^0.11.0",
                 "@types/promisify-node": "^0.4.0",
                 "@types/react": "^16.4.14",
@@ -280,7 +279,7 @@
                 "yargs-parser": "^13.1.2"
             },
             "engines": {
-                "vscode": "^1.67.0-insider"
+                "vscode": "^1.68.0-insider"
             },
             "optionalDependencies": {
                 "canvas": "^2.7.0",
@@ -3887,12 +3886,6 @@
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
             "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
-            "dev": true
-        },
-        "node_modules/@types/path-browserify": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@types/path-browserify/-/path-browserify-1.0.0.tgz",
-            "integrity": "sha512-XMCcyhSvxcch8b7rZAtFAaierBYdeHXVvg2iYnxOV0MCQHmPuRRmGZPFDRzPayxcGiiSL1Te9UIO+f3cuj0tfw==",
             "dev": true
         },
         "node_modules/@types/pdfkit": {
@@ -27871,7 +27864,7 @@
                 "minimist": "~1.2.0",
                 "moment": "^2.24.0",
                 "path-browserify": "^1.0.0",
-                "url-parse": "~1.5.1"
+                "url-parse": "1.5.8"
             }
         },
         "@jupyterlab/nbformat": {
@@ -28954,12 +28947,6 @@
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
             "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
-            "dev": true
-        },
-        "@types/path-browserify": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@types/path-browserify/-/path-browserify-1.0.0.tgz",
-            "integrity": "sha512-XMCcyhSvxcch8b7rZAtFAaierBYdeHXVvg2iYnxOV0MCQHmPuRRmGZPFDRzPayxcGiiSL1Te9UIO+f3cuj0tfw==",
             "dev": true
         },
         "@types/pdfkit": {
@@ -31406,7 +31393,7 @@
             "requires": {
                 "@mapbox/node-pre-gyp": "^1.0.0",
                 "nan": "^2.15.0",
-                "simple-get": "^3.0.3"
+                "simple-get": "3.1.1"
             }
         },
         "caseless": {
@@ -45486,8 +45473,7 @@
             }
         },
         "url-parse": {
-            "version": "1.5.10",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+            "version": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
             "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
             "requires": {
                 "querystringify": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2257,7 +2257,6 @@
         "@types/nock": "^10.0.3",
         "@types/node": "^14.17.4",
         "@types/node-fetch": "^2.5.7",
-        "@types/path-browserify": "^1.0.0",
         "@types/pdfkit": "^0.11.0",
         "@types/promisify-node": "^0.4.0",
         "@types/react": "^16.4.14",

--- a/src/webviews/extension-side/variablesView/variableView.node.ts
+++ b/src/webviews/extension-side/variablesView/variableView.node.ts
@@ -4,7 +4,6 @@
 import '../../../platform/common/extensions';
 
 import * as path from '../../../platform/vscode-path/path';
-import * as pathBrowser from 'path-browserify';
 import { WebviewView as vscodeWebviewView } from 'vscode';
 
 import { captureTelemetry, sendTelemetryEvent } from '../../../telemetry';
@@ -78,7 +77,6 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
         this.documentManager.onDidChangeActiveTextEditor(this.activeTextEditorChanged, this, this.disposables);
 
         this.dataViewerChecker = new DataViewerChecker(configuration, appShell);
-        console.log(`Dirname up one is ${pathBrowser.join(__dirname, '..')}`);
         console.log(`Dirname up one is ${path.join(__dirname, '..')}`);
         console.log(`Done initing variables`);
     }

--- a/src/webviews/webview-side/react-common/relativeImage.tsx
+++ b/src/webviews/webview-side/react-common/relativeImage.tsx
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 'use strict';
-import * as path from 'path-browserify';
 import * as React from 'react';
+import * as path from '../../../platform/vscode-path/path';
 
 // This special function finds relative paths when loading inside of vscode. It's not defined
 // when loading outside, so the Image component should still work.


### PR DESCRIPTION
I noticed that while we were using a cross-environment version of `path`, in a couple of places we were still using `@types/path-browserify`. I asked about it and this seems unintentional. Here's a PR removing this package.