### PR TITLE
Better debuggable web tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -99,6 +99,27 @@
         },
         {
             "name": "Web Tests",
+            "type": "extensionHost",
+            "debugWebWorkerHost": true,
+            "request": "launch",
+            "args": [
+                "${workspaceFolder}/src/test/datascience",
+                "--extensionDevelopmentPath=${workspaceFolder}",
+                "--enable-proposed-api",
+                "--extensionDevelopmentKind=web",
+                "--extensionTestsPath=${workspaceFolder}/out/extension.web.bundle"
+            ],
+            "outFiles": ["${workspaceFolder}/out/**/*.*"],
+            "sourceMaps": true,
+            "preLaunchTask": "Start Jupyter Server",
+            "postDebugTask": "Stop Jupyter Server",
+            "presentation": {
+                "group": "2_tests",
+                "order": 11
+            }
+        },
+        {
+            "name": "Web Tests (without debugging)",
             "type": "node",
             "program": "${workspaceFolder}/build/launchWebTest.js",
             "request": "launch",
@@ -108,6 +129,9 @@
             "presentation": {
                 "group": "2_tests",
                 "order": 11
+            },
+            "env": {
+                "CI_PYTHON_PATH": "" // Update with path to real python interpereter used for testing.
             }
         },
         {
@@ -201,13 +225,13 @@
                 "VSC_JUPYTER_FORCE_LOGGING": "1",
                 "VSC_JUPYTER_CI_TEST_GREP": "", // Leave as `VSCode Notebook` to run only Notebook tests.
                 "VSC_JUPYTER_CI_TEST_INVERT_GREP": "", // Initialize this to invert the grep (exclude tests with value defined in grep).
-                "CI_PYTHON_PATH": "", // Update with path to real python interpereter used for testing.
+                "CI_PYTHON_PATH": "/Users/donjayamanne/crap/.venv/bin/python", // Update with path to real python interpereter used for testing.
                 "VSC_JUPYTER_CI_RUN_NON_PYTHON_NB_TEST": "", // Initialize this to run tests again Julia & other kernels.
                 "VSC_JUPYTER_WEBVIEW_TEST_MIDDLEWARE": "true", // Initialize to create the webview test middleware
                 "VSC_JUPYTER_LOAD_EXPERIMENTS_FROM_FILE": "true",
                 // "TF_BUILD": "", // Set to anything to force full logging
                 "TEST_FILES_SUFFIX": "*.vscode.test,*.vscode.common.test",
-                "VSC_JUPYTER_REMOTE_NATIVE_TEST": "false", // Change to `true` to run the Native Notebook tests with remote jupyter connections.
+                "VSC_JUPYTER_REMOTE_NATIVE_TEST": "true", // Change to `true` to run the Native Notebook tests with remote jupyter connections.
                 "VSC_JUPYTER_NON_RAW_NATIVE_TEST": "false", // Change to `true` to run the Native Notebook tests with non-raw kernels (i.e. local jupyter server).
                 "XVSC_JUPYTER_INSTRUMENT_CODE_FOR_COVERAGE": "1",
                 "XVSC_JUPYTER_INSTRUMENT_CODE_FOR_COVERAGE_HTML": "1", //Enable to get full coverage repor (in coverage folder).
@@ -215,7 +239,7 @@
             },
             "sourceMaps": true,
             "outFiles": ["${workspaceFolder}/out/**/*.js", "!${workspaceFolder}/**/node_modules**/*"],
-            "preLaunchTask": "Compile",
+            // "preLaunchTask": "Compile",
             "skipFiles": ["<node_internals>/**"],
             "presentation": {
                 "group": "2_tests",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -77,6 +77,39 @@
             "group": {
                 "kind": "build"
             }
+        },
+        {
+            "label": "Start Jupyter Server",
+            "type": "npm",
+            "dependsOn": "compile-web-test",
+            "isBackground": false,
+            "script": "startJupyterServer",
+            "problemMatcher": [],
+            "options": {
+                "env": {
+                    "CI_PYTHON_PATH": "" // Update with path to real python interpereter used for testing.
+                }
+            }
+        },
+        {
+            "label": "Start Jupyter Server Task",
+            "command": "echo ${input:terminateJupyterServerTask}",
+            "type": "shell",
+            "problemMatcher": []
+        },
+        {
+            "label": "Stop Jupyter Server",
+            "type": "npm",
+            "script": "stopJupyterServer",
+            "problemMatcher": []
+        }
+    ],
+    "inputs": [
+        {
+            "id": "terminateJupyterServerTask",
+            "type": "command",
+            "command": "workbench.action.tasks.terminate",
+            "args": "terminateAll"
         }
     ]
 }

