### PR TITLE
Proposal: All the non-Node-specific fileSystem methods to allow both strings and Uris

### DIFF
--- a/src/platform/common/platform/fileSystem.node.ts
+++ b/src/platform/common/platform/fileSystem.node.ts
@@ -3,7 +3,6 @@ import * as glob from 'glob';
 import { inject, injectable } from 'inversify';
 import * as tmp from 'tmp';
 import { promisify } from 'util';
-import * as vscode from 'vscode';
 import { TemporaryFile } from './types';
 import { IFileSystemNode } from './types.node';
 import { FileSystem as FileSystemBase } from './fileSystem';
@@ -58,13 +57,6 @@ export class FileSystem extends FileSystemBase implements IFileSystemNode {
         return fs.ensureDir(path);
     }
 
-    public async localDirectoryExists(dirname: string): Promise<boolean> {
-        return this.exists(vscode.Uri.file(dirname), vscode.FileType.Directory);
-    }
-
-    public async localFileExists(filename: string): Promise<boolean> {
-        return this.exists(vscode.Uri.file(filename), vscode.FileType.File);
-    }
     public override async deleteLocalFile(path: string): Promise<void> {
         await fs.unlink(path);
     }

--- a/src/platform/common/platform/types.node.ts
+++ b/src/platform/common/platform/types.node.ts
@@ -18,7 +18,5 @@ export interface IFileSystemNode extends IFileSystem {
     createTemporaryLocalFile(fileExtension: string): Promise<TemporaryFile>;
     deleteLocalDirectory(dirname: string): Promise<void>;
     ensureLocalDir(path: string): Promise<void>;
-    localDirectoryExists(dirname: string): Promise<boolean>;
-    localFileExists(filename: string): Promise<boolean>;
     searchLocal(globPattern: string, cwd?: string, dot?: boolean): Promise<string[]>;
 }

--- a/src/platform/common/platform/types.ts
+++ b/src/platform/common/platform/types.ts
@@ -48,22 +48,24 @@ export interface IExecutables {
 
 export const IFileSystem = Symbol('IFileSystem');
 export interface IFileSystem {
-    areLocalPathsSame(path1: string, path2: string): boolean;
-    createLocalDirectory(path: string): Promise<void>;
-    copyLocal(source: string, destination: string): Promise<void>;
-    deleteLocalFile(path: string): Promise<void>;
-    readLocalData(path: string): Promise<Buffer>;
-    readLocalFile(path: string): Promise<string>;
-    writeLocalFile(path: string, text: string | Buffer): Promise<void>;
-    arePathsSame(path1: vscode.Uri, path2: vscode.Uri): boolean;
-    copy(source: vscode.Uri, destination: vscode.Uri): Promise<void>;
-    createDirectory(uri: vscode.Uri): Promise<void>;
-    delete(uri: vscode.Uri): Promise<void>;
-    readFile(uri: vscode.Uri): Promise<string>;
-    stat(uri: vscode.Uri): Promise<vscode.FileStat>;
-    writeFile(uri: vscode.Uri, text: string | Buffer): Promise<void>;
-    getFiles(dir: vscode.Uri): Promise<vscode.Uri[]>;
+    areLocalPathsSame(path1: string | vscode.Uri, path2: string | vscode.Uri): boolean;
+    createLocalDirectory(path: string | vscode.Uri): Promise<void>;
+    copyLocal(source: string | vscode.Uri, destination: string | vscode.Uri): Promise<void>;
+    localDirectoryExists(dirname: string | vscode.Uri): Promise<boolean>;
+    localFileExists(filename: string | vscode.Uri): Promise<boolean>;
+    deleteLocalFile(path: string | vscode.Uri): Promise<void>;
+    readLocalData(path: string | vscode.Uri): Promise<Buffer>;
+    readLocalFile(path: string | vscode.Uri): Promise<string>;
+    writeLocalFile(path: string | vscode.Uri, text: string | Buffer): Promise<void>;
+    arePathsSame(path1: string | vscode.Uri, path2: string | vscode.Uri): boolean;
+    copy(source: string | vscode.Uri, destination: string | vscode.Uri): Promise<void>;
+    createDirectory(path: string | vscode.Uri): Promise<void>;
+    delete(path: string | vscode.Uri): Promise<void>;
+    readFile(path: string | vscode.Uri): Promise<string>;
+    stat(path: string | vscode.Uri): Promise<vscode.FileStat>;
+    writeFile(path: string | vscode.Uri, text: string | Buffer): Promise<void>;
+    getFiles(dir: string | vscode.Uri): Promise<vscode.Uri[]>;
     createTemporaryFile(options: { fileExtension?: string; prefix?: string }): Promise<TemporaryFileUri>;
-    exists(uri: vscode.Uri, fileType?: vscode.FileType): Promise<boolean>;
-    getFileHash(filename: vscode.Uri): Promise<string>;
+    exists(path: string | vscode.Uri, fileType?: vscode.FileType): Promise<boolean>;
+    getFileHash(path: string | vscode.Uri): Promise<string>;
 }


### PR DESCRIPTION
How about this change? It would help me streamline some of the web Variable Viewer changes.

Pros:
- Centralizes new functionalities without requiring changes at the leaf references of these methods.
- Allows new features to be implemented on top of URIs without forcing old features to be updated (reducing the number of possible bugs that could arise from changing things that are already working).

Cons:
- Makes these file system methods and API a bit more complex.