### PR TITLE
Create traceback formatter to remove dependency on CellHashProvider

### DIFF
--- a/src/interactive-window/outputs/tracebackFormatter.ts
+++ b/src/interactive-window/outputs/tracebackFormatter.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { inject, injectable } from 'inversify';
+import { NotebookCell } from 'vscode';
+import { ITracebackFormatter } from '../../kernels/types';
+import { InteractiveWindowView } from '../../notebooks/constants';
+import { CellHashProviderFactory } from '../editor-integration/cellHashProviderFactory';
+
+@injectable()
+export class InteractiveWindowTracebackFormatter implements ITracebackFormatter {
+    constructor(@inject(CellHashProviderFactory) private readonly cellHashProviderFactory: CellHashProviderFactory) {}
+    format(cell: NotebookCell, traceback: string[]): string[] {
+        if (cell.notebook.notebookType !== InteractiveWindowView) {
+            return traceback;
+        }
+        const cellHasProvider = this.cellHashProviderFactory.get(cell.notebook);
+        return cellHasProvider ? cellHasProvider.modifyTraceback(traceback) : traceback;
+    }
+}

--- a/src/interactive-window/serviceRegistry.node.ts
+++ b/src/interactive-window/serviceRegistry.node.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 
+import { ITracebackFormatter } from '../kernels/types';
 import { IExtensionSyncActivationService, IExtensionSingleActivationService } from '../platform/activation/types';
 import { IDataScienceCommandListener } from '../platform/common/types';
 import { IServiceManager } from '../platform/ioc/types';
@@ -16,6 +17,7 @@ import { HoverProvider } from './editor-integration/hoverProvider';
 import { ICodeWatcher, ICodeLensFactory, IDataScienceCodeLensProvider } from './editor-integration/types';
 import { InteractiveWindowCommandListener } from './interactiveWindowCommandListener.node';
 import { InteractiveWindowProvider } from './interactiveWindowProvider.node';
+import { InteractiveWindowTracebackFormatter } from './outputs/tracebackFormatter';
 import { IExportCommands, IInteractiveWindowProvider } from './types';
 
 export function registerTypes(serviceManager: IServiceManager) {
@@ -35,4 +37,5 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, Decorator);
     serviceManager.addSingleton<IExportCommands>(IExportCommands, ExportCommands);
     serviceManager.addSingleton<CellHashProviderFactory>(CellHashProviderFactory, CellHashProviderFactory);
+    serviceManager.addSingleton<ITracebackFormatter>(ITracebackFormatter, InteractiveWindowTracebackFormatter);
 }

--- a/src/interactive-window/serviceRegistry.web.ts
+++ b/src/interactive-window/serviceRegistry.web.ts
@@ -2,15 +2,18 @@
 // Licensed under the MIT License.
 'use strict';
 
+import { ITracebackFormatter } from '../kernels/types';
 import { IExtensionSingleActivationService } from '../platform/activation/types';
 import { IServiceManager } from '../platform/ioc/types';
 import { CommandRegistry } from './commands/commandRegistry.web';
 import { ExportCommands } from './commands/exportCommands';
 import { CellHashProviderFactory } from './editor-integration/cellHashProviderFactory';
+import { InteractiveWindowTracebackFormatter } from './outputs/tracebackFormatter';
 import { IExportCommands } from './types';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<CellHashProviderFactory>(CellHashProviderFactory, CellHashProviderFactory);
     serviceManager.addSingleton<IExportCommands>(IExportCommands, ExportCommands);
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, CommandRegistry);
+    serviceManager.addSingleton<ITracebackFormatter>(ITracebackFormatter, InteractiveWindowTracebackFormatter);
 }

