### PR TITLE
Use notebook instead of deprecated document prop

### DIFF
--- a/src/intellisense/emptyNotebookCellLanguageService.ts
+++ b/src/intellisense/emptyNotebookCellLanguageService.ts
@@ -46,7 +46,7 @@ export class EmptyNotebookCellLanguageService implements IExtensionSingleActivat
         if (!isJupyterNotebook(document)) {
             return;
         }
-        const editor = this.notebook.notebookEditors.find((item) => item.document === document);
+        const editor = this.notebook.notebookEditors.find((item) => item.notebook === document);
         if (!editor) {
             return;
         }
@@ -86,7 +86,7 @@ export class EmptyNotebookCellLanguageService implements IExtensionSingleActivat
         }
 
         const monacoLanguage = translateKernelLanguageToMonaco(language);
-        chainWithPendingUpdates(editor.document, async () => {
+        chainWithPendingUpdates(editor.notebook, async () => {
             await emptyCodeCells.map(async (cell) => {
                 if (monacoLanguage.toLowerCase() === cell.document.languageId) {
                     return;

--- a/src/intellisense/logReplayService.node.ts
+++ b/src/intellisense/logReplayService.node.ts
@@ -62,7 +62,7 @@ export class LogReplayService implements IExtensionSingleActivationService {
         if (vscode.window.activeNotebookEditor) {
             const file = await this.appShell.showOpenDialog({ title: 'Open Pylance Output Log' });
             if (file && file.length === 1) {
-                this.activeNotebook = vscode.window.activeNotebookEditor.document;
+                this.activeNotebook = vscode.window.activeNotebookEditor.notebook;
                 this.steps = await this.parsePylanceLogSteps(file[0].fsPath);
                 this.index = -1;
                 void this.isLogActive?.set(true);
@@ -76,7 +76,7 @@ export class LogReplayService implements IExtensionSingleActivationService {
         if (
             this.steps.length - 1 > this.index &&
             this.steps.length > 0 &&
-            this.activeNotebook === vscode.window.activeNotebookEditor?.document &&
+            this.activeNotebook === vscode.window.activeNotebookEditor?.notebook &&
             this.activeNotebook
         ) {
             void this.appShell.showInformationMessage(`Replaying step ${this.index + 2} of ${this.steps.length}`);
@@ -224,7 +224,7 @@ export class LogReplayService implements IExtensionSingleActivationService {
                 this.index = -1;
             }
         } else if (
-            this.activeNotebook?.toString() !== vscode.window.activeNotebookEditor?.document.uri.toString() &&
+            this.activeNotebook?.toString() !== vscode.window.activeNotebookEditor?.notebook.uri.toString() &&
             this.index < this.steps.length - 1
         ) {
             void this.appShell.showErrorMessage(

--- a/src/interactive-window/commands/exportCommands.ts
+++ b/src/interactive-window/commands/exportCommands.ts
@@ -73,7 +73,7 @@ export class ExportCommands implements IExportCommands, IDisposable {
         const notebookUri = isUri(context) ? context : context?.notebookEditor?.notebookUri;
         const document = notebookUri
             ? this.notebooks.notebookDocuments.find((item) => this.fs.arePathsSame(item.uri, notebookUri))
-            : this.notebooks.activeNotebookEditor?.document;
+            : this.notebooks.activeNotebookEditor?.notebook;
 
         if (document) {
             const interpreter =
@@ -95,7 +95,7 @@ export class ExportCommands implements IExportCommands, IDisposable {
             // if no source document was passed then this was called from the command palette,
             // so we need to get the active editor
             sourceDocument =
-                this.notebooks.activeNotebookEditor?.document ||
+                this.notebooks.activeNotebookEditor?.notebook ||
                 (this.interactiveProvider
                     ? getActiveInteractiveWindow(this.interactiveProvider)?.notebookDocument
                     : undefined);

--- a/src/interactive-window/editor-integration/cellFactory.ts
+++ b/src/interactive-window/editor-integration/cellFactory.ts
@@ -140,7 +140,7 @@ export function hasCells(document: TextDocument, settings?: IJupyterSettings): b
 }
 
 export function generateCellRangesFromDocument(document: TextDocument, settings?: IJupyterSettings): ICellRange[] {
-    // Implmentation of getCells here based on Don's Jupyter extension work
+    // Implementation of getCells here based on Don's Jupyter extension work
     const matcher = new CellMatcher(settings);
     const cells: ICellRange[] = [];
     for (let index = 0; index < document.lineCount; index += 1) {

--- a/src/interactive-window/interactiveWindow.node.ts
+++ b/src/interactive-window/interactiveWindow.node.ts
@@ -78,10 +78,10 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         return this._submitters;
     }
     public get notebookUri(): Uri {
-        return this.notebookEditor.document.uri;
+        return this.notebookEditor.notebook.uri;
     }
     public get notebookDocument(): NotebookDocument {
-        return this.notebookEditor.document;
+        return this.notebookEditor.notebook;
     }
     public get kernelConnectionMetadata(): KernelConnectionMetadata | undefined {
         return this.currentKernelInfo.metadata;
@@ -351,7 +351,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         const controllerChangeListener = controller.controller.onDidChangeSelectedNotebooks(
             (selectedEvent: { notebook: NotebookDocument; selected: boolean }) => {
                 // Controller was deselected for this InteractiveWindow's NotebookDocument
-                if (selectedEvent.selected === false && selectedEvent.notebook === this.notebookEditor.document) {
+                if (selectedEvent.selected === false && selectedEvent.notebook === this.notebookEditor.notebook) {
                     controllerChangeListener.dispose();
                     this.disconnectKernel();
                 }
@@ -362,7 +362,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
     }
 
     private listenForControllerSelection() {
-        const controller = this.notebookControllerManager.getSelectedNotebookController(this.notebookEditor.document);
+        const controller = this.notebookControllerManager.getSelectedNotebookController(this.notebookEditor.notebook);
         if (controller !== undefined) {
             this.registerControllerChangeListener(controller);
         }
@@ -370,7 +370,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         // Ensure we hear about any controller changes so we can update our cached promises
         this.notebookControllerManager.onNotebookControllerSelected(
             (e: { notebook: NotebookDocument; controller: IVSCodeNotebookController }) => {
-                if (e.notebook !== this.notebookEditor.document) {
+                if (e.notebook !== this.notebookEditor.notebook) {
                     return;
                 }
 
@@ -406,14 +406,14 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         const markdownCell = new NotebookCellData(NotebookCellKind.Markup, message, MARKDOWN_LANGUAGE);
         markdownCell.metadata = { isInteractiveWindowMessageCell: true };
         const insertionIndex =
-            notebookCell && notebookCell.index >= 0 ? notebookCell.index : this.notebookEditor.document.cellCount;
+            notebookCell && notebookCell.index >= 0 ? notebookCell.index : this.notebookEditor.notebook.cellCount;
         // If possible display the error message in the cell.
-        const controller = this.notebookControllerManager.getSelectedNotebookController(this.notebookEditor.document);
+        const controller = this.notebookControllerManager.getSelectedNotebookController(this.notebookEditor.notebook);
         const output = createOutputWithErrorMessageForDisplay(message);
-        if (this.notebookEditor.document.cellCount === 0 || !controller || !output || !notebookCell) {
+        if (this.notebookEditor.notebook.cellCount === 0 || !controller || !output || !notebookCell) {
             const edit = new WorkspaceEdit();
             edit.replaceNotebookCells(
-                this.notebookEditor.document.uri,
+                this.notebookEditor.notebook.uri,
                 new NotebookRange(insertionIndex, insertionIndex),
                 [markdownCell]
             );
@@ -630,10 +630,10 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
 
     public async expandAllCells() {
         await Promise.all(
-            this.notebookEditor.document.getCells().map(async (_cell, index) => {
+            this.notebookEditor.notebook.getCells().map(async (_cell, index) => {
                 await this.commandManager.executeCommand('notebook.cell.expandCellInput', {
                     ranges: [{ start: index, end: index + 1 }],
-                    document: this.notebookEditor.document.uri
+                    document: this.notebookEditor.notebook.uri
                 });
             })
         );
@@ -641,13 +641,13 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
 
     public async collapseAllCells() {
         await Promise.all(
-            this.notebookEditor.document.getCells().map(async (cell, index) => {
+            this.notebookEditor.notebook.getCells().map(async (cell, index) => {
                 if (cell.kind !== NotebookCellKind.Code) {
                     return;
                 }
                 await this.commandManager.executeCommand('notebook.cell.collapseCellInput', {
                     ranges: [{ start: index, end: index + 1 }],
-                    document: this.notebookEditor.document.uri
+                    document: this.notebookEditor.notebook.uri
                 });
             })
         );
@@ -655,7 +655,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
 
     public async scrollToCell(id: string): Promise<void> {
         await this.show();
-        const matchingCell = this.notebookEditor.document
+        const matchingCell = this.notebookEditor.notebook
             .getCells()
             .find((cell) => getInteractiveCellMetadata(cell)?.id === id);
         if (matchingCell) {
@@ -692,7 +692,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
     }
 
     public async hasCell(id: string): Promise<boolean> {
-        return this.notebookEditor.document.getCells().some((cell) => getInteractiveCellMetadata(cell)?.id === id);
+        return this.notebookEditor.notebook.getCells().some((cell) => getInteractiveCellMetadata(cell)?.id === id);
     }
 
     public get owningResource(): Resource {
@@ -745,15 +745,15 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         file: Uri,
         line: number
     ): Promise<{ cell: NotebookCell; wasScrolled: boolean }> {
-        const notebookDocument = this.notebookEditor.document;
+        const notebookDocument = this.notebookEditor.notebook;
 
         // Compute if we should scroll based on last notebook cell before adding a notebook cell,
         // since the notebook cell we're going to add is by definition not visible
         const shouldScroll =
             this.notebookEditor.visibleRanges.find((r) => {
-                return r.end === this.notebookEditor.document.cellCount;
+                return r.end === this.notebookEditor.notebook.cellCount;
             }) != undefined ||
-            this.pendingNotebookScrolls.find((r) => r.end == this.notebookEditor.document.cellCount - 1) != undefined;
+            this.pendingNotebookScrolls.find((r) => r.end == this.notebookEditor.notebook.cellCount - 1) != undefined;
 
         // Strip #%% and store it in the cell metadata so we can reconstruct the cell structure when exporting to Python files
         const settings = this.configuration.getSettings(this.owningResource);
@@ -809,7 +809,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         }
 
         const { magicCommandsAsComments } = this.configuration.getSettings(this.owningResource);
-        const cells = generateCellsFromNotebookDocument(this.notebookEditor.document, magicCommandsAsComments);
+        const cells = generateCellsFromNotebookDocument(this.notebookEditor.notebook, magicCommandsAsComments);
 
         // Should be an array of cells
         if (cells && this.exportDialog) {

--- a/src/interactive-window/interactiveWindowCommandListener.node.ts
+++ b/src/interactive-window/interactiveWindowCommandListener.node.ts
@@ -440,7 +440,7 @@ export class InteractiveWindowCommandListener implements IDataScienceCommandList
             context === undefined
                 ? interactiveWindow?.notebookEditor?.selections
                 : [new NotebookRange(context.index, context.index + 1)];
-        const document = context === undefined ? interactiveWindow?.notebookEditor?.document : context.notebook;
+        const document = context === undefined ? interactiveWindow?.notebookEditor?.notebook : context.notebook;
 
         if (ranges !== undefined && document !== undefined) {
             await chainWithPendingUpdates(document, (edit) => {

--- a/src/interactive-window/interactiveWindowProvider.node.ts
+++ b/src/interactive-window/interactiveWindowProvider.node.ts
@@ -62,7 +62,7 @@ export class InteractiveWindowProvider implements IInteractiveWindowProvider, IA
         return this._windows.find(
             (win) =>
                 window.activeNotebookEditor !== undefined &&
-                win.notebookUri?.toString() === window.activeNotebookEditor?.document.uri.toString()
+                win.notebookUri?.toString() === window.activeNotebookEditor?.notebook.uri.toString()
         );
     }
     public get windows(): ReadonlyArray<IInteractiveWindow> {

--- a/src/kernels/ipywidgets-message-coordination/notebookIPyWidgetCoordinator.ts
+++ b/src/kernels/ipywidgets-message-coordination/notebookIPyWidgetCoordinator.ts
@@ -127,7 +127,7 @@ export class NotebookIPyWidgetCoordinator implements IExtensionSyncActivationSer
             this.messageCoordinators.delete(e.notebook);
             this.attachedEditors.delete(e.notebook);
             this.notebook.notebookEditors
-                .filter((editor) => editor.document === e.notebook)
+                .filter((editor) => editor.notebook === e.notebook)
                 .forEach((editor) => {
                     const comms = this.notebookCommunications.get(editor);
                     this.previouslyInitialized.delete(editor);
@@ -149,22 +149,22 @@ export class NotebookIPyWidgetCoordinator implements IExtensionSyncActivationSer
         this.notebook.notebookEditors.forEach((editor) => this.initializeNotebookCommunication(editor, e.controller));
     }
     private initializeNotebookCommunication(editor: NotebookEditor, controller: IVSCodeNotebookController | undefined) {
-        const notebook = editor.document;
+        const notebook = editor.notebook;
         if (!controller) {
             traceVerbose(
                 `No controller, hence notebook communications cannot be initialized for editor ${getDisplayPath(
-                    editor.document.uri
+                    editor.notebook.uri
                 )}`
             );
             return;
         }
         if (this.notebookCommunications.has(editor)) {
             traceVerbose(
-                `notebook communications already initialized for editor ${getDisplayPath(editor.document.uri)}`
+                `notebook communications already initialized for editor ${getDisplayPath(editor.notebook.uri)}`
             );
             return;
         }
-        traceVerbose(`Intiailize notebook communications for editor ${getDisplayPath(editor.document.uri)}`);
+        traceVerbose(`Intiailize notebook communications for editor ${getDisplayPath(editor.notebook.uri)}`);
         const comms = new NotebookCommunication(editor, controller);
         this.addNotebookDisposables(notebook, [comms]);
         this.notebookCommunications.set(editor, comms);
@@ -198,7 +198,7 @@ export class NotebookIPyWidgetCoordinator implements IExtensionSyncActivationSer
         // Find any new editors that may be associated with the current notebook.
         // This can happen when users split editors.
         e.forEach((editor) => {
-            const controller = this.controllerManager.getSelectedNotebookController(editor.document);
+            const controller = this.controllerManager.getSelectedNotebookController(editor.notebook);
             this.initializeNotebookCommunication(editor, controller);
         });
     }

--- a/src/kernels/kernelCommandListener.ts
+++ b/src/kernels/kernelCommandListener.ts
@@ -82,7 +82,7 @@ export class KernelCommandListener implements IDataScienceCommandListener {
     public async interruptKernel(notebookUri: Uri | undefined): Promise<void> {
         const uri =
             notebookUri ??
-            window.activeNotebookEditor?.document.uri ??
+            window.activeNotebookEditor?.notebook.uri ??
             this.interactiveWindowProvider?.activeWindow?.notebookUri ??
             (window.activeTextEditor?.document.uri &&
                 this.interactiveWindowProvider?.get(window.activeTextEditor.document.uri)?.notebookUri);
@@ -104,7 +104,7 @@ export class KernelCommandListener implements IDataScienceCommandListener {
     private async restartKernel(notebookUri: Uri | undefined) {
         const uri =
             notebookUri ??
-            window.activeNotebookEditor?.document.uri ??
+            window.activeNotebookEditor?.notebook.uri ??
             this.interactiveWindowProvider?.activeWindow?.notebookUri ??
             (window.activeTextEditor?.document.uri &&
                 this.interactiveWindowProvider?.get(window.activeTextEditor.document.uri)?.notebookUri);

--- a/src/kernels/variables/debuggerVariables.node.ts
+++ b/src/kernels/variables/debuggerVariables.node.ts
@@ -403,12 +403,12 @@ export class DebuggerVariables
 
     private activeNotebookIsDebugging(): boolean {
         const activeNotebook = this.vscNotebook.activeNotebookEditor;
-        return !!activeNotebook && this.debuggingManager.isDebugging(activeNotebook.document);
+        return !!activeNotebook && this.debuggingManager.isDebugging(activeNotebook.notebook);
     }
 
     // This handles all the debug session calls, variable handling, and refresh calls needed for notebook debugging
     private async handleNotebookVariables(stoppedMessage: DebugProtocol.StoppedEvent): Promise<void> {
-        const doc = this.vscNotebook.activeNotebookEditor?.document;
+        const doc = this.vscNotebook.activeNotebookEditor?.notebook;
         const threadId = stoppedMessage.body.threadId;
 
         if (doc) {

--- a/src/notebooks/controllers/kernelSelector.ts
+++ b/src/notebooks/controllers/kernelSelector.ts
@@ -61,7 +61,7 @@ export function findNotebookEditor(
             ? notebooks.notebookDocuments.find((item) => getComparisonKey(item.uri, true) === key)
             : undefined;
     const targetNotebookEditor =
-        notebook && notebooks.activeNotebookEditor?.document === notebook ? notebooks.activeNotebookEditor : undefined;
+        notebook && notebooks.activeNotebookEditor?.notebook === notebook ? notebooks.activeNotebookEditor : undefined;
     const targetInteractiveNotebookEditor =
         resource && getResourceType(resource) === 'interactive'
             ? interactiveWindowProvider?.get(resource)?.notebookEditor

--- a/src/notebooks/controllers/liveKernelSwitcher.ts
+++ b/src/notebooks/controllers/liveKernelSwitcher.ts
@@ -57,7 +57,7 @@ export class LiveKernelSwitcher implements IExtensionSingleActivationService {
         // Do this in a loop as it may fail
         const success = await waitForCondition(
             async () => {
-                if (this.vscNotebook.activeNotebookEditor?.document === n) {
+                if (this.vscNotebook.activeNotebookEditor?.notebook === n) {
                     await this.commandManager.executeCommand('notebook.selectKernel', {
                         id: kernel.id,
                         extension: JVSC_EXTENSION_ID

--- a/src/notebooks/controllers/remoteSwitcher.ts
+++ b/src/notebooks/controllers/remoteSwitcher.ts
@@ -60,7 +60,7 @@ export class RemoteSwitcher implements IExtensionSingleActivationService {
         await this.serverSelector.selectJupyterURI(true, 'nativeNotebookToolbar');
     }
     private async updateStatusBar() {
-        if (!this.notebook.activeNotebookEditor || !isJupyterNotebook(this.notebook.activeNotebookEditor.document)) {
+        if (!this.notebook.activeNotebookEditor || !isJupyterNotebook(this.notebook.activeNotebookEditor.notebook)) {
             this.statusBarItem.hide();
             return;
         }

--- a/src/notebooks/controllers/vscodeNotebookController.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.ts
@@ -588,7 +588,7 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
                 : Telemetry.SelectRemoteJupyterKernel;
             sendKernelTelemetryEvent(document.uri, telemetryEvent);
             this.notebookApi.notebookEditors
-                .filter((editor) => editor.document === document)
+                .filter((editor) => editor.notebook === document)
                 .forEach((editor) =>
                     this.postMessage(
                         { message: IPyWidgetMessages.IPyWidgets_onKernelChanged, payload: undefined },

--- a/src/notebooks/execution/notebookUpdater.ts
+++ b/src/notebooks/execution/notebookUpdater.ts
@@ -54,7 +54,7 @@ export async function chainWithPendingUpdates(
 
 export function clearPendingChainedUpdatesForTests() {
     const editor: NotebookEditor | undefined = window.activeNotebookEditor;
-    if (editor?.document) {
-        pendingCellUpdates.delete(editor.document);
+    if (editor?.notebook) {
+        pendingCellUpdates.delete(editor.notebook);
     }
 }

--- a/src/notebooks/notebookCommandListener.ts
+++ b/src/notebooks/notebookCommandListener.ts
@@ -72,7 +72,7 @@ export class NotebookCommandListener implements IDataScienceCommandListener {
     }
 
     private removeAllCells() {
-        const document = this.notebooks.activeNotebookEditor?.document;
+        const document = this.notebooks.activeNotebookEditor?.notebook;
         if (!document) {
             return;
         }
@@ -84,7 +84,7 @@ export class NotebookCommandListener implements IDataScienceCommandListener {
         ).then(noop, noop);
     }
     private collapseAll() {
-        const document = this.notebooks.activeNotebookEditor?.document;
+        const document = this.notebooks.activeNotebookEditor?.notebook;
         if (!document) {
             return;
         }
@@ -98,7 +98,7 @@ export class NotebookCommandListener implements IDataScienceCommandListener {
     }
 
     private expandAll() {
-        const document = this.notebooks.activeNotebookEditor?.document;
+        const document = this.notebooks.activeNotebookEditor?.notebook;
         if (!document) {
             return;
         }

--- a/src/notebooks/outputs/errorRendererComms.node.ts
+++ b/src/notebooks/outputs/errorRendererComms.node.ts
@@ -104,14 +104,14 @@ export class ErrorRendererCommunicationHandler implements IExtensionSyncActivati
         const uri = Uri.parse(cellUri);
 
         // Show the matching notebook if there is one
-        let editor = this.notebooks.notebookEditors.find((n) => arePathsSame(n.document.uri.fsPath, uri.fsPath));
+        let editor = this.notebooks.notebookEditors.find((n) => arePathsSame(n.notebook.uri.fsPath, uri.fsPath));
         if (editor) {
             // If there is one, go to the cell that matches
-            const cell = editor.document.getCells().find((c) => c.document.uri.toString() === cellUri);
+            const cell = editor.notebook.getCells().find((c) => c.document.uri.toString() === cellUri);
             if (cell) {
                 const cellRange = new NotebookRange(cell.index, cell.index);
                 return this.notebooks
-                    .showNotebookDocument(editor.document.uri, { selections: [cellRange] })
+                    .showNotebookDocument(editor.notebook.uri, { selections: [cellRange] })
                     .then((_e) => {
                         return this.commandManager.executeCommand('notebook.cell.edit').then(() => {
                             const cellEditor = this.documentManager.visibleTextEditors.find(

--- a/src/notebooks/outputs/rendererCommunication.node.ts
+++ b/src/notebooks/outputs/rendererCommunication.node.ts
@@ -45,7 +45,7 @@ export class RendererCommunication implements IExtensionSingleActivationService,
         };
         api.onDidReceiveMessage(
             ({ editor, message }) => {
-                const document = editor.document || window.activeNotebookEditor?.document;
+                const document = editor.notebook || window.activeNotebookEditor?.notebook;
                 if (!document) {
                     return;
                 }

--- a/src/platform/common/activeEditorContext.ts
+++ b/src/platform/common/activeEditorContext.ts
@@ -139,7 +139,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
 
     private updateNativeNotebookCellContext() {
         // Separate for debugging.
-        const hasNativeCells = (this.vscNotebook.activeNotebookEditor?.document.cellCount || 0) > 0;
+        const hasNativeCells = (this.vscNotebook.activeNotebookEditor?.notebook.cellCount || 0) > 0;
         this.hasNativeNotebookCells.set(hasNativeCells).ignoreErrors();
     }
     private onDidChangeActiveInteractiveWindow(e?: IInteractiveWindow) {
@@ -149,11 +149,11 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
         this.updateContextOfActiveInteractiveWindowKernel();
     }
     private onDidChangeActiveNotebookEditor(e?: NotebookEditor) {
-        const isJupyterNotebookDoc = e ? e.document.notebookType === JupyterNotebookView : false;
+        const isJupyterNotebookDoc = e ? e.notebook.notebookType === JupyterNotebookView : false;
         this.nativeContext.set(isJupyterNotebookDoc).ignoreErrors();
 
         this.isPythonNotebook
-            .set(e && isJupyterNotebookDoc ? isPythonNotebook(getNotebookMetadata(e.document)) : false)
+            .set(e && isJupyterNotebookDoc ? isPythonNotebook(getNotebookMetadata(e.notebook)) : false)
             .ignoreErrors();
         this.updateContextOfActiveNotebookKernel(e);
         this.updateContextOfActiveInteractiveWindowKernel();
@@ -172,8 +172,8 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
     }
     private updateContextOfActiveNotebookKernel(activeEditor?: NotebookEditor) {
         const kernel =
-            activeEditor && activeEditor.document.notebookType === JupyterNotebookView
-                ? this.kernelProvider.get(activeEditor.document.uri)
+            activeEditor && activeEditor.notebook.notebookType === JupyterNotebookView
+                ? this.kernelProvider.get(activeEditor.notebook.uri)
                 : undefined;
         if (kernel) {
             const canStart = kernel.status !== 'unknown';
@@ -188,8 +188,8 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
     }
     private updateSelectedKernelContext() {
         const document =
-            this.vscNotebook.activeNotebookEditor?.document ||
-            getActiveInteractiveWindow(this.interactiveProvider)?.notebookEditor?.document;
+            this.vscNotebook.activeNotebookEditor?.notebook ||
+            getActiveInteractiveWindow(this.interactiveProvider)?.notebookEditor?.notebook;
         if (document && isJupyterNotebook(document) && this.controllers.getSelectedNotebookController(document)) {
             this.isJupyterKernelSelected.set(true).catch(noop);
         } else {
@@ -197,7 +197,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
         }
     }
     private updateContextOfActiveInteractiveWindowKernel() {
-        const notebook = getActiveInteractiveWindow(this.interactiveProvider)?.notebookEditor?.document;
+        const notebook = getActiveInteractiveWindow(this.interactiveProvider)?.notebookEditor?.notebook;
         const kernel = notebook ? this.kernelProvider.get(notebook.uri) : undefined;
         if (kernel) {
             const canStart = kernel.status !== 'unknown';
@@ -216,7 +216,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
             this.updateContextOfActiveInteractiveWindowKernel();
         } else if (
             notebook?.notebookType === JupyterNotebookView &&
-            notebook === this.vscNotebook.activeNotebookEditor?.document
+            notebook === this.vscNotebook.activeNotebookEditor?.notebook
         ) {
             this.updateContextOfActiveNotebookKernel(this.vscNotebook.activeNotebookEditor);
         }

--- a/src/platform/interpreter/display/visibilityFilter.node.ts
+++ b/src/platform/interpreter/display/visibilityFilter.node.ts
@@ -43,7 +43,7 @@ export class InterpreterStatusBarVisibility
     }
     public get hidden() {
         return this.vscNotebook.activeNotebookEditor &&
-            isJupyterNotebook(this.vscNotebook.activeNotebookEditor.document)
+            isJupyterNotebook(this.vscNotebook.activeNotebookEditor.notebook)
             ? true
             : false;
     }

--- a/src/test/client/api.vscode.test.ts
+++ b/src/test/client/api.vscode.test.ts
@@ -81,7 +81,7 @@ suite('3rd Party Kernel Service API', function () {
 
         await createEmptyPythonNotebook(disposables);
         await insertCodeCell('print("123412341234")', { index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await Promise.all([runCell(cell), waitForTextOutput(cell, '123412341234')]);
 
         await onDidChangeKernels.assertFiredExactly(1);
@@ -90,12 +90,12 @@ suite('3rd Party Kernel Service API', function () {
         assert.isAtLeast(kernels!.length, 1);
         assert.strictEqual(
             kernels![0].uri!.toString(),
-            vscodeNotebook.activeNotebookEditor?.document.uri.toString(),
+            vscodeNotebook.activeNotebookEditor?.notebook.uri.toString(),
             'Kernel notebook is not the active notebook'
         );
 
         assert.isObject(kernels![0].metadata, 'Kernel Connection is undefined');
-        const kernel = kernelService?.getKernel(vscodeNotebook.activeNotebookEditor!.document!.uri);
+        const kernel = kernelService?.getKernel(vscodeNotebook.activeNotebookEditor!.notebook!.uri);
         assert.strictEqual(kernels![0].metadata, kernel!.metadata, 'Kernel Connection not same for the document');
 
         await closeNotebooksAndCleanUpAfterTests(disposables);

--- a/src/test/datascience/debugger.vscode.test.ts
+++ b/src/test/datascience/debugger.vscode.test.ts
@@ -86,7 +86,7 @@ suite('VSCode Notebook - Run By Line', function () {
         this.skip();
         // Run by line seems to end up on the second line of the function, not the first
         const cell = await insertCodeCell('a=1\na', { index: 0 });
-        const doc = vscodeNotebook.activeNotebookEditor?.document!;
+        const doc = vscodeNotebook.activeNotebookEditor?.notebook!;
         traceInfo(`Inserted cell`);
 
         await commandManager.executeCommand(Commands.RunByLine, cell);
@@ -129,7 +129,7 @@ suite('VSCode Notebook - Run By Line', function () {
 
     test('Interrupt during debugging', async function () {
         const cell = await insertCodeCell('a=1\na', { index: 0 });
-        const doc = vscodeNotebook.activeNotebookEditor?.document!;
+        const doc = vscodeNotebook.activeNotebookEditor?.notebook!;
 
         await commandManager.executeCommand(Commands.RunByLine, cell);
         const { debugAdapter } = await getDebugSessionAndAdapter(debuggingManager, doc);
@@ -149,7 +149,7 @@ suite('VSCode Notebook - Run By Line', function () {
         // See https://github.com/microsoft/vscode-jupyter/issues/9130
         this.skip();
         const cell = await insertCodeCell('def foo():\n    print(1)\n\nfoo()', { index: 0 });
-        const doc = vscodeNotebook.activeNotebookEditor?.document!;
+        const doc = vscodeNotebook.activeNotebookEditor?.notebook!;
 
         await commandManager.executeCommand(Commands.RunByLine, cell);
         const { debugAdapter, session } = await getDebugSessionAndAdapter(debuggingManager, doc);
@@ -182,7 +182,7 @@ suite('VSCode Notebook - Run By Line', function () {
         // https://github.com/microsoft/vscode-jupyter/issues/8757
         const cell0 = await insertCodeCell('def foo():\n    print(1)');
         const cell1 = await insertCodeCell('foo()');
-        const doc = vscodeNotebook.activeNotebookEditor?.document!;
+        const doc = vscodeNotebook.activeNotebookEditor?.notebook!;
 
         await runCell(cell0);
         await commandManager.executeCommand(Commands.RunByLine, cell1);
@@ -209,7 +209,7 @@ suite('VSCode Notebook - Run By Line', function () {
                 index: 0
             }
         );
-        const doc = vscodeNotebook.activeNotebookEditor?.document!;
+        const doc = vscodeNotebook.activeNotebookEditor?.notebook!;
         const cell = doc.getCells()[0];
 
         void commandManager.executeCommand(Commands.RunByLine, cell);

--- a/src/test/datascience/helpers.node.ts
+++ b/src/test/datascience/helpers.node.ts
@@ -183,7 +183,7 @@ export async function runCurrentFile(interactiveWindowProvider: IInteractiveWind
 export async function closeInteractiveWindow(interactiveWindow: IInteractiveWindow) {
     if (interactiveWindow.notebookDocument) {
         const editor = vscode.window.visibleNotebookEditors.find(
-            (n) => n.document === interactiveWindow.notebookDocument
+            (n) => n.notebook === interactiveWindow.notebookDocument
         );
         if (editor) {
             await vscode.commands.executeCommand('workbench.action.focusSecondEditorGroup');

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -222,7 +222,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
 
         await openNotebook(nbFile);
         await waitForKernelToGetAutoSelected();
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         assert.equal(cell.outputs.length, 0);
 
         // The prompt should be displayed when we run a cell.
@@ -596,7 +596,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         // Now that IPyKernel is missing, if we attempt to restart a kernel, we should get a prompt.
         // Previously things just hang at weird spots, its not a likely scenario, but this test ensures the code works as expected.
         const startController = controllerManager.getSelectedNotebookController(
-            vscodeNotebook.activeNotebookEditor?.document!
+            vscodeNotebook.activeNotebookEditor?.notebook!
         );
         assert.ok(startController);
 
@@ -619,7 +619,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
             waitForCondition(
                 async () => {
                     const newController = controllerManager.getSelectedNotebookController(
-                        vscodeNotebook.activeNotebookEditor?.document!
+                        vscodeNotebook.activeNotebookEditor?.notebook!
                     );
                     assert.ok(newController);
                     assert.notEqual(startController?.id, newController!.id);
@@ -654,7 +654,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
 
         await openNotebook(nbFile);
         await waitForKernelToGetAutoSelected();
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         assert.equal(cell.outputs.length, 0);
 
         // Insert another cell so we can test run all
@@ -703,7 +703,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         promptToInstall.dispose();
 
         assert.strictEqual(
-            window.activeNotebookEditor?.document.cellAt(0).outputs.length,
+            window.activeNotebookEditor?.notebook.cellAt(0).outputs.length,
             0,
             'Should not have any outputs with ipykernel missing error'
         );
@@ -806,7 +806,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
                 );
                 selectADifferentKernelStub = result.selectADifferentKernelStub;
             }
-            const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+            const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
 
             console.log('Stepc');
             await Promise.all([

--- a/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
@@ -94,7 +94,7 @@ suite('DataScience - Kernel Dependency Service', () => {
                         instance(interactiveWindowProvider)
                     );
                 }
-                when(editor.document).thenReturn(instance(document));
+                when(editor.notebook).thenReturn(instance(document));
             });
             teardown(() => token.dispose());
             test('Check if ipykernel is installed', async () => {

--- a/src/test/datascience/notebook/diagnosticProvider.vscode.test.ts
+++ b/src/test/datascience/notebook/diagnosticProvider.vscode.test.ts
@@ -38,7 +38,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
                 .getAll<NotebookCellBangInstallDiagnosticsProvider>(IExtensionSyncActivationService)
                 .find((item) => item instanceof NotebookCellBangInstallDiagnosticsProvider)!;
             await createEmptyPythonNotebook(disposables);
-            activeNotebook = vscodeNotebook.activeNotebookEditor!.document;
+            activeNotebook = vscodeNotebook.activeNotebookEditor!.notebook;
             assert.isOk(activeNotebook, 'No active notebook');
             traceInfo(`Start Test (completed) ${this.currentTest?.title}`);
         } catch (e) {
@@ -53,7 +53,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
     });
     test('Show error for pip install', async () => {
         await insertCodeCell('!pip install xyz', { index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
 
         await waitForCondition(
             async () => (diagnosticProvider.problems.get(cell.document.uri) || []).length > 0,
@@ -69,7 +69,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
     });
     test('Show error for conda install', async () => {
         await insertCodeCell('!conda install xyz', { index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
 
         await waitForCondition(
             async () => (diagnosticProvider.problems.get(cell.document.uri) || []).length > 0,

--- a/src/test/datascience/notebook/executionService.vscode.test.ts
+++ b/src/test/datascience/notebook/executionService.vscode.test.ts
@@ -121,20 +121,20 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
     suiteTeardown(() => closeNotebooksAndCleanUpAfterTests(disposables));
     test('Execute cell using VSCode Kernel', async () => {
         await insertCodeCell('print("123412341234")', { index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
 
         await Promise.all([runCell(cell), waitForTextOutput(cell, '123412341234')]);
     });
     test('Test __vsc_ipynb_file__ defined in cell using VSCode Kernel', async () => {
-        const uri = vscodeNotebook.activeNotebookEditor?.document.uri;
+        const uri = vscodeNotebook.activeNotebookEditor?.notebook.uri;
         if (uri && uri.scheme === 'file') {
             await insertCodeCell('print(__vsc_ipynb_file__)', { index: 0 });
-            const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+            const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
             await Promise.all([runCell(cell), waitForTextOutput(cell, `${uri.fsPath}`)]);
         }
     });
     test('Test exceptions have hrefs', async () => {
-        const uri = vscodeNotebook.activeNotebookEditor?.document.uri;
+        const uri = vscodeNotebook.activeNotebookEditor?.notebook.uri;
         if (uri && uri.scheme === 'file') {
             let ipythonVersionCell = await insertCodeCell(IPYTHON_VERSION_CODE, { index: 0 });
             await runCell(ipythonVersionCell);
@@ -163,7 +163,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
     });
     test('Leading whitespace not suppressed', async () => {
         await insertCodeCell('print("\tho")\nprint("\tho")\nprint("\tho")\n', { index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
 
         await Promise.all([runCell(cell), waitForTextOutput(cell, '\tho\n\tho\n\tho\n', 0, true)]);
     });
@@ -191,7 +191,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
     test('Empty cells will not have an execution order nor have a status of success', async () => {
         await insertCodeCell('');
         await insertCodeCell('print("Hello World")');
-        const cells = vscodeNotebook.activeNotebookEditor?.document.getCells()!;
+        const cells = vscodeNotebook.activeNotebookEditor?.notebook.getCells()!;
 
         await Promise.all([runAllCellsInActiveNotebook(), waitForTextOutput(cells[1], 'Hello World')]);
 
@@ -204,7 +204,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         await waitForKernelToGetAutoSelected();
 
         // Confirm we have execution order and output.
-        const cells = vscodeNotebook.activeNotebookEditor?.document.getCells()!;
+        const cells = vscodeNotebook.activeNotebookEditor?.notebook.getCells()!;
         assert.equal(cells[0].executionSummary?.executionOrder, 1);
         await waitForTextOutput(cells[0], 'Hello World');
 
@@ -227,7 +227,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
     });
     test('Verify Cell output, execution count and status', async () => {
         await insertCodeCell('print("Hello World")');
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
 
         await Promise.all([runAllCellsInActiveNotebook(), waitForTextOutput(cell, 'Hello World', 0, false)]);
 
@@ -237,7 +237,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
     test('Verify multiple cells get executed', async () => {
         await insertCodeCell('print("Foo Bar")');
         await insertCodeCell('print("Hello World")');
-        const cells = vscodeNotebook.activeNotebookEditor?.document.getCells()!;
+        const cells = vscodeNotebook.activeNotebookEditor?.notebook.getCells()!;
 
         await Promise.all([
             runAllCellsInActiveNotebook(),
@@ -252,7 +252,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
     });
     test('Verify metadata for successfully executed cell', async () => {
         await insertCodeCell('print("Foo Bar")');
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
 
         await Promise.all([
             runAllCellsInActiveNotebook(),
@@ -265,7 +265,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
     });
     test('Verify output & metadata for executed cell with errors', async () => {
         await insertCodeCell('print(abcd)');
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
 
         await Promise.all([
             runAllCellsInActiveNotebook(),
@@ -286,8 +286,8 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         await insertCodeCell('from IPython.display import Markdown\n');
         await insertCodeCell('dh = display(display_id=True)\n');
         await insertCodeCell('dh.update(Markdown("foo"))\n');
-        const displayCell = vscodeNotebook.activeNotebookEditor?.document.getCells()![1]!;
-        const updateCell = vscodeNotebook.activeNotebookEditor?.document.getCells()![2]!;
+        const displayCell = vscodeNotebook.activeNotebookEditor?.notebook.getCells()![1]!;
+        const updateCell = vscodeNotebook.activeNotebookEditor?.notebook.getCells()![2]!;
 
         await runAllCellsInActiveNotebook();
 
@@ -313,7 +313,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
                     print("End")`,
             { index: 0 }
         );
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         runAllCellsInActiveNotebook().catch(noop);
 
         await Promise.all([
@@ -338,11 +338,11 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
 
         // Interrupt the kernel).
         traceInfo(
-            `Interrupt requested for ${getDisplayPath(vscodeNotebook.activeNotebookEditor?.document?.uri)} in test`
+            `Interrupt requested for ${getDisplayPath(vscodeNotebook.activeNotebookEditor?.notebook?.uri)} in test`
         );
         await commands.executeCommand(
             'jupyter.notebookeditor.interruptkernel',
-            vscodeNotebook.activeNotebookEditor?.document.uri
+            vscodeNotebook.activeNotebookEditor?.notebook.uri
         );
         await waitForExecutionCompletedWithErrors(cell);
         // Verify that it hasn't got added (even after interrupting).
@@ -364,7 +364,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
                 display('bar')`,
             { index: 0 }
         );
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
 
         await runAllCellsInActiveNotebook();
 
@@ -384,7 +384,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         await insertCodeCell('import os', { index: 1 });
         await insertCodeCell('print(os.getenv("PATH"))', { index: 2 });
         await insertCodeCell('print(sys.executable)', { index: 3 });
-        const [, , cell3, cell4] = vscodeNotebook.activeNotebookEditor?.document.getCells()!;
+        const [, , cell3, cell4] = vscodeNotebook.activeNotebookEditor?.notebook.getCells()!;
 
         // Basically anything such as `!which python` and the like should point to the right executable.
         // For that to work, the first directory in the PATH must be the Python environment.
@@ -411,7 +411,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         await insertCodeCell(getOSType() === OSType.Windows ? '!where python' : '!which python', { index: 0 });
         await insertCodeCell('import sys', { index: 1 });
         await insertCodeCell('print(sys.executable)', { index: 2 });
-        const [cell1, , cell3] = vscodeNotebook.activeNotebookEditor!.document.getCells()!;
+        const [cell1, , cell3] = vscodeNotebook.activeNotebookEditor!.notebook.getCells()!;
 
         // Basically anything such as `!which python` and the like should point to the right executable.
         // For that to work, the first directory in the PATH must be the Python environment.
@@ -481,7 +481,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
                     print("End")`,
             { index: 0 }
         );
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
 
         await Promise.all([
             runAllCellsInActiveNotebook(),
@@ -503,7 +503,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
                                             a="<a href=f>"
                                             print(a)`);
         await insertCodeCell('raise Exception("<whatever>")');
-        const cells = vscodeNotebook.activeNotebookEditor?.document.getCells()!;
+        const cells = vscodeNotebook.activeNotebookEditor?.notebook.getCells()!;
 
         await Promise.all([
             runAllCellsInActiveNotebook(),
@@ -526,7 +526,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
     test('Verify display updates', async () => {
         await insertCodeCell('from IPython.display import Markdown', { index: 0 });
         await insertCodeCell('dh = display(Markdown("foo"), display_id=True)', { index: 1 });
-        const [, cell2] = vscodeNotebook.activeNotebookEditor?.document.getCells()!;
+        const [, cell2] = vscodeNotebook.activeNotebookEditor?.notebook.getCells()!;
 
         await Promise.all([runAllCellsInActiveNotebook(), waitForTextOutput(cell2, 'foo', 0, false)]);
         const cell3 = await insertCodeCell(
@@ -567,7 +567,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         `,
             { index: 0 }
         );
-        const cells = vscodeNotebook.activeNotebookEditor?.document.getCells()!;
+        const cells = vscodeNotebook.activeNotebookEditor?.notebook.getCells()!;
 
         await Promise.all([
             runAllCellsInActiveNotebook(),
@@ -633,7 +633,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
             { index: 0 }
         );
         await insertCodeCell('print("HELLO")', { index: 1 });
-        const [cell1, cell2] = vscodeNotebook.activeNotebookEditor?.document.getCells()!;
+        const [cell1, cell2] = vscodeNotebook.activeNotebookEditor?.notebook.getCells()!;
 
         await Promise.all([
             runAllCellsInActiveNotebook(),
@@ -756,7 +756,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         if (!vscodeNotebook.activeNotebookEditor) {
             throw new Error('No active document');
         }
-        const cells = vscodeNotebook.activeNotebookEditor!.document.getCells();
+        const cells = vscodeNotebook.activeNotebookEditor!.notebook.getCells();
         traceInfo('1. Start execution for test of Stderr & stdout outputs');
         traceInfo('2. Start execution for test of Stderr & stdout outputs');
         await Promise.all([
@@ -820,7 +820,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         );
         await insertCodeCell('print("\\rExecute\\rExecute\\nExecute 8\\rExecute 9\\r\\r")', { index: 5 });
 
-        const cells = vscodeNotebook.activeNotebookEditor!.document.getCells();
+        const cells = vscodeNotebook.activeNotebookEditor!.notebook.getCells();
         await Promise.all([runAllCellsInActiveNotebook(), waitForExecutionCompletedSuccessfully(cells[5])]);
 
         // Wait for the outputs.
@@ -838,13 +838,13 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         await insertCodeCell('raise Error("fail")', { index: 0 });
         await insertCodeCell('print("after fail")', { index: 1 });
 
-        const cells = vscodeNotebook.activeNotebookEditor!.document.getCells();
+        const cells = vscodeNotebook.activeNotebookEditor!.notebook.getCells();
         await Promise.all([runAllCellsInActiveNotebook(), waitForExecutionCompletedWithErrors(cells[0])]);
 
         // Second cell output should be empty
         assert.equal(cells[1].outputs.length, 0, 'Second cell is not empty on run all');
 
-        const cell = vscodeNotebook.activeNotebookEditor?.document.getCells()![1]!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.getCells()![1]!;
         await Promise.all([
             runCell(cell),
             // Wait till execution count changes and status is success.
@@ -856,7 +856,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         await insertCodeCell('Hello World', { index: 1, language: 'raw' });
         await insertCodeCell('print(5678)', { index: 2 });
 
-        const [cell1, cell2, cell3] = vscodeNotebook.activeNotebookEditor!.document.getCells();
+        const [cell1, cell2, cell3] = vscodeNotebook.activeNotebookEditor!.notebook.getCells();
         await Promise.all([
             runAllCellsInActiveNotebook(),
             waitForCellExecutionToComplete(cell1),
@@ -1128,7 +1128,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
             IPython.get_ipython().set_next_input("print('REPLACE')", replace=True)`,
             { index: 1 }
         );
-        const cells = vscodeNotebook.activeNotebookEditor?.document.getCells()!;
+        const cells = vscodeNotebook.activeNotebookEditor?.notebook.getCells()!;
 
         await Promise.all([
             runAllCellsInActiveNotebook(),
@@ -1137,14 +1137,14 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
             waitForExecutionCompletedSuccessfully(cells[0]),
             waitForExecutionCompletedSuccessfully(cells[1]),
             waitForCondition(
-                async () => vscodeNotebook.activeNotebookEditor?.document.cellCount === 3,
+                async () => vscodeNotebook.activeNotebookEditor?.notebook.cellCount === 3,
                 defaultNotebookTestTimeout,
                 'New cell not inserted'
             )
         ]);
 
         // Check our output, one cell should have been inserted, and one been replaced
-        const cellsPostExecute = vscodeNotebook.activeNotebookEditor?.document.getCells()!;
+        const cellsPostExecute = vscodeNotebook.activeNotebookEditor?.notebook.getCells()!;
         expect(cellsPostExecute.length).to.equal(3);
         expect(cellsPostExecute[0].document.getText()).to.equal(
             dedent`
@@ -1199,7 +1199,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
     async function insertRandomCells(options?: { count: number; addMarkdownCells: boolean }) {
         const cellInfo: { runToCompletion: Function; cell: NotebookCell }[] = [];
         const numberOfCellsToAdd = options?.count ?? 10;
-        const startIndex = vscodeNotebook.activeNotebookEditor!.document.cellCount;
+        const startIndex = vscodeNotebook.activeNotebookEditor!.notebook.cellCount;
         const endIndex = startIndex + numberOfCellsToAdd;
         // Insert the necessary amount of cells
         for (let index = startIndex; index < endIndex; index++) {

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -85,14 +85,14 @@ export async function insertMarkdownCell(source: string, options?: { index?: num
     if (!activeEditor) {
         throw new Error('No active editor');
     }
-    const startNumber = options?.index ?? activeEditor.document.cellCount;
-    await chainWithPendingUpdates(activeEditor.document, (edit) => {
+    const startNumber = options?.index ?? activeEditor.notebook.cellCount;
+    await chainWithPendingUpdates(activeEditor.notebook, (edit) => {
         const cellData = new NotebookCellData(NotebookCellKind.Markup, source, MARKDOWN_LANGUAGE);
         cellData.outputs = [];
         cellData.metadata = {};
-        edit.replaceNotebookCells(activeEditor.document.uri, new NotebookRange(startNumber, startNumber), [cellData]);
+        edit.replaceNotebookCells(activeEditor.notebook.uri, new NotebookRange(startNumber, startNumber), [cellData]);
     });
-    return activeEditor.document.cellAt(startNumber)!;
+    return activeEditor.notebook.cellAt(startNumber)!;
 }
 export async function insertCodeCell(source: string, options?: { language?: string; index?: number }) {
     const { vscodeNotebook } = await getServices();
@@ -100,38 +100,38 @@ export async function insertCodeCell(source: string, options?: { language?: stri
     if (!activeEditor) {
         throw new Error('No active editor');
     }
-    const startNumber = options?.index ?? activeEditor.document.cellCount;
+    const startNumber = options?.index ?? activeEditor.notebook.cellCount;
     const edit = new WorkspaceEdit();
     const cellData = new NotebookCellData(NotebookCellKind.Code, source, options?.language || PYTHON_LANGUAGE);
     cellData.outputs = [];
     cellData.metadata = {};
-    edit.replaceNotebookCells(activeEditor.document.uri, new NotebookRange(startNumber, startNumber), [cellData]);
+    edit.replaceNotebookCells(activeEditor.notebook.uri, new NotebookRange(startNumber, startNumber), [cellData]);
     await workspace.applyEdit(edit);
 
-    return activeEditor.document.cellAt(startNumber)!;
+    return activeEditor.notebook.cellAt(startNumber)!;
 }
 export async function deleteCell(index: number = 0) {
     const { vscodeNotebook } = await getServices();
     const activeEditor = vscodeNotebook.activeNotebookEditor;
-    if (!activeEditor || activeEditor.document.cellCount === 0) {
+    if (!activeEditor || activeEditor.notebook.cellCount === 0) {
         return;
     }
     if (!activeEditor) {
         assert.fail('No active editor');
         return;
     }
-    await chainWithPendingUpdates(activeEditor.document, (edit) =>
-        edit.replaceNotebookCells(activeEditor.document.uri, new NotebookRange(index, index + 1), [])
+    await chainWithPendingUpdates(activeEditor.notebook, (edit) =>
+        edit.replaceNotebookCells(activeEditor.notebook.uri, new NotebookRange(index, index + 1), [])
     );
 }
 export async function deleteAllCellsAndWait() {
     const { vscodeNotebook } = await getServices();
     const activeEditor = vscodeNotebook.activeNotebookEditor;
-    if (!activeEditor || activeEditor.document.cellCount === 0) {
+    if (!activeEditor || activeEditor.notebook.cellCount === 0) {
         return;
     }
-    await chainWithPendingUpdates(activeEditor.document, (edit) =>
-        edit.replaceNotebookCells(activeEditor.document.uri, new NotebookRange(0, activeEditor.document.cellCount), [])
+    await chainWithPendingUpdates(activeEditor.notebook, (edit) =>
+        edit.replaceNotebookCells(activeEditor.notebook.uri, new NotebookRange(0, activeEditor.notebook.cellCount), [])
     );
 }
 
@@ -320,7 +320,7 @@ async function waitForKernelToChangeImpl(
     }
     traceInfo(`Switching to kernel id ${id}`);
     const isRightKernel = () => {
-        const doc = vscodeNotebook.activeNotebookEditor?.document;
+        const doc = vscodeNotebook.activeNotebookEditor?.notebook;
         if (!doc) {
             return false;
         }
@@ -384,7 +384,7 @@ export async function waitForKernelToGetAutoSelected(
     const notebookControllers = notebookControllerManager.getRegisteredNotebookControllers();
 
     // Make sure we don't already have a selection (this function gets run even after opening a document)
-    if (notebookControllerManager.getSelectedNotebookController(vscodeNotebook.activeNotebookEditor!.document)) {
+    if (notebookControllerManager.getSelectedNotebookController(vscodeNotebook.activeNotebookEditor!.notebook)) {
         return;
     }
 
@@ -396,7 +396,7 @@ export async function waitForKernelToGetAutoSelected(
         await waitForCondition(
             async () => {
                 preferred = notebookControllerManager.getPreferredNotebookController(
-                    vscodeNotebook.activeNotebookEditor!.document
+                    vscodeNotebook.activeNotebookEditor!.notebook
                 );
                 return preferred != undefined;
             },
@@ -479,7 +479,7 @@ export async function prewarmNotebooks() {
         await editorProvider.createNew();
         await insertCodeCell('print("Hello World1")', { index: 0 });
         await waitForKernelToGetAutoSelected();
-        const cell = vscodeNotebook.activeNotebookEditor!.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor!.notebook.cellAt(0)!;
         traceInfoIfCI(`Running all cells in prewarm notebooks`);
         await Promise.all([waitForExecutionCompletedSuccessfully(cell, 60_000), runAllCellsInActiveNotebook()]);
         await closeActiveWindows();
@@ -817,14 +817,14 @@ export async function runCell(cell: NotebookCell, waitForExecutionToComplete = f
     const api = await initialize();
     const vscodeNotebook = api.serviceContainer.get<IVSCodeNotebook>(IVSCodeNotebook);
     await waitForKernelToGetAutoSelected(undefined, false, 60_000);
-    if (!vscodeNotebook.activeNotebookEditor || !vscodeNotebook.activeNotebookEditor.document) {
+    if (!vscodeNotebook.activeNotebookEditor || !vscodeNotebook.activeNotebookEditor.notebook) {
         throw new Error('No notebook or document');
     }
 
     const promise = commands.executeCommand(
         'notebook.cell.execute',
         { start: cell.index, end: cell.index + 1 },
-        vscodeNotebook.activeNotebookEditor.document.uri
+        vscodeNotebook.activeNotebookEditor.notebook.uri
     );
 
     if (waitForExecutionToComplete) {
@@ -836,12 +836,12 @@ export async function runAllCellsInActiveNotebook(waitForExecutionToComplete = f
     const vscodeNotebook = api.serviceContainer.get<IVSCodeNotebook>(IVSCodeNotebook);
     await waitForKernelToGetAutoSelected(undefined, false, 60_000);
 
-    if (!vscodeNotebook.activeNotebookEditor || !vscodeNotebook.activeNotebookEditor.document) {
+    if (!vscodeNotebook.activeNotebookEditor || !vscodeNotebook.activeNotebookEditor.notebook) {
         throw new Error('No editor or document');
     }
 
     const promise = commands
-        .executeCommand('notebook.execute', vscodeNotebook.activeNotebookEditor.document.uri)
+        .executeCommand('notebook.execute', vscodeNotebook.activeNotebookEditor.notebook.uri)
         .then(noop, noop);
 
     if (waitForExecutionToComplete) {

--- a/src/test/datascience/notebook/intellisense/completion.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/completion.vscode.test.ts
@@ -70,7 +70,7 @@ suite('DataScience - VSCode Intellisense Notebook and Interactive Code Completio
     suiteTeardown(() => closeNotebooksAndCleanUpAfterTests(disposables));
     test('Execute cell and get completions for variable', async () => {
         await insertCodeCell('import sys\nprint(sys.executable)\na = 1', { index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
 
         await runCell(cell);
 
@@ -79,7 +79,7 @@ suite('DataScience - VSCode Intellisense Notebook and Interactive Code Completio
         const outputText = getTextOutputValue(cell.outputs[0]).trim();
         traceInfo(`Cell Output ${outputText}`);
         await insertCodeCell('a.', { index: 1 });
-        const cell2 = vscodeNotebook.activeNotebookEditor!.document.cellAt(1);
+        const cell2 = vscodeNotebook.activeNotebookEditor!.notebook.cellAt(1);
 
         const position = new Position(0, 2);
         traceInfo('Get completions in test');

--- a/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/completionProvider.vscode.test.ts
@@ -110,7 +110,7 @@ suite('DataScience - VSCode Intellisense Notebook - (Code Completion via Jupyter
         await insertCodeCell('%pip install pandas', {
             index: 0
         });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
 
         await runCell(cell);
 
@@ -121,7 +121,7 @@ suite('DataScience - VSCode Intellisense Notebook - (Code Completion via Jupyter
         await insertCodeCell(`import pandas as pd\ndf = pd.read_csv("${namesCsvPath}")\n`, {
             index: 1
         });
-        const cell2 = vscodeNotebook.activeNotebookEditor?.document.cellAt(1)!;
+        const cell2 = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(1)!;
 
         await runCell(cell2);
 
@@ -136,7 +136,7 @@ suite('DataScience - VSCode Intellisense Notebook - (Code Completion via Jupyter
 
         // Now add the cell to check intellisense.
         await insertCodeCell(cellCode);
-        const cell4 = vscodeNotebook.activeNotebookEditor!.document.cellAt(3);
+        const cell4 = vscodeNotebook.activeNotebookEditor!.notebook.cellAt(3);
 
         const token = new CancellationTokenSource().token;
         // If we're testing string completions, ensure the cursor position is inside the string quotes.
@@ -210,27 +210,27 @@ suite('DataScience - VSCode Intellisense Notebook - (Code Completion via Jupyter
         );
     }
     test('Dataframe completions', async () => {
-        const fileName = path.basename(vscodeNotebook.activeNotebookEditor!.document.uri.fsPath);
+        const fileName = path.basename(vscodeNotebook.activeNotebookEditor!.notebook.uri.fsPath);
         await testCompletions('df.', '.', fileName, 'Age', 'N', 'Name');
     });
     test('Dataframe column completions', async () => {
-        const fileName = path.basename(vscodeNotebook.activeNotebookEditor!.document.uri.fsPath);
+        const fileName = path.basename(vscodeNotebook.activeNotebookEditor!.notebook.uri.fsPath);
         await testCompletions('df.Name.', '.', fileName, 'add_prefix', 'add_s', 'add_suffix');
     });
     test('Dataframe assignment completions', async () => {
-        const fileName = path.basename(vscodeNotebook.activeNotebookEditor!.document.uri.fsPath);
+        const fileName = path.basename(vscodeNotebook.activeNotebookEditor!.notebook.uri.fsPath);
         await testCompletions('var_name = df.', '.', fileName, 'Age', 'N', 'Name');
     });
     test('Dataframe assignment column completions', async () => {
-        const fileName = path.basename(vscodeNotebook.activeNotebookEditor!.document.uri.fsPath);
+        const fileName = path.basename(vscodeNotebook.activeNotebookEditor!.notebook.uri.fsPath);
         await testCompletions(fileName.substring(0, 1), fileName);
     });
     test('File path completions with double quotes', async () => {
-        const fileName = path.basename(vscodeNotebook.activeNotebookEditor!.document.uri.fsPath);
+        const fileName = path.basename(vscodeNotebook.activeNotebookEditor!.notebook.uri.fsPath);
         await testCompletions(`"${fileName.substring(0, 1)}"`, undefined, fileName);
     });
     test('File path completions with single quotes', async () => {
-        const fileName = path.basename(vscodeNotebook.activeNotebookEditor!.document.uri.fsPath);
+        const fileName = path.basename(vscodeNotebook.activeNotebookEditor!.notebook.uri.fsPath);
         await testCompletions(`'${fileName.substring(0, 1)}'`, undefined, fileName);
     });
     test('Provider is registered', async () => {
@@ -251,7 +251,7 @@ suite('DataScience - VSCode Intellisense Notebook - (Code Completion via Jupyter
             }
         );
         await insertCodeCell('a.', { index: 1 });
-        const cell2 = vscodeNotebook.activeNotebookEditor!.document.cellAt(1);
+        const cell2 = vscodeNotebook.activeNotebookEditor!.notebook.cellAt(1);
 
         const position = new Position(0, 2);
         traceInfo('Get completions in test');

--- a/src/test/datascience/notebook/intellisense/diagnostics.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/diagnostics.vscode.test.ts
@@ -54,7 +54,7 @@ suite('DataScience - VSCode Intellisense Notebook Diagnostics', function () {
     suiteTeardown(() => closeNotebooksAndCleanUpAfterTests(disposables));
     test('Add cells and make sure errors show up', async () => {
         await insertCodeCell('import system', { index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
 
         traceInfo('Get diagnostics in test');
         // Ask for the list of diagnostics

--- a/src/test/datascience/notebook/intellisense/hover.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/hover.vscode.test.ts
@@ -55,7 +55,7 @@ suite('DataScience - VSCode Intellisense Notebook Hover', function () {
     suiteTeardown(() => closeNotebooksAndCleanUpAfterTests(disposables));
     test('Insert cell and get hover text', async () => {
         await insertCodeCell('import sys\nprint(sys.executable)\na = 1', { index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         const position = new Position(1, 2);
         traceInfo('Get hover in test');
         const hovers = await waitForHover(cell.document.uri, position);

--- a/src/test/datascience/notebook/intellisense/interpreterSwitch.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/interpreterSwitch.vscode.test.ts
@@ -120,7 +120,7 @@ suite('DataScience - Intellisense Switch interpreters in a notebook', function (
         await waitForKernelToChange({ interpreterPath: venvNoKernelPythonPath });
 
         // Wait for an error to show up
-        cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await waitForCondition(
             async () => {
                 diagnostics = languages.getDiagnostics(cell.document.uri);
@@ -134,7 +134,7 @@ suite('DataScience - Intellisense Switch interpreters in a notebook', function (
         await waitForKernelToChange({ interpreterPath: venvKernelPythonPath });
 
         // Now there should be 1 error again
-        cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await waitForCondition(
             async () => {
                 diagnostics = languages.getDiagnostics(cell.document.uri);

--- a/src/test/datascience/notebook/intellisense/semanticTokens.vscode.test.ts
+++ b/src/test/datascience/notebook/intellisense/semanticTokens.vscode.test.ts
@@ -60,8 +60,8 @@ suite('DataScience - VSCode semantic token tests', function () {
     test('Open a notebook and add a bunch of cells', async function () {
         await insertCodeCell('import sys\nprint(sys.executable)\na = 1');
         await insertCodeCell('\ndef test():\n  print("test")\ntest()');
-        const cell1 = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
-        const cell2 = vscodeNotebook.activeNotebookEditor?.document.cellAt(1)!;
+        const cell1 = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
+        const cell2 = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(1)!;
 
         // Wait for tokens on the first cell (it works with just plain pylance)
         await waitForCondition(
@@ -89,8 +89,8 @@ suite('DataScience - VSCode semantic token tests', function () {
     test('Edit cells in a notebook', async function () {
         await insertCodeCell('import sys\nprint(sys.executable)\na = 1');
         await insertCodeCell('\ndef test():\n  print("test")\ntest()');
-        const cell1 = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
-        const cell2 = vscodeNotebook.activeNotebookEditor?.document.cellAt(1)!;
+        const cell1 = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
+        const cell2 = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(1)!;
 
         const editor = window.visibleTextEditors.find((e) => e.document.uri === cell1.document.uri);
         await editor?.edit((b) => {
@@ -127,8 +127,8 @@ suite('DataScience - VSCode semantic token tests', function () {
             'import sqllite3 as sql\n\nconn = sql.connect("test.db")\ncur = conn.cursor()\n# BLAH BLAH'
         );
         await insertCodeCell('\n');
-        const cell1 = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
-        const cell2 = vscodeNotebook.activeNotebookEditor?.document.cellAt(1)!;
+        const cell1 = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
+        const cell2 = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(1)!;
 
         const editor = window.visibleTextEditors.find((e) => e.document.uri === cell2.document.uri);
         await editor?.edit((b) => {

--- a/src/test/datascience/notebook/interruptRestart.vscode.test.ts
+++ b/src/test/datascience/notebook/interruptRestart.vscode.test.ts
@@ -88,7 +88,7 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
 
     test('Interrupting kernel with Cancelling token will cancel cell execution', async () => {
         await insertCodeCell('import time\nfor i in range(10000):\n  print(i)\n  time.sleep(0.1)', { index: 0 });
-        const cell = vscEditor.document.cellAt(0);
+        const cell = vscEditor.notebook.cellAt(0);
         const appShell = api.serviceContainer.get<IApplicationShell>(IApplicationShell);
         const showInformationMessage = sinon.stub(appShell, 'showInformationMessage');
         showInformationMessage.resolves(); // Ignore message to restart kernel.
@@ -101,7 +101,7 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
         traceInfo('Step 3');
 
         // Interrupt the kernel.
-        commandManager.executeCommand(Commands.NotebookEditorInterruptKernel, vscEditor.document.uri).then(noop, noop);
+        commandManager.executeCommand(Commands.NotebookEditorInterruptKernel, vscEditor.notebook.uri).then(noop, noop);
         traceInfo('Step 4');
 
         // Wait for interruption (cell will fail with errors).
@@ -114,7 +114,7 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
         }
         traceInfo('Step 1');
         await insertCodeCell('import time\nfor i in range(10000):\n  print(i)\n  time.sleep(0.1)', { index: 0 });
-        const cell = vscEditor.document.cellAt(0);
+        const cell = vscEditor.notebook.cellAt(0);
         // Ensure we click `Yes` when prompted to restart the kernel.
         disposables.push(await clickOKForRestartPrompt());
 
@@ -154,7 +154,7 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
 
         // Don't have to wait for interrupt, as sometimes interrupt can timeout & we get a prompt to restart.
         // Stop execution of the cell (if possible) in kernel.
-        commandManager.executeCommand(Commands.NotebookEditorInterruptKernel, vscEditor.document.uri).then(noop, noop);
+        commandManager.executeCommand(Commands.NotebookEditorInterruptKernel, vscEditor.notebook.uri).then(noop, noop);
         // Stop the cell (cleaner way to tear down this test, else VS Code can hang due to the fact that we delete/close notebooks & rest of the code is trying to access it).
 
         traceInfo('Step 14');
@@ -220,7 +220,7 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
         await insertCodeCell('import time\nfor i in range(10000):\n  print(i)\n  time.sleep(0.2)', { index: 1 });
         await insertCodeCell('3', { index: 2 });
 
-        const [cell1, cell2, cell3] = vscEditor.document.getCells();
+        const [cell1, cell2, cell3] = vscEditor.notebook.getCells();
         const appShell = api.serviceContainer.get<IApplicationShell>(IApplicationShell);
         const showInformationMessage = sinon.stub(appShell, 'showInformationMessage');
         showInformationMessage.resolves(); // Ignore message to restart kernel.
@@ -237,7 +237,7 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
         console.log('Step2');
 
         // Interrupt the kernel & wait for 2 to cancel & 3 to get de-queued.
-        commandManager.executeCommand(Commands.NotebookEditorInterruptKernel, vscEditor.document.uri).then(noop, noop);
+        commandManager.executeCommand(Commands.NotebookEditorInterruptKernel, vscEditor.notebook.uri).then(noop, noop);
         console.log('Step3');
 
         await Promise.all([
@@ -273,7 +273,7 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
         assert.equal(cell2.executionSummary?.executionOrder, 3, 'Execution order of cell 2 should be 3');
 
         // Interrupt the kernel & wait for 2.
-        commandManager.executeCommand(Commands.NotebookEditorInterruptKernel, vscEditor.document.uri).then(noop, noop);
+        commandManager.executeCommand(Commands.NotebookEditorInterruptKernel, vscEditor.notebook.uri).then(noop, noop);
         console.log('Step7');
         await Promise.all([
             waitForExecutionCompletedWithErrors(cell2),
@@ -306,7 +306,7 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
         console.log('Step9');
 
         // Interrupt the kernel & wait for 2 to cancel & 3 to get de-queued.
-        commandManager.executeCommand(Commands.NotebookEditorInterruptKernel, vscEditor.document.uri).then(noop, noop);
+        commandManager.executeCommand(Commands.NotebookEditorInterruptKernel, vscEditor.notebook.uri).then(noop, noop);
         console.log('Step10');
 
         await Promise.all([
@@ -342,7 +342,7 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
             index: 1
         });
 
-        const [cell1, cell2] = vscEditor.document.getCells();
+        const [cell1, cell2] = vscEditor.notebook.getCells();
         // Ensure we click `Yes` when prompted to restart the kernel.
         disposables.push(await clickOKForRestartPrompt());
 

--- a/src/test/datascience/notebook/ipywidget.vscode.test.ts
+++ b/src/test/datascience/notebook/ipywidget.vscode.test.ts
@@ -63,11 +63,11 @@ suite('DataScience - VSCode Notebook - IPyWidget test', () => {
     test('Can run a widget notebook (webview-test)', async function () {
         await openNotebook(testWidgetNb);
         await waitForKernelToGetAutoSelected();
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
 
         // This flag will be resolved when the widget loads
         const flag = createDeferred<boolean>();
-        flagForWebviewLoad(flag, vscodeNotebook.activeNotebookEditor?.document!);
+        flagForWebviewLoad(flag, vscodeNotebook.activeNotebookEditor?.notebook!);
 
         // Execute cell. It should load and render the widget
         await runCell(cell);
@@ -80,7 +80,7 @@ suite('DataScience - VSCode Notebook - IPyWidget test', () => {
     test('Can run a widget notebook twice (webview-test)', async function () {
         await openNotebook(testWidgetNb);
         await waitForKernelToGetAutoSelected();
-        let cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        let cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         // Execute cell. It should load and render the widget
         await runCell(cell);
 
@@ -92,11 +92,11 @@ suite('DataScience - VSCode Notebook - IPyWidget test', () => {
 
         await openNotebook(testWidgetNb);
         await waitForKernelToGetAutoSelected();
-        cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
 
         // This flag will be resolved when the widget loads
         const flag = createDeferred<boolean>();
-        flagForWebviewLoad(flag, vscodeNotebook.activeNotebookEditor?.document!);
+        flagForWebviewLoad(flag, vscodeNotebook.activeNotebookEditor?.notebook!);
 
         // Execute cell. It should load and render the widget
         await runCell(cell);
@@ -112,11 +112,11 @@ suite('DataScience - VSCode Notebook - IPyWidget test', () => {
         await openNotebook(testWidgetNb);
         await waitForKernelToGetAutoSelected();
         // 6th cell has code that needs requireJS
-        const cell = vscodeNotebook.activeNotebookEditor?.document.getCells()![6]!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.getCells()![6]!;
 
         // This flag will be resolved when the widget loads
         const flag = createDeferred<boolean>();
-        flagForWebviewLoad(flag, vscodeNotebook.activeNotebookEditor?.document!);
+        flagForWebviewLoad(flag, vscodeNotebook.activeNotebookEditor?.notebook!);
 
         // Execute cell. It should load and render the widget
         await runCell(cell);
@@ -143,7 +143,7 @@ suite('DataScience - VSCode Notebook - IPyWidget test', () => {
     function getNotebookCommunications(notebook: NotebookDocument) {
         const items: INotebookCommunication[] = [];
         window.visibleNotebookEditors.forEach((editor) => {
-            if (editor.document !== notebook) {
+            if (editor.notebook !== notebook) {
                 return;
             }
             const comm = widgetCoordinator.notebookCommunications.get(editor);

--- a/src/test/datascience/notebook/kernelCrashes.vscode.test.ts
+++ b/src/test/datascience/notebook/kernelCrashes.vscode.test.ts
@@ -111,10 +111,10 @@ suite('DataScience - VSCode Notebook Kernel Error Handling - (Execution) (slow)'
         test('Ensure kernel is automatically restarted by jupyter & we get a status of restarting & autorestarting when kernel dies while executing a cell', async function () {
             await insertCodeCell('print("123412341234")', { index: 0 });
             await insertCodeCell(codeToKillKernel, { index: 1 });
-            const [cell1, cell2] = vscodeNotebook.activeNotebookEditor!.document.getCells();
+            const [cell1, cell2] = vscodeNotebook.activeNotebookEditor!.notebook.getCells();
 
             await Promise.all([runCell(cell1), waitForExecutionCompletedSuccessfully(cell1)]);
-            const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.document.uri)!;
+            const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.notebook.uri)!;
             const restartingEventFired = createDeferred<boolean>();
             const autoRestartingEventFired = createDeferred<boolean>();
 
@@ -160,10 +160,10 @@ suite('DataScience - VSCode Notebook Kernel Error Handling - (Execution) (slow)'
         async function runAndFailWithKernelCrash() {
             await insertCodeCell('print("123412341234")', { index: 0 });
             await insertCodeCell(codeToKillKernel, { index: 1 });
-            const [cell1, cell2] = vscodeNotebook.activeNotebookEditor!.document.getCells();
+            const [cell1, cell2] = vscodeNotebook.activeNotebookEditor!.notebook.getCells();
 
             await Promise.all([runCell(cell1), waitForExecutionCompletedSuccessfully(cell1)]);
-            const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.document.uri)!;
+            const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.notebook.uri)!;
             const terminatingEventFired = createDeferred<boolean>();
             const deadEventFired = createDeferred<boolean>();
             const expectedErrorMessage = DataScience.kernelDiedWithoutError().format(
@@ -216,8 +216,8 @@ suite('DataScience - VSCode Notebook Kernel Error Handling - (Execution) (slow)'
         test('Ensure we get a modal prompt to restart kernel when running cells against a dead kernel', async function () {
             await runAndFailWithKernelCrash();
             await insertCodeCell('print("123412341234")', { index: 2 });
-            const cell3 = vscodeNotebook.activeNotebookEditor!.document.cellAt(2);
-            const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.document.uri)!;
+            const cell3 = vscodeNotebook.activeNotebookEditor!.notebook.cellAt(2);
+            const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.notebook.uri)!;
 
             const expectedErrorMessage = DataScience.cannotRunCellKernelIsDead().format(
                 getDisplayNameOrNameOfKernelConnection(kernel.kernelConnectionMetadata)
@@ -239,8 +239,8 @@ suite('DataScience - VSCode Notebook Kernel Error Handling - (Execution) (slow)'
         test('Ensure we get a modal prompt to restart kernel when running cells against a dead kernel (dismiss and run again)', async function () {
             await runAndFailWithKernelCrash();
             await insertCodeCell('print("123412341234")', { index: 2 });
-            const cell3 = vscodeNotebook.activeNotebookEditor!.document.cellAt(2);
-            const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.document.uri)!;
+            const cell3 = vscodeNotebook.activeNotebookEditor!.notebook.cellAt(2);
+            const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.notebook.uri)!;
 
             const expectedErrorMessage = DataScience.cannotRunCellKernelIsDead().format(
                 getDisplayNameOrNameOfKernelConnection(kernel.kernelConnectionMetadata)
@@ -280,8 +280,8 @@ suite('DataScience - VSCode Notebook Kernel Error Handling - (Execution) (slow)'
         test('Ensure we get an error displayed in cell output and prompt when user has a file named random.py next to the ipynb file', async function () {
             await runAndFailWithKernelCrash();
             await insertCodeCell('print("123412341234")', { index: 2 });
-            const cell3 = vscodeNotebook.activeNotebookEditor!.document.cellAt(2);
-            const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.document.uri)!;
+            const cell3 = vscodeNotebook.activeNotebookEditor!.notebook.cellAt(2);
+            const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.notebook.uri)!;
 
             const expectedErrorMessage = DataScience.cannotRunCellKernelIsDead().format(
                 getDisplayNameOrNameOfKernelConnection(kernel.kernelConnectionMetadata)
@@ -303,8 +303,8 @@ suite('DataScience - VSCode Notebook Kernel Error Handling - (Execution) (slow)'
         test('Ensure cell output does not have errors when execution fails due to dead kernel', async function () {
             await runAndFailWithKernelCrash();
             await insertCodeCell('print("123412341234")', { index: 2 });
-            const cell3 = vscodeNotebook.activeNotebookEditor!.document.cellAt(2);
-            const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.document.uri)!;
+            const cell3 = vscodeNotebook.activeNotebookEditor!.notebook.cellAt(2);
+            const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.notebook.uri)!;
 
             const expectedErrorMessage = DataScience.cannotRunCellKernelIsDead().format(
                 getDisplayNameOrNameOfKernelConnection(kernel.kernelConnectionMetadata)
@@ -325,7 +325,7 @@ suite('DataScience - VSCode Notebook Kernel Error Handling - (Execution) (slow)'
         test('Ensure we get only one prompt to restart kernel when running all cells against a dead kernel', async function () {
             await runAndFailWithKernelCrash();
             await insertCodeCell('print("123412341234")', { index: 2 });
-            const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.document.uri)!;
+            const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.notebook.uri)!;
 
             const expectedErrorMessage = DataScience.cannotRunCellKernelIsDead().format(
                 getDisplayNameOrNameOfKernelConnection(kernel.kernelConnectionMetadata)
@@ -391,7 +391,7 @@ suite('DataScience - VSCode Notebook Kernel Error Handling - (Execution) (slow)'
             prompt.dispose();
 
             // Verify we have an output in the cell that contains the same information (about overirding built in modules).
-            const cell = window.activeNotebookEditor!.document.cellAt(0);
+            const cell = window.activeNotebookEditor!.notebook.cellAt(0);
             await waitForCondition(async () => cell.outputs.length > 0, defaultNotebookTestTimeout, 'No output');
             const err = translateCellErrorOutput(cell.outputs[0]);
             assert.include(err.traceback.join(''), 'random.py');

--- a/src/test/datascience/notebook/kernelRefresh.vscode.test.ts
+++ b/src/test/datascience/notebook/kernelRefresh.vscode.test.ts
@@ -81,7 +81,7 @@ suite('DataScience - VSCode Notebook - (Conda Env Detection) (slow)', function (
         const uniqueCondaEnvName = `bogustTestEnv${Date.now()}`;
         await insertCodeCell(`!conda create -n ${uniqueCondaEnvName} python -y`, { index: 0 });
 
-        const cells = window.activeNotebookEditor!.document.getCells();
+        const cells = window.activeNotebookEditor!.notebook.getCells();
         await Promise.all([runAllCellsInActiveNotebook(), waitForExecutionCompletedSuccessfully(cells[0])]);
 
         // Wait for this conda env to get added to the list of kernels.

--- a/src/test/datascience/notebook/kernelSelection.vscode.test.ts
+++ b/src/test/datascience/notebook/kernelSelection.vscode.test.ts
@@ -165,7 +165,7 @@ suite('DataScience - VSCode Notebook - Kernel Selection', function () {
         await insertCodeCell('import sys\nsys.executable', { index: 0 });
 
         // Run all cells
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await Promise.all([runAllCellsInActiveNotebook(), waitForExecutionCompletedSuccessfully(cell)]);
 
         await waitForCondition(
@@ -201,7 +201,7 @@ suite('DataScience - VSCode Notebook - Kernel Selection', function () {
         await waitForKernelToGetAutoSelected(undefined);
 
         // Run all cells
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await Promise.all([
             runAllCellsInActiveNotebook(),
             waitForExecutionCompletedSuccessfully(cell),
@@ -219,8 +219,8 @@ suite('DataScience - VSCode Notebook - Kernel Selection', function () {
         await insertCodeCell('import sys\nsys.executable', { index: 0 });
         await insertCodeCell('print("Hello World")', { index: 1 });
 
-        const cell1 = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
-        const cell2 = vscodeNotebook.activeNotebookEditor?.document.getCells()![1]!;
+        const cell1 = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
+        const cell2 = vscodeNotebook.activeNotebookEditor?.notebook.getCells()![1]!;
 
         // If it was successfully selected, then we know a Python kernel was correctly selected & managed to run the code.
         await Promise.all([
@@ -238,7 +238,7 @@ suite('DataScience - VSCode Notebook - Kernel Selection', function () {
         await waitForKernelToGetAutoSelected(undefined);
 
         // Run all cells
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await Promise.all([
             runAllCellsInActiveNotebook(),
             waitForExecutionCompletedSuccessfully(cell),
@@ -265,7 +265,7 @@ suite('DataScience - VSCode Notebook - Kernel Selection', function () {
         await insertCodeCell('import sys\nsys.executable', { index: 0 });
 
         // Run all cells
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await Promise.all([
             runAllCellsInActiveNotebook(),
             waitForExecutionCompletedSuccessfully(cell),
@@ -282,7 +282,7 @@ suite('DataScience - VSCode Notebook - Kernel Selection', function () {
         }
 
         // Very this kernel gets disposed when we switch the notebook kernel.
-        const kernel = kernelProvider.get(window.activeNotebookEditor!.document.uri)!;
+        const kernel = kernelProvider.get(window.activeNotebookEditor!.notebook.uri)!;
         assert.ok(kernel, 'Kernel is not defined');
         const eventListener = createEventHandler(kernel, 'onDisposed');
 
@@ -304,7 +304,7 @@ suite('DataScience - VSCode Notebook - Kernel Selection', function () {
 
         // Verify the new kernel is not the same as the old.
         assert.isFalse(
-            kernel === kernelProvider.get(window.activeNotebookEditor!.document.uri),
+            kernel === kernelProvider.get(window.activeNotebookEditor!.notebook.uri),
             'Kernels should not be the same'
         );
     });
@@ -316,7 +316,7 @@ suite('DataScience - VSCode Notebook - Kernel Selection', function () {
         await insertCodeCell('import sys\nsys.executable', { index: 0 });
 
         // Run all cells
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await Promise.all([
             runAllCellsInActiveNotebook(),
             waitForExecutionCompletedSuccessfully(cell),

--- a/src/test/datascience/notebook/memory.vscode.test.ts
+++ b/src/test/datascience/notebook/memory.vscode.test.ts
@@ -109,7 +109,7 @@ suite('DataScience - Memory Test', function () {
     });
     test('Track memory usage of standard test', async () => {
         await insertCodeCell('print("123412341234")', { index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await Promise.all([runCell(cell), waitForTextOutput(cell, '123412341234')]);
         // Wait for tokens on the first cell (it works with just plain pylance)
         await waitForCondition(

--- a/src/test/datascience/notebook/nonPythonKernels.vscode.test.node.ts
+++ b/src/test/datascience/notebook/nonPythonKernels.vscode.test.node.ts
@@ -162,9 +162,9 @@ suite('DataScience - VSCode Notebook - Kernels (non-python-kernel) (slow)', () =
 
         await waitForCondition(
             async () =>
-                vscodeNotebook.activeNotebookEditor?.document.cellAt(0).document.languageId.toLowerCase() === 'julia',
+                vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0).document.languageId.toLowerCase() === 'julia',
             5_000,
-            `First cell is not julia, it is ${vscodeNotebook.activeNotebookEditor?.document
+            `First cell is not julia, it is ${vscodeNotebook.activeNotebookEditor?.notebook
                 .cellAt(0)
                 .document.languageId.toLowerCase()}`
         );
@@ -185,7 +185,7 @@ suite('DataScience - VSCode Notebook - Kernels (non-python-kernel) (slow)', () =
         await openNotebook(testJuliaNb);
         await waitForKernelToGetAutoSelected('julia');
         await insertCodeCell('123456', { language: 'julia', index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         // Wait till execution count changes and status is success.
         await Promise.all([
             runCell(cell),
@@ -205,7 +205,7 @@ suite('DataScience - VSCode Notebook - Kernels (non-python-kernel) (slow)', () =
         await waitForKernelToGetAutoSelected('c#');
         await runAllCellsInActiveNotebook();
 
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         // Wait till execution count changes and status is success.
         await waitForExecutionCompletedSuccessfully(cell);
 

--- a/src/test/datascience/notebook/outputDisplayOrder.vscode.test.ts
+++ b/src/test/datascience/notebook/outputDisplayOrder.vscode.test.ts
@@ -39,7 +39,7 @@ suite('DataScience - VSCode Notebook - (Validate Output order)', function () {
     suiteTeardown(() => closeNotebooksAndCleanUpAfterTests());
     test('Verify order of outputs in existing ipynb file', async () => {
         await openNotebook(Uri.file(templateIPynb));
-        const cells = window.activeNotebookEditor?.document?.getCells()!;
+        const cells = window.activeNotebookEditor?.notebook?.getCells()!;
 
         const expectedOutputItemMimeTypes = [
             [['text/html', 'text/plain']],

--- a/src/test/datascience/notebook/remoteNotebookEditor.vscode.common.ts
+++ b/src/test/datascience/notebook/remoteNotebookEditor.vscode.common.ts
@@ -116,7 +116,7 @@ export function sharedRemoteNotebookEditorTests(
         await waitForKernelToGetAutoSelected(PYTHON_LANGUAGE);
         await deleteAllCellsAndWait();
         await insertCodeCell('print("123412341234")', { index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await Promise.all([runAllCellsInActiveNotebook(), waitForExecutionCompletedSuccessfully(cell)]);
 
         // Wait for MRU to get updated & encrypted storage to get updated.
@@ -159,7 +159,7 @@ export function sharedRemoteNotebookEditorTests(
         });
 
         await insertCodeCell('print("123412341234")', { index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await Promise.all([runCell(cell), waitForTextOutput(cell, '123412341234')]);
     });
 
@@ -171,7 +171,7 @@ export function sharedRemoteNotebookEditorTests(
         assert.isOk(nbEditor, 'No active notebook');
         // Cell 1 = `a = "Hello World"`
         // Cell 2 = `print(a)`
-        let cell2 = nbEditor.document.getCells()![1]!;
+        let cell2 = nbEditor.notebook.getCells()![1]!;
         await Promise.all([
             runAllCellsInActiveNotebook(),
             waitForExecutionCompletedSuccessfully(cell2),
@@ -216,7 +216,7 @@ export async function runCellAndVerifyUpdateOfPreferredRemoteKernelId(
     assert.isOk(nbEditor, 'No active notebook');
     // Cell 1 = `a = "Hello World"`
     // Cell 2 = `print(a)`
-    let cell2 = nbEditor.document.getCells()![1]!;
+    let cell2 = nbEditor.notebook.getCells()![1]!;
     await Promise.all([
         runAllCellsInActiveNotebook(),
         waitForExecutionCompletedSuccessfully(cell2),
@@ -228,7 +228,7 @@ export async function runCellAndVerifyUpdateOfPreferredRemoteKernelId(
     // If we nb it as soon as output appears, its possible the kernel id hasn't been saved yet & we mess that up.
     // Optionally we could wait for 100ms.
     await waitForCondition(
-        async () => !!remoteKernelIdProvider.getPreferredRemoteKernelId(nbEditor.document.uri),
+        async () => !!remoteKernelIdProvider.getPreferredRemoteKernelId(nbEditor.notebook.uri),
         5_000,
         'Remote Kernel id not saved'
     );
@@ -254,13 +254,13 @@ export async function reopeningNotebookUsesSameRemoteKernel(ipynbFile: Uri, serv
 
     // Wait till output is empty for both cells
     await waitForCondition(
-        async () => !nbEditor.document.getCells().some((cell) => cell.outputs.length > 0),
+        async () => !nbEditor.notebook.getCells().some((cell) => cell.outputs.length > 0),
         5_000,
         'Cell output not cleared'
     );
 
     // Execute second cell (same kernel so should be able to get results)
-    const cell2 = nbEditor.document.getCells()![1]!;
+    const cell2 = nbEditor.notebook.getCells()![1]!;
     await Promise.all([
         runCell(cell2),
         waitForExecutionCompletedSuccessfully(cell2),

--- a/src/test/datascience/notebook/remoteNotebookEditor.vscode.test.ts
+++ b/src/test/datascience/notebook/remoteNotebookEditor.vscode.test.ts
@@ -203,8 +203,8 @@ suite('DataScience - VSCode Notebook - (Remote) (Execution) (slow)', function ()
         await createEmptyPythonNotebook(disposables);
         await insertCodeCell('a = "123412341234"', { index: 0 });
         await insertCodeCell('print(a)', { index: 1 });
-        const cell1 = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
-        const cell2 = vscodeNotebook.activeNotebookEditor?.document.cellAt(1)!;
+        const cell1 = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
+        const cell2 = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(1)!;
         await runCell(cell1);
 
         // Now that we don't have any remote kernels, connect to a remote jupyter server.
@@ -231,7 +231,7 @@ suite('DataScience - VSCode Notebook - (Remote) (Execution) (slow)', function ()
         assert.isOk(nbEditor, 'No active notebook');
         // Cell 1 = `a = "Hello World"`
         // Cell 2 = `print(a)`
-        let cell2 = nbEditor.document.getCells()![1]!;
+        let cell2 = nbEditor.notebook.getCells()![1]!;
         await Promise.all([
             runAllCellsInActiveNotebook(),
             waitForExecutionCompletedSuccessfully(cell2),
@@ -269,7 +269,7 @@ suite('DataScience - VSCode Notebook - (Remote) (Execution) (slow)', function ()
         assert.isOk(nbEditor, 'No active notebook');
         // Cell 1 = `a = "Hello World"`
         // Cell 2 = `print(a)`
-        let cell2 = nbEditor.document.getCells()![1]!;
+        let cell2 = nbEditor.notebook.getCells()![1]!;
         await Promise.all([
             runAllCellsInActiveNotebook(),
             waitForExecutionCompletedSuccessfully(cell2),
@@ -284,12 +284,12 @@ suite('DataScience - VSCode Notebook - (Remote) (Execution) (slow)', function ()
         const controllerManager = svcContainer.get<INotebookControllerManager>(INotebookControllerManager);
 
         // Verify we're connected to a remote kernel.
-        const remoteController = controllerManager.getSelectedNotebookController(nbEditor.document);
+        const remoteController = controllerManager.getSelectedNotebookController(nbEditor.notebook);
         assert.strictEqual(isLocalConnection(remoteController!.connection), false, 'Should be a remote connection');
 
         // Verify we have a preferred remote kernel stored.
         assert.isNotEmpty(
-            remoteKernelIdProvider.getPreferredRemoteKernelId(nbEditor.document.uri),
+            remoteKernelIdProvider.getPreferredRemoteKernelId(nbEditor.notebook.uri),
             'Preferred remote kernel id cannot be empty'
         );
 
@@ -309,19 +309,19 @@ suite('DataScience - VSCode Notebook - (Remote) (Execution) (slow)', function ()
 
         // Wait for the controller to get selected.
         await waitForCondition(
-            async () => controllerManager.getSelectedNotebookController(nbEditor.document) === localKernelController,
+            async () => controllerManager.getSelectedNotebookController(nbEditor.notebook) === localKernelController,
             5_000,
             `Controller not swtiched to local kernel, instead it is ${
-                controllerManager.getSelectedNotebookController(nbEditor.document)?.id
+                controllerManager.getSelectedNotebookController(nbEditor.notebook)?.id
             }`
         );
 
         // Wait for the preferred remote kernel id to be cleared for this notebook.
         await waitForCondition(
-            async () => !remoteKernelIdProvider.getPreferredRemoteKernelId(nbEditor.document.uri),
+            async () => !remoteKernelIdProvider.getPreferredRemoteKernelId(nbEditor.notebook.uri),
             5_000,
             `Remote Kernel is not empty, instead the value is ${remoteKernelIdProvider.getPreferredRemoteKernelId(
-                nbEditor.document.uri
+                nbEditor.notebook.uri
             )}`
         );
     });

--- a/src/test/datascience/notebook/saving.vscode.test.ts
+++ b/src/test/datascience/notebook/saving.vscode.test.ts
@@ -73,10 +73,10 @@ suite('DataScience - VSCode Notebook - (Saving) (slow)', function () {
         let cell4: NotebookCell;
 
         function initializeCells() {
-            cell1 = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
-            cell2 = vscodeNotebook.activeNotebookEditor?.document.getCells()![1]!;
-            cell3 = vscodeNotebook.activeNotebookEditor?.document.getCells()![2]!;
-            cell4 = vscodeNotebook.activeNotebookEditor?.document.getCells()![3]!;
+            cell1 = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
+            cell2 = vscodeNotebook.activeNotebookEditor?.notebook.getCells()![1]!;
+            cell3 = vscodeNotebook.activeNotebookEditor?.notebook.getCells()![2]!;
+            cell4 = vscodeNotebook.activeNotebookEditor?.notebook.getCells()![3]!;
         }
         initializeCells();
         await waitForKernelToGetAutoSelected(PYTHON_LANGUAGE);

--- a/src/test/datascience/plotViewer/plotViewer.vscode.test.ts
+++ b/src/test/datascience/plotViewer/plotViewer.vscode.test.ts
@@ -60,7 +60,7 @@ plt.show()`,
             { index: 0 }
         );
 
-        const plotCell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const plotCell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
 
         await runAllCellsInActiveNotebook();
         await waitForExecutionCompletedSuccessfully(plotCell);
@@ -102,7 +102,7 @@ plt.show()`,
             { index: 0 }
         );
 
-        const plotCell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const plotCell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
 
         await runAllCellsInActiveNotebook();
         await waitForExecutionCompletedSuccessfully(plotCell);

--- a/src/test/datascience/telemetry.vscode.test.ts
+++ b/src/test/datascience/telemetry.vscode.test.ts
@@ -142,7 +142,7 @@ suite('Telemetry validation', function () {
     });
     test('Execute cell using VSCode Kernel', async () => {
         await insertCodeCell('print("123412341234")', { index: 0 });
-        const cell = vscode.window.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscode.window.activeNotebookEditor?.notebook.cellAt(0)!;
         await Promise.all([runCell(cell), waitForTextOutput(cell, '123412341234')]);
 
         // Check for expected events

--- a/src/test/datascience/variableView/variableView.vscode.test.ts
+++ b/src/test/datascience/variableView/variableView.vscode.test.ts
@@ -85,13 +85,13 @@ suite('DataScience - VariableView', function () {
 
         // Add one simple cell and execute it
         await insertCodeCell('test = "MYTESTVALUE"', { index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await runCell(cell);
         await waitForExecutionCompletedSuccessfully(cell);
 
         // Send a second cell
         await insertCodeCell('test2 = "MYTESTVALUE2"', { index: 1 });
-        const cell2 = vscodeNotebook.activeNotebookEditor?.document.getCells()![1]!;
+        const cell2 = vscodeNotebook.activeNotebookEditor?.notebook.getCells()![1]!;
         await runCell(cell2);
 
         // Parse the HTML for our expected variables
@@ -113,13 +113,13 @@ suite('DataScience - VariableView', function () {
 
         // Add cell that overrides print
         await insertCodeCell('def print():\n  x = 1', { index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await runCell(cell);
         await waitForExecutionCompletedSuccessfully(cell);
 
         // Send a second cell
         await insertCodeCell('test2 = "MYTESTVALUE2"', { index: 1 });
-        const cell2 = vscodeNotebook.activeNotebookEditor?.document.getCells()![1]!;
+        const cell2 = vscodeNotebook.activeNotebookEditor?.notebook.getCells()![1]!;
         await runCell(cell2);
 
         // Parse the HTML for our expected variables
@@ -139,7 +139,7 @@ suite('DataScience - VariableView', function () {
 
         // Add one simple cell and execute it
         await insertCodeCell('test = "MYTESTVALUE"', { index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.getCells()![0]!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.getCells()![0]!;
         await Promise.all([runCell(cell), waitForExecutionCompletedSuccessfully(cell)]);
 
         // Parse the HTML for our expected variables
@@ -154,12 +154,12 @@ suite('DataScience - VariableView', function () {
 
         // Execute a cell on the second document
         await insertCodeCell('test2 = "MYTESTVALUE2"', { index: 0 });
-        const cell2 = vscodeNotebook.activeNotebookEditor?.document.getCells()![0]!;
+        const cell2 = vscodeNotebook.activeNotebookEditor?.notebook.getCells()![0]!;
         await Promise.all([runCell(cell2), waitForExecutionCompletedSuccessfully(cell2)]);
 
         // Execute a second cell on the second document
         await insertCodeCell('test3 = "MYTESTVALUE3"', { index: 1 });
-        const cell3 = vscodeNotebook.activeNotebookEditor?.document.getCells()![1]!;
+        const cell3 = vscodeNotebook.activeNotebookEditor?.notebook.getCells()![1]!;
         await Promise.all([runCell(cell3), waitForExecutionCompletedSuccessfully(cell3)]);
 
         // Parse the HTML for our expected variables
@@ -195,7 +195,7 @@ class MyClass:
 myClass = MyClass()
 `;
         await insertCodeCell(code, { index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await runCell(cell);
         await waitForExecutionCompletedSuccessfully(cell);
 
@@ -235,7 +235,7 @@ myDict = {'a': 1}
 mySet = {1, 2, 3}
 `;
         await insertCodeCell(code, { index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await runCell(cell);
         await waitForExecutionCompletedSuccessfully(cell);
 
@@ -266,12 +266,12 @@ mySet = {1, 2, 3}
 
         // Add one simple cell and execute it
         await insertCodeCell('test = [1, 2, 3]');
-        const cell = vscodeNotebook.activeNotebookEditor?.document.getCells()![0]!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.getCells()![0]!;
         await Promise.all([runCell(cell), waitForExecutionCompletedSuccessfully(cell)]);
 
         // Add another cell so we have two lists
         await insertCodeCell('test2 = [1, 2, 3]');
-        const cell2 = vscodeNotebook.activeNotebookEditor?.document.getCells()![1]!;
+        const cell2 = vscodeNotebook.activeNotebookEditor?.notebook.getCells()![1]!;
         await Promise.all([runCell(cell2), waitForExecutionCompletedSuccessfully(cell2)]);
 
         // Parse the HTML for our expected variables

--- a/src/test/datascience/widgets/standard.vscode.test.ts
+++ b/src/test/datascience/widgets/standard.vscode.test.ts
@@ -145,19 +145,19 @@ suite('Standard IPyWidget (Execution) (slow) (WIDGET_TEST)', function () {
 
     test('Slider Widget', async function () {
         const comms = await initializeNotebook({ templateFile: 'slider_widgets.ipynb' });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await executeCellAndWaitForOutput(cell, comms);
         await assertOutputContainsHtml(cell, comms, ['6519'], '.widget-readout');
     });
     test('Textbox Widget', async () => {
         const comms = await initializeNotebook({ templateFile: 'standard_widgets.ipynb' });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(1)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(1)!;
         await executeCellAndWaitForOutput(cell, comms);
         await assertOutputContainsHtml(cell, comms, ['<input type="text', 'Enter your name:'], '.widget-text');
     });
     test('Linking Widgets slider to textbox widget', async function () {
         const comms = await initializeNotebook({ templateFile: 'slider_widgets.ipynb' });
-        const [, cell1, cell2, cell3] = vscodeNotebook.activeNotebookEditor!.document.getCells()!;
+        const [, cell1, cell2, cell3] = vscodeNotebook.activeNotebookEditor!.notebook.getCells()!;
         await executeCellAndDontWaitForOutput(cell1);
         await executeCellAndWaitForOutput(cell2, comms);
         await executeCellAndWaitForOutput(cell3, comms);
@@ -172,13 +172,13 @@ suite('Standard IPyWidget (Execution) (slow) (WIDGET_TEST)', function () {
     });
     test('Checkbox Widget', async () => {
         const comms = await initializeNotebook({ templateFile: 'standard_widgets.ipynb' });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(2)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(2)!;
         await executeCellAndWaitForOutput(cell, comms);
         await assertOutputContainsHtml(cell, comms, ['Check me', '<input type="checkbox'], '.widget-checkbox');
     });
     test('Button Widget (click button)', async () => {
         const comms = await initializeNotebook({ templateFile: 'button_widgets.ipynb' });
-        const [cell0, cell1, cell2] = vscodeNotebook.activeNotebookEditor!.document.getCells();
+        const [cell0, cell1, cell2] = vscodeNotebook.activeNotebookEditor!.notebook.getCells();
 
         await executeCellAndWaitForOutput(cell0, comms);
         await executeCellAndWaitForOutput(cell1, comms);
@@ -194,7 +194,7 @@ suite('Standard IPyWidget (Execution) (slow) (WIDGET_TEST)', function () {
     });
     test('Button Widget (click button in output of another cell)', async () => {
         const comms = await initializeNotebook({ templateFile: 'button_widgets.ipynb' });
-        const [cell0, cell1, cell2] = vscodeNotebook.activeNotebookEditor!.document.getCells();
+        const [cell0, cell1, cell2] = vscodeNotebook.activeNotebookEditor!.notebook.getCells();
 
         await executeCellAndWaitForOutput(cell0, comms);
         await executeCellAndWaitForOutput(cell1, comms);
@@ -210,14 +210,14 @@ suite('Standard IPyWidget (Execution) (slow) (WIDGET_TEST)', function () {
     });
     test('Render IPySheets', async () => {
         const comms = await initializeNotebook({ templateFile: 'ipySheet_widgets.ipynb' });
-        const [, cell1] = vscodeNotebook.activeNotebookEditor!.document.getCells();
+        const [, cell1] = vscodeNotebook.activeNotebookEditor!.notebook.getCells();
 
         await executeCellAndWaitForOutput(cell1, comms);
         await assertOutputContainsHtml(cell1, comms, ['Hello', 'World', '42.000']);
     });
     test('Render IPySheets & search', async () => {
         const comms = await initializeNotebook({ templateFile: 'ipySheet_widgets_search.ipynb' });
-        const [, cell1, cell2] = vscodeNotebook.activeNotebookEditor!.document.getCells();
+        const [, cell1, cell2] = vscodeNotebook.activeNotebookEditor!.notebook.getCells();
 
         await executeCellAndWaitForOutput(cell1, comms);
         await executeCellAndWaitForOutput(cell2, comms);
@@ -230,7 +230,7 @@ suite('Standard IPyWidget (Execution) (slow) (WIDGET_TEST)', function () {
     });
     test('Render IPySheets & slider', async () => {
         const comms = await initializeNotebook({ templateFile: 'ipySheet_widgets_slider.ipynb' });
-        const [, cell1, cell2, cell3] = vscodeNotebook.activeNotebookEditor!.document.getCells();
+        const [, cell1, cell2, cell3] = vscodeNotebook.activeNotebookEditor!.notebook.getCells();
 
         await executeCellAndWaitForOutput(cell1, comms);
         await executeCellAndWaitForOutput(cell2, comms);
@@ -245,28 +245,28 @@ suite('Standard IPyWidget (Execution) (slow) (WIDGET_TEST)', function () {
     });
     test.skip('Render ipyvolume (slider, color picker, figure)', async function () {
         const comms = await initializeNotebook({ templateFile: 'ipyvolume_widgets.ipynb' });
-        const cell = vscodeNotebook.activeNotebookEditor!.document.cellAt(1);
+        const cell = vscodeNotebook.activeNotebookEditor!.notebook.cellAt(1);
 
         await executeCellAndWaitForOutput(cell, comms);
         await assertOutputContainsHtml(cell, comms, ['<input type="color"', '>Slider1<', '>Slider2<', '<canvas']);
     });
     test.skip('Render pythreejs', async function () {
         const comms = await initializeNotebook({ templateFile: 'pythreejs_widgets.ipynb' });
-        const cell = vscodeNotebook.activeNotebookEditor!.document.cellAt(1);
+        const cell = vscodeNotebook.activeNotebookEditor!.notebook.cellAt(1);
 
         await executeCellAndWaitForOutput(cell, comms);
         await assertOutputContainsHtml(cell, comms, ['<canvas']);
     });
     test.skip('Render pythreejs, 2', async function () {
         const comms = await initializeNotebook({ templateFile: 'pythreejs_widgets2.ipynb' });
-        const cell = vscodeNotebook.activeNotebookEditor!.document.cellAt(1);
+        const cell = vscodeNotebook.activeNotebookEditor!.notebook.cellAt(1);
 
         await executeCellAndWaitForOutput(cell, comms);
         await assertOutputContainsHtml(cell, comms, ['<canvas']);
     });
     test.skip('Render matplotlib, interactive inline', async function () {
         const comms = await initializeNotebook({ templateFile: 'matplotlib_widgets_interactive.ipynb' });
-        const cell = vscodeNotebook.activeNotebookEditor!.document.cellAt(1);
+        const cell = vscodeNotebook.activeNotebookEditor!.notebook.cellAt(1);
 
         await executeCellAndWaitForOutput(cell, comms);
         await assertOutputContainsHtml(cell, comms, ['>m<', '>b<', '<img src="data:image']);
@@ -275,7 +275,7 @@ suite('Standard IPyWidget (Execution) (slow) (WIDGET_TEST)', function () {
         // Skipping this test as the renderer is not a widget renderer, its an html renderer.
         // Need to modify that code too to add the classes so we can query the html rendered.
         await initializeNotebook({ templateFile: 'matplotlib_widgets_inline.ipynb' });
-        const cell = vscodeNotebook.activeNotebookEditor!.document.cellAt(2);
+        const cell = vscodeNotebook.activeNotebookEditor!.notebook.cellAt(2);
 
         const mimTypes = () => cell.outputs.map((output) => output.items.map((item) => item.mime).join(',')).join(',');
         await executeCellAndDontWaitForOutput(cell);
@@ -287,14 +287,14 @@ suite('Standard IPyWidget (Execution) (slow) (WIDGET_TEST)', function () {
     });
     test.skip('Render matplotlib, widget', async function () {
         const comms = await initializeNotebook({ templateFile: 'matplotlib_widgets_widget.ipynb' });
-        const cell = vscodeNotebook.activeNotebookEditor!.document.cellAt(3);
+        const cell = vscodeNotebook.activeNotebookEditor!.notebook.cellAt(3);
 
         await executeCellAndWaitForOutput(cell, comms);
         await assertOutputContainsHtml(cell, comms, ['>Figure 1<', '<canvas', 'Download plot']);
     });
     test.skip('Render matplotlib, widget in multiple cells', async function () {
         const comms = await initializeNotebook({ templateFile: 'matplotlib_multiple_cells_widgets.ipynb' });
-        const [, cell1, cell2, cell3, cell4] = vscodeNotebook.activeNotebookEditor!.document.getCells();
+        const [, cell1, cell2, cell3, cell4] = vscodeNotebook.activeNotebookEditor!.notebook.getCells();
 
         await executeCellAndDontWaitForOutput(cell1);
         await executeCellAndDontWaitForOutput(cell2);
@@ -306,12 +306,12 @@ suite('Standard IPyWidget (Execution) (slow) (WIDGET_TEST)', function () {
     test.skip('Widget renders after executing a notebook which was saved after previous execution', async () => {
         // https://github.com/microsoft/vscode-jupyter/issues/8748
         let comms = await initializeNotebook({ templateFile: 'standard_widgets.ipynb' });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await executeCellAndWaitForOutput(cell, comms);
         await assertOutputContainsHtml(cell, comms, ['66'], '.widget-readout');
 
         // Restart the kernel.
-        const uri = vscodeNotebook.activeNotebookEditor!.document.uri;
+        const uri = vscodeNotebook.activeNotebookEditor!.notebook.uri;
         await commands.executeCommand('workbench.action.files.save');
         await closeActiveWindows();
 
@@ -326,12 +326,12 @@ suite('Standard IPyWidget (Execution) (slow) (WIDGET_TEST)', function () {
     });
     test.skip('Widget renders after restarting kernel', async () => {
         const comms = await initializeNotebook({ templateFile: 'standard_widgets.ipynb' });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await executeCellAndWaitForOutput(cell, comms);
         await assertOutputContainsHtml(cell, comms, ['66'], '.widget-readout');
 
         // Restart the kernel.
-        const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.document.uri)!;
+        const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.notebook.uri)!;
         await kernel.restart();
         await executeCellAndWaitForOutput(cell, comms);
         await assertOutputContainsHtml(cell, comms, ['66'], '.widget-readout');
@@ -347,12 +347,12 @@ suite('Standard IPyWidget (Execution) (slow) (WIDGET_TEST)', function () {
     test.skip('Widget renders after interrupting kernel', async () => {
         // https://github.com/microsoft/vscode-jupyter/issues/8749
         const comms = await initializeNotebook({ templateFile: 'standard_widgets.ipynb' });
-        const cell = vscodeNotebook.activeNotebookEditor?.document.cellAt(0)!;
+        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
         await executeCellAndWaitForOutput(cell, comms);
         await assertOutputContainsHtml(cell, comms, ['66'], '.widget-readout');
 
         // Restart the kernel.
-        const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.document.uri)!;
+        const kernel = kernelProvider.get(vscodeNotebook.activeNotebookEditor!.notebook.uri)!;
         await kernel.interrupt();
         await executeCellAndWaitForOutput(cell, comms);
         await assertOutputContainsHtml(cell, comms, ['66'], '.widget-readout');

--- a/src/webviews/extension-side/variablesView/notebookWatcher.ts
+++ b/src/webviews/extension-side/variablesView/notebookWatcher.ts
@@ -48,7 +48,7 @@ export class NotebookWatcher implements INotebookWatcher {
         return this._onDidRestartActiveNotebook.event;
     }
     public get activeKernel(): IKernel | undefined {
-        const activeNotebook = this.notebooks.activeNotebookEditor?.document;
+        const activeNotebook = this.notebooks.activeNotebookEditor?.notebook;
         const activeJupyterNotebookKernel =
             activeNotebook?.notebookType == JupyterNotebookView
                 ? this.kernelProvider.get(activeNotebook.uri)
@@ -182,8 +182,8 @@ export class NotebookWatcher implements INotebookWatcher {
     private activeEditorChanged(editor: NotebookEditor | undefined) {
         const changeEvent: IActiveNotebookChangedEvent = {};
 
-        if (editor && isJupyterNotebook(editor.document)) {
-            const executionCount = this._executionCountTracker.get(editor.document);
+        if (editor && isJupyterNotebook(editor.notebook)) {
+            const executionCount = this._executionCountTracker.get(editor.notebook);
             executionCount && (changeEvent.executionCount = executionCount);
         }
 


### PR DESCRIPTION
Removes the usage of the deprecated `NotebookEditor.document` property 
