### PR TITLE
Enforce Prettier to align with linting CI

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -48,6 +48,7 @@
         "source.fixAll.eslint": true,
         "source.fixAll.tslint": true
     },
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "python.languageServer": "Pylance",
     "python.analysis.logLevel": "Trace",
     "python.linting.pylintEnabled": false,


### PR DESCRIPTION
VS Code ships with typescript formatter, which will be used as we have `editor.formatOnSave` in the workspace setting, but it has a different style as Prettier, which is the one we use in CI. Setting `editor.defaultFormatter` to Prettier to prevent that from happening.