### PR TITLE
Some fixes for the Variables View

### DIFF
--- a/package.json
+++ b/package.json
@@ -786,7 +786,7 @@
                 "shortTitle": "%jupyter.command.jupyter.openVariableView.shorttitle%",
                 "icon": "$(variable-group)",
                 "category": "Jupyter",
-                "enablement": "notebookType == jupyter-notebook && isWorkspaceTrusted && !jupyter.webExtension || notebookType == interactive && isWorkspaceTrusted && !jupyter.webExtension"
+                "enablement": "notebookType == jupyter-notebook && isWorkspaceTrusted || notebookType == interactive && isWorkspaceTrusted"
             },
             {
                 "command": "jupyter.openOutlineView",

--- a/package.nls.json
+++ b/package.nls.json
@@ -133,7 +133,7 @@
     "DataScience.viewJupyterLogForFurtherInfo": "View Jupyter [log](command:jupyter.viewOutput) for further details.",
     "jupyter.showJupyterLogs": "Show Jupyter Logs",
     "jupyter.command.jupyter.clearSavedJupyterUris.title": "Clear Jupyter remote server list",
-    "jupyter.command.jupyter.openVariableView.title": "Open Variable View",
+    "jupyter.command.jupyter.openVariableView.title": "Open Variables View",
     "jupyter.command.jupyter.openVariableView.shorttitle": "Variables",
     "jupyter.command.jupyter.openOutlineView.title": "Show Table Of Contents (Outline View)",
     "jupyter.command.jupyter.openOutlineView.shorttitle": "Outline",

--- a/src/notebooks/debugger/runByLineController.ts
+++ b/src/notebooks/debugger/runByLineController.ts
@@ -131,7 +131,7 @@ export class RunByLineController implements IDebuggingDelegate {
                 sourceModified: false
             });
 
-            // Open variable view
+            // Open variables view
             const settings = this.settings.getSettings();
             if (settings.showVariableViewWhenDebugging) {
                 void this.commandManager.executeCommand(Commands.OpenVariableView);


### PR DESCRIPTION
Here's a first PR addressing some of the issues found in the last day or so, specifically:


- The Notebook button should say "Variables View".
- The "Variables" button in the interactive window should be enabled on the web.

How does this look? Feedback appreciated.

If approved, this PR:

Fixes  #10246
Fixes #10208