### PR TITLE
Support standard ipywidgets in the web extension

### DIFF
--- a/.github/actions/create-venv-for-tests/action.yml
+++ b/.github/actions/create-venv-for-tests/action.yml
@@ -1,5 +1,5 @@
 name: 'Create Virtual Environment'
-description: "Create Virtual Env for tests"
+description: 'Create Virtual Env for tests'
 
 outputs:
   path:
@@ -28,6 +28,7 @@ runs:
         python -m pip uninstall jedi --yes
         python -m pip install jedi==0.17.2
         python -m pip install pandas
+        python -m pip install ipywidgets
 
         python -m venv .venvnokernel
         source .venvnokernel/bin/activate

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -173,12 +173,13 @@
             ],
             "env": {
                 "VSC_JUPYTER_FORCE_LOGGING": "1",
-                "VSC_JUPYTER_CI_TEST_GREP": "", // Leave as `VSCode Notebook` to run only Notebook tests.
+                "VSC_JUPYTER_CI_TEST_GREP": "Standard IPyWidgets", // Leave as `VSCode Notebook` to run only Notebook tests.
                 "VSC_JUPYTER_CI_TEST_INVERT_GREP": "", // Initialize this to invert the grep (exclude tests with value defined in grep).
                 "CI_PYTHON_PATH": "", // Update with path to real python interpereter used for testing.
                 "VSC_JUPYTER_CI_RUN_NON_PYTHON_NB_TEST": "", // Initialize this to run tests again Julia & other kernels.
                 "VSC_JUPYTER_WEBVIEW_TEST_MIDDLEWARE": "true", // Initialize to create the webview test middleware
                 "VSC_JUPYTER_LOAD_EXPERIMENTS_FROM_FILE": "true",
+                "TF_BUILD": "", // Set to anything to force full logging
                 "TEST_FILES_SUFFIX": "vscode.test",
                 "VSC_JUPYTER_REMOTE_NATIVE_TEST": "false", // Change to `true` to run the Native Notebook tests with remote jupyter connections.
                 "VSC_JUPYTER_NON_RAW_NATIVE_TEST": "false", // Change to `true` to run the Native Notebook tests with non-raw kernels (i.e. local jupyter server).

--- a/news/2 Fixes/10051.md
+++ b/news/2 Fixes/10051.md
@@ -1,0 +1,1 @@
+Support standard ipywidgets in the web extension.

--- a/src/kernels/common/kernelSocketWrapper.ts
+++ b/src/kernels/common/kernelSocketWrapper.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import * as WebSocketWS from 'ws';
 import { ClassType } from '../../platform/ioc/types';
+import { traceError } from '../../platform/logging';
 import { IKernelSocket } from '../types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -97,7 +98,8 @@ export function KernelSocketWrapper<T extends ClassType<IWebSocketLike>>(SuperCl
                 // c) Next message happens after this one (so this side can handle the message before another event goes through)
                 this.msgChain = this.msgChain
                     .then(() => Promise.all(this.receiveHooks.map((p) => p(args[0]))))
-                    .then(() => superHandler(event, ...args));
+                    .then(() => superHandler(event, ...args))
+                    .catch((e) => traceError(`Exception while handling messages: ${e}`));
                 // True value indicates there were handlers. We definitely have 'message' handlers.
                 return true;
             } else {

--- a/src/kernels/common/kernelSocketWrapper.ts
+++ b/src/kernels/common/kernelSocketWrapper.ts
@@ -59,6 +59,10 @@ export function KernelSocketWrapper<T extends ClassType<IWebSocketLike>>(SuperCl
             this.sendHooks = [];
         }
 
+        protected patchSuperEmit(patch: (event: string | symbol, ...args: any[]) => boolean) {
+            super.emit = patch;
+        }
+
         public sendToRealKernel(data: any, a2: any) {
             // This will skip the send hooks. It's coming from
             // the UI side.
@@ -80,7 +84,11 @@ export function KernelSocketWrapper<T extends ClassType<IWebSocketLike>>(SuperCl
             }
         }
 
-        public override emit(event: string | symbol, ...args: any[]): boolean {
+        protected handleEvent(
+            superHandler: (event: string | symbol, ...args: any[]) => boolean,
+            event: string | symbol,
+            ...args: any[]
+        ): boolean {
             if (event === 'message' && this.receiveHooks.length) {
                 // Stick the receive hooks into the message chain. We use chain
                 // to ensure that:
@@ -89,12 +97,16 @@ export function KernelSocketWrapper<T extends ClassType<IWebSocketLike>>(SuperCl
                 // c) Next message happens after this one (so this side can handle the message before another event goes through)
                 this.msgChain = this.msgChain
                     .then(() => Promise.all(this.receiveHooks.map((p) => p(args[0]))))
-                    .then(() => super.emit(event, ...args));
+                    .then(() => superHandler(event, ...args));
                 // True value indicates there were handlers. We definitely have 'message' handlers.
                 return true;
             } else {
-                return super.emit(event, ...args);
+                return superHandler(event, ...args);
             }
+        }
+
+        public override emit(event: string | symbol, ...args: any[]): boolean {
+            return this.handleEvent((ev, args) => super.emit(ev, args), event, args);
         }
 
         public addReceiveHook(hook: (data: WebSocketWS.Data) => Promise<void>) {

--- a/src/kernels/common/kernelSocketWrapper.ts
+++ b/src/kernels/common/kernelSocketWrapper.ts
@@ -106,7 +106,7 @@ export function KernelSocketWrapper<T extends ClassType<IWebSocketLike>>(SuperCl
         }
 
         public override emit(event: string | symbol, ...args: any[]): boolean {
-            return this.handleEvent((ev, args) => super.emit(ev, args), event, args);
+            return this.handleEvent((ev, ...args) => super.emit(ev, ...args), event, ...args);
         }
 
         public addReceiveHook(hook: (data: WebSocketWS.Data) => Promise<void>) {

--- a/src/kernels/ipywidgets-message-coordination/commonMessageCoordinator.ts
+++ b/src/kernels/ipywidgets-message-coordination/commonMessageCoordinator.ts
@@ -18,7 +18,7 @@ import {
 import { Common, DataScience } from '../../platform/common/utils/localize';
 import { noop } from '../../platform/common/utils/misc';
 import { stripAnsi } from '../../platform/common/utils/regexp';
-import { InteractiveWindowMessages } from '../../platform/messageTypes';
+import { InteractiveWindowMessages, IPyWidgetMessages } from '../../platform/messageTypes';
 import { IServiceContainer } from '../../platform/ioc/types';
 import { sendTelemetryEvent } from '../../telemetry';
 import { getTelemetrySafeHashedString } from '../../telemetry/helpers';
@@ -33,6 +33,8 @@ import { IPyWidgetMessageDispatcherFactory } from './ipyWidgetMessageDispatcherF
 import { IPyWidgetScriptSource } from './ipyWidgetScriptSource';
 import { IIPyWidgetMessageDispatcher, ILocalResourceUriConverter, IWidgetScriptSourceProviderFactory } from './types';
 import { ConsoleForegroundColors } from '../../platform/logging/types';
+import { INotebookCommunication } from '../../notebooks/types';
+import { createDeferred } from '../../platform/common/utils/async';
 
 /**
  * This class wraps all of the ipywidgets communication with a backing notebook
@@ -59,8 +61,9 @@ export class CommonMessageCoordinator {
     private disposables: IDisposableRegistry;
     private jupyterOutput: IOutputChannel;
     private readonly configService: IConfigurationService;
+    private webview: INotebookCommunication | undefined;
 
-    private constructor(
+    public constructor(
         private readonly document: NotebookDocument,
         private readonly serviceContainer: IServiceContainer
     ) {
@@ -71,20 +74,61 @@ export class CommonMessageCoordinator {
         this.configService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
     }
 
-    public static async create(
-        document: NotebookDocument,
-        serviceContainer: IServiceContainer
-    ): Promise<CommonMessageCoordinator> {
-        const result = new CommonMessageCoordinator(document, serviceContainer);
-        await result.initialize();
-        traceVerbose('Created and initailized CommonMessageCoordinator');
-        return result;
-    }
-
     public dispose() {
         this.cachedMessages = [];
         this.ipyWidgetMessageDispatcher?.dispose(); // NOSONAR
         this.ipyWidgetScriptSource?.dispose(); // NOSONAR
+    }
+
+    public async attach(webview: INotebookCommunication) {
+        if (this.webview !== webview) {
+            // New webview, make sure to initialize.
+            await this.initialize();
+
+            // Save the webview
+            this.webview = webview;
+            const promise = createDeferred<void>();
+
+            // Attach message requests to this webview (should dupe to all of them)
+            this.postMessage(
+                (e) => {
+                    traceInfoIfCI(`${ConsoleForegroundColors.Green}Widget Coordinator sent ${e.message}`);
+                    // Special case for webview URI translation
+                    if (e.message === InteractiveWindowMessages.ConvertUriForUseInWebViewRequest) {
+                        this.onMessage(InteractiveWindowMessages.ConvertUriForUseInWebViewResponse, {
+                            request: e.payload,
+                            response: webview.asWebviewUri(e.payload)
+                        });
+                    } else {
+                        void webview.postMessage({ type: e.message, payload: e.payload });
+                    }
+                },
+                this,
+                this.disposables
+            );
+            webview.onDidReceiveMessage(
+                (m) => {
+                    traceInfoIfCI(`${ConsoleForegroundColors.Green}Widget Coordinator received ${m.type}`);
+                    this.onMessage(m.type, m.payload);
+
+                    // Special case the WidgetManager loaded message. It means we're ready
+                    // to use a kernel. (IPyWidget Dispatcher uses this too)
+                    if (m.type === IPyWidgetMessages.IPyWidgets_Ready) {
+                        promise.resolve();
+                    }
+                },
+                this,
+                this.disposables
+            );
+            // In case the webview loaded earlier and it already sent the IPyWidgetMessages.IPyWidgets_Ready message
+            // This way we don't make assumptions, we just query widgets and ask its its ready (avoids timing issues etc).
+            webview
+                .postMessage({ type: IPyWidgetMessages.IPyWidgets_IsReadyRequest, payload: undefined })
+                .then(noop, noop);
+
+            // Wait for the widgets ready message
+            await promise.promise;
+        }
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/kernels/ipywidgets-message-coordination/commonMessageCoordinator.ts
+++ b/src/kernels/ipywidgets-message-coordination/commonMessageCoordinator.ts
@@ -82,6 +82,7 @@ export class CommonMessageCoordinator {
     }
 
     public dispose() {
+        this.cachedMessages = [];
         this.ipyWidgetMessageDispatcher?.dispose(); // NOSONAR
         this.ipyWidgetScriptSource?.dispose(); // NOSONAR
     }

--- a/src/kernels/ipywidgets-message-coordination/ipyWidgetMessageDispatcher.ts
+++ b/src/kernels/ipywidgets-message-coordination/ipyWidgetMessageDispatcher.ts
@@ -164,10 +164,10 @@ export class IPyWidgetMessageDispatcher implements IIPyWidgetMessageDispatcher {
         }
 
         // If we have any pending targets, register them now
-        const notebook = this.getKernel();
-        if (notebook) {
-            this.subscribeToKernelSocket(notebook);
-            this.registerCommTargets(notebook);
+        const kernel = this.getKernel();
+        if (kernel) {
+            this.subscribeToKernelSocket(kernel);
+            this.registerCommTargets(kernel);
         }
         traceVerbose('IPyWidgetMessageDispatcher.initialize');
     }

--- a/src/kernels/ipywidgets-message-coordination/notebookIPyWidgetCoordinator.ts
+++ b/src/kernels/ipywidgets-message-coordination/notebookIPyWidgetCoordinator.ts
@@ -212,6 +212,7 @@ export class NotebookIPyWidgetCoordinator implements IExtensionSyncActivationSer
         this.messageCoordinators.delete(notebook);
 
         this.attachedEditors.delete(notebook);
+        editors.forEach((editor) => this.previouslyInitialized.delete(editor));
     }
     private attachCoordinator(
         document: NotebookDocument,

--- a/src/kernels/raw/finder/localPythonAndRelatedNonPythonKernelSpecFinder.node.ts
+++ b/src/kernels/raw/finder/localPythonAndRelatedNonPythonKernelSpecFinder.node.ts
@@ -403,13 +403,6 @@ export class LocalPythonAndRelatedNonPythonKernelSpecFinder extends LocalKernelS
                 traceVerbose(`Kernel ${kernelSpec.name} matches ${i.displayName} based on display name.`);
                 return true;
             }
-
-            // We used to use Python 2 or Python 3 to match an interpreter based on version
-            // but this seems too ambitious. The kernel spec should just launch with the default
-            // python and no environment. Otherwise how do we know which interpreter is the best
-            // match?
-            traceInfoIfCI(`Kernel ${kernelSpec.name} does not match ${i.displayName} interpreter.`);
-
             return false;
         });
     }

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -254,10 +254,6 @@ export async function closeNotebooks(disposables: IDisposable[] = []) {
     await closeActiveWindows();
     disposeAllDisposables(disposables);
     await shutdownAllNotebooks();
-
-    // Sleep a bit. VS code needs to clear out the documents, otherwise
-    // it won't reset the scripts
-    await sleep(1000);
 }
 
 let waitForKernelPendingPromise: Promise<void> | undefined;

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -253,6 +253,11 @@ export async function closeNotebooks(disposables: IDisposable[] = []) {
     VSCodeNotebookController.kernelAssociatedWithDocument = undefined;
     await closeActiveWindows();
     disposeAllDisposables(disposables);
+    await shutdownAllNotebooks();
+
+    // Sleep a bit. VS code needs to clear out the documents, otherwise
+    // it won't reset the scripts
+    await sleep(1000);
 }
 
 let waitForKernelPendingPromise: Promise<void> | undefined;

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -55,6 +55,7 @@ import * as uuid from 'uuid/v4';
 import { swallowExceptions } from '../../../platform/common/utils/misc';
 import { IPlatformService } from '../../../platform/common/platform/types';
 import { waitForCondition } from '../../common';
+import { VSCodeNotebook } from '../../../platform/common/application/notebook';
 
 // Running in Conda environments, things can be a little slower.
 export const defaultNotebookTestTimeout = 60_000;
@@ -250,7 +251,10 @@ export async function closeNotebooks(disposables: IDisposable[] = []) {
     if (!isInsiders()) {
         return false;
     }
+    const api = await initialize();
     VSCodeNotebookController.kernelAssociatedWithDocument = undefined;
+    const notebooks = api.serviceManager.get<IVSCodeNotebook>(IVSCodeNotebook) as VSCodeNotebook;
+    await notebooks.closeActiveNotebooks();
     await closeActiveWindows();
     disposeAllDisposables(disposables);
     await shutdownAllNotebooks();

--- a/src/test/datascience/notebook/ipywidget.vscode.common.ts
+++ b/src/test/datascience/notebook/ipywidget.vscode.common.ts
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+import * as sinon from 'sinon';
+import { assert } from 'chai';
+import { NotebookDocument, Uri, window } from 'vscode';
+import { IVSCodeNotebook } from '../../../platform/common/application/types';
+import { IDisposable } from '../../../platform/common/types';
+import { IExtensionTestApi, waitForCondition } from '../../common';
+import { openNotebook } from '../helpers';
+import {
+    closeNotebooks,
+    closeNotebooksAndCleanUpAfterTests,
+    createTemporaryNotebook,
+    defaultNotebookTestTimeout,
+    runCell,
+    waitForCellExecutionToComplete,
+    waitForKernelToGetAutoSelected
+} from './helper';
+import { createDeferred, Deferred } from '../../../platform/common/utils/async';
+import { InteractiveWindowMessages } from '../../../platform/messageTypes';
+import { NotebookIPyWidgetCoordinator } from '../../../kernels/ipywidgets-message-coordination/notebookIPyWidgetCoordinator';
+import { INotebookCommunication } from '../../../notebooks/types';
+import { initialize } from '../../initialize';
+import { IServiceContainer } from '../../../platform/ioc/types';
+import { PYTHON_LANGUAGE } from '../../../platform/common/constants';
+import { traceInfo } from '../../../platform/logging';
+
+/* eslint-disable @typescript-eslint/no-explicit-any, no-invalid-this */
+export function sharedIPyWidgetStandardTests(
+    suite: Mocha.Suite,
+    finishSuiteSetup: (serviceContainer: IServiceContainer) => void,
+    finishTestSetup: () => Promise<void>,
+    handleTestTeardown: (context: Mocha.Context) => Promise<void>
+) {
+    suite.timeout(120_000);
+    let api: IExtensionTestApi;
+    const disposables: IDisposable[] = [];
+    let vscodeNotebook: IVSCodeNotebook;
+    let widgetCoordinator: NotebookIPyWidgetCoordinator;
+    let testWidgetNb: Uri;
+    suiteSetup(async function () {
+        api = await initialize();
+        sinon.restore();
+        vscodeNotebook = api.serviceContainer.get<IVSCodeNotebook>(IVSCodeNotebook);
+        widgetCoordinator = api.serviceContainer.get<NotebookIPyWidgetCoordinator>(NotebookIPyWidgetCoordinator);
+        await finishSuiteSetup(api.serviceContainer);
+    });
+    setup(async function () {
+        sinon.restore();
+        await closeNotebooks();
+        // Don't use same file (due to dirty handling, we might save in dirty.)
+        testWidgetNb = await createTemporaryNotebook(
+            [
+                {
+                    cell_type: 'code',
+                    execution_count: null,
+                    metadata: {},
+                    outputs: [],
+                    source: ['import ipywidgets as widgets\n', 'widgets.IntSlider(value=6519, min=5555, max=7777)']
+                }
+            ],
+            disposables
+        );
+        await finishTestSetup();
+    });
+    teardown(async function () {
+        traceInfo(`Ended Test ${this.currentTest?.title}`);
+        await handleTestTeardown(this);
+        await closeNotebooksAndCleanUpAfterTests(disposables);
+        traceInfo(`Ended Test (completed) ${this.currentTest?.title}`);
+    });
+    suiteTeardown(() => closeNotebooksAndCleanUpAfterTests(disposables));
+    test('Can run a widget notebook (webview-test)', async function () {
+        const notebook = await openNotebook(testWidgetNb);
+        await waitForKernelToGetAutoSelected(PYTHON_LANGUAGE);
+        const cell = notebook.cellAt(0);
+
+        // This flag will be resolved when the widget loads
+        const flag = createDeferred<boolean>();
+        flagForWebviewLoad(flag, vscodeNotebook.activeNotebookEditor?.document!);
+
+        // Execute cell. It should load and render the widget
+        await runCell(cell);
+        await waitForCellExecutionToComplete(cell);
+
+        // Wait for the flag to be set as it may take a while
+        await waitForCondition(
+            () => flag.promise,
+            defaultNotebookTestTimeout,
+            'Widget did not load successfully during execution'
+        );
+    });
+    test('Can run a widget notebook twice (webview-test)', async function () {
+        let notebook = await openNotebook(testWidgetNb);
+        await waitForKernelToGetAutoSelected(PYTHON_LANGUAGE);
+        let cell = notebook.cellAt(0);
+
+        // Execute cell. It should load and render the widget
+        await runCell(cell);
+
+        // Wait till execution count changes and status is success.
+        await waitForCellExecutionToComplete(cell);
+
+        // Close notebook and open again.
+        await closeNotebooks();
+
+        notebook = await openNotebook(testWidgetNb);
+        await waitForKernelToGetAutoSelected(PYTHON_LANGUAGE);
+        cell = notebook.cellAt(0);
+
+        // This flag will be resolved when the widget loads
+        const flag = createDeferred<boolean>();
+        flagForWebviewLoad(flag, vscodeNotebook.activeNotebookEditor?.document!);
+
+        // Execute cell. It should load and render the widget
+        await runCell(cell);
+
+        // Wait till execution count changes and status is success.
+        await waitForCellExecutionToComplete(cell);
+        // Wait for the flag to be set as it may take a while
+        await waitForCondition(
+            () => flag.promise,
+            defaultNotebookTestTimeout,
+            'Widget did not load successfully during execution'
+        );
+    });
+
+    // Resolve a deferred when we see the target uri has an associated webview and the webview
+    // loaded a widget successfully
+    function flagForWebviewLoad(flag: Deferred<boolean>, targetDoc: NotebookDocument) {
+        const commsList = getNotebookCommunications(targetDoc);
+        assert.equal(commsList.length, 1, 'No webviews found in kernel provider');
+        if (Array.isArray(commsList) && commsList.length > 0) {
+            commsList[0].onDidReceiveMessage((e) => {
+                if (e.type === InteractiveWindowMessages.IPyWidgetLoadSuccess) {
+                    flag.resolve(true);
+                }
+            });
+        }
+    }
+    function getNotebookCommunications(notebook: NotebookDocument) {
+        const items: INotebookCommunication[] = [];
+        window.visibleNotebookEditors.forEach((editor) => {
+            if (editor.document !== notebook) {
+                return;
+            }
+            const comm = widgetCoordinator.notebookCommunications.get(editor);
+            if (comm) {
+                items.push(comm);
+            }
+        });
+        return items;
+    }
+}

--- a/src/test/datascience/notebook/ipywidget.vscode.web.test.ts
+++ b/src/test/datascience/notebook/ipywidget.vscode.web.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { sharedIPyWidgetStandardTests } from './ipywidget.vscode.common';
 
-suite('DataScience - VSCode Notebook - Standard IPyWidgets node', function () {
+suite('DataScience - VSCode Notebook - Standard IPyWidgets web', function () {
     // Use the shared code that runs the tests
     sharedIPyWidgetStandardTests(
         this,

--- a/src/test/datascience/setupTestEnvs.cmd
+++ b/src/test/datascience/setupTestEnvs.cmd
@@ -10,6 +10,7 @@ python -m pip install ipykernel
 python -m ipykernel install --user --name .venvkernel --display-name .venvkernel
 python -m pip uninstall jedi --yes
 python -m pip install jedi==0.17.2
+python -m pip install ipywidgets
 
 call .venvnokernel\Scripts\activate
 python --version

--- a/src/webviews/webview-side/ipywidgets/kernel/index.ts
+++ b/src/webviews/webview-side/ipywidgets/kernel/index.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 /* eslint-disable no-console */
 import type * as nbformat from '@jupyterlab/nbformat';
-import { logMessage } from '../../react-common/logger';
 import { KernelMessagingApi, PostOffice } from '../../react-common/postOffice';
 import { WidgetManager } from '../common/manager';
 import { ScriptManager } from '../common/scriptManager';
@@ -127,6 +126,7 @@ function renderIPyWidget(
     container: HTMLElement,
     logger: (message: string) => void
 ) {
+    console.log(`Rendering IPyWidget ${outputId} with model ${model.model_id}`);
     if (renderedWidgets.has(outputId)) {
         return console.error('already rendering');
     }
@@ -244,7 +244,7 @@ function attemptInitialize(context?: KernelMessagingApi) {
     console.log('Attempt Initialize IpyWidgets kernel.js', context);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if ((window as any).vscIPyWidgets) {
-        logMessage('IPyWidget kernel initializing...');
+        console.log('IPyWidget kernel initializing...');
         initialize(capturedContext);
     } else {
         setTimeout(attemptInitialize, 100);


### PR DESCRIPTION
Fixes #10051

This does not include stuff like matplotlib or ipyleaflets. This is merely getting this to work:

```
import ipywidgets as widgets
widgets.IntSlider()
```

I also fixed an issue where the timing around the ipywidgets communication can get messed up. This happens when reopening a notebook for the second time after creating a widget.

