### PR TITLE
FetchError is undefined in the web, and capturing errors by .name

### DIFF
--- a/src/platform/errors/index.ts
+++ b/src/platform/errors/index.ts
@@ -13,7 +13,8 @@ export function populateTelemetryWithErrorInfo(props: Partial<TelemetryErrorProp
     props.failed = true;
     // Don't blow away what we already have.
     props.failureCategory = props.failureCategory || getErrorCategory(error);
-    if (props.failureCategory === 'unknown' && isErrorType(error, FetchError)) {
+    // FetchError is undefined on Web.
+    if (props.failureCategory === 'unknown' && isErrorType(error, FetchError.name || 'FetchError')) {
         props.failureCategory = 'fetcherror';
     }
     props.stackTrace = serializeStackTrace(error);
@@ -81,7 +82,10 @@ function getCallSite(frame: stackTrace.StackFrame) {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Constructor<T> = { new (...args: any[]): T };
-function isErrorType<T>(error: Error, expectedType: Constructor<T>) {
+function isErrorType<T>(error: Error, expectedType: Constructor<T> | string) {
+    if (typeof expectedType === 'string') {
+        return error.name === expectedType;
+    }
     if (error instanceof expectedType) {
         return true;
     }


### PR DESCRIPTION
Since `FetchError` is undefined in the web, `isErrorType(error, FetchError)` on `populateTelemetryWithErrorInfo` causes an error: `Uncaught (in promise) TypeError: Right-hand side of 'instanceof" is not an object`.

This PR ensures that we're able to catch errors of the type `FetchError` in the web.

It also proposes a change to `isErrorType` to also accept error names in the second parameter.