### PR TITLE
Exclude package.json in vscode dir

### DIFF
--- a/src/platform/common/application/extensions.node.ts
+++ b/src/platform/common/application/extensions.node.ts
@@ -40,7 +40,8 @@ export class Extensions implements IExtensions {
                         return result[1];
                     }
                 })
-                .filter((item) => item && !item.toLowerCase().startsWith(jupyterExtRoot)) as string[];
+                .filter((item) => item && !item.toLowerCase().startsWith(jupyterExtRoot))
+                .filter((item) => this.all.some((ext) => item!.includes(ext.extensionUri.path))) as string[];
             stacktrace.parse(new Error('Ex')).forEach((item) => {
                 const fileName = item.getFileName();
                 if (fileName && !fileName.toLowerCase().startsWith(jupyterExtRoot)) {

--- a/src/platform/common/application/extensions.node.ts
+++ b/src/platform/common/application/extensions.node.ts
@@ -41,7 +41,11 @@ export class Extensions implements IExtensions {
                     }
                 })
                 .filter((item) => item && !item.toLowerCase().startsWith(jupyterExtRoot))
-                .filter((item) => this.all.some((ext) => item!.includes(ext.extensionUri.path))) as string[];
+                .filter((item) =>
+                    this.all.some(
+                        (ext) => item!.includes(ext.extensionUri.path) || item!.includes(ext.extensionUri.fsPath)
+                    )
+                ) as string[];
             stacktrace.parse(new Error('Ex')).forEach((item) => {
                 const fileName = item.getFileName();
                 if (fileName && !fileName.toLowerCase().startsWith(jupyterExtRoot)) {


### PR DESCRIPTION
when looking for package.json we could end up picking up vscodes package.json which is wrong (at which point we don't know the calling extension).