### PR TITLE
escape windows paths again for python script

### DIFF
--- a/src/notebooks/debugger/kernelDebugAdapter.ts
+++ b/src/notebooks/debugger/kernelDebugAdapter.ts
@@ -45,7 +45,8 @@ export class KernelDebugAdapter extends KernelDebugAdapterBase {
             // Create our python string of file names
             const fileListString = fileValues
                 .map((filePath) => {
-                    return '"' + filePath.path + '"';
+                    // escape Windows path separators again for python
+                    return '"' + filePath.path.replace(/\\/g, '\\\\') + '"';
                 })
                 .join(',');
 


### PR DESCRIPTION
fixes #10275

we aren't properly cleaning up temp debug files because the \ becomes an escape character when the file list is interpolated into the python code.