### PR TITLE
For untitled notebook, show simple dialog instead of native one.

### DIFF
--- a/src/platform/export/exportDialog.ts
+++ b/src/platform/export/exportDialog.ts
@@ -9,6 +9,7 @@ import { SaveDialogOptions, Uri } from 'vscode';
 import { IApplicationShell, IWorkspaceService } from '../common/application/types';
 import * as localize from '../common/utils/localize';
 import { ExportFormat, IExportDialog } from './types';
+import { IsWebExtension } from '../common/types';
 
 // File extensions for each export method
 export const PDFExtensions = { PDF: ['pdf'] };
@@ -19,7 +20,8 @@ export const PythonExtensions = { Python: ['py'] };
 export class ExportDialog implements IExportDialog {
     constructor(
         @inject(IApplicationShell) private readonly applicationShell: IApplicationShell,
-        @inject(IWorkspaceService) private workspaceService: IWorkspaceService
+        @inject(IWorkspaceService) private workspaceService: IWorkspaceService,
+        @inject(IsWebExtension) private readonly isWebExtension: boolean
     ) {}
 
     public async showDialog(
@@ -70,7 +72,12 @@ export class ExportDialog implements IExportDialog {
         return this.applicationShell.showSaveDialog(options);
     }
 
-    private async getDefaultUri(source: Uri | undefined, targetFileName: string): Promise<Uri> {
+    private async getDefaultUri(source: Uri | undefined, targetFileName: string): Promise<Uri | undefined> {
+        if (source && source.scheme === 'untitled' && this.isWebExtension) {
+            // Force using simple file dialog
+            return undefined;
+        }
+
         if (
             !source ||
             source.scheme === 'file' ||


### PR DESCRIPTION
Currently we will show a native dialog when exporting untitled notebook. However whether a file is saved to disk or current workspace should be treated differently (i.e., how to open it). I'll suggest we currently only use Simple Dialog for now.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
