### PR TITLE
skip perf report for warmup run

### DIFF
--- a/src/test/perfTest.node.ts
+++ b/src/test/perfTest.node.ts
@@ -30,7 +30,7 @@ class TestRunner {
     }
 
     private async launchTest(testFile: string, warmupRun?: boolean) {
-        console.log('Launch bootstrapper for test run');
+        console.log(`Launch bootstrapper for ${warmupRun ? 'warmup ' : ''}test run`);
         await new Promise<void>((resolve, reject) => {
             const env: Record<string, string> = {
                 TEST_FILES_SUFFIX: testFile,

--- a/src/test/testHooks.node.ts
+++ b/src/test/testHooks.node.ts
@@ -22,7 +22,11 @@ export const rootHooks: Mocha.RootHookObject = {
         telemetryReporter = new reporter(extensionId, extensionVersion, AppinsightsKey, true);
     },
     afterEach(this: Context) {
-        if (!IS_CI_SERVER || (process.env.GIT_BRANCH && process.env.GIT_BRANCH !== 'main')) {
+        if (
+            !IS_CI_SERVER ||
+            (process.env.GIT_BRANCH && process.env.GIT_BRANCH !== 'main') ||
+            (process.env.VSC_JUPYTER_WARMUP && process.env.VSC_JUPYTER_WARMUP == 'true')
+        ) {
             return;
         }
 
@@ -34,10 +38,6 @@ export const rootHooks: Mocha.RootHookObject = {
             testName: this.currentTest!.title,
             testResult: result
         };
-
-        if (process.env.VSC_JUPYTER_WARMUP) {
-            dimensions = { ...dimensions, perfWarmup: 'true' };
-        }
 
         if (this.currentTest?.perfCheckpoints) {
             dimensions = { ...dimensions, timedCheckpoints: JSON.stringify(this.currentTest?.perfCheckpoints) };


### PR DESCRIPTION
I'm not seeing the warmup dimension, but we should just skip collecting data from those runs anyway