### PR TITLE
Fix #10272. Always open exported file in workspace on Web.

### DIFF
--- a/src/platform/export/exportFileOpener.ts
+++ b/src/platform/export/exportFileOpener.ts
@@ -31,7 +31,7 @@ export class ExportFileOpener {
                 opened: true
             });
         } else {
-            const opened = await this.askOpenFile(uri);
+            const opened = await this.askOpenFile(uri, openDirectly);
             sendTelemetryEvent(Telemetry.ExportNotebookAs, undefined, {
                 format: format,
                 successful: true,
@@ -58,7 +58,7 @@ export class ExportFileOpener {
         });
     }
 
-    private async askOpenFile(uri: Uri): Promise<boolean> {
+    private async askOpenFile(uri: Uri, openDirectly: boolean): Promise<boolean> {
         const yes = localize.DataScience.openExportFileYes();
         const no = localize.DataScience.openExportFileNo();
         const items = [yes, no];
@@ -68,7 +68,11 @@ export class ExportFileOpener {
             .then((item) => item);
 
         if (selected === yes) {
-            this.browserService.launch(uri.toString());
+            if (openDirectly) {
+                void this.documentManager.showTextDocument(uri);
+            } else {
+                this.browserService.launch(uri.toString());
+            }
             return true;
         }
         return false;


### PR DESCRIPTION
Fixes #10272

On Web, the `env.openExternal` API doesn't open the file directly for us yet so we should try open the file in current workspace.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
