### PR TITLE
Enable IW in web

### DIFF
--- a/news/1 Enhancements/9717.md
+++ b/news/1 Enhancements/9717.md
@@ -1,0 +1,1 @@
+Enabled the Interactive Window in web.

--- a/package.json
+++ b/package.json
@@ -520,7 +520,7 @@
                 "command": "jupyter.createnewinteractive",
                 "title": "%jupyter.command.jupyter.createnewinteractive.title%",
                 "category": "Jupyter",
-                "enablement": "isWorkspaceTrusted && !jupyter.webExtension"
+                "enablement": "isWorkspaceTrusted"
             },
             {
                 "command": "jupyter.runFileInteractive",

--- a/package.json
+++ b/package.json
@@ -514,7 +514,7 @@
                 "command": "jupyter.execSelectionInteractive",
                 "title": "%jupyter.command.jupyter.execSelectionInteractive.title%",
                 "category": "Jupyter",
-                "enablement": "isWorkspaceTrusted"
+                "enablement": "isWorkspaceTrusted && !jupyter.webExtension"
             },
             {
                 "command": "jupyter.createnewinteractive",
@@ -806,7 +806,6 @@
                 "command": "jupyter.interactive.clearAllCells",
                 "title": "%DataScience.interactiveClearAllCells%",
                 "icon": "$(close)",
-                "enablement": "!jupyter.webExtension",
                 "category": "Jupyter"
             },
             {
@@ -828,7 +827,7 @@
                 "title": "%DataScience.exportDialogTitle%",
                 "shortTitle": "%DataScience.exportAsNotebook.shorttitle%",
                 "icon": "$(save-as)",
-                "enablement": "notebookType == interactive",
+                "enablement": "notebookType == interactive && !jupyter.webExtension",
                 "category": "Jupyter"
             },
             {
@@ -838,7 +837,7 @@
                     "light": "resources/light/export_to_python.svg",
                     "dark": "resources/dark/export_to_python.svg"
                 },
-                "enablement": "notebookType == interactive",
+                "enablement": "notebookType == interactive && !jupyter.webExtension",
                 "category": "Jupyter"
             },
             {

--- a/package.json
+++ b/package.json
@@ -376,7 +376,7 @@
                 "command": "jupyter.runcurrentcell",
                 "title": "%jupyter.command.jupyter.runcurrentcell.title%",
                 "category": "Jupyter",
-                "enablement": "isWorkspaceTrusted && !jupyter.webExtension"
+                "enablement": "isWorkspaceTrusted"
             },
             {
                 "command": "jupyter.debugcell",
@@ -490,19 +490,19 @@
                 "command": "jupyter.runcurrentcelladvance",
                 "title": "%jupyter.command.jupyter.runcurrentcelladvance.title%",
                 "category": "Jupyter",
-                "enablement": "isWorkspaceTrusted && !jupyter.webExtension"
+                "enablement": "isWorkspaceTrusted"
             },
             {
                 "command": "jupyter.runcurrentcellandallbelow.palette",
                 "title": "%jupyter.command.jupyter.runcurrentcellandallbelow.palette.title%",
                 "category": "Jupyter",
-                "enablement": "isWorkspaceTrusted && !jupyter.webExtension"
+                "enablement": "isWorkspaceTrusted"
             },
             {
                 "command": "jupyter.runallcellsabove.palette",
                 "title": "%jupyter.command.jupyter.runallcellsabove.palette.title%",
                 "category": "Jupyter",
-                "enablement": "isWorkspaceTrusted && !jupyter.webExtension"
+                "enablement": "isWorkspaceTrusted"
             },
             {
                 "command": "jupyter.debugcurrentcell.palette",
@@ -514,7 +514,7 @@
                 "command": "jupyter.execSelectionInteractive",
                 "title": "%jupyter.command.jupyter.execSelectionInteractive.title%",
                 "category": "Jupyter",
-                "enablement": "isWorkspaceTrusted && !jupyter.webExtension"
+                "enablement": "isWorkspaceTrusted"
             },
             {
                 "command": "jupyter.createnewinteractive",
@@ -526,7 +526,7 @@
                 "command": "jupyter.runFileInteractive",
                 "title": "%jupyter.command.jupyter.runFileInteractive.title%",
                 "category": "Jupyter",
-                "enablement": "isWorkspaceTrusted && !jupyter.webExtension"
+                "enablement": "isWorkspaceTrusted"
             },
             {
                 "command": "jupyter.debugFileInteractive",
@@ -538,25 +538,25 @@
                 "command": "jupyter.runallcells",
                 "title": "%jupyter.command.jupyter.runallcells.title%",
                 "category": "Jupyter",
-                "enablement": "isWorkspaceTrusted && !jupyter.webExtension"
+                "enablement": "isWorkspaceTrusted"
             },
             {
                 "command": "jupyter.runallcellsabove",
                 "title": "%jupyter.command.jupyter.runallcellsabove.title%",
                 "category": "Jupyter",
-                "enablement": "isWorkspaceTrusted && !jupyter.webExtension"
+                "enablement": "isWorkspaceTrusted"
             },
             {
                 "command": "jupyter.runcellandallbelow",
                 "title": "%jupyter.command.jupyter.runcellandallbelow.title%",
                 "category": "Jupyter",
-                "enablement": "isWorkspaceTrusted && !jupyter.webExtension"
+                "enablement": "isWorkspaceTrusted"
             },
             {
                 "command": "jupyter.runcell",
                 "title": "%jupyter.command.jupyter.runcell.title%",
                 "category": "Jupyter",
-                "enablement": "isWorkspaceTrusted && !jupyter.webExtension"
+                "enablement": "isWorkspaceTrusted"
             },
             {
                 "command": "jupyter.runtoline",
@@ -1807,7 +1807,7 @@
                 },
                 "jupyter.codeLenses": {
                     "type": "string",
-                    "default": "jupyter.runcell,  jupyter.runallcellsabove, jupyter.debugcell",
+                    "default": "jupyter.runcell, jupyter.runallcellsabove, jupyter.debugcell",
                     "description": "Set of commands to put as code lens above a cell.",
                     "scope": "resource"
                 },

