### PR TITLE
Remove unnecessary quoting of args

### DIFF
--- a/src/kernels/raw/launcher/kernelProcess.node.ts
+++ b/src/kernels/raw/launcher/kernelProcess.node.ts
@@ -480,20 +480,8 @@ export class KernelProcess implements IKernelProcess {
                     promiseCancellation as Promise<NodeJS.ProcessEnv | undefined>
                 ])
             ]);
-            // Add quotations to arguments if they have a blank space in them.
-            // This will mainly quote paths so that they can run, other arguments shouldn't be quoted or it may cause errors.
             // The first argument is sliced because it is the executable command.
-            const args = this.launchKernelSpec.argv.slice(1).map((a) => {
-                // Some kernel specs (non-python) can have argv as `--connection-file={connection_file}`
-                // The `connection-file` will be quoted when we update it with the real path.
-                if (a.includes('--connection-file')) {
-                    return a;
-                }
-                if (a.includes(' ')) {
-                    return `"${a}"`;
-                }
-                return a;
-            });
+            const args = this.launchKernelSpec.argv.slice(1);
             exeObs = executionService.execObservable(executable, args, {
                 env,
                 cwd: workingDirectory

--- a/src/kernels/raw/launcher/kernelProcess.node.ts
+++ b/src/kernels/raw/launcher/kernelProcess.node.ts
@@ -354,10 +354,10 @@ export class KernelProcess implements IKernelProcess {
             // Remember, non-python kernels can have argv as `--connection-file={connection_file}`,
             // hence we should not replace the entire entry, but just replace the text `{connection_file}`
             // See https://github.com/microsoft/vscode-jupyter/issues/7203
+            const connectionFile = this.connectionFile.includes(' ')
+                ? `"${this.connectionFile}"` // Quoted for spaces in file paths.
+                : this.connectionFile;
             if (this.launchKernelSpec.argv[indexOfConnectionFile].includes('--connection-file')) {
-                const connectionFile = this.connectionFile.includes(' ')
-                    ? `"${this.connectionFile}"` // Quoted for spaces in file paths.
-                    : this.connectionFile;
                 this.launchKernelSpec.argv[indexOfConnectionFile] = this.launchKernelSpec.argv[
                     indexOfConnectionFile
                 ].replace(connectionFilePlaceholder, connectionFile);
@@ -366,7 +366,7 @@ export class KernelProcess implements IKernelProcess {
                 // E.g. in Python the name of the argument is `-f` and in.
                 this.launchKernelSpec.argv[indexOfConnectionFile] = this.launchKernelSpec.argv[
                     indexOfConnectionFile
-                ].replace(connectionFilePlaceholder, this.connectionFile);
+                ].replace(connectionFilePlaceholder, connectionFile);
             }
         }
     }
@@ -409,7 +409,10 @@ export class KernelProcess implements IKernelProcess {
 
         // We still put in the tmp name to make sure the kernel picks a valid connection file name. It won't read it as
         // we passed in the arguments, but it will use it as the file name so it doesn't clash with other kernels.
-        newConnectionArgs.push(`--f=${this.connectionFile}`);
+        const connectionFile = this.connectionFile!.includes(' ')
+            ? `"${this.connectionFile}"` // Quoted for spaces in file paths.
+            : this.connectionFile;
+        newConnectionArgs.push(`--f=${connectionFile}`);
 
         return newConnectionArgs;
     }

--- a/src/test/datascience/kernelProcess.unit.test.ts
+++ b/src/test/datascience/kernelProcess.unit.test.ts
@@ -347,9 +347,9 @@ suite('kernel Process', () => {
             `--Session.signature_scheme="${connection.signature_scheme}"`,
             `--Session.key=b"${connection.key}"`,
             `--shell=${connection.shell_port}`,
-            `--transport="${connection.transport}"`,
+            `--transport=${connection.transport}`,
             `--iopub=${connection.iopub_port}`,
-            `--f=${tempFile}`,
+            `--f="${tempFile}"`,
             `--debug`
         ];
         await kernelProcess.launch(__dirname, 0, token.token);

--- a/src/test/datascience/kernelProcess.unit.test.ts
+++ b/src/test/datascience/kernelProcess.unit.test.ts
@@ -301,7 +301,7 @@ suite('kernel Process', () => {
             `--shell=${connection.shell_port}`,
             `--transport="${connection.transport}"`,
             `--iopub=${connection.iopub_port}`,
-            `--f=${expectedConnectionFile}`,
+            `--f="${expectedConnectionFile}"`,
             `--debug`
         ];
         await kernelProcess.launch(__dirname, 0, token.token);

--- a/src/test/datascience/kernelProcess.unit.test.ts
+++ b/src/test/datascience/kernelProcess.unit.test.ts
@@ -347,7 +347,7 @@ suite('kernel Process', () => {
             `--Session.signature_scheme="${connection.signature_scheme}"`,
             `--Session.key=b"${connection.key}"`,
             `--shell=${connection.shell_port}`,
-            `--transport=${connection.transport}`,
+            `--transport="${connection.transport}"`,
             `--iopub=${connection.iopub_port}`,
             `--f="${tempFile}"`,
             `--debug`


### PR DESCRIPTION
Found an issue with a kernel, and the root cause was we were adding double quotes to all arguments even when something could have already had double quotes.

E.g. if we have a kernel spec with argv as follows `['connection_file={connectionFile}', 'x="hello world"]`, 
then we update it as follows:
`['connection_file=<replaced with real connection file>', '"x="hello world""]`

All we need to do is update the `{connectionFile}` and leave everything else as is, i.e. its wrong to modify any other variables except for `connectionFile`.
