### PR TITLE
No interactive window dependencies in notebook

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -177,7 +177,7 @@ module.exports = {
         'no-only-tests'
     ],
     rules: {
-        // 'no-only-tests/no-only-tests': 'error',
+        'no-only-tests/no-only-tests': 'error',
         // Overriding ESLint rules with Typescript-specific ones
         '@typescript-eslint/ban-ts-comment': [
             'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -177,7 +177,7 @@ module.exports = {
         'no-only-tests'
     ],
     rules: {
-        'no-only-tests/no-only-tests': 'error',
+        // 'no-only-tests/no-only-tests': 'error',
         // Overriding ESLint rules with Typescript-specific ones
         '@typescript-eslint/ban-ts-comment': [
             'error',
@@ -293,7 +293,12 @@ module.exports = {
                         target: './src/extension.web.ts',
                         from: './src/**/*.node.ts',
                         message: 'Importing node modules into extension.web.ts is not allowed.'
-                    }
+                    },
+                    {
+                        target: './src/notebooks/**/*.ts',
+                        from: './src/interactive-window/**/*.ts',
+                        message: 'Importing modules from ./src/interactive-window into ./src/notebooks code is not allowed.'
+                    },
                 ]
             }
         ],

--- a/src/intellisense/intellisenseProvider.node.ts
+++ b/src/intellisense/intellisenseProvider.node.ts
@@ -18,10 +18,9 @@ import { IDisposableRegistry, IConfigurationService, IsPreRelease } from '../pla
 import { IInterpreterService } from '../platform/interpreter/contracts';
 import { PythonEnvironment } from '../platform/pythonEnvironments/info';
 import { getInterpreterId } from '../platform/pythonEnvironments/info/interpreter';
-import { isJupyterNotebook, findAssociatedNotebookDocument } from '../notebooks/helpers';
-import { INotebookControllerManager, INotebookCompletionProvider } from '../notebooks/types';
+import { isJupyterNotebook } from '../notebooks/helpers';
+import { INotebookControllerManager, INotebookCompletionProvider, INotebookEditorProvider } from '../notebooks/types';
 import { LanguageServer } from './languageServer.node';
-import { IInteractiveWindowProvider } from '../interactive-window/types';
 import { IVSCodeNotebookController } from '../notebooks/controllers/types';
 import { getComparisonKey } from '../platform/vscode-path/resources';
 import { CompletionRequest } from 'vscode-languageclient';
@@ -45,11 +44,11 @@ export class IntellisenseProvider implements INotebookCompletionProvider, IExten
     constructor(
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
         @inject(INotebookControllerManager) private readonly notebookControllerManager: INotebookControllerManager,
+        @inject(INotebookEditorProvider) private readonly notebookEditorProvider: INotebookEditorProvider,
         @inject(IVSCodeNotebook) private readonly notebooks: IVSCodeNotebook,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IPythonExtensionChecker) private readonly extensionChecker: IPythonExtensionChecker,
-        @inject(IInteractiveWindowProvider) private readonly interactiveWindowProvider: IInteractiveWindowProvider,
         @inject(IConfigurationService) private readonly configService: IConfigurationService,
         @inject(IsPreRelease) private readonly isPreRelease: Promise<boolean>,
         @inject(NotebookPythonPathService) private readonly notebookPythonPathService: NotebookPythonPathService
