### PR TITLE
Hook up JupyterUri handle change

### DIFF
--- a/src/kernels/jupyter/jupyterConnection.ts
+++ b/src/kernels/jupyter/jupyterConnection.ts
@@ -3,20 +3,18 @@
 
 import { inject, injectable } from 'inversify';
 import { IExtensionSyncActivationService } from '../../platform/activation/types';
-import { Identifiers } from '../../platform/common/constants';
 import { IDisposableRegistry } from '../../platform/common/types';
 import { RemoteJupyterServerUriProviderError } from '../../platform/errors/remoteJupyterServerUriProviderError';
 import { BaseError } from '../../platform/errors/types';
 import { IJupyterConnection } from '../types';
-import { computeServerId, createRemoteConnectionInfo } from './jupyterUtils';
+import { computeServerId, createRemoteConnectionInfo, extractJupyterServerHandleAndId } from './jupyterUtils';
 import { ServerConnectionType } from './launcher/serverConnectionType';
 import {
     IJupyterServerUri,
     IJupyterServerUriStorage,
     IJupyterSessionManager,
     IJupyterSessionManagerFactory,
-    IJupyterUriProviderRegistration,
-    JupyterServerUriHandle
+    IJupyterUriProviderRegistration
 } from './types';
 
 @injectable()
@@ -92,7 +90,7 @@ export class JupyterConnection implements IExtensionSyncActivationService {
     }
 
     public async updateServerUri(uri: string): Promise<void> {
-        const idAndHandle = this.extractJupyterServerHandleAndId(uri);
+        const idAndHandle = extractJupyterServerHandleAndId(uri);
         if (idAndHandle) {
             try {
                 const serverUri = await this.jupyterPickerRegistration.getJupyterServerUri(
@@ -120,17 +118,9 @@ export class JupyterConnection implements IExtensionSyncActivationService {
     }
 
     private getServerUri(uri: string): IJupyterServerUri | undefined {
-        const idAndHandle = this.extractJupyterServerHandleAndId(uri);
+        const idAndHandle = extractJupyterServerHandleAndId(uri);
         if (idAndHandle) {
             return this.uriToJupyterServerUri.get(uri);
         }
-    }
-    private extractJupyterServerHandleAndId(uri: string): { handle: JupyterServerUriHandle; id: string } | undefined {
-        const url: URL = new URL(uri);
-
-        // Id has to be there too.
-        const id = url.searchParams.get(Identifiers.REMOTE_URI_ID_PARAM);
-        const uriHandle = url.searchParams.get(Identifiers.REMOTE_URI_HANDLE_PARAM);
-        return id && uriHandle ? { handle: uriHandle, id } : undefined;
     }
 }

--- a/src/kernels/jupyter/jupyterRemoteCachedKernelValidator.ts
+++ b/src/kernels/jupyter/jupyterRemoteCachedKernelValidator.ts
@@ -43,7 +43,7 @@ export class JupyterRemoteCachedKernelValidator implements IJupyterRemoteCachedK
         const providers = await providersPromise;
         const provider = providers.find((item) => item.id === info.id);
         if (!provider) {
-            // Extension may have been uninstalled.
+            traceWarning(`Extension may have been uninstalled for provider ${info.id}, handle ${info.handle}`);
             return false;
         }
         if (provider.getHandles) {

--- a/src/kernels/jupyter/jupyterRemoteCachedKernelValidator.ts
+++ b/src/kernels/jupyter/jupyterRemoteCachedKernelValidator.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { inject, injectable } from 'inversify';
+import { traceWarning } from '../../platform/logging';
+import { LiveRemoteKernelConnectionMetadata } from '../types';
+import { computeServerId, extractJupyterServerHandleAndId } from './jupyterUtils';
+import {
+    IJupyterRemoteCachedKernelValidator,
+    IJupyterServerUriStorage,
+    IJupyterUriProviderRegistration,
+    ILiveRemoteKernelConnectionUsageTracker
+} from './types';
+
+@injectable()
+export class JupyterRemoteCachedKernelValidator implements IJupyterRemoteCachedKernelValidator {
+    constructor(
+        @inject(ILiveRemoteKernelConnectionUsageTracker)
+        private readonly liveKernelConnectionTracker: ILiveRemoteKernelConnectionUsageTracker,
+
+        @inject(IJupyterServerUriStorage) private readonly uriStorage: IJupyterServerUriStorage,
+        @inject(IJupyterUriProviderRegistration) private readonly providerRegistration: IJupyterUriProviderRegistration
+    ) {}
+    public async isValid(kernel: LiveRemoteKernelConnectionMetadata): Promise<boolean> {
+        // Only list live kernels that was used by the user,
+        if (!this.liveKernelConnectionTracker.wasKernelUsed(kernel)) {
+            return false;
+        }
+        const providersPromise = this.providerRegistration.getProviders();
+        const currentList = await this.uriStorage.getSavedUriList();
+        const item = currentList.find((item) => computeServerId(item.uri) === kernel.serverId);
+        if (!item) {
+            // Server has been removed and we have some old cached data.
+            return false;
+        }
+        // Check if this has a provider associated with it.
+        const info = extractJupyterServerHandleAndId(item.uri);
+        if (!info) {
+            // Could be a regular remote Jupyter Uri entered by the user.
+            // As its in the list, its still valid.
+            return true;
+        }
+        const providers = await providersPromise;
+        const provider = providers.find((item) => item.id === info.id);
+        if (!provider) {
+            // Extension may have been uninstalled.
+            return false;
+        }
+        if (provider.getHandles) {
+            const handles = await provider.getHandles();
+            if (handles.includes(info.handle)) {
+                return true;
+            } else {
+                traceWarning(
+                    `Hiding remote kernel ${kernel.id} as the remote Jupyter Server ${item.uri} is no longer available`
+                );
+                // 3rd party extensions own these kernels, if these are no longer
+                // available, then just don't display them.
+                return false;
+            }
+        }
+
+        // List this old cached kernel even if such a server matching this kernel no longer exists.
+        // This way things don't just disappear from the kernel picker &
+        // user will get notified when they attempt to re-use this kernel.
+        return true;
+    }
+}

--- a/src/kernels/jupyter/jupyterUriProviderRegistration.ts
+++ b/src/kernels/jupyter/jupyterUriProviderRegistration.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { inject, injectable, named } from 'inversify';
-import { Memento } from 'vscode';
+import { EventEmitter, Memento } from 'vscode';
 
-import { GLOBAL_MEMENTO, IExtensions, IMemento } from '../../platform/common/types';
+import { GLOBAL_MEMENTO, IDisposableRegistry, IExtensions, IMemento } from '../../platform/common/types';
 import { swallowExceptions } from '../../platform/common/utils/decorators';
 import * as localize from '../../platform/common/utils/localize';
 import { noop } from '../../platform/common/utils/misc';
@@ -19,14 +19,19 @@ import {
 const REGISTRATION_ID_EXTENSION_OWNER_MEMENTO_KEY = 'REGISTRATION_ID_EXTENSION_OWNER_MEMENTO_KEY';
 @injectable()
 export class JupyterUriProviderRegistration implements IJupyterUriProviderRegistration {
+    private readonly _onProvidersChanged = new EventEmitter<void>();
     private loadedOtherExtensionsPromise: Promise<void> | undefined;
     private providers = new Map<string, Promise<IJupyterUriProvider>>();
     private providerExtensionMapping = new Map<string, string>();
+    public readonly onProvidersChanged = this._onProvidersChanged.event;
 
     constructor(
         @inject(IExtensions) private readonly extensions: IExtensions,
+        @inject(IDisposableRegistry) disposables: IDisposableRegistry,
         @inject(IMemento) @named(GLOBAL_MEMENTO) private readonly globalMemento: Memento
-    ) {}
+    ) {
+        disposables.push(this._onProvidersChanged);
+    }
 
     public async getProviders(): Promise<ReadonlyArray<IJupyterUriProvider>> {
         await this.checkOtherExtensions();
@@ -41,8 +46,8 @@ export class JupyterUriProviderRegistration implements IJupyterUriProviderRegist
         } else {
             throw new Error(`IJupyterUriProvider already exists with id ${provider.id}`);
         }
+        this._onProvidersChanged.fire();
     }
-
     public async getJupyterServerUri(id: string, handle: JupyterServerUriHandle): Promise<IJupyterServerUri> {
         await this.checkOtherExtensions();
 

--- a/src/kernels/jupyter/jupyterUriProviderRegistration.ts
+++ b/src/kernels/jupyter/jupyterUriProviderRegistration.ts
@@ -23,7 +23,7 @@ export class JupyterUriProviderRegistration implements IJupyterUriProviderRegist
     private loadedOtherExtensionsPromise: Promise<void> | undefined;
     private providers = new Map<string, Promise<IJupyterUriProvider>>();
     private providerExtensionMapping = new Map<string, string>();
-    public readonly onProvidersChanged = this._onProvidersChanged.event;
+    public readonly onDidChangeProviders = this._onProvidersChanged.event;
 
     constructor(
         @inject(IExtensions) private readonly extensions: IExtensions,

--- a/src/kernels/jupyter/jupyterUtils.ts
+++ b/src/kernels/jupyter/jupyterUtils.ts
@@ -143,3 +143,14 @@ export function generateUriFromRemoteProvider(id: string, result: JupyterServerU
         Identifiers.REMOTE_URI_HANDLE_PARAM
     }=${encodeURI(result)}`;
 }
+
+export function extractJupyterServerHandleAndId(
+    uri: string
+): { handle: JupyterServerUriHandle; id: string } | undefined {
+    const url: URL = new URL(uri);
+
+    // Id has to be there too.
+    const id = url.searchParams.get(Identifiers.REMOTE_URI_ID_PARAM);
+    const uriHandle = url.searchParams.get(Identifiers.REMOTE_URI_HANDLE_PARAM);
+    return id && uriHandle ? { handle: uriHandle, id } : undefined;
+}

--- a/src/kernels/jupyter/serviceRegistry.node.ts
+++ b/src/kernels/jupyter/serviceRegistry.node.ts
@@ -25,6 +25,7 @@ import { NbConvertInterpreterDependencyChecker } from './interpreter/nbconvertIn
 import { CellOutputMimeTypeTracker } from './jupyterCellOutputMimeTypeTracker.node';
 import { JupyterConnection } from './jupyterConnection';
 import { JupyterKernelService } from './jupyterKernelService.node';
+import { JupyterRemoteCachedKernelValidator } from './jupyterRemoteCachedKernelValidator';
 import { JupyterUriProviderRegistration } from './jupyterUriProviderRegistration';
 import { JupyterCommandLineSelector } from './launcher/commandLineSelector';
 import { JupyterNotebookProvider } from './launcher/jupyterNotebookProvider';
@@ -64,7 +65,8 @@ import {
     IJupyterRequestCreator,
     IJupyterRequestAgentCreator,
     INotebookServerFactory,
-    ILiveRemoteKernelConnectionUsageTracker
+    ILiveRemoteKernelConnectionUsageTracker,
+    IJupyterRemoteCachedKernelValidator
 } from './types';
 import { IJupyterCommandFactory, IJupyterSubCommandExecutionService } from './types.node';
 
@@ -158,5 +160,9 @@ export function registerTypes(serviceManager: IServiceManager, _isDevMode: boole
     serviceManager.addSingleton<IExtensionSyncActivationService>(
         IExtensionSyncActivationService,
         RemoteKernelConnectionHandler
+    );
+    serviceManager.addSingleton<IJupyterRemoteCachedKernelValidator>(
+        IJupyterRemoteCachedKernelValidator,
+        JupyterRemoteCachedKernelValidator
     );
 }

--- a/src/kernels/jupyter/serviceRegistry.web.ts
+++ b/src/kernels/jupyter/serviceRegistry.web.ts
@@ -9,6 +9,7 @@ import { CommandRegistry } from './commands/commandRegistry';
 import { JupyterServerSelectorCommand } from './commands/serverSelector';
 import { JupyterConnection } from './jupyterConnection';
 import { JupyterKernelService } from './jupyterKernelService.web';
+import { JupyterRemoteCachedKernelValidator } from './jupyterRemoteCachedKernelValidator';
 import { JupyterUriProviderRegistration } from './jupyterUriProviderRegistration';
 import { JupyterCommandLineSelector } from './launcher/commandLineSelector';
 import { JupyterNotebookProvider } from './launcher/jupyterNotebookProvider';
@@ -38,7 +39,8 @@ import {
     IJupyterExecution,
     IJupyterRequestCreator,
     INotebookServerFactory,
-    ILiveRemoteKernelConnectionUsageTracker
+    ILiveRemoteKernelConnectionUsageTracker,
+    IJupyterRemoteCachedKernelValidator
 } from './types';
 
 export function registerTypes(serviceManager: IServiceManager, _isDevMode: boolean) {
@@ -83,5 +85,9 @@ export function registerTypes(serviceManager: IServiceManager, _isDevMode: boole
     serviceManager.addSingleton<IExtensionSyncActivationService>(
         IExtensionSyncActivationService,
         RemoteKernelConnectionHandler
+    );
+    serviceManager.addSingleton<IJupyterRemoteCachedKernelValidator>(
+        IJupyterRemoteCachedKernelValidator,
+        JupyterRemoteCachedKernelValidator
     );
 }

--- a/src/kernels/jupyter/types.ts
+++ b/src/kernels/jupyter/types.ts
@@ -207,7 +207,7 @@ export interface IJupyterUriProvider {
      * Should be a unique string (like a guid)
      */
     readonly id: string;
-    onDidChangeHandlers?: Event<void>;
+    onDidChangeHandles?: Event<void>;
     getQuickPickEntryItems?(): QuickPickItem[];
     handleQuickPick?(item: QuickPickItem, backEnabled: boolean): Promise<JupyterServerUriHandle | 'back' | undefined>;
     /**
@@ -223,6 +223,7 @@ export interface IJupyterUriProvider {
 export const IJupyterUriProviderRegistration = Symbol('IJupyterUriProviderRegistration');
 
 export interface IJupyterUriProviderRegistration {
+    onProvidersChanged: Event<void>;
     getProviders(): Promise<ReadonlyArray<IJupyterUriProvider>>;
     registerProvider(picker: IJupyterUriProvider): void;
     getJupyterServerUri(id: string, handle: JupyterServerUriHandle): Promise<IJupyterServerUri>;
@@ -310,4 +311,9 @@ export interface ILiveRemoteKernelConnectionUsageTracker {
      * Tracks the fact that the provided remote kernel for a given server is no longer used by a notebook defined by the uri.
      */
     trackKernelIdAsNotUsed(resource: Uri, serverId: string, kernelId: string): void;
+}
+
+export const IJupyterRemoteCachedKernelValidator = Symbol('IJupyterRemoteCachedKernelValidator');
+export interface IJupyterRemoteCachedKernelValidator {
+    isValid(kernel: LiveRemoteKernelConnectionMetadata): Promise<boolean>;
 }

--- a/src/kernels/jupyter/types.ts
+++ b/src/kernels/jupyter/types.ts
@@ -223,7 +223,7 @@ export interface IJupyterUriProvider {
 export const IJupyterUriProviderRegistration = Symbol('IJupyterUriProviderRegistration');
 
 export interface IJupyterUriProviderRegistration {
-    onProvidersChanged: Event<void>;
+    onDidChangeProviders: Event<void>;
     getProviders(): Promise<ReadonlyArray<IJupyterUriProvider>>;
     registerProvider(picker: IJupyterUriProvider): void;
     getJupyterServerUri(id: string, handle: JupyterServerUriHandle): Promise<IJupyterServerUri>;

--- a/src/kernels/kernelFinder.node.ts
+++ b/src/kernels/kernelFinder.node.ts
@@ -5,7 +5,7 @@ import { Memento } from 'vscode';
 import { IFileSystemNode } from '../platform/common/platform/types.node';
 import { GLOBAL_MEMENTO, IMemento } from '../platform/common/types';
 import { ServerConnectionType } from './jupyter/launcher/serverConnectionType';
-import { IJupyterServerUriStorage, ILiveRemoteKernelConnectionUsageTracker } from './jupyter/types';
+import { IJupyterRemoteCachedKernelValidator, IJupyterServerUriStorage } from './jupyter/types';
 import { BaseKernelFinder } from './kernelFinder.base';
 import { PreferredRemoteKernelIdProvider } from './jupyter/preferredRemoteKernelIdProvider';
 import { ILocalKernelFinder, IRemoteKernelFinder } from './raw/types';
@@ -22,8 +22,8 @@ export class KernelFinder extends BaseKernelFinder {
         @inject(IFileSystemNode) private readonly fs: IFileSystemNode,
         @inject(IJupyterServerUriStorage) serverUriStorage: IJupyterServerUriStorage,
         @inject(ServerConnectionType) serverConnectionType: ServerConnectionType,
-        @inject(ILiveRemoteKernelConnectionUsageTracker)
-        private readonly liveKernelConnectionTracker: ILiveRemoteKernelConnectionUsageTracker
+        @inject(IJupyterRemoteCachedKernelValidator)
+        protected readonly cachedRemoteKernelValidator: IJupyterRemoteCachedKernelValidator
     ) {
         super(
             preferredRemoteFinder,
@@ -56,11 +56,7 @@ export class KernelFinder extends BaseKernelFinder {
                 // Always fetch the latest kernels from remotes, no need to display cached remote kernels.
                 return false;
             case 'connectToLiveRemoteKernel':
-                // Only list live kernels that was used by the user,
-                // Even if such a kernel no longer exists on the sever.
-                // This way things don't just disappear from the list &
-                // user will get notified when they attempt to re-use this kernel.
-                return this.liveKernelConnectionTracker.wasKernelUsed(kernel);
+                return this.cachedRemoteKernelValidator.isValid(kernel);
         }
 
         return true;

--- a/src/notebooks/controllers/jupyterUriHandleWatcher.ts
+++ b/src/notebooks/controllers/jupyterUriHandleWatcher.ts
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { inject, injectable } from 'inversify';
+import { computeServerId, extractJupyterServerHandleAndId } from '../../kernels/jupyter/jupyterUtils';
+import {
+    IJupyterServerUriStorage,
+    IJupyterUriProvider,
+    IJupyterUriProviderRegistration
+} from '../../kernels/jupyter/types';
+import { isLocalConnection } from '../../kernels/types';
+import { IExtensionSyncActivationService } from '../../platform/activation/types';
+import { IDisposableRegistry } from '../../platform/common/types';
+import { INotebookControllerManager } from '../types';
+
+@injectable()
+export class RemoteKernelControllerWatcher implements IExtensionSyncActivationService {
+    private readonly handledProviders = new WeakSet<IJupyterUriProvider>();
+    constructor(
+        @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
+        @inject(IJupyterUriProviderRegistration) private readonly providerRegistry: IJupyterUriProviderRegistration,
+        @inject(IJupyterServerUriStorage) private readonly uriStorage: IJupyterServerUriStorage,
+        @inject(INotebookControllerManager) private readonly controllers: INotebookControllerManager
+    ) {}
+    activate(): void {
+        this.providerRegistry.onProvidersChanged(this.addProviderHandlers, this, this.disposables);
+    }
+    private async addProviderHandlers() {
+        const providers = await this.providerRegistry.getProviders();
+        providers.forEach((provider) => {
+            if (provider.onDidChangeHandles && !this.handledProviders.has(provider)) {
+                provider.onDidChangeHandles(this.onProviderHandlesChanged.bind(this, provider), this, this.disposables);
+            }
+        });
+    }
+    private async onProviderHandlesChanged(provider: IJupyterUriProvider) {
+        if (!provider.getHandles) {
+            return;
+        }
+        const [handles, uris] = await Promise.all([provider.getHandles(), this.uriStorage.getSavedUriList()]);
+        const serverJupyterProviderMap = new Map<string, { uri: string; providerId: string; handle: string }>();
+        await Promise.all(
+            uris.map(async (item) => {
+                // Check if this url is associated with a provider.
+                const info = extractJupyterServerHandleAndId(item.uri);
+                if (!info || info.id !== provider.id) {
+                    return;
+                }
+                serverJupyterProviderMap.set(computeServerId(item.uri), {
+                    uri: item.uri,
+                    providerId: info.id,
+                    handle: info.handle
+                });
+
+                // Check if this handle is still valid.
+                // If not then remove this uri from the list.
+                if (!handles.includes(info.handle)) {
+                    // Looks like the 3rd party provider has updated its handles and this server is no longer available.
+                    await this.uriStorage.removeUri(item.uri);
+                }
+            })
+        );
+        const controllers = this.controllers.getRegisteredNotebookControllers();
+        controllers.forEach((controller) => {
+            const info = serverJupyterProviderMap.get(controller.connection.id);
+            if (!isLocalConnection(controller.connection) || !info) {
+                return;
+            }
+            if (!info) {
+                return;
+            }
+            if (!handles.includes(info.handle)) {
+                // Looks like the 3rd party provider has updated its handles and this server is no longer available.
+                controller.dispose();
+            }
+        });
+    }
+}

--- a/src/notebooks/controllers/types.ts
+++ b/src/notebooks/controllers/types.ts
@@ -4,8 +4,9 @@
 
 import * as vscode from 'vscode';
 import { KernelConnectionMetadata } from '../../kernels/types';
+import { IDisposable } from '../../platform/common/types';
 
-export interface IVSCodeNotebookController {
+export interface IVSCodeNotebookController extends IDisposable {
     readonly connection: KernelConnectionMetadata;
     readonly controller: vscode.NotebookController;
     readonly id: string;

--- a/src/notebooks/serviceRegistry.node.ts
+++ b/src/notebooks/serviceRegistry.node.ts
@@ -23,6 +23,7 @@ import { NotebookUsageTracker } from './notebookUsageTracker';
 import { IDataScienceCommandListener } from '../platform/common/types';
 import { CondaControllerRefresher } from './controllers/condaControllerRefresher.node';
 import { IntellisenseProvider } from '../intellisense/intellisenseProvider.node';
+import { RemoteKernelControllerWatcher } from './controllers/jupyterUriHandleWatcher';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, RemoteSwitcher);
@@ -62,4 +63,8 @@ export function registerTypes(serviceManager: IServiceManager) {
     );
     serviceManager.addSingleton<INotebookCompletionProvider>(INotebookCompletionProvider, IntellisenseProvider);
     serviceManager.addBinding(INotebookCompletionProvider, IExtensionSyncActivationService);
+    serviceManager.addSingleton<IExtensionSyncActivationService>(
+        IExtensionSyncActivationService,
+        RemoteKernelControllerWatcher
+    );
 }

--- a/src/notebooks/serviceRegistry.node.ts
+++ b/src/notebooks/serviceRegistry.node.ts
@@ -23,7 +23,7 @@ import { NotebookUsageTracker } from './notebookUsageTracker';
 import { IDataScienceCommandListener } from '../platform/common/types';
 import { CondaControllerRefresher } from './controllers/condaControllerRefresher.node';
 import { IntellisenseProvider } from '../intellisense/intellisenseProvider.node';
-import { RemoteKernelControllerWatcher } from './controllers/jupyterUriHandleWatcher';
+import { RemoteKernelControllerWatcher } from './controllers/remoteKernelControllerWatcher';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, RemoteSwitcher);

--- a/src/notebooks/serviceRegistry.web.ts
+++ b/src/notebooks/serviceRegistry.web.ts
@@ -14,6 +14,7 @@ import { CellOutputDisplayIdTracker } from './execution/cellDisplayIdTracker';
 import { INotebookControllerManager, INotebookEditorProvider } from './types';
 import { NotebookUsageTracker } from './notebookUsageTracker';
 import { NotebookEditorProvider } from './notebookEditorProvider';
+import { RemoteKernelControllerWatcher } from './controllers/jupyterUriHandleWatcher';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, RemoteSwitcher);
@@ -31,5 +32,9 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,
         NotebookUsageTracker
+    );
+    serviceManager.addSingleton<IExtensionSyncActivationService>(
+        IExtensionSyncActivationService,
+        RemoteKernelControllerWatcher
     );
 }

--- a/src/notebooks/serviceRegistry.web.ts
+++ b/src/notebooks/serviceRegistry.web.ts
@@ -14,7 +14,7 @@ import { CellOutputDisplayIdTracker } from './execution/cellDisplayIdTracker';
 import { INotebookControllerManager, INotebookEditorProvider } from './types';
 import { NotebookUsageTracker } from './notebookUsageTracker';
 import { NotebookEditorProvider } from './notebookEditorProvider';
-import { RemoteKernelControllerWatcher } from './controllers/jupyterUriHandleWatcher';
+import { RemoteKernelControllerWatcher } from './controllers/remoteKernelControllerWatcher';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, RemoteSwitcher);

--- a/src/test/datascience/jupyterUriProviderRegistration.unit.test.ts
+++ b/src/test/datascience/jupyterUriProviderRegistration.unit.test.ts
@@ -11,6 +11,8 @@ import { Extensions } from '../../platform/common/application/extensions.node';
 import { FileSystem } from '../../platform/common/platform/fileSystem.node';
 import { JupyterUriProviderRegistration } from '../../kernels/jupyter/jupyterUriProviderRegistration';
 import { IJupyterUriProvider, JupyterServerUriHandle, IJupyterServerUri } from '../../kernels/jupyter/types';
+import { IDisposable } from '../../platform/common/types';
+import { disposeAllDisposables } from '../../platform/common/helpers';
 
 class MockProvider implements IJupyterUriProvider {
     public get id() {
@@ -55,7 +57,11 @@ class MockProvider implements IJupyterUriProvider {
 
 /* eslint-disable , @typescript-eslint/no-explicit-any */
 suite('DataScience URI Picker', () => {
-    teardown(() => sinon.restore());
+    const disposables: IDisposable[] = [];
+    teardown(() => {
+        sinon.restore();
+        disposeAllDisposables(disposables);
+    });
     suiteSetup(() => sinon.restore());
     async function createRegistration(providerIds: string[]) {
         let registration: JupyterUriProviderRegistration | undefined;
@@ -68,7 +74,7 @@ suite('DataScience URI Picker', () => {
         const memento = mock<vscode.Memento>();
         when(memento.get<string[]>(anything())).thenReturn([]);
         when(memento.get<string[]>(anything(), anything())).thenReturn([]);
-        registration = new JupyterUriProviderRegistration(extensions, instance(memento));
+        registration = new JupyterUriProviderRegistration(extensions, disposables, instance(memento));
         await Promise.all(
             providerIds.map(async (id) => {
                 const extension = TypeMoq.Mock.ofType<vscode.Extension<any>>();

--- a/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
@@ -56,7 +56,7 @@ import { NotebookProvider } from '../../../kernels/jupyter/launcher/notebookProv
 import { RemoteKernelFinder } from '../../../kernels/jupyter/remoteKernelFinder';
 import { JupyterServerUriStorage } from '../../../kernels/jupyter/launcher/serverUriStorage';
 import { ServerConnectionType } from '../../../kernels/jupyter/launcher/serverConnectionType';
-import { ILiveRemoteKernelConnectionUsageTracker } from '../../../kernels/jupyter/types';
+import { IJupyterRemoteCachedKernelValidator } from '../../../kernels/jupyter/types';
 
 [false, true].forEach((isWindows) => {
     suite(`Local Kernel Finder ${isWindows ? 'Windows' : 'Unix'}`, () => {
@@ -72,7 +72,7 @@ import { ILiveRemoteKernelConnectionUsageTracker } from '../../../kernels/jupyte
         let tempDirForKernelSpecs: Uri;
         let jupyterPaths: JupyterPaths;
         let preferredRemote: PreferredRemoteKernelIdProvider;
-        let liveKernelUsageTracker: ILiveRemoteKernelConnectionUsageTracker;
+        let cachedRemoteKernelValidator: IJupyterRemoteCachedKernelValidator;
         type TestData = {
             interpreters?: (
                 | PythonEnvironment
@@ -234,7 +234,7 @@ import { ILiveRemoteKernelConnectionUsageTracker } from '../../../kernels/jupyte
                     instance(memento)
                 )
             );
-            liveKernelUsageTracker = mock<ILiveRemoteKernelConnectionUsageTracker>();
+            cachedRemoteKernelValidator = mock<IJupyterRemoteCachedKernelValidator>();
             preferredRemote = mock(PreferredRemoteKernelIdProvider);
             const notebookProvider = mock(NotebookProvider);
             const serverUriStorage = mock(JupyterServerUriStorage);
@@ -254,7 +254,7 @@ import { ILiveRemoteKernelConnectionUsageTracker } from '../../../kernels/jupyte
                 instance(fs),
                 instance(serverUriStorage),
                 instance(connectionType),
-                instance(liveKernelUsageTracker)
+                instance(cachedRemoteKernelValidator)
             );
         }
         teardown(() => {

--- a/src/test/datascience/notebook/controllers/remoteKernelControllerWatcher.unit.test.ts
+++ b/src/test/datascience/notebook/controllers/remoteKernelControllerWatcher.unit.test.ts
@@ -1,0 +1,165 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { assert } from 'chai';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { EventEmitter } from 'vscode';
+import { computeServerId, generateUriFromRemoteProvider } from '../../../../kernels/jupyter/jupyterUtils';
+import {
+    IJupyterServerUriStorage,
+    IJupyterUriProvider,
+    IJupyterUriProviderRegistration,
+    JupyterServerUriHandle
+} from '../../../../kernels/jupyter/types';
+import { IJupyterKernelSpec, LiveKernelModel } from '../../../../kernels/types';
+import { RemoteKernelControllerWatcher } from '../../../../notebooks/controllers/remoteKernelControllerWatcher';
+import { IVSCodeNotebookController } from '../../../../notebooks/controllers/types';
+import { INotebookControllerManager } from '../../../../notebooks/types';
+import { disposeAllDisposables } from '../../../../platform/common/helpers';
+import { IDisposable } from '../../../../platform/common/types';
+import { waitForCondition } from '../../../common';
+
+suite('RemoteKernelControllerWatcher', () => {
+    let watcher: RemoteKernelControllerWatcher;
+    const disposables: IDisposable[] = [];
+    let uriProviderRegistration: IJupyterUriProviderRegistration;
+    let uriStorage: IJupyterServerUriStorage;
+    let controllers: INotebookControllerManager;
+    let onDidChangeProviders: EventEmitter<void>;
+    setup(() => {
+        uriProviderRegistration = mock<IJupyterUriProviderRegistration>();
+        uriStorage = mock<IJupyterServerUriStorage>();
+        controllers = mock<INotebookControllerManager>();
+        onDidChangeProviders = new EventEmitter<void>();
+        disposables.push(onDidChangeProviders);
+        when(uriProviderRegistration.onDidChangeProviders).thenReturn(onDidChangeProviders.event);
+        when(uriStorage.removeUri(anything())).thenResolve();
+        watcher = new RemoteKernelControllerWatcher(
+            disposables,
+            instance(uriProviderRegistration),
+            instance(uriStorage),
+            instance(controllers)
+        );
+    });
+    teardown(() => {
+        disposeAllDisposables(disposables);
+    });
+
+    test('Dispose controllers associated with an old handle', async () => {
+        const provider1Id = 'provider1';
+        const provider1Handle1: JupyterServerUriHandle = 'provider1Handle1';
+        const remoteUriForProvider1 = generateUriFromRemoteProvider(provider1Id, provider1Handle1);
+        const serverId = computeServerId(remoteUriForProvider1);
+
+        let onDidChangeHandles: undefined | (() => Promise<void>);
+        const provider1 = mock<IJupyterUriProvider>();
+        when(provider1.id).thenReturn(provider1Id);
+        when(provider1.getHandles!()).thenResolve([provider1Handle1]);
+        when(provider1.onDidChangeHandles).thenReturn(
+            (cb: Function, ctx: Object) => (onDidChangeHandles = cb.bind(ctx))
+        );
+
+        const provider2 = mock<IJupyterUriProvider>();
+        when(provider2.id).thenReturn('provider2');
+        when(provider2.getHandles).thenReturn(undefined);
+        when(provider2.onDidChangeHandles).thenReturn(undefined);
+
+        const provider3 = mock<IJupyterUriProvider>();
+        let onDidChangeHandles3: undefined | (() => Promise<void>);
+        when(provider3.id).thenReturn('provider3');
+        when(provider3.getHandles!()).thenResolve(['provider3Handle1']);
+        when(provider3.onDidChangeHandles).thenReturn(
+            (cb: Function, ctx: Object) => (onDidChangeHandles3 = cb.bind(ctx))
+        );
+
+        when(uriProviderRegistration.getProviders()).thenResolve([
+            instance(provider1),
+            instance(provider2),
+            instance(provider3)
+        ]);
+
+        const localKernel = mock<IVSCodeNotebookController>();
+        when(localKernel.dispose()).thenReturn();
+        when(localKernel.connection).thenReturn({
+            id: 'local1',
+            kind: 'startUsingLocalKernelSpec',
+            kernelSpec: mock<IJupyterKernelSpec>()
+        });
+        const remoteKernelSpec = mock<IVSCodeNotebookController>();
+        when(remoteKernelSpec.dispose()).thenReturn();
+        when(remoteKernelSpec.connection).thenReturn({
+            id: 'remote1',
+            kind: 'startUsingRemoteKernelSpec',
+            baseUrl: remoteUriForProvider1,
+            kernelSpec: mock<IJupyterKernelSpec>(),
+            serverId
+        });
+        const remoteLiveKernel = mock<IVSCodeNotebookController>();
+        when(remoteLiveKernel.dispose()).thenReturn();
+        when(remoteLiveKernel.connection).thenReturn({
+            id: 'live1',
+            kind: 'connectToLiveRemoteKernel',
+            baseUrl: remoteUriForProvider1,
+            kernelModel: mock<LiveKernelModel>(),
+            serverId
+        });
+        when(controllers.getRegisteredNotebookControllers()).thenReturn([
+            instance(localKernel),
+            instance(remoteKernelSpec),
+            instance(remoteLiveKernel)
+        ]);
+
+        when(uriStorage.getSavedUriList()).thenResolve([
+            { time: 1, uri: remoteUriForProvider1, displayName: 'Something' }
+        ]);
+
+        watcher.activate();
+
+        await waitForCondition(
+            async () => {
+                verify(provider1.onDidChangeHandles).atLeast(1);
+                return true;
+            },
+            5_000,
+            'Timed out waiting for onDidChangeHandles to be called'
+        );
+
+        // 1. Verify that none of the controllers were disposed.
+        verify(localKernel.dispose()).never();
+        verify(remoteKernelSpec.dispose()).never();
+        verify(remoteLiveKernel.dispose()).never();
+
+        // 2. When a provider triggers a change in its handles and we're not using its handles, then none of the controllers should get disposed.
+        when(provider1.getHandles!()).thenResolve([provider1Handle1]);
+        await onDidChangeHandles3!();
+
+        verify(localKernel.dispose()).never();
+        verify(remoteKernelSpec.dispose()).never();
+        verify(remoteLiveKernel.dispose()).never();
+
+        // 3. When we trigger a change in the handles, but the same handles are still returned, then
+        // Verify that none of the controllers were disposed.
+        when(provider1.getHandles!()).thenResolve([provider1Handle1]);
+        await onDidChangeHandles!();
+
+        assert.isOk(onDidChangeHandles, 'onDidChangeHandles should be defined');
+        verify(uriStorage.removeUri(anything())).never();
+        verify(localKernel.dispose()).never();
+        verify(remoteKernelSpec.dispose()).never();
+        verify(remoteLiveKernel.dispose()).never();
+
+        // 4. When we trigger a change in the handles, & different handles are returned, then
+        // Verify that the old controllers have been disposed.
+        when(provider1.getHandles!()).thenResolve(['somethingElse']);
+        await onDidChangeHandles!();
+
+        assert.isOk(onDidChangeHandles, 'onDidChangeHandles should be defined');
+        verify(uriStorage.removeUri(remoteUriForProvider1)).once();
+        verify(localKernel.dispose()).never();
+        verify(remoteKernelSpec.dispose()).once();
+        verify(remoteLiveKernel.dispose()).once();
+    });
+});


### PR DESCRIPTION
Part of #9683

* When the `onDidChangeHandles` event is fired, then look for controllers that belong to jupyter handles that are no longer valid. List of valid handles returned by the provider using the `getHandles` method
* When loading cached controllers, ensure they are validated against the `getHandles` method of the corresponding provider.
	* E.g. when re-loading vscode, the cahched controllers will not be displayed if the handle is outdated.
	* (kind of a moot point caching at this point, as its possible fetching the latest kernels would be fast enough).

