### PR TITLE
Revert fixes introduced in #10155

### DIFF
--- a/src/notebooks/execution/cellExecutionMessageHandler.ts
+++ b/src/notebooks/execution/cellExecutionMessageHandler.ts
@@ -168,8 +168,8 @@ export class CellExecutionMessageHandler implements IDisposable {
                 this.completedExecution = true;
                 // We're only interested in messages after execution has completed.
                 // See https://github.com/microsoft/vscode-jupyter/issues/9503 for more information.
-                this.kernel.anyMessage.connect(this.onKernelAnyMessage, this);
-                this.kernel.iopubMessage.connect(this.onKernelIOPubMessage, this);
+                // this.kernel.anyMessage.connect(this.onKernelAnyMessage, this);
+                // this.kernel.iopubMessage.connect(this.onKernelIOPubMessage, this);
 
                 this.endCellExecution();
             })

--- a/src/test/datascience/widgets/standard.vscode.common.ts
+++ b/src/test/datascience/widgets/standard.vscode.common.ts
@@ -215,7 +215,7 @@ export function sharedIPyWidgetsTests(
         await assertOutputContainsHtml(cell1, comms, ['Button clicked']);
         await assertOutputContainsHtml(cell2, comms, ['Button clicked']);
     });
-    test('Button Widget with custom comm message', async () => {
+    test.skip('Button Widget with custom comm message', async () => {
         const comms = await initializeNotebook({ templateFile: 'button_widget_comm_msg.ipynb' });
         const [cell0, cell1] = vscodeNotebook.activeNotebookEditor!.notebook.getCells();
 
@@ -227,7 +227,7 @@ export function sharedIPyWidgetsTests(
         await click(comms, cell0, 'button');
         await waitForTextOutput(cell0, 'Button clicked.', 1, false);
     });
-    test('Button Widget with custom comm message rendering a matplotlib widget', async () => {
+    test.skip('Button Widget with custom comm message rendering a matplotlib widget', async () => {
         const comms = await initializeNotebook({ templateFile: 'button_widget_comm_msg_matplotlib.ipynb' });
         const [cell0, cell1] = vscodeNotebook.activeNotebookEditor!.notebook.getCells();
 


### PR DESCRIPTION
When testing found that something as simple as the following doesn't work as it used to.
Basically if you move the slider around, then we get a lot of messages, when we should only get one.

```python
import ipywidgets as widgets
from ipywidgets import interact

def fn(rng):
	return rng

interact(fn, rng=widgets.IntRangeSlider())
```
