### PR TITLE
getActiveInteractiveWindow to getActiveOrAssociatedInteractiveWindow

### DIFF
--- a/src/interactive-window/commands/exportCommands.ts
+++ b/src/interactive-window/commands/exportCommands.ts
@@ -95,7 +95,7 @@ export class ExportCommands implements IExportCommands, IDisposable {
             // so we need to get the active editor
             sourceDocument =
                 this.notebooks.activeNotebookEditor?.notebook ||
-                this.interactiveProvider?.getActiveInteractiveWindow()?.notebookDocument;
+                this.interactiveProvider?.getActiveOrAssociatedInteractiveWindow()?.notebookDocument;
             if (!sourceDocument) {
                 traceInfo('Export called without a valid exportable document active');
                 return;

--- a/src/interactive-window/interactiveWindowCommandListener.ts
+++ b/src/interactive-window/interactiveWindowCommandListener.ts
@@ -445,7 +445,7 @@ export class InteractiveWindowCommandListener implements IDataScienceCommandList
     }
 
     private async removeCellInInteractiveWindow(context?: NotebookCell) {
-        const interactiveWindow = this.interactiveWindowProvider.getActiveInteractiveWindow();
+        const interactiveWindow = this.interactiveWindowProvider.getActiveOrAssociatedInteractiveWindow();
         const ranges =
             context === undefined
                 ? interactiveWindow?.notebookEditor?.selections
@@ -496,7 +496,7 @@ export class InteractiveWindowCommandListener implements IDataScienceCommandList
                 (w) => w.notebookUri?.toString() === notebookUri.toString()
             );
         } else {
-            targetInteractiveWindow = this.interactiveWindowProvider.getActiveInteractiveWindow();
+            targetInteractiveWindow = this.interactiveWindowProvider.getActiveOrAssociatedInteractiveWindow();
         }
         return targetInteractiveWindow;
     }

--- a/src/interactive-window/interactiveWindowProvider.ts
+++ b/src/interactive-window/interactiveWindowProvider.ts
@@ -339,7 +339,9 @@ export class InteractiveWindowProvider
         const targetInteractiveNotebookEditor =
             resource && getResourceType(resource) === 'interactive' ? this.get(resource)?.notebookEditor : undefined;
         const activeInteractiveNotebookEditor =
-            getResourceType(resource) === 'interactive' ? this.getActiveOrAssociatedInteractiveWindow()?.notebookEditor : undefined;
+            getResourceType(resource) === 'interactive'
+                ? this.getActiveOrAssociatedInteractiveWindow()?.notebookEditor
+                : undefined;
 
         return targetInteractiveNotebookEditor || activeInteractiveNotebookEditor;
     }

--- a/src/interactive-window/interactiveWindowProvider.ts
+++ b/src/interactive-window/interactiveWindowProvider.ts
@@ -322,7 +322,7 @@ export class InteractiveWindowProvider
         this.raiseOnDidChangeActiveInteractiveWindow();
     }
 
-    public getActiveInteractiveWindow(): IInteractiveWindow | undefined {
+    public getActiveOrAssociatedInteractiveWindow(): IInteractiveWindow | undefined {
         if (this.activeWindow) {
             return this.activeWindow;
         }
@@ -339,7 +339,7 @@ export class InteractiveWindowProvider
         const targetInteractiveNotebookEditor =
             resource && getResourceType(resource) === 'interactive' ? this.get(resource)?.notebookEditor : undefined;
         const activeInteractiveNotebookEditor =
-            getResourceType(resource) === 'interactive' ? this.getActiveInteractiveWindow()?.notebookEditor : undefined;
+            getResourceType(resource) === 'interactive' ? this.getActiveOrAssociatedInteractiveWindow()?.notebookEditor : undefined;
 
         return targetInteractiveNotebookEditor || activeInteractiveNotebookEditor;
     }

--- a/src/interactive-window/types.ts
+++ b/src/interactive-window/types.ts
@@ -46,7 +46,10 @@ export interface IInteractiveWindowProvider {
      * @param owner The URI of a text document which may be associated with an interactive window.
      */
     get(owner: Uri): IInteractiveWindow | undefined;
-    getActiveInteractiveWindow(): IInteractiveWindow | undefined;
+    /**
+     * The active interactive window if it has the focus, or the interactive window associated with current active text editor
+     */
+    getActiveOrAssociatedInteractiveWindow(): IInteractiveWindow | undefined;
 }
 
 export interface IInteractiveBase extends Disposable {

--- a/src/platform/common/activeEditorContext.ts
+++ b/src/platform/common/activeEditorContext.ts
@@ -188,7 +188,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
     private updateSelectedKernelContext() {
         const document =
             this.vscNotebook.activeNotebookEditor?.notebook ||
-            this.interactiveProvider?.getActiveInteractiveWindow()?.notebookEditor?.notebook;
+            this.interactiveProvider?.getActiveOrAssociatedInteractiveWindow()?.notebookEditor?.notebook;
         if (document && isJupyterNotebook(document) && this.controllers.getSelectedNotebookController(document)) {
             this.isJupyterKernelSelected.set(true).catch(noop);
         } else {
@@ -196,7 +196,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
         }
     }
     private updateContextOfActiveInteractiveWindowKernel() {
-        const notebook = this.interactiveProvider?.getActiveInteractiveWindow()?.notebookEditor?.notebook;
+        const notebook = this.interactiveProvider?.getActiveOrAssociatedInteractiveWindow()?.notebookEditor?.notebook;
         const kernel = notebook ? this.kernelProvider.get(notebook.uri) : undefined;
         if (kernel) {
             const canStart = kernel.status !== 'unknown';

--- a/src/webviews/extension-side/variablesView/notebookWatcher.ts
+++ b/src/webviews/extension-side/variablesView/notebookWatcher.ts
@@ -111,7 +111,7 @@ export class NotebookWatcher implements INotebookWatcher {
         );
     }
     private getActiveInteractiveWindowDocument() {
-        const interactiveWindow = this.interactiveWindowProvider.getActiveInteractiveWindow();
+        const interactiveWindow = this.interactiveWindowProvider.getActiveOrAssociatedInteractiveWindow();
         if (!interactiveWindow) {
             return;
         }


### PR DESCRIPTION
Follow up of #10153

As @DonJayamanne pointed out in https://github.com/microsoft/vscode-jupyter/pull/10153#discussion_r883187198, `IInteractiveWindowProvider` already has `activeWindow` getter, which gives you the currently active/focused interactive window instance in VS Code. The newly introduced `getActiveInteractiveWindow` is ambiguous as it actually does two things:

* get active interactive window, same as `activeWindow` getter
* if there is no `activeWindow` but there is an active text editor, find its associated interactive window

Thus I think it's better to rename this function to `getActiveOrAssociatedInteractiveWindow` to reflect its purpose better.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