@@ -207,7 +206,7 @@ export class IntellisenseProvider implements INotebookCompletionProvider, IExten
     private shouldAllowIntellisense(uri: Uri, interpreterId: string, _interpreterPath: Uri) {
         // We should allow intellisense for a URI when the interpreter matches
         // the controller for the uri
-        const notebook = findAssociatedNotebookDocument(uri, this.notebooks, this.interactiveWindowProvider);
+        const notebook = this.notebookEditorProvider.findAssociatedNotebookDocument(uri);
         const controller = notebook
             ? this.notebookControllerManager.getSelectedNotebookController(notebook)
             : undefined;

--- a/src/intellisense/notebookPythonPathService.ts
+++ b/src/intellisense/notebookPythonPathService.ts
@@ -4,12 +4,9 @@
 
 import { inject, injectable } from 'inversify';
 import { Disposable, extensions, Uri, workspace } from 'vscode';
-import { IInteractiveWindowProvider } from '../interactive-window/types';
-import { findAssociatedNotebookDocument } from '../notebooks/helpers';
-import { INotebookControllerManager } from '../notebooks/types';
+import { INotebookControllerManager, INotebookEditorProvider } from '../notebooks/types';
 import { IExtensionSingleActivationService } from '../platform/activation/types';
 import { IPythonApiProvider } from '../platform/api/types';
-import { IVSCodeNotebook } from '../platform/common/application/types';
 import { PylanceExtension, PythonExtension } from '../platform/common/constants';
 import { getFilePath } from '../platform/common/platform/fs-paths';
 import { IConfigurationService } from '../platform/common/types';
@@ -30,8 +27,7 @@ export class NotebookPythonPathService implements IExtensionSingleActivationServ
 
     constructor(
         @inject(IPythonApiProvider) private readonly apiProvider: IPythonApiProvider,
-        @inject(IVSCodeNotebook) private readonly notebooks: IVSCodeNotebook,
-        @inject(IInteractiveWindowProvider) private readonly interactiveWindowProvider: IInteractiveWindowProvider,
+        @inject(INotebookEditorProvider) private readonly notebookEditorProvider: INotebookEditorProvider,
         @inject(INotebookControllerManager) private readonly notebookControllerManager: INotebookControllerManager,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IConfigurationService) private readonly configService: IConfigurationService
@@ -119,7 +115,7 @@ export class NotebookPythonPathService implements IExtensionSingleActivationServ
      * path used by Pylance. Return undefined to allow Python to determine the path.
      */
     private async _jupyterPythonPathFunction(uri: Uri): Promise<string | undefined> {
-        const notebook = findAssociatedNotebookDocument(uri, this.notebooks, this.interactiveWindowProvider);
+        const notebook = this.notebookEditorProvider.findAssociatedNotebookDocument(uri);
         if (!notebook) {
             traceVerbose(`_jupyterPythonPathFunction: "${uri}" is not a notebook`);
             return undefined;

--- a/src/interactive-window/commands/exportCommands.ts
+++ b/src/interactive-window/commands/exportCommands.ts
@@ -14,7 +14,6 @@ import { DataScience } from '../../platform/common/utils/localize';
 import { isUri } from '../../platform/common/utils/misc';
 import { PythonEnvironment } from '../../platform/pythonEnvironments/info';
 import { sendTelemetryEvent } from '../../telemetry';
-import { getActiveInteractiveWindow } from '../helpers';
 import { getNotebookMetadata, isPythonNotebook } from '../../notebooks/helpers';
 import { INotebookControllerManager } from '../../notebooks/types';
 import { Commands, Telemetry } from '../../platform/common/constants';
@@ -96,9 +95,7 @@ export class ExportCommands implements IExportCommands, IDisposable {
             // so we need to get the active editor
             sourceDocument =
                 this.notebooks.activeNotebookEditor?.notebook ||
-                (this.interactiveProvider
-                    ? getActiveInteractiveWindow(this.interactiveProvider)?.notebookDocument
-                    : undefined);
+                this.interactiveProvider?.getActiveInteractiveWindow()?.notebookDocument;
             if (!sourceDocument) {
                 traceInfo('Export called without a valid exportable document active');
                 return;

--- a/src/interactive-window/helpers.ts
+++ b/src/interactive-window/helpers.ts
@@ -1,35 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { NotebookCell, window } from 'vscode';
-import { NotebookCellScheme } from '../platform/common/constants';
+import { NotebookCell } from 'vscode';
 import { IJupyterSettings } from '../platform/common/types';
 import { removeLinesFromFrontAndBackNoConcat, appendLineFeed } from '../webviews/webview-side/common';
 import { uncommentMagicCommands } from './editor-integration/cellFactory';
 import { CellMatcher } from './editor-integration/cellMatcher';
 import { InteractiveCellMetadata } from './editor-integration/types';
-import { IInteractiveWindowProvider, IInteractiveWindow } from './types';
 
 export function getInteractiveCellMetadata(cell: NotebookCell): InteractiveCellMetadata | undefined {
     if (cell.metadata.interactive !== undefined) {
         return cell.metadata as InteractiveCellMetadata;
-    }
-}
-export function getActiveInteractiveWindow(
-    interactiveWindowProvider: IInteractiveWindowProvider | undefined
-): IInteractiveWindow | undefined {
-    if (!interactiveWindowProvider) {
-        return;
-    }
-    if (interactiveWindowProvider.activeWindow) {
-        return interactiveWindowProvider.activeWindow;
-    }
-    if (window.activeTextEditor === undefined) {
-        return;
-    }
-    const textDocumentUri = window.activeTextEditor.document.uri;
-    if (textDocumentUri.scheme !== NotebookCellScheme) {
-        return interactiveWindowProvider.get(textDocumentUri);
     }
 }
 

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -575,7 +575,9 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
                 this.interactiveWindowDebugger.enable(kernel);
             }
             traceInfoIfCI('InteractiveWindow.ts.createExecutionPromise.kernel.executeCell');
-            success = (await kernel!.executeCell(cell)) !== NotebookCellRunState.Error;
+            const iwCellMetadata = getInteractiveCellMetadata(cell);
+            success =
+                (await kernel!.executeCell(cell, iwCellMetadata?.generatedCode?.code)) !== NotebookCellRunState.Error;
             traceInfoIfCI('InteractiveWindow.ts.createExecutionPromise.kernel.executeCell.finished');
         } finally {
             await detachKernel();

--- a/src/interactive-window/interactiveWindowCommandListener.ts
+++ b/src/interactive-window/interactiveWindowCommandListener.ts
@@ -31,7 +31,6 @@ import * as localize from '../platform/common/utils/localize';
 import { captureTelemetry } from '../telemetry';
 import { CommandSource } from '../platform/testing/common/constants';
 import { JupyterInstallError } from '../platform/errors/jupyterInstallError';
-import { getActiveInteractiveWindow } from './helpers';
 import { INotebookControllerManager, INotebookEditorProvider } from '../notebooks/types';
 import { KernelConnectionMetadata } from '../kernels/types';
 import { chainWithPendingUpdates } from '../notebooks/execution/notebookUpdater';
@@ -446,7 +445,7 @@ export class InteractiveWindowCommandListener implements IDataScienceCommandList
     }
 
     private async removeCellInInteractiveWindow(context?: NotebookCell) {
-        const interactiveWindow = getActiveInteractiveWindow(this.interactiveWindowProvider);
+        const interactiveWindow = this.interactiveWindowProvider.getActiveInteractiveWindow();
         const ranges =
             context === undefined
                 ? interactiveWindow?.notebookEditor?.selections
@@ -497,7 +496,7 @@ export class InteractiveWindowCommandListener implements IDataScienceCommandList
                 (w) => w.notebookUri?.toString() === notebookUri.toString()
             );
         } else {
-            targetInteractiveWindow = getActiveInteractiveWindow(this.interactiveWindowProvider);
+            targetInteractiveWindow = this.interactiveWindowProvider.getActiveInteractiveWindow();
         }
         return targetInteractiveWindow;
     }

--- a/src/interactive-window/types.ts
+++ b/src/interactive-window/types.ts
@@ -46,6 +46,7 @@ export interface IInteractiveWindowProvider {
      * @param owner The URI of a text document which may be associated with an interactive window.
      */
     get(owner: Uri): IInteractiveWindow | undefined;
+    getActiveInteractiveWindow(): IInteractiveWindow | undefined;
 }
 
 export interface IInteractiveBase extends Disposable {

--- a/src/kernels/kernel.base.ts
+++ b/src/kernels/kernel.base.ts
@@ -192,12 +192,12 @@ export abstract class BaseKernel implements IKernel {
     public get pendingCells(): readonly NotebookCell[] {
         return this.kernelExecution.queue;
     }
-    public async executeCell(cell: NotebookCell): Promise<NotebookCellRunState> {
+    public async executeCell(cell: NotebookCell, codeOverride?: string): Promise<NotebookCellRunState> {
         traceCellMessage(cell, `kernel.executeCell, ${getDisplayPath(cell.notebook.uri)}`);
         sendKernelTelemetryEvent(this.resourceUri, Telemetry.ExecuteCell);
         const stopWatch = new StopWatch();
         const sessionPromise = this.startJupyterSession();
-        const promise = this.kernelExecution.executeCell(sessionPromise, cell);
+        const promise = this.kernelExecution.executeCell(sessionPromise, cell, codeOverride);
         this.trackNotebookCellPerceivedColdTime(stopWatch, sessionPromise, promise).catch(noop);
         void promise.then((state) => traceInfo(`Cell ${cell.index} executed with state ${state}`));
         return promise;

--- a/src/kernels/types.ts
+++ b/src/kernels/types.ts
@@ -181,7 +181,11 @@ export interface IKernel extends IAsyncDisposable {
     start(options?: IDisplayOptions): Promise<void>;
     interrupt(): Promise<void>;
     restart(): Promise<void>;
-    executeCell(cell: NotebookCell): Promise<NotebookCellRunState>;
+    /**
+     * @param cell Cell to execute
+     * @param codeOverride Override the code to execute
+     */
+    executeCell(cell: NotebookCell, codeOverride?: string): Promise<NotebookCellRunState>;
     /**
      * Executes arbitrary code against the kernel without incrementing the execution count.
      */

--- a/src/notebooks/execution/cellExecutionQueue.ts
+++ b/src/notebooks/execution/cellExecutionQueue.ts
@@ -51,13 +51,13 @@ export class CellExecutionQueue implements Disposable {
     /**
      * Queue the cell for execution & start processing it immediately.
      */
-    public queueCell(cell: NotebookCell): void {
+    public queueCell(cell: NotebookCell, codeOverride?: string): void {
         const existingCellExecution = this.queueOfCellsToExecute.find((item) => item.cell === cell);
         if (existingCellExecution) {
             traceCellMessage(cell, 'Use existing cell execution');
             return;
         }
-        const cellExecution = this.executionFactory.create(cell, this.metadata);
+        const cellExecution = this.executionFactory.create(cell, codeOverride, this.metadata);
         this.disposables.push(cellExecution);
         cellExecution.preExecute((c) => this._onPreExecute.fire(c), this, this.disposables);
         this.queueOfCellsToExecute.push(cellExecution);

--- a/src/notebooks/execution/kernelExecution.ts
+++ b/src/notebooks/execution/kernelExecution.ts
@@ -61,7 +61,8 @@ export class KernelExecution implements IDisposable {
     }
     public async executeCell(
         sessionPromise: Promise<IJupyterSession>,
-        cell: NotebookCell
+        cell: NotebookCell,
+        codeOverride?: string
     ): Promise<NotebookCellRunState> {
         traceCellMessage(cell, `KernelExecution.executeCell (1), ${getDisplayPath(cell.notebook.uri)}`);
         if (cell.kind == NotebookCellKind.Markup) {
@@ -75,7 +76,7 @@ export class KernelExecution implements IDisposable {
 
         traceCellMessage(cell, `KernelExecution.executeCell (2), ${getDisplayPath(cell.notebook.uri)}`);
         const executionQueue = this.getOrCreateCellExecutionQueue(cell.notebook, sessionPromise);
-        executionQueue.queueCell(cell);
+        executionQueue.queueCell(cell, codeOverride);
         const result = await executionQueue.waitForCompletion([cell]);
         traceCellMessage(cell, `KernelExecution.executeCell completed (3), ${getDisplayPath(cell.notebook.uri)}`);
         return result[0];

--- a/src/notebooks/helpers.ts
+++ b/src/notebooks/helpers.ts
@@ -14,7 +14,6 @@ import {
     NotebookCellKind,
     NotebookCellExecutionState,
     WorkspaceEdit,
-    Uri,
     workspace,
     TextDocument,
     NotebookEdit
@@ -26,7 +25,7 @@ import cloneDeep = require('lodash/cloneDeep');
 import fastDeepEqual = require('fast-deep-equal');
 import * as path from '../platform/vscode-path/path';
 import * as uriPath from '../platform/vscode-path/resources';
-import { IVSCodeNotebook, IDocumentManager } from '../platform/common/application/types';
+import { IDocumentManager } from '../platform/common/application/types';
 import { PYTHON_LANGUAGE } from '../platform/common/constants';
 import { traceInfoIfCI, traceError, traceWarning } from '../platform/logging';
 import { getInterpreterHash } from '../platform/pythonEnvironments/info/interpreter';
@@ -42,8 +41,6 @@ import {
 import { IJupyterKernelSpec, KernelConnectionMetadata } from '../kernels/types';
 import { JupyterNotebookView, InteractiveWindowView } from './constants';
 import { CellOutputMimeTypes } from './types';
-import { IInteractiveWindowProvider } from '../interactive-window/types';
-import { getOSType, OSType } from '../platform/common/utils/platform';
 
 /**
  * Whether this is a Notebook we created/manage/use.
@@ -753,24 +750,6 @@ export function hasErrorOutput(outputs: readonly NotebookCellOutput[]) {
     );
 
     return !!errorOutput;
-}
-
-export function findAssociatedNotebookDocument(
-    uri: Uri,
-    vscodeNotebook: IVSCodeNotebook,
-    iwp: IInteractiveWindowProvider | undefined
-) {
-    const ignoreCase = getOSType() === OSType.Windows;
-    let notebook = vscodeNotebook.notebookDocuments.find((n) => {
-        // Use the path part of the URI. It should match the path for the notebook
-        return ignoreCase ? n.uri.path.toLowerCase() === uri.path.toLowerCase() : n.uri.path === uri.path;
-    });
-    if (!notebook && iwp) {
-        // Might be an interactive window input
-        const interactiveWindow = iwp.windows.find((w) => w.inputUri?.toString() === uri.toString());
-        notebook = interactiveWindow?.notebookDocument;
-    }
-    return notebook;
 }
 
 // eslint-disable-next-line complexity

--- a/src/notebooks/types.ts
+++ b/src/notebooks/types.ts
@@ -80,9 +80,17 @@ export interface INotebookCompletionProvider {
     ): Promise<CompletionItem[] | null | undefined>;
 }
 
+export interface IEmbedNotebookEditorProvider {
+    findNotebookEditor(resource: Resource): NotebookEditor | undefined;
+    findAssociatedNotebookDocument(uri: Uri): NotebookDocument | undefined;
+}
+
 // For native editing, the provider acts like the IDocumentManager for normal docs
 export const INotebookEditorProvider = Symbol('INotebookEditorProvider');
 export interface INotebookEditorProvider {
     open(file: Uri): Promise<void>;
     createNew(options?: { contents?: string; defaultCellLanguage?: string }): Promise<void>;
+    findNotebookEditor(resource: Resource): NotebookEditor | undefined;
+    findAssociatedNotebookDocument(uri: Uri): NotebookDocument | undefined;
+    registerEmbedNotebookProvider(provider: IEmbedNotebookEditorProvider): void;
 }

--- a/src/platform/common/activeEditorContext.ts
+++ b/src/platform/common/activeEditorContext.ts
@@ -12,7 +12,6 @@ import { EditorContexts, PYTHON_LANGUAGE } from './constants';
 import { ContextKey } from './contextKey';
 import { IDisposable, IDisposableRegistry } from './types';
 import { isNotebookCell, noop } from './utils/misc';
-import { getActiveInteractiveWindow } from '../../interactive-window/helpers';
 import { InteractiveWindowView, JupyterNotebookView } from '../../notebooks/constants';
 import { INotebookControllerManager } from '../../notebooks/types';
 import { IInteractiveWindowProvider, IInteractiveWindow } from '../../interactive-window/types';
@@ -189,7 +188,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
     private updateSelectedKernelContext() {
         const document =
             this.vscNotebook.activeNotebookEditor?.notebook ||
-            getActiveInteractiveWindow(this.interactiveProvider)?.notebookEditor?.notebook;
+            this.interactiveProvider?.getActiveInteractiveWindow()?.notebookEditor?.notebook;
         if (document && isJupyterNotebook(document) && this.controllers.getSelectedNotebookController(document)) {
             this.isJupyterKernelSelected.set(true).catch(noop);
         } else {
@@ -197,7 +196,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
         }
     }
     private updateContextOfActiveInteractiveWindowKernel() {
-        const notebook = getActiveInteractiveWindow(this.interactiveProvider)?.notebookEditor?.notebook;
+        const notebook = this.interactiveProvider?.getActiveInteractiveWindow()?.notebookEditor?.notebook;
         const kernel = notebook ? this.kernelProvider.get(notebook.uri) : undefined;
         if (kernel) {
             const canStart = kernel.status !== 'unknown';

--- a/src/webviews/extension-side/variablesView/notebookWatcher.ts
+++ b/src/webviews/extension-side/variablesView/notebookWatcher.ts
@@ -12,7 +12,6 @@ import {
     NotebookEditor
 } from 'vscode';
 import '../../../platform/common/extensions';
-import { getActiveInteractiveWindow } from '../../../interactive-window/helpers';
 import { IKernel, IKernelProvider } from '../../../kernels/types';
 import { JupyterNotebookView } from '../../../notebooks/constants';
 import { isJupyterNotebook } from '../../../notebooks/helpers';
@@ -112,7 +111,7 @@ export class NotebookWatcher implements INotebookWatcher {
         );
     }
     private getActiveInteractiveWindowDocument() {
-        const interactiveWindow = getActiveInteractiveWindow(this.interactiveWindowProvider);
+        const interactiveWindow = this.interactiveWindowProvider.getActiveInteractiveWindow();
         if (!interactiveWindow) {
             return;
         }


### PR DESCRIPTION
Part of https://github.com/microsoft/vscode-jupyter/issues/10152

This PR includes two major changes:

* Instead of asking interactive window what's the associated editor/document for a resource Uri, the interactive window module register a provider which can help find editor/document 6d1c30e9f112149b4fcc1efc72ce0e1b49e8d566
* Instead of checking if a document is interactive window and then read `code` from cell's special metadata, the interactive window will pass in source code override when requesting cell execution 692233057f86b469bd5cd9de7d43846c80be68a7