--- a/src/kernels/kernel.base.ts
+++ b/src/kernels/kernel.base.ts
@@ -50,6 +50,7 @@ import {
     INotebookProvider,
     InterruptResult,
     isLocalConnection,
+    ITracebackFormatter,
     KernelActionSource,
     KernelConnectionMetadata,
     KernelSocketInformation,
@@ -148,7 +149,8 @@ export abstract class BaseKernel implements IKernel {
         readonly cellHashProviderFactory: CellHashProviderFactory,
         private readonly statusProvider: IStatusProvider,
         public readonly creator: KernelActionSource,
-        context: IExtensionContext
+        context: IExtensionContext,
+        tracebackFormatters: ITracebackFormatter[]
     ) {
         this.kernelExecution = new KernelExecution(
             this,
@@ -159,7 +161,8 @@ export abstract class BaseKernel implements IKernel {
             controller,
             outputTracker,
             cellHashProviderFactory,
-            context
+            context,
+            tracebackFormatters
         );
         this.kernelExecution.onPreExecute((c) => this._onPreExecute.fire(c), this, disposables);
     }

--- a/src/kernels/kernel.node.ts
+++ b/src/kernels/kernel.node.ts
@@ -15,7 +15,13 @@ import { CodeSnippets } from '../webviews/webview-side/common/constants';
 import { CellOutputDisplayIdTracker } from '../notebooks/execution/cellDisplayIdTracker';
 import { isLocalHostConnection, isPythonKernelConnection } from './helpers';
 import { expandWorkingDir } from './jupyter/jupyterUtils';
-import { INotebookProvider, isLocalConnection, ITracebackFormatter, KernelActionSource, KernelConnectionMetadata } from './types';
+import {
+    INotebookProvider,
+    isLocalConnection,
+    ITracebackFormatter,
+    KernelActionSource,
+    KernelConnectionMetadata
+} from './types';
 import { AddRunCellHook } from '../platform/common/constants.node';
 import { IStatusProvider } from '../platform/progress/types';
 import { getAssociatedNotebookDocument } from '../notebooks/controllers/kernelSelector';

--- a/src/kernels/kernel.node.ts
+++ b/src/kernels/kernel.node.ts
@@ -15,7 +15,7 @@ import { CodeSnippets } from '../webviews/webview-side/common/constants';
 import { CellOutputDisplayIdTracker } from '../notebooks/execution/cellDisplayIdTracker';
 import { isLocalHostConnection, isPythonKernelConnection } from './helpers';
 import { expandWorkingDir } from './jupyter/jupyterUtils';
-import { INotebookProvider, isLocalConnection, KernelActionSource, KernelConnectionMetadata } from './types';
+import { INotebookProvider, isLocalConnection, ITracebackFormatter, KernelActionSource, KernelConnectionMetadata } from './types';
 import { AddRunCellHook } from '../platform/common/constants.node';
 import { IStatusProvider } from '../platform/progress/types';
 import { getAssociatedNotebookDocument } from '../notebooks/controllers/kernelSelector';
@@ -41,7 +41,8 @@ export class Kernel extends BaseKernel {
         private readonly pythonExecutionFactory: IPythonExecutionFactory,
         statusProvider: IStatusProvider,
         creator: KernelActionSource,
-        context: IExtensionContext
+        context: IExtensionContext,
+        tracebackFormatters: ITracebackFormatter[]
     ) {
         super(
             id,
@@ -59,7 +60,8 @@ export class Kernel extends BaseKernel {
             cellHashProviderFactory,
             statusProvider,
             creator,
-            context
+            context,
+            tracebackFormatters
         );
     }
 

--- a/src/kernels/kernel.web.ts
+++ b/src/kernels/kernel.web.ts
@@ -6,7 +6,7 @@ import { NotebookController, Uri } from 'vscode';
 import { IApplicationShell, IWorkspaceService } from '../platform/common/application/types';
 import { Resource, IDisposableRegistry, IConfigurationService, IExtensionContext } from '../platform/common/types';
 import { CellHashProviderFactory } from '../interactive-window/editor-integration/cellHashProviderFactory';
-import { INotebookProvider, KernelActionSource, KernelConnectionMetadata } from './types';
+import { INotebookProvider, ITracebackFormatter, KernelActionSource, KernelConnectionMetadata } from './types';
 import { BaseKernel } from './kernel.base';
 import { CellOutputDisplayIdTracker } from '../notebooks/execution/cellDisplayIdTracker';
 import { IStatusProvider } from '../platform/progress/types';
@@ -35,7 +35,8 @@ export class Kernel extends BaseKernel {
         workspaceService: IWorkspaceService,
         statusProvider: IStatusProvider,
         creator: KernelActionSource,
-        context: IExtensionContext
+        context: IExtensionContext,
+        tracebackFormatters: ITracebackFormatter[]
     ) {
         super(
             id,
@@ -53,7 +54,8 @@ export class Kernel extends BaseKernel {
             cellHashProviderFactory,
             statusProvider,
             creator,
-            context
+            context,
+            tracebackFormatters
         );
     }
 

--- a/src/kernels/kernelProvider.node.ts
+++ b/src/kernels/kernelProvider.node.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 'use strict';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, multiInject } from 'inversify';
 import { Uri, workspace } from 'vscode';
 import { IApplicationShell, IWorkspaceService, IVSCodeNotebook } from '../platform/common/application/types';
 import { IFileSystemNode } from '../platform/common/platform/types.node';
@@ -17,7 +17,7 @@ import { CellHashProviderFactory } from '../interactive-window/editor-integratio
 import { InteractiveWindowView } from '../notebooks/constants';
 import { CellOutputDisplayIdTracker } from '../notebooks/execution/cellDisplayIdTracker';
 import { Kernel } from './kernel.node';
-import { IKernel, INotebookProvider, KernelOptions } from './types';
+import { IKernel, INotebookProvider, ITracebackFormatter, KernelOptions } from './types';
 import { IStatusProvider } from '../platform/progress/types';
 import { BaseKernelProvider } from './kernelProvider.base';
 
@@ -36,7 +36,8 @@ export class KernelProvider extends BaseKernelProvider {
         @inject(IVSCodeNotebook) notebook: IVSCodeNotebook,
         @inject(IPythonExecutionFactory) private readonly pythonExecutionFactory: IPythonExecutionFactory,
         @inject(IStatusProvider) private readonly statusProvider: IStatusProvider,
-        @inject(IExtensionContext) private readonly context: IExtensionContext
+        @inject(IExtensionContext) private readonly context: IExtensionContext,
+        @multiInject(ITracebackFormatter) private readonly tracebackFormatters: ITracebackFormatter[]
     ) {
         super(asyncDisposables, disposables, notebook);
     }
@@ -70,7 +71,8 @@ export class KernelProvider extends BaseKernelProvider {
             this.pythonExecutionFactory,
             this.statusProvider,
             options.creator,
-            this.context
+            this.context,
+            this.tracebackFormatters
         );
         kernel.onRestarted(() => this._onDidRestartKernel.fire(kernel), this, this.disposables);
         kernel.onDisposed(() => this._onDidDisposeKernel.fire(kernel), this, this.disposables);

--- a/src/kernels/kernelProvider.web.ts
+++ b/src/kernels/kernelProvider.web.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 'use strict';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, multiInject } from 'inversify';
 import { Uri, workspace } from 'vscode';
 import { IApplicationShell, IWorkspaceService, IVSCodeNotebook } from '../platform/common/application/types';
 import {
@@ -14,7 +14,7 @@ import {
 import { CellHashProviderFactory } from '../interactive-window/editor-integration/cellHashProviderFactory';
 import { InteractiveWindowView } from '../notebooks/constants';
 import { Kernel } from './kernel.web';
-import { IKernel, INotebookProvider, KernelOptions } from './types';
+import { IKernel, INotebookProvider, ITracebackFormatter, KernelOptions } from './types';
 import { BaseKernelProvider } from './kernelProvider.base';
 import { CellOutputDisplayIdTracker } from '../notebooks/execution/cellDisplayIdTracker';
 import { IStatusProvider } from '../platform/progress/types';
@@ -32,7 +32,8 @@ export class KernelProvider extends BaseKernelProvider {
         @inject(CellHashProviderFactory) private cellHashProviderFactory: CellHashProviderFactory,
         @inject(IVSCodeNotebook) notebook: IVSCodeNotebook,
         @inject(IStatusProvider) private readonly statusProvider: IStatusProvider,
-        @inject(IExtensionContext) private readonly context: IExtensionContext
+        @inject(IExtensionContext) private readonly context: IExtensionContext,
+        @multiInject(ITracebackFormatter) private readonly tracebackFormatters: ITracebackFormatter[]
     ) {
         super(asyncDisposables, disposables, notebook);
     }
@@ -64,7 +65,8 @@ export class KernelProvider extends BaseKernelProvider {
             this.workspaceService,
             this.statusProvider,
             options.creator,
-            this.context
+            this.context,
+            this.tracebackFormatters
         );
         kernel.onRestarted(() => this._onDidRestartKernel.fire(kernel), this, this.disposables);
         kernel.onDisposed(() => this._onDidDisposeKernel.fire(kernel), this, this.disposables);

--- a/src/kernels/types.ts
+++ b/src/kernels/types.ts
@@ -547,3 +547,8 @@ export interface IKernelFinder {
 export type KernelAction = 'start' | 'interrupt' | 'restart' | 'execution';
 
 export type KernelActionSource = 'jupyterExtension' | '3rdPartyExtension';
+
+export const ITracebackFormatter = Symbol('ITracebackFormatter');
+export interface ITracebackFormatter {
+    format(cell: NotebookCell, traceback: string[]): string[];
+}

--- a/src/notebooks/execution/kernelExecution.ts
+++ b/src/notebooks/execution/kernelExecution.ts
@@ -21,6 +21,7 @@ import {
     IJupyterSession,
     IKernel,
     InterruptResult,
+    ITracebackFormatter,
     KernelConnectionMetadata,
     NotebookCellRunState
 } from '../../kernels/types';
@@ -48,16 +49,17 @@ export class KernelExecution implements IDisposable {
         controller: NotebookController,
         outputTracker: CellOutputDisplayIdTracker,
         cellHashProviderFactory: CellHashProviderFactory,
-        context: IExtensionContext
+        context: IExtensionContext,
+        tracebackFormatters: ITracebackFormatter[]
     ) {
         this.executionFactory = new CellExecutionFactory(
-            kernel,
             appShell,
             disposables,
             controller,
             outputTracker,
             cellHashProviderFactory,
-            context
+            context,
+            tracebackFormatters
         );
     }
 

--- a/src/notebooks/outputs/tracebackFormatter.ts
+++ b/src/notebooks/outputs/tracebackFormatter.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { injectable } from 'inversify';
+import { NotebookCell } from 'vscode';
+import { ITracebackFormatter } from '../../kernels/types';
+import { getFilePath } from '../../platform/common/platform/fs-paths';
+import { DataScience } from '../../platform/common/utils/localize';
+import { JupyterNotebookView } from '../constants';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const LineNumberMatchRegex = /(;32m[ ->]*?)(\d+)(.*)/g;
+
+@injectable()
+export class NotebookTracebackFormatter implements ITracebackFormatter {
+    format(cell: NotebookCell, traceback: string[]): string[] {
+        if (cell.notebook.notebookType !== JupyterNotebookView) {
+            return traceback;
+        }
+        return traceback.map((line) => {
+            const inputMatch = /^Input.*?\[.*32mIn\s+\[(\d+).*?0;36m(.*?)\n.*/.exec(line);
+
+            // We have a match, replace source lines first
+            const afterLineReplace = line.replace(LineNumberMatchRegex, (_s, prefix, num, suffix) => {
+                const n = parseInt(num, 10);
+                return `${prefix}<a href='${cell.document.uri.toString()}?line=${n - 1}'>${n}</a>${suffix}`;
+            });
+
+            return !inputMatch
+                ? afterLineReplace
+                : // Then replace the input line with our uri for this cell
+                  afterLineReplace.replace(
+                      /.*?\n/,
+                      `\u001b[1;32m${DataScience.cellAtFormat().format(
+                          getFilePath(cell.document.uri),
+                          (cell.index + 1).toString()
+                      )}\u001b[0m in \u001b[0;36m${inputMatch[2]}\n`
+                  );
+        });
+    }
+}

--- a/src/notebooks/serviceRegistry.node.ts
+++ b/src/notebooks/serviceRegistry.node.ts
@@ -24,6 +24,8 @@ import { IDataScienceCommandListener } from '../platform/common/types';
 import { CondaControllerRefresher } from './controllers/condaControllerRefresher.node';
 import { IntellisenseProvider } from '../intellisense/intellisenseProvider.node';
 import { RemoteKernelControllerWatcher } from './controllers/remoteKernelControllerWatcher';
+import { ITracebackFormatter } from '../kernels/types';
+import { NotebookTracebackFormatter } from './outputs/tracebackFormatter';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, RemoteSwitcher);
@@ -67,4 +69,5 @@ export function registerTypes(serviceManager: IServiceManager) {
         IExtensionSyncActivationService,
         RemoteKernelControllerWatcher
     );
+    serviceManager.addSingleton<ITracebackFormatter>(ITracebackFormatter, NotebookTracebackFormatter);
 }


### PR DESCRIPTION
Part of #10037

The fact that cell hash provider knows how to format tracebacks should not be known by the kernel layer.
Thats an implmenetation detail.
I've split the formatter into two, one for IW & one for Notebooks (Ipynb).

This way, we can now have more formatters that will allow us to modify the error messages to include custom links or the like.
E.g. in the past we wanted to add custom messages & links based on different errors, now that we have a formatter we can do this without having to modify the kernel layer.

