### PR TITLE
Fix padding and margin on jupyter alert styles

### DIFF
--- a/news/1 Enhancements/8399.md
+++ b/news/1 Enhancements/8399.md
@@ -1,0 +1,2 @@
+Alert boxes of the form `<div style="alert alert-danger">` are now styled as colored boxes, to match how they are in Jupyter.
+(thanks [Eric Wieser](https://github.com/eric-wieser/))

--- a/resources/jupyter-markdown-style.css
+++ b/resources/jupyter-markdown-style.css
@@ -1,5 +1,24 @@
 /* These classnames are inherited from bootstrap, but are present in most notebook renderers */
 
+.alert {
+    width: auto;
+    padding: 1em;
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+.alert > *:last-child {
+    margin-bottom: 0;
+}
+#preview > .alert:last-child {
+    /* Prevent this being set to zero by the default notebook stylesheet */
+    padding-bottom: 1em;
+}
+
+.alert-success {
+    /* Note there is no suitable color available, so we just copy "info" */
+    background-color: var(--theme-info-background);
+    color: var(--theme-info-foreground);
+}
 .alert-info {
     background-color: var(--theme-info-background);
     color: var(--theme-info-foreground);


### PR DESCRIPTION
I should have tested this more in #10021; the styles were better than nothing, but quite ugly.

Here's how this looks now:

![image](https://user-images.githubusercontent.com/425260/168495763-c0004d7a-38c9-4339-a05d-bd031f5251e9.png)

![image](https://user-images.githubusercontent.com/425260/168495799-581f02eb-0f55-4e86-ada2-33f3a64b8b14.png)


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~~Has sufficient logging.~~
-   [x] ~~Has telemetry for feature-requests.~~
-   [x] ~~Unit tests & system/integration tests are added/updated.~~
-   [x] ~~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~~
-   [x] ~~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~~
