### PR TITLE
Move notebook debugger into notebook folder

### DIFF
--- a/src/platform/debugger/jupyter/helper.node.ts
+++ b/src/platform/debugger/jupyter/helper.node.ts
@@ -123,7 +123,6 @@ export function shortNameMatchesLongName(shortNamePath: string, longNamePath: st
     return r.test(longNamePath);
 }
 
-
 export async function cellDebugSetup(kernel: IKernel, debugAdapter: IKernelDebugAdapter): Promise<void> {
     // remove this if when https://github.com/microsoft/debugpy/issues/706 is fixed and ipykernel ships it
     // executing this code restarts debugpy and fixes https://github.com/microsoft/vscode-jupyter/issues/7251

--- a/src/platform/debugger/jupyter/helper.node.ts
+++ b/src/platform/debugger/jupyter/helper.node.ts
@@ -3,7 +3,7 @@
 
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { IKernel } from '../../../kernels/types';
-import { IKernelDebugAdapterConfig, KernelDebugMode } from '../types';
+import { IKernelDebugAdapter, IKernelDebugAdapterConfig, KernelDebugMode } from '../types';
 
 export enum IpykernelCheckResult {
     Unknown,
@@ -121,4 +121,14 @@ export function isShortNamePath(path: string): boolean {
 export function shortNameMatchesLongName(shortNamePath: string, longNamePath: string): boolean {
     const r = new RegExp(shortNamePath.replace(/\\/g, '\\\\').replace(/~\d+\\\\/g, '[^\\\\]+\\\\'), 'i');
     return r.test(longNamePath);
+}
+
+
+export async function cellDebugSetup(kernel: IKernel, debugAdapter: IKernelDebugAdapter): Promise<void> {
+    // remove this if when https://github.com/microsoft/debugpy/issues/706 is fixed and ipykernel ships it
+    // executing this code restarts debugpy and fixes https://github.com/microsoft/vscode-jupyter/issues/7251
+    const code = 'import debugpy\ndebugpy.debug_this_thread()';
+    await kernel.executeHidden(code);
+
+    await debugAdapter.dumpAllCells();
 }

--- a/src/platform/debugger/jupyter/kernelDebugAdapter.node.ts
+++ b/src/platform/debugger/jupyter/kernelDebugAdapter.node.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { KernelMessage } from '@jupyterlab/services';
-import * as path from '../../../platform/vscode-path/path';
+import * as path from '../../vscode-path/path';
 import {
     debug,
     DebugAdapter,
@@ -57,7 +57,7 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
     onDidSendMessage: Event<DebugProtocolMessage> = this.sendMessage.event;
     onDidEndSession: Event<DebugSession> = this.endSession.event;
     public readonly debugCell: NotebookCell | undefined;
-    private disconected: boolean = false;
+    private disconnected: boolean = false;
     private kernelEventHook = (_event: 'willRestart' | 'willInterrupt') => this.disconnect();
 
     constructor(
@@ -109,7 +109,7 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
                     if (
                         this.configuration.__cellIndex === cellStateChange.cell.index &&
                         cellStateChange.state === NotebookCellExecutionState.Idle &&
-                        !this.disconected
+                        !this.disconnected
                     ) {
                         sendTelemetryEvent(DebuggingTelemetry.endedSession, undefined, { reason: 'normally' });
                         void this.disconnect();
@@ -190,7 +190,7 @@ export class KernelDebugAdapter implements DebugAdapter, IKernelDebugAdapter, ID
     public async disconnect() {
         await this.session.customRequest('disconnect', { restart: false });
         this.endSession.fire(this.session);
-        this.disconected = true;
+        this.disconnected = true;
         this.kernel?.removeEventHook(this.kernelEventHook);
     }
 

--- a/src/platform/debugger/jupyter/notebook/debugCellControllers.node.ts
+++ b/src/platform/debugger/jupyter/notebook/debugCellControllers.node.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { DebugProtocolMessage, NotebookCell } from 'vscode';
+import { DebugProtocol } from 'vscode-debugprotocol';
+import { ICommandManager } from '../../../common/application/types';
+import { IKernel } from '../../../../kernels/types';
+import { sendTelemetryEvent } from '../../../../telemetry';
+import { DebuggingTelemetry } from '../../constants';
+import { IDebuggingDelegate, IKernelDebugAdapter } from '../../types';
+import { cellDebugSetup } from '../helper.node';
+
+export class DebugCellController implements IDebuggingDelegate {
+    constructor(
+        private readonly debugAdapter: IKernelDebugAdapter,
+        public readonly debugCell: NotebookCell,
+        private readonly kernel: IKernel,
+        private readonly commandManager: ICommandManager
+    ) {
+        sendTelemetryEvent(DebuggingTelemetry.successfullyStartedRunAndDebugCell);
+    }
+
+    public async willSendEvent(_msg: DebugProtocolMessage): Promise<boolean> {
+        return false;
+    }
+
+    public async willSendRequest(request: DebugProtocol.Request): Promise<void> {
+        if (request.command === 'configurationDone') {
+            await cellDebugSetup(this.kernel, this.debugAdapter);
+
+            void this.commandManager.executeCommand('notebook.cell.execute', {
+                ranges: [{ start: this.debugCell.index, end: this.debugCell.index + 1 }],
+                document: this.debugCell.document.uri
+            });
+        }
+    }
+}

--- a/src/platform/debugger/jupyter/notebook/debuggingManager.node.ts
+++ b/src/platform/debugger/jupyter/notebook/debuggingManager.node.ts
@@ -17,25 +17,26 @@ import {
     EventEmitter,
     NotebookEditor
 } from 'vscode';
-import * as path from '../../../platform/vscode-path/path';
-import { IKernel, IKernelProvider } from '../../../kernels/types';
-import { IConfigurationService, IDisposable } from '../../common/types';
-import { KernelDebugAdapter } from './kernelDebugAdapter.node';
-import { IExtensionSingleActivationService } from '../../activation/types';
-import { ContextKey } from '../../common/contextKey';
-import { IApplicationShell, ICommandManager, IVSCodeNotebook } from '../../common/application/types';
-import { traceError, traceInfo, traceInfoIfCI } from '../../logging';
-import { DataScience } from '../../common/utils/localize';
-import { Commands as DSCommands, EditorContexts } from '../../../webviews/webview-side/common/constants';
-import { IPlatformService } from '../../common/platform/types';
-import { IDebuggingManager, IKernelDebugAdapterConfig, KernelDebugMode } from '../types';
-import { DebuggingTelemetry, pythonKernelDebugAdapter } from '../constants';
-import { sendTelemetryEvent } from '../../../telemetry';
-import { DebugCellController, RunByLineController } from './debugControllers.node';
-import { assertIsDebugConfig, IpykernelCheckResult, isUsingIpykernel6OrLater } from './helper.node';
-import { Debugger } from './debugger.node';
-import { INotebookControllerManager } from '../../../notebooks/types';
-import { IFileSystem } from '../../common/platform/types.node';
+import * as path from '../../../vscode-path/path';
+import { IKernel, IKernelProvider } from '../../../../kernels/types';
+import { IConfigurationService, IDisposable } from '../../../common/types';
+import { KernelDebugAdapter } from '../kernelDebugAdapter.node';
+import { IExtensionSingleActivationService } from '../../../activation/types';
+import { ContextKey } from '../../../common/contextKey';
+import { IApplicationShell, ICommandManager, IVSCodeNotebook } from '../../../common/application/types';
+import { traceError, traceInfo, traceInfoIfCI } from '../../../logging';
+import { DataScience } from '../../../common/utils/localize';
+import { Commands as DSCommands, EditorContexts } from '../../../../webviews/webview-side/common/constants';
+import { IPlatformService } from '../../../common/platform/types';
+import { IDebuggingManager, IKernelDebugAdapterConfig, KernelDebugMode } from '../../types';
+import { DebuggingTelemetry, pythonKernelDebugAdapter } from '../../constants';
+import { sendTelemetryEvent } from '../../../../telemetry';
+import { DebugCellController } from './debugCellControllers.node';
+import { assertIsDebugConfig, IpykernelCheckResult, isUsingIpykernel6OrLater } from '../helper.node';
+import { Debugger } from '../debugger.node';
+import { INotebookControllerManager } from '../../../../notebooks/types';
+import { IFileSystem } from '../../../common/platform/types.node';
+import { RunByLineController } from './runByLineController.node';
 
 /**
  * The DebuggingManager maintains the mapping between notebook documents and debug sessions.

--- a/src/platform/serviceRegistry.node.ts
+++ b/src/platform/serviceRegistry.node.ts
@@ -33,7 +33,7 @@ import { GlobalActivation } from './common/globalActivation';
 import { PreReleaseChecker } from './common/prereleaseChecker.node';
 import { IConfigurationService, IDataScienceCommandListener, IExtensionContext } from './common/types';
 import { DebugLocationTrackerFactory } from './debugger/debugLocationTrackerFactory.node';
-import { DebuggingManager } from './debugger/jupyter/debuggingManager.node';
+import { DebuggingManager } from './debugger/jupyter/notebook/debuggingManager.node';
 import { IDebugLocationTracker, IDebuggingManager } from './debugger/types';
 import { DataScienceErrorHandler } from './errors/errorHandler';
 import { IDataScienceErrorHandler } from './errors/types';


### PR DESCRIPTION
Part of #10037

The plan is to have the following folder structure:
src->platform->debugger->jupyter->notebook (specific to notebook debugging)
src->platform->debugger->jupyter->interactiveWindow (specific to IW debugging)
src->platform->debugger->jupyter->common (Stuff thats common to both will eventually move into this folder)

