### PR TITLE
Updates for CI test run telemetry

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -830,6 +830,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python: [3.9]
     steps:
+      - name: Set environment variables
+        run: |
+          echo "GIT_SHA=${GITHUB_SHA}" >> $GITHUB_ENV
+          echo "GIT_BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1574,7 +1574,9 @@ export interface IEventNamePropertyMapping {
     [Telemetry.RunTest]: {
         testName: string;
         testResult: string;
-        perfWarmup?: boolean;
+        perfWarmup?: 'true';
+        commitHash?: string;
+        timedCheckpoints?: string;
     };
     [Telemetry.PreferredKernelExactMatch]: {
         matchedReason: PreferredKernelExactMatchReason;

--- a/src/test/testHooks.node.ts
+++ b/src/test/testHooks.node.ts
@@ -4,7 +4,6 @@ import TelemetryReporter from '@vscode/extension-telemetry/lib/telemetryReporter
 import { IS_CI_SERVER } from './ciConstants.node';
 import { extensions } from 'vscode';
 import { sleep } from '../platform/common/utils/async';
-import { traceInfo } from '../platform/logging';
 
 let telemetryReporter: TelemetryReporter;
 
@@ -23,13 +22,7 @@ export const rootHooks: Mocha.RootHookObject = {
         telemetryReporter = new reporter(extensionId, extensionVersion, AppinsightsKey, true);
     },
     afterEach(this: Context) {
-        if (!IS_CI_SERVER) {
-            return;
-        }
-
-        // temporary log to make sure we get the branch name check right before implementing
-        if (process.env.GIT_BRANCH && process.env.GIT_BRANCH !== 'main') {
-            traceInfo(`not sending test result telemetry for runs on ${process.env.GIT_BRANCH} branch`);
+        if (!IS_CI_SERVER || (process.env.GIT_BRANCH && process.env.GIT_BRANCH !== 'main')) {
             return;
         }
 


### PR DESCRIPTION
Put timedCheckpoint data into a single property that only needs to be classified once. As measures, each named checkpoint would have to classified, making it more difficult to add new data for a test.

Add commit info to test run events and only send when run on the main branch

Fixes #9898 
