### PR TITLE
don't show python extension install popup when autostarting kernels

### DIFF
--- a/news/2 Fixes/10011.md
+++ b/news/2 Fixes/10011.md
@@ -1,0 +1,1 @@
+Don't show the python extension install ui when auto starting kernels.

--- a/src/kernels/jupyter/launcher/notebookProvider.ts
+++ b/src/kernels/jupyter/launcher/notebookProvider.ts
@@ -53,7 +53,9 @@ export class NotebookProvider implements INotebookProvider {
             return this.jupyterNotebookProvider.connect(options).finally(() => handler.dispose());
         } else {
             handler.dispose();
-            await this.extensionChecker.showPythonExtensionInstallRequiredPrompt();
+            if (!this.startupUi.disableUI) {
+                await this.extensionChecker.showPythonExtensionInstallRequiredPrompt();
+            }
             throw new Error('Python extension is not installed');
         }
     }


### PR DESCRIPTION
Fixes #10011

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