--- a/build/postDebugWebTest.js
+++ b/build/postDebugWebTest.js
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const fs = require('fs-extra');
+const path = require('path');
+
+try {
+    const file = path.join(__dirname, '..', 'temp', 'jupyter.pid');
+    if (fs.existsSync(file)) {
+        const pid = parseInt(fs.readFileSync(file).toString().trim());
+        fs.unlinkSync(file);
+        if (pid > 0) {
+            process.kill(pid);
+        }
+    }
+} catch (ex) {
+    console.warn(`Failed to kill Jupyter Server`, ex);
+}

--- a/build/preDebugWebTest.js
+++ b/build/preDebugWebTest.js
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const fs = require('fs-extra');
+const path = require('path');
+const { startJupyter } = require('./preLaunchWebTest');
+const jsonc = require('jsonc-parser');
+
+const settingsFile = path.join(__dirname, '..', 'src', 'test', 'datascience', '.vscode', 'settings.json');
+async function go() {
+    const { server, url } = await startJupyter(true);
+    fs.writeFileSync(path.join(__dirname, '..', 'temp', 'jupyter.pid'), server.pid.toString());
+    const settingsJson = fs.readFileSync(settingsFile).toString();
+    const edits = jsonc.modify(settingsJson, ['jupyter.DEBUG_JUPYTER_SERVER_URI'], url, {});
+    const updatedSettingsJson = jsonc.applyEdits(settingsJson, edits);
+    fs.writeFileSync(settingsFile, updatedSettingsJson);
+    process.exit(0);
+}
+void go();

--- a/build/preLaunchWebTest.js
+++ b/build/preLaunchWebTest.js
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const path = require('path');
+const jupyterServer = require('../out/test/datascience/jupyterServer.node');
+const fs = require('fs-extra');
+
+exports.startJupyter = async function startJupyter(detached) {
+    const server = jupyterServer.JupyterServer.instance;
+    // Need to start jupyter here before starting the test as it requires node to start it.
+    const uri = await server.startJupyterWithToken({ detached });
+
+    // Use this token to write to the bundle so we can transfer this into the test.
+    const extensionDevelopmentPath = path.resolve(__dirname, '../');
+    const bundlePath = path.join(extensionDevelopmentPath, 'out', 'extension.web.bundle');
+    const bundleFile = `${bundlePath}.js`;
+    if (await fs.pathExists(bundleFile)) {
+        const bundleContents = await fs.readFile(bundleFile, { encoding: 'utf-8' });
+        const newContents = bundleContents.replace(
+            /^exports\.JUPYTER_SERVER_URI = '(.*)';$/gm,
+            `exports.JUPYTER_SERVER_URI = 'HELLO-DON-${uri.toString()}';`
+        );
+        if (newContents === bundleContents) {
+            throw new Error('JUPYTER_SERVER_URI in bundle not updated');
+        }
+        await fs.writeFile(bundleFile, newContents);
+    }
+    return { server, url: uri.toString() };
+};

--- a/package.json
+++ b/package.json
@@ -2142,7 +2142,9 @@
         "postdownload-api": "vscode-dts main",
         "generateTelemetry": "gulp generateTelemetryMd",
         "openInBrowser": "vscode-test-web --extensionDevelopmentPath=. ./src/test/datascience",
-        "prepare": "husky install"
+        "prepare": "husky install",
+        "startJupyterServer": "node build/preDebugWebTest.js",
+        "stopJupyterServer": "node build/postDebugWebTest.js"
     },
     "dependencies": {
         "@enonic/fnv-plus": "^1.3.0",

--- a/src/test/common.web.ts
+++ b/src/test/common.web.ts
@@ -35,9 +35,11 @@ export function initializeCommonWebApi() {
             };
         },
         async startJupyterServer(notebook?: NotebookDocument): Promise<void> {
+            // DEBUG_JUPYTER_SERVER_URI is not a valid setting, but updated when we launch the tests via vscode debugger.
+            const url = workspace.getConfiguration('jupyter').get('DEBUG_JUPYTER_SERVER_URI', JUPYTER_SERVER_URI);
+            console.log(`ServerURI for remote test: ${url}`);
             // Server URI should have been embedded in the constants file
-            const uri = Uri.parse(JUPYTER_SERVER_URI);
-            console.log(`ServerURI for remote test: ${JUPYTER_SERVER_URI}`);
+            const uri = Uri.parse(url);
             // Use this URI to set our jupyter server URI
             await commands.executeCommand('jupyter.selectjupyteruri', false, uri, notebook);
         },


### PR DESCRIPTION
Was finding it impossible to debug web tests when working on IW debugging for web. Was using this for enabling IW debugger, wanted to submit this as a seprate PR.
This was in the launch.json in the past, but for some reason was removed (perhapsh because there was no way to get url working).

The current entry in launch.json doesn't allow debugging, it merely launches the web tests.
Now one can debug web tests end to end.