--- a/package.nls.json
+++ b/package.nls.json
@@ -534,6 +534,7 @@
     "DataScience.interactiveWindowModeBannerSwitchYes": "Yes",
     "DataScience.interactiveWindowModeBannerSwitchAlways": "Always",
     "DataScience.interactiveWindowModeBannerSwitchNo": "No",
+    "DataScience.noKernelsSpecifyRemote": "No kernel available for cell execution, please [specify a Jupyter server for connections](command:jupyter.selectjupyteruri)",
     "DataScience.ipykernelNotInstalled": "IPyKernel not installed into interpreter {0}",
     "DataScience.ipykernelNotInstalledBecauseCanceled": "IPyKernel not installed into interpreter. Installation canceled.",
     "DataScience.needIpykernel6": "Ipykernel setup required for this feature",

--- a/src/interactive-window/editor-integration/codeLensFactory.ts
+++ b/src/interactive-window/editor-integration/codeLensFactory.ts
@@ -17,7 +17,13 @@ import {
 import { IDocumentManager, IVSCodeNotebook, IWorkspaceService } from '../../platform/common/application/types';
 import { traceWarning, traceInfoIfCI } from '../../platform/logging';
 
-import { ICellRange, IConfigurationService, IDisposableRegistry, Resource } from '../../platform/common/types';
+import {
+    ICellRange,
+    IConfigurationService,
+    IDisposableRegistry,
+    IsWebExtension,
+    Resource
+} from '../../platform/common/types';
 import * as localize from '../../platform/common/utils/localize';
 import { getInteractiveCellMetadata } from '../helpers';
 import { IKernelProvider } from '../../kernels/types';
@@ -234,9 +240,10 @@ export class CodeLensFactory implements ICodeLensFactory {
             fullCommandList = fullCommandList.concat(CodeLensCommands.DefaultDebuggingLenses);
         }
 
+        let commandsToBeDisabled: string[] = [];
         // If workspace is not trusted, then exclude execution related commands.
         if (!this.workspace.isTrusted) {
-            const commandsToBeDisabledIfNotTrusted = [
+            commandsToBeDisabled = [
                 ...CodeLensCommands.DebuggerCommands,
                 ...CodeLensCommands.DebuggerCommands,
                 Commands.RunAllCells,
@@ -256,8 +263,13 @@ export class CodeLensFactory implements ICodeLensFactory {
                 Commands.DebugStop,
                 Commands.RunCellAndAllBelowPalette
             ];
-            fullCommandList = fullCommandList.filter((item) => !commandsToBeDisabledIfNotTrusted.includes(item));
+        } else if (IsWebExtension) {
+            commandsToBeDisabled = [Commands.DebugCell];
         }
+        if (commandsToBeDisabled) {
+            fullCommandList = fullCommandList.filter((item) => !commandsToBeDisabled.includes(item));
+        }
+
         return fullCommandList;
     }
 

--- a/src/interactive-window/editor-integration/codeLensFactory.ts
+++ b/src/interactive-window/editor-integration/codeLensFactory.ts
@@ -63,7 +63,8 @@ export class CodeLensFactory implements ICodeLensFactory {
         @inject(IDisposableRegistry) disposables: IDisposableRegistry,
         @inject(IGeneratedCodeStorageFactory)
         private readonly generatedCodeStorageFactory: IGeneratedCodeStorageFactory,
-        @inject(IKernelProvider) kernelProvider: IKernelProvider
+        @inject(IKernelProvider) kernelProvider: IKernelProvider,
+        @inject(IsWebExtension) private readonly isWebExtension: boolean
     ) {
         this.documentManager.onDidCloseTextDocument(this.onClosedDocument, this, disposables);
         this.workspace.onDidGrantWorkspaceTrust(() => this.codeLensCache.clear(), this, disposables);
@@ -263,8 +264,9 @@ export class CodeLensFactory implements ICodeLensFactory {
                 Commands.DebugStop,
                 Commands.RunCellAndAllBelowPalette
             ];
-        } else if (IsWebExtension) {
-            commandsToBeDisabled = [Commands.DebugCell];
+        }
+        if (this.isWebExtension) {
+            commandsToBeDisabled.push(Commands.DebugCell);
         }
         if (commandsToBeDisabled) {
             fullCommandList = fullCommandList.filter((item) => !commandsToBeDisabled.includes(item));

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -126,7 +126,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         private readonly exportDialog: IExportDialog,
         private readonly notebookControllerManager: INotebookControllerManager,
         private readonly serviceContainer: IServiceContainer,
-        private readonly interactiveWindowDebugger: IInteractiveWindowDebugger,
+        private readonly interactiveWindowDebugger: IInteractiveWindowDebugger | undefined,
         private readonly errorHandler: IDataScienceErrorHandler,
         preferredController: IVSCodeNotebookController | undefined,
         public readonly notebookEditor: NotebookEditor,
@@ -571,10 +571,14 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
             if (isDebug && (settings.forceIPyKernelDebugger || !isLocalConnection(kernel.kernelConnectionMetadata))) {
                 // New ipykernel 7 debugger using the Jupyter protocol.
                 await this.debuggingManager.start(this.notebookEditor, cell);
-            } else if (isDebug && isLocalConnection(kernel.kernelConnectionMetadata)) {
+            } else if (
+                isDebug &&
+                isLocalConnection(kernel.kernelConnectionMetadata) &&
+                this.interactiveWindowDebugger
+            ) {
                 // Old ipykernel 6 debugger.
                 // If debugging attach to the kernel but don't enable tracing just yet
-                detachKernel = async () => this.interactiveWindowDebugger.detach(kernel);
+                detachKernel = async () => this.interactiveWindowDebugger?.detach(kernel);
                 await this.interactiveWindowDebugger.attach(kernel);
                 await this.interactiveWindowDebugger.updateSourceMaps(
                     this.storageFactory.get({ notebook: cell.notebook })?.all || []

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -34,7 +34,7 @@ import { traceInfoIfCI } from '../platform/logging';
 import { IFileSystem } from '../platform/common/platform/types';
 import * as uuid from 'uuid/v4';
 
-import { IConfigurationService, InteractiveWindowMode, Resource } from '../platform/common/types';
+import { IConfigurationService, InteractiveWindowMode, IsWebExtension, Resource } from '../platform/common/types';
 import { noop } from '../platform/common/utils/misc';
 import {
     IKernel,
@@ -160,6 +160,8 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         if (preferredController) {
             // Also start connecting to our kernel but don't wait for it to finish
             this.startKernel(preferredController.controller, preferredController.connection).ignoreErrors();
+        } else if (IsWebExtension) {
+            this.insertInfoMessage(DataScience.noKernelsSpecifyRemote()).ignoreErrors();
         }
     }
 
@@ -277,9 +279,13 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         kernelMetadata: KernelConnectionMetadata,
         reason: SysInfoReason
     ): Promise<NotebookCell> {
+        const message = this.getSysInfoMessage(kernelMetadata, reason);
+        return this.insertInfoMessage(message);
+    }
+
+    private async insertInfoMessage(message: string): Promise<NotebookCell> {
         if (!this._insertSysInfoPromise) {
             const func = async () => {
-                const message = this.getSysInfoMessage(kernelMetadata, reason);
                 await chainWithPendingUpdates(this.notebookDocument, (edit) => {
                     const markdownCell = new NotebookCellData(NotebookCellKind.Markup, message, MARKDOWN_LANGUAGE);
                     markdownCell.metadata = { isInteractiveWindowMessageCell: true, isPlaceholder: true };
@@ -296,6 +302,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         }
         return this._insertSysInfoPromise;
     }
+
     private updateSysInfoMessage(newMessage: string, finish: boolean, cellPromise: Promise<NotebookCell>) {
         if (finish) {
             this._insertSysInfoPromise = undefined;
@@ -488,7 +495,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
 
     private async submitCodeImpl(code: string, fileUri: Uri, line: number, isDebug: boolean) {
         // Do not execute or render empty cells
-        if (this.cellMatcher.isEmptyCell(code)) {
+        if (this.cellMatcher.isEmptyCell(code) || !this.currentKernelInfo.controller) {
             return true;
         }
 

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -34,7 +34,7 @@ import { traceInfoIfCI } from '../platform/logging';
 import { IFileSystem } from '../platform/common/platform/types';
 import * as uuid from 'uuid/v4';
 
-import { IConfigurationService, InteractiveWindowMode, IsWebExtension, Resource } from '../platform/common/types';
+import { IConfigurationService, InteractiveWindowMode, Resource } from '../platform/common/types';
 import { noop } from '../platform/common/utils/misc';
 import {
     IKernel,
@@ -134,7 +134,8 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         public readonly appShell: IApplicationShell,
         private readonly codeGeneratorFactory: ICodeGeneratorFactory,
         private readonly storageFactory: IGeneratedCodeStorageFactory,
-        private readonly debuggingManager: IInteractiveWindowDebuggingManager
+        private readonly debuggingManager: IInteractiveWindowDebuggingManager,
+        private readonly isWebExtension: boolean
     ) {
         // Set our owner and first submitter
         if (this._owner) {
@@ -160,7 +161,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         if (preferredController) {
             // Also start connecting to our kernel but don't wait for it to finish
             this.startKernel(preferredController.controller, preferredController.connection).ignoreErrors();
-        } else if (IsWebExtension) {
+        } else if (this.isWebExtension) {
             this.insertInfoMessage(DataScience.noKernelsSpecifyRemote()).ignoreErrors();
         }
     }

--- a/src/interactive-window/interactiveWindowProvider.ts
+++ b/src/interactive-window/interactiveWindowProvider.ts
@@ -166,7 +166,7 @@ export class InteractiveWindowProvider implements IInteractiveWindowProvider, IA
                 this.serviceContainer.get<IExportDialog>(IExportDialog),
                 this.notebookControllerManager,
                 this.serviceContainer,
-                this.serviceContainer.get<IInteractiveWindowDebugger>(IInteractiveWindowDebugger),
+                this.serviceContainer.tryGet<IInteractiveWindowDebugger>(IInteractiveWindowDebugger),
                 this.serviceContainer.get<IDataScienceErrorHandler>(IDataScienceErrorHandler),
                 preferredController,
                 editor,

--- a/src/interactive-window/interactiveWindowProvider.ts
+++ b/src/interactive-window/interactiveWindowProvider.ts
@@ -22,6 +22,7 @@ import {
     IDisposableRegistry,
     IMemento,
     InteractiveWindowMode,
+    IsWebExtension,
     Resource
 } from '../platform/common/types';
 import { chainable } from '../platform/common/utils/decorators';
@@ -174,7 +175,8 @@ export class InteractiveWindowProvider implements IInteractiveWindowProvider, IA
                 this.appShell,
                 this.serviceContainer.get<ICodeGeneratorFactory>(ICodeGeneratorFactory),
                 this.serviceContainer.get<IGeneratedCodeStorageFactory>(IGeneratedCodeStorageFactory),
-                this.serviceContainer.get<IInteractiveWindowDebuggingManager>(IInteractiveWindowDebuggingManager)
+                this.serviceContainer.get<IInteractiveWindowDebuggingManager>(IInteractiveWindowDebuggingManager),
+                this.serviceContainer.get<boolean>(IsWebExtension)
             );
             this._windows.push(result);
 

--- a/src/notebooks/controllers/notebookControllerManager.ts
+++ b/src/notebooks/controllers/notebookControllerManager.ts
@@ -233,7 +233,11 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
                     ? this.notebook.notebookDocuments.find((item) => item.notebookType === notebookType)
                     : undefined;
             const controller = await this.createDefaultRemoteController(notebookType, notebook);
-            return controller;
+            if (controller || IsWebExtension) {
+                return controller;
+            }
+            traceVerbose('No default remote controller, hence returning the active interpreter');
+            return this.createActiveInterpreterController(notebookType, resource);
         }
     }
 

--- a/src/notebooks/controllers/notebookControllerManager.ts
+++ b/src/notebooks/controllers/notebookControllerManager.ts
@@ -234,7 +234,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
                     : undefined;
             const controller = await this.createDefaultRemoteController(notebookType, notebook);
             // If we're running on web, there is no active interpreter to fall back to
-            if (controller || IsWebExtension) {
+            if (controller || this.isWeb) {
                 return controller;
             }
             traceVerbose('No default remote controller, hence returning the active interpreter');

--- a/src/notebooks/controllers/notebookControllerManager.ts
+++ b/src/notebooks/controllers/notebookControllerManager.ts
@@ -233,11 +233,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
                     ? this.notebook.notebookDocuments.find((item) => item.notebookType === notebookType)
                     : undefined;
             const controller = await this.createDefaultRemoteController(notebookType, notebook);
-            if (controller) {
-                return controller;
-            }
-            traceVerbose('No default remote controller, hence returning the active interpreter');
-            return this.createActiveInterpreterController(notebookType, resource);
+            return controller;
         }
     }
 

--- a/src/notebooks/controllers/notebookControllerManager.ts
+++ b/src/notebooks/controllers/notebookControllerManager.ts
@@ -233,6 +233,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
                     ? this.notebook.notebookDocuments.find((item) => item.notebookType === notebookType)
                     : undefined;
             const controller = await this.createDefaultRemoteController(notebookType, notebook);
+            // If we're running on web, there is no active interpreter to fall back to
             if (controller || IsWebExtension) {
                 return controller;
             }

--- a/src/platform/common/utils/localize.ts
+++ b/src/platform/common/utils/localize.ts
@@ -1025,6 +1025,10 @@ export namespace DataScience {
     );
     export const connected = localize('DataScience.connected', 'Connected');
     export const disconnected = localize('DataScience.disconnected', 'Disconnected');
+    export const noKernelsSpecifyRemote = localize(
+        'DataScience.noKernelsSpecifyRemote',
+        'No kernel available for cell execution, please [specify a Jupyter server for connections](command:jupyter.selectjupyteruri)'
+    );
     export const ipykernelNotInstalled = localize(
         'DataScience.ipykernelNotInstalled',
         'IPyKernel not installed into interpreter {0}'

--- a/src/test/datascience/.vscode/settings.json
+++ b/src/test/datascience/.vscode/settings.json
@@ -30,5 +30,6 @@
     // Python experiments have to be on for insiders to work
     "python.experiments.enabled": true,
     "jupyter.generateSVGPlots": false,
-    "jupyter.forceIPyKernelDebugger": false
+    "jupyter.forceIPyKernelDebugger": true,
+    "python.defaultInterpreterPath": "python"
 }

--- a/src/test/datascience/editor-integration/codewatcher.unit.test.ts
+++ b/src/test/datascience/editor-integration/codewatcher.unit.test.ts
@@ -163,7 +163,8 @@ suite('DataScience Code Watcher Unit Tests', () => {
             instance(notebook),
             disposables,
             instance(storageFactory),
-            instance(kernelProvider)
+            instance(kernelProvider),
+            false
         );
         serviceContainer
             .setup((c) => c.get(TypeMoq.It.isValue(ICodeWatcher)))


### PR DESCRIPTION
Fixes #9717

One notable command that was not enabled is `execute selection` since it uses an execution service to get the applicable block of code from a selection and I haven't taken the time to convert that yet.