### PR TITLE
Add alert box styling for notebooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -2063,6 +2063,9 @@
                 "type": "Python Kernel Debug Adapter",
                 "label": "Python Kernel Debug Adapter"
             }
+        ],
+        "markdown.previewStyles": [
+            "resources/jupyter-markdown-style.css"
         ]
     },
     "enabledApiProposals": [

--- a/resources/jupyter-markdown-style.css
+++ b/resources/jupyter-markdown-style.css
@@ -1,0 +1,14 @@
+/* These classnames are inherited from bootstrap, but are present in most notebook renderers */
+
+.alert-info {
+    background-color: var(--theme-info-background);
+    color: var(--theme-info-foreground);
+}
+.alert-warning {
+    background-color: var(--theme-warning-background);
+    color: var(--theme-warning-foreground);
+}
+.alert-danger {
+    background-color: var(--theme-error-background);
+    color: var(--theme-error-foreground);
+}


### PR DESCRIPTION
These style names are inherited from bootstrap, but seem to be the defacto standard for jupyter notebooks.
See https://nbviewer.org/github/ipython/ipython-in-depth/blob/master/examples/Notebook/Notebook%20Basics.ipynb for an example by ipython of these styles being used.
Note there is no appropriate color to uses for `success`.

Partially addresses #8399

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~~Has sufficient logging.~~
-   [x] ~~Has telemetry for feature-requests.~~
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [x] ~~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~~
