### PR TITLE
Handling of unhandled Promise rejections

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -206,7 +206,12 @@ module.exports = {
         'no-useless-constructor': 'off',
         '@typescript-eslint/no-useless-constructor': 'error',
         '@typescript-eslint/no-var-requires': 'off',
-        '@typescript-eslint/no-floating-promises': 'error',
+        '@typescript-eslint/no-floating-promises': [
+            'error',
+            {
+                ignoreVoid: false
+            }
+        ],
 
         // Other rules
         'class-methods-use-this': 'off',

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -324,6 +324,9 @@ jobs:
         id: test_unittests
         run: npm run test:unittests
 
+      - name: Verify there are no unhandled errors
+        run: npm run verifyUnhandledErrors
+
       - name: Publish Test Report
         uses: scacap/action-surefire-report@v1
         if: steps.test_unittests.outcome == 'failure' && failure()
@@ -739,6 +742,9 @@ jobs:
           name: SD-memtest.json
           path: './SD-memtest.json'
           retention-days: 20
+
+      - name: Verify there are no unhandled errors
+        run: npm run verifyUnhandledErrors
 
   smoke-tests:
     timeout-minutes: 30

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -388,3 +388,11 @@ gulp.task('validateDependencies', async () => {
         }
     }
 });
+gulp.task('verifyUnhandledErrors', async () => {
+    const fileName = path.join(__dirname, 'unhandledErrors.txt');
+    const contents = fs.pathExistsSync(fileName) ? fs.readFileSync(fileName, 'utf8') : '';
+    if (contents.trim().length) {
+        console.error(contents);
+        throw new Error('Unhandled errors detected. Please fix them before merging this PR.', contents);
+    }
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -382,12 +382,15 @@ gulp.task('validateDependencies', async () => {
         console.log(modules);
         if (modules.length > 1 || modules[0] !== '@jupyterlab/coreutils') {
             // we already validate that we are not using moment in @jupyterlab/coreutils
-            const message = `The following modules require moment: ${modules.join(', ')}. Please validate if moment is being used.`;
+            const message = `The following modules require moment: ${modules.join(
+                ', '
+            )}. Please validate if moment is being used.`;
             console.error(message);
             throw new Error(message);
         }
     }
 });
+
 gulp.task('verifyUnhandledErrors', async () => {
     const fileName = path.join(__dirname, 'unhandledErrors.txt');
     const contents = fs.pathExistsSync(fileName) ? fs.readFileSync(fileName, 'utf8') : '';

--- a/package.json
+++ b/package.json
@@ -2124,6 +2124,7 @@
         "startJupyterServer": "node build/preDebugWebTest.js",
         "stopJupyterServer": "node build/postDebugWebTest.js",
         "validateTelemetryMD": "gulp validateTelemetryMD",
+        "verifyUnhandledErrors": "gulp verifyUnhandledErrors",
         "prepare": "husky install"
     },
     "dependencies": {

--- a/src/extension.node.ts
+++ b/src/extension.node.ts
@@ -204,7 +204,7 @@ async function handleError(ex: Error, startupDurations: Record<string, number>) 
 
 function notifyUser(msg: string) {
     try {
-        void window.showErrorMessage(msg);
+        window.showErrorMessage(msg).then(noop, noop);
     } catch (ex) {
         traceError('failed to notify user', ex);
     }
@@ -300,9 +300,9 @@ async function activateLegacy(
         });
     serviceManager.addSingletonInstance<Promise<boolean>>(IsPreRelease, isPreReleasePromise);
     if (isDevMode) {
-        void commands.executeCommand('setContext', 'jupyter.development', true);
+        commands.executeCommand('setContext', 'jupyter.development', true).then(noop, noop);
     }
-    void commands.executeCommand('setContext', 'jupyter.webExtension', false);
+    commands.executeCommand('setContext', 'jupyter.webExtension', false).then(noop, noop);
 
     // Set the logger home dir (we can compute this in a node app)
     setHomeDirectory(require('untildify')('~') || '');

--- a/src/extension.web.ts
+++ b/src/extension.web.ts
@@ -197,7 +197,7 @@ async function handleError(ex: Error, startupDurations: Record<string, number>) 
 
 function notifyUser(msg: string) {
     try {
-        void window.showErrorMessage(msg);
+        window.showErrorMessage(msg).then(noop, noop);
     } catch (ex) {
         traceError('failed to notify user', ex);
     }
@@ -274,9 +274,9 @@ async function activateLegacy(
     serviceManager.addSingletonInstance<boolean>(IsDevMode, isDevMode);
     serviceManager.addSingletonInstance<boolean>(IsWebExtension, true);
     if (isDevMode) {
-        void commands.executeCommand('setContext', 'jupyter.development', true);
+        commands.executeCommand('setContext', 'jupyter.development', true).then(noop, noop);
     }
-    void commands.executeCommand('setContext', 'jupyter.webExtension', true);
+    commands.executeCommand('setContext', 'jupyter.webExtension', true).then(noop, noop);
 
     // Output channel is special. We need it before everything else
     addOutputChannel(context, serviceManager, isDevMode);

--- a/src/interactive-window/commands/commandRegistry.ts
+++ b/src/interactive-window/commands/commandRegistry.ts
@@ -120,7 +120,7 @@ export class CommandRegistry implements IDisposable, IExtensionSingleActivationS
         this.registerCommand(Commands.RunCurrentCell, this.runCurrentCell);
         this.registerCommand(Commands.RunCurrentCellAdvance, this.runCurrentCellAndAdvance);
         this.registerCommand(Commands.ExecSelectionInInteractiveWindow, (textOrUri: string | undefined | Uri) => {
-            void this.runSelectionOrLine(textOrUri);
+            this.runSelectionOrLine(textOrUri).catch(noop);
         });
         this.registerCommand(Commands.RunAllCellsAbove, this.runAllCellsAbove);
         this.registerCommand(Commands.RunCellAndAllBelow, this.runCellAndAllBelow);

--- a/src/interactive-window/commands/commandRegistry.ts
+++ b/src/interactive-window/commands/commandRegistry.ts
@@ -334,7 +334,7 @@ export class CommandRegistry implements IDisposable, IExtensionSingleActivationS
     private async debugStepOver(): Promise<void> {
         // Make sure that we are in debug mode
         if (this.debugService?.activeDebugSession) {
-            void this.commandManager.executeCommand('workbench.action.debug.stepOver');
+            this.commandManager.executeCommand('workbench.action.debug.stepOver').then(noop, noop);
         }
     }
 
@@ -352,7 +352,7 @@ export class CommandRegistry implements IDisposable, IExtensionSingleActivationS
                 }
             }
 
-            void this.commandManager.executeCommand('workbench.action.debug.stop');
+            this.commandManager.executeCommand('workbench.action.debug.stop').then(noop, noop);
         }
     }
 
@@ -360,7 +360,7 @@ export class CommandRegistry implements IDisposable, IExtensionSingleActivationS
     private async debugContinue(): Promise<void> {
         // Make sure that we are in debug mode
         if (this.debugService?.activeDebugSession) {
-            void this.commandManager.executeCommand('workbench.action.debug.continue');
+            this.commandManager.executeCommand('workbench.action.debug.continue').then(noop, noop);
         }
     }
 
@@ -508,7 +508,10 @@ export class CommandRegistry implements IDisposable, IExtensionSingleActivationS
     }
 
     private openPythonExtensionPage() {
-        void env.openExternal(Uri.parse(`https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter`));
+        env.openExternal(Uri.parse(`https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter`)).then(
+            noop,
+            noop
+        );
     }
 
     // Open up our variable viewer using the command that VS Code provides for this
@@ -576,7 +579,7 @@ export class CommandRegistry implements IDisposable, IExtensionSingleActivationS
             } catch (e) {
                 sendTelemetryEvent(EventName.OPEN_DATAVIEWER_FROM_VARIABLE_WINDOW_ERROR, undefined, undefined, e);
                 traceError(e);
-                void this.errorHandler.handleError(e);
+                this.errorHandler.handleError(e).then(noop, noop);
             }
         }
     }

--- a/src/interactive-window/commands/exportCommands.ts
+++ b/src/interactive-window/commands/exportCommands.ts
@@ -11,7 +11,7 @@ import { IApplicationShell, ICommandManager, IVSCodeNotebook } from '../../platf
 import { traceInfo } from '../../platform/logging';
 import { IDisposable } from '../../platform/common/types';
 import { DataScience } from '../../platform/common/utils/localize';
-import { isUri } from '../../platform/common/utils/misc';
+import { isUri, noop } from '../../platform/common/utils/misc';
 import { PythonEnvironment } from '../../platform/pythonEnvironments/info';
 import { sendTelemetryEvent } from '../../telemetry';
 import { INotebookControllerManager } from '../../notebooks/types';
@@ -141,7 +141,9 @@ export class ExportCommands implements IExportCommands, IDisposable {
                     sendTelemetryEvent(Telemetry.ClickedExportNotebookAsQuickPick, undefined, {
                         format: ExportFormat.python
                     });
-                    void this.commandManager.executeCommand(Commands.ExportAsPythonScript, sourceDocument, interpreter);
+                    this.commandManager
+                        .executeCommand(Commands.ExportAsPythonScript, sourceDocument, interpreter)
+                        .then(noop, noop);
                 }
             });
         }
@@ -155,12 +157,9 @@ export class ExportCommands implements IExportCommands, IDisposable {
                         sendTelemetryEvent(Telemetry.ClickedExportNotebookAsQuickPick, undefined, {
                             format: ExportFormat.html
                         });
-                        void this.commandManager.executeCommand(
-                            Commands.ExportToHTML,
-                            sourceDocument,
-                            defaultFileName,
-                            interpreter
-                        );
+                        this.commandManager
+                            .executeCommand(Commands.ExportToHTML, sourceDocument, defaultFileName, interpreter)
+                            .then(noop, noop);
                     }
                 },
                 {
@@ -170,12 +169,9 @@ export class ExportCommands implements IExportCommands, IDisposable {
                         sendTelemetryEvent(Telemetry.ClickedExportNotebookAsQuickPick, undefined, {
                             format: ExportFormat.pdf
                         });
-                        void this.commandManager.executeCommand(
-                            Commands.ExportToPDF,
-                            sourceDocument,
-                            defaultFileName,
-                            interpreter
-                        );
+                        this.commandManager
+                            .executeCommand(Commands.ExportToPDF, sourceDocument, defaultFileName, interpreter)
+                            .then(noop, noop);
                     }
                 }
             ]

--- a/src/interactive-window/debugger/jupyter/debuggingManager.ts
+++ b/src/interactive-window/debugger/jupyter/debuggingManager.ts
@@ -35,6 +35,7 @@ import { DebuggingManagerBase } from '../../../notebooks/debugger/debuggingManag
 import { IConfigurationService } from '../../../platform/common/types';
 import { IFileGeneratedCodes } from '../../editor-integration/types';
 import { buildSourceMap } from '../helper';
+import { noop } from '../../../platform/common/utils/misc';
 
 /**
  * The DebuggingManager maintains the mapping between notebook documents and debug sessions.
@@ -91,7 +92,7 @@ export class InteractiveWindowDebuggingManager
                     return;
                 case IpykernelCheckResult.Outdated:
                 case IpykernelCheckResult.Unknown: {
-                    void this.promptInstallIpykernel6();
+                    this.promptInstallIpykernel6().then(noop, noop);
                     return;
                 }
                 case IpykernelCheckResult.Ok: {
@@ -157,7 +158,7 @@ export class InteractiveWindowDebuggingManager
             return;
         }
         if (!kernel?.session) {
-            void this.appShell.showInformationMessage(DataScience.kernelWasNotStarted());
+            this.appShell.showInformationMessage(DataScience.kernelWasNotStarted()).then(noop, noop);
             return;
         }
         const adapter = new KernelDebugAdapter(

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -218,7 +218,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
                 if (ev === 'willRestart' && this.notebookDocument && this.currentKernelInfo.metadata) {
                     this._insertSysInfoPromise = undefined;
                     // If we're about to restart, insert a 'restarting' message as it happens
-                    void this.insertSysInfoMessage(this.currentKernelInfo.metadata, SysInfoReason.Restart);
+                    this.insertSysInfoMessage(this.currentKernelInfo.metadata, SysInfoReason.Restart).then(noop, noop);
                 }
             };
             // Hook pre interrupt so we can stick in a message
@@ -442,8 +442,8 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
                 execution.start(notebookCell.executionSummary?.timing?.startTime);
             }
             execution.executionOrder = notebookCell.executionSummary?.executionOrder;
-            void execution.appendOutput(output);
-            void execution.end(false, notebookCell.executionSummary?.timing?.endTime);
+            execution.appendOutput(output).then(noop, noop);
+            execution.end(false, notebookCell.executionSummary?.timing?.endTime);
         }
     }
 
@@ -535,7 +535,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
                     notebookCellPromise
                         .then((cell) => {
                             if (ex.cell !== cell) {
-                                void this.addErrorMessage(DataScience.cellStopOnErrorMessage(), cell);
+                                this.addErrorMessage(DataScience.cellStopOnErrorMessage(), cell).then(noop, noop);
                             }
                         })
                         .catch(noop);

--- a/src/interactive-window/interactiveWindowCommandListener.ts
+++ b/src/interactive-window/interactiveWindowCommandListener.ts
@@ -47,6 +47,7 @@ import { generateCellsFromDocument } from './editor-integration/cellFactory';
 import { IInteractiveWindowProvider } from './types';
 import { getDisplayPath, getFilePath } from '../platform/common/platform/fs-paths';
 import { chainWithPendingUpdates } from '../kernels/execution/notebookUpdater';
+import { noop } from '../platform/common/utils/misc';
 
 @injectable()
 export class InteractiveWindowCommandListener implements IDataScienceCommandListener {
@@ -195,7 +196,7 @@ export class InteractiveWindowCommandListener implements IDataScienceCommandList
             return result;
         } catch (err) {
             traceError('listenForErrors', err as any);
-            void this.dataScienceErrorHandler.handleError(err);
+            this.dataScienceErrorHandler.handleError(err).then(noop, noop);
         }
         return result;
     }

--- a/src/kernels/activation.node.ts
+++ b/src/kernels/activation.node.ts
@@ -13,7 +13,6 @@ import { IPythonExecutionFactory, IPythonDaemonExecutionService } from '../platf
 import { IDisposableRegistry } from '../platform/common/types';
 import { isJupyterNotebook } from '../platform/common/utils';
 import { debounceAsync, swallowExceptions } from '../platform/common/utils/decorators';
-import { noop } from '../platform/common/utils/misc';
 import { sendTelemetryEvent } from '../telemetry';
 import { JupyterInterpreterService } from './jupyter/interpreter/jupyterInterpreterService.node';
 import { IRawNotebookSupportedService } from './raw/types';

--- a/src/kernels/activation.node.ts
+++ b/src/kernels/activation.node.ts
@@ -13,6 +13,7 @@ import { IPythonExecutionFactory, IPythonDaemonExecutionService } from '../platf
 import { IDisposableRegistry } from '../platform/common/types';
 import { isJupyterNotebook } from '../platform/common/utils';
 import { debounceAsync, swallowExceptions } from '../platform/common/utils/decorators';
+import { noop } from '../platform/common/utils/misc';
 import { sendTelemetryEvent } from '../telemetry';
 import { JupyterInterpreterService } from './jupyter/interpreter/jupyterInterpreterService.node';
 import { IRawNotebookSupportedService } from './raw/types';

--- a/src/kernels/common/baseJupyterSession.ts
+++ b/src/kernels/common/baseJupyterSession.ts
@@ -32,6 +32,7 @@ import { getResourceType } from '../../platform/common/utils';
 import { KernelProgressReporter } from '../../platform/progress/kernelProgressReporter';
 import { isTestExecution } from '../../platform/common/constants';
 import { KernelConnectionWrapper } from './kernelConnectionWrapper';
+import { KernelProcessExitedError } from '../../platform/errors/kernelProcessExitedError';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function suppressShutdownErrors(realKernel: any) {
@@ -204,18 +205,27 @@ export abstract class BaseJupyterSession implements IJupyterSession {
         // Just switch to the other session. It should already be ready
 
         // Start the restart session now in case it wasn't started
-        const newSession = await this.startRestartSession(false);
-        this.setSession(newSession);
+        try {
+            const newSession = await this.startRestartSession(false);
+            this.setSession(newSession);
 
-        if (newSession.kernel) {
-            traceInfo(`Got new session ${newSession.kernel.id}`);
+            if (newSession.kernel) {
+                traceInfo(`Got new session ${newSession.kernel.id}`);
 
-            // Rewire our status changed event.
-            newSession.statusChanged.connect(this.statusHandler);
-        }
-        traceInfo('Started new restart session');
-        if (oldStatusHandler && oldSession) {
-            oldSession.statusChanged.disconnect(oldStatusHandler);
+                // Rewire our status changed event.
+                newSession.statusChanged.connect(this.statusHandler);
+            }
+            traceInfo('Started new restart session');
+            if (oldStatusHandler && oldSession) {
+                oldSession.statusChanged.disconnect(oldStatusHandler);
+            }
+        } catch (ex) {
+            throw new KernelProcessExitedError(
+                ex.exitCode,
+                ex.stdErr,
+                ex.kernelConnectionMetadata,
+                'Kernel died in kernelCommandListener.restart'
+            );
         }
         this.shutdownSession(oldSession, undefined, false).ignoreErrors();
     }

--- a/src/kernels/debugger/kernelDebugAdapterBase.ts
+++ b/src/kernels/debugger/kernelDebugAdapterBase.ts
@@ -38,6 +38,7 @@ import { traceError, traceInfo, traceInfoIfCI, traceVerbose, traceWarning } from
 import { assertIsDebugConfig, isShortNamePath, shortNameMatchesLongName, getMessageSourceAndHookIt } from './helper';
 import { IDisposable } from '../../platform/common/types';
 import { executeSilently } from '../helpers';
+import { noop } from '../../platform/common/utils/misc';
 
 /**
  * For info on the custom requests implemented by jupyter see:
@@ -84,7 +85,7 @@ export abstract class KernelDebugAdapterBase implements DebugAdapter, IKernelDeb
             this.kernel.addEventHook(this.kernelEventHook);
             this.disposables.push(
                 this.kernel.onDisposed(() => {
-                    void debug.stopDebugging(this.session);
+                    debug.stopDebugging(this.session).then(noop, noop);
                     this.endSession.fire(this.session);
                     sendTelemetryEvent(DebuggingTelemetry.endedSession, undefined, { reason: 'onKernelDisposed' });
                 })

--- a/src/kernels/debugger/multiplexingDebugService.ts
+++ b/src/kernels/debugger/multiplexingDebugService.ts
@@ -20,6 +20,7 @@ import { IJupyterDebugService } from './types';
 import { ICommandManager, IDebugService } from '../../platform/common/application/types';
 import { Identifiers } from '../../platform/common/constants';
 import { IDisposableRegistry } from '../../platform/common/types';
+import { noop } from '../../platform/common/utils/misc';
 
 /**
  * IJupyterDebugService that will pick the correct debugger based on if doing run by line or normal debugging.
@@ -169,7 +170,7 @@ export class MultiplexingDebugService implements IJupyterDebugService {
             this.jupyterDebugService.stop();
         } else {
             // Stop our debugging UI session, no await as we just want it stopped
-            void this.commandManager.executeCommand('workbench.action.debug.stop');
+            this.commandManager.executeCommand('workbench.action.debug.stop').then(noop, noop);
         }
     }
 

--- a/src/kernels/execution/kernelExecution.ts
+++ b/src/kernels/execution/kernelExecution.ts
@@ -28,6 +28,7 @@ import { traceCellMessage } from './helpers';
 import { getDisplayPath } from '../../platform/common/platform/fs-paths';
 import { CellExecutionMessageHandlerService } from './cellExecutionMessageHandlerService';
 import { getAssociatedNotebookDocument } from '../helpers';
+import { noop } from '../../platform/common/utils/misc';
 
 /**
  * Separate class that deals just with kernel execution.
@@ -169,10 +170,12 @@ export class KernelExecution implements IDisposable {
         // Restart the active execution
         if (!this._restartPromise) {
             this._restartPromise = this.restartExecution(session);
-            this._restartPromise.finally(() => {
-                // Done restarting, clear restart promise
-                this._restartPromise = undefined;
-            });
+            this._restartPromise
+                .finally(() => {
+                    // Done restarting, clear restart promise
+                    this._restartPromise = undefined;
+                })
+                .catch(noop);
         }
         await this._restartPromise;
     }

--- a/src/kernels/execution/kernelExecution.ts
+++ b/src/kernels/execution/kernelExecution.ts
@@ -171,10 +171,8 @@ export class KernelExecution implements IDisposable {
         if (!this._restartPromise) {
             this._restartPromise = this.restartExecution(session);
             this._restartPromise
-                .finally(() => {
-                    // Done restarting, clear restart promise
-                    this._restartPromise = undefined;
-                })
+                // Done restarting, clear restart promise
+                .finally(() => (this._restartPromise = undefined))
                 .catch(noop);
         }
         await this._restartPromise;

--- a/src/kernels/ipywidgets-message-coordination/commonMessageCoordinator.ts
+++ b/src/kernels/ipywidgets-message-coordination/commonMessageCoordinator.ts
@@ -100,7 +100,7 @@ export class CommonMessageCoordinator {
                             response: webview.asWebviewUri(e.payload)
                         });
                     } else {
-                        void webview.postMessage({ type: e.message, payload: e.payload });
+                        webview.postMessage({ type: e.message, payload: e.payload }).then(noop, noop);
                     }
                 },
                 this,
@@ -193,7 +193,9 @@ export class CommonMessageCoordinator {
                             this.appShell.openUrl('https://aka.ms/PVSCIPyWidgets');
                             break;
                         case enableDownloads:
-                            void this.commandManager.executeCommand(Commands.EnableLoadingWidgetsFrom3rdPartySource);
+                            this.commandManager
+                                .executeCommand(Commands.EnableLoadingWidgetsFrom3rdPartySource)
+                                .then(noop, noop);
                             break;
                         default:
                             break;

--- a/src/kernels/ipywidgets-message-coordination/ipyWidgetScriptSource.ts
+++ b/src/kernels/ipywidgets-message-coordination/ipyWidgetScriptSource.ts
@@ -21,6 +21,7 @@ import { IPyWidgetScriptSourceProvider } from './ipyWidgetScriptSourceProvider';
 import { ILocalResourceUriConverter, IWidgetScriptSourceProviderFactory, WidgetScriptSource } from './types';
 import { ConsoleForegroundColors } from '../../platform/logging/types';
 import { getAssociatedNotebookDocument } from '../helpers';
+import { noop } from '../../platform/common/utils/misc';
 
 export class IPyWidgetScriptSource {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -108,7 +109,8 @@ export class IPyWidgetScriptSource {
                             this.sendWidgetSource(moduleName, moduleVersion).catch(
                                 traceError.bind(undefined, 'Failed to send widget sources upon ready')
                             );
-                        });
+                        })
+                        .catch(noop);
                 } else {
                     traceInfo(`${ConsoleForegroundColors.Green}Fetch Script for ${JSON.stringify(payload)}`);
                     this.sendWidgetSource(moduleName, moduleVersion).catch(

--- a/src/kernels/jupyter/import-export/jupyterExporter.node.ts
+++ b/src/kernels/jupyter/import-export/jupyterExporter.node.ts
@@ -21,6 +21,7 @@ import { IDataScienceErrorHandler } from '../../../platform/errors/types';
 import { concatMultilineString } from '../../../webviews/webview-side/common';
 import { defaultNotebookFormat, CodeSnippets } from '../../../webviews/webview-side/common/constants';
 import { INotebookExporter, IJupyterExecution } from '../types';
+import { noop } from '../../../platform/common/utils/misc';
 
 @injectable()
 export class JupyterExporter implements INotebookExporter {
@@ -56,7 +57,7 @@ export class JupyterExporter implements INotebookExporter {
                 return;
             }
             const openQuestion1 = DataScience.exportOpenQuestion1();
-            void this.applicationShell
+            this.applicationShell
                 .showInformationMessage(DataScience.exportDialogComplete().format(file), openQuestion1)
                 .then(async (str: string | undefined) => {
                     try {
@@ -67,13 +68,15 @@ export class JupyterExporter implements INotebookExporter {
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any
                         await this.errorHandler.handleError(e as any);
                     }
-                });
+                }, noop);
         } catch (exc) {
             traceError('Error in exporting notebook file');
-            void this.applicationShell.showInformationMessage(
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                DataScience.exportDialogFailed().format(exc as any)
-            );
+            this.applicationShell
+                .showInformationMessage(
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    DataScience.exportDialogFailed().format(exc as any)
+                )
+                .then(noop, noop);
         }
     }
     public async translateToNotebook(

--- a/src/kernels/jupyter/launcher/commandLineSelector.ts
+++ b/src/kernels/jupyter/launcher/commandLineSelector.ts
@@ -10,6 +10,7 @@ import { ConfigurationChangeEvent, ConfigurationTarget, QuickPickItem, Uri } fro
 import { IWorkspaceService, IApplicationShell, ICommandManager } from '../../../platform/common/application/types';
 import { IConfigurationService } from '../../../platform/common/types';
 import { DataScience } from '../../../platform/common/utils/localize';
+import { noop } from '../../../platform/common/utils/misc';
 import {
     IMultiStepInputFactory,
     IMultiStepInput,
@@ -47,7 +48,7 @@ export class JupyterCommandLineSelector {
                 reload
             );
             if (item === reload) {
-                void this.commandManager.executeCommand('workbench.action.reloadWindow');
+                this.commandManager.executeCommand('workbench.action.reloadWindow').then(noop, noop);
             }
         }
     }

--- a/src/kernels/jupyter/launcher/serverPreload.node.ts
+++ b/src/kernels/jupyter/launcher/serverPreload.node.ts
@@ -19,6 +19,7 @@ import { IInteractiveWindowProvider, IInteractiveWindow } from '../../../interac
 import { DisplayOptions } from '../../displayOptions';
 import { IRawNotebookProvider } from '../../raw/types';
 import { isJupyterNotebook } from '../../../platform/common/utils';
+import { noop } from '../../../platform/common/utils/misc';
 
 const LastPythonNotebookCreatedKey = 'last-python-notebook-created';
 const LastNotebookCreatedKey = 'last-notebook-created';
@@ -123,10 +124,10 @@ export class ServerPreload implements IExtensionSingleActivationService {
     private kernelStarted(kernel: IKernel) {
         const language = getKernelConnectionLanguage(kernel.kernelConnectionMetadata);
 
-        void this.mementoStorage.update(LastNotebookCreatedKey, Date.now());
+        this.mementoStorage.update(LastNotebookCreatedKey, Date.now()).then(noop, noop);
 
         if (language === PYTHON_LANGUAGE) {
-            void this.mementoStorage.update(LastPythonNotebookCreatedKey, Date.now());
+            this.mementoStorage.update(LastPythonNotebookCreatedKey, Date.now()).then(noop, noop);
         }
     }
 }

--- a/src/kernels/jupyter/session/jupyterSession.ts
+++ b/src/kernels/jupyter/session/jupyterSession.ts
@@ -28,6 +28,7 @@ import { DisplayOptions } from '../../displayOptions';
 import { IBackupFile, IJupyterBackingFileCreator, IJupyterKernelService, IJupyterRequestCreator } from '../types';
 import { Uri } from 'vscode';
 import { generateBackingIPyNbFileName } from './backingFileCreator.base';
+import { noop } from '../../../platform/common/utils/misc';
 
 // function is
 export class JupyterSession extends BaseJupyterSession implements IJupyterServerSession {
@@ -180,12 +181,14 @@ export class JupyterSession extends BaseJupyterSession implements IJupyterServer
         const token = new CancellationTokenSource();
         const promise = this.createRestartSession(disableUI, this.session, token.token);
         this.restartSessionPromise = { token, promise };
-        promise.finally(() => {
-            token.dispose();
-            if (this.restartSessionPromise?.promise === promise) {
-                this.restartSessionPromise = undefined;
-            }
-        });
+        promise
+            .finally(() => {
+                token.dispose();
+                if (this.restartSessionPromise?.promise === promise) {
+                    this.restartSessionPromise = undefined;
+                }
+            })
+            .catch(noop);
         return promise;
     }
 

--- a/src/kernels/kernelCrashMonitor.ts
+++ b/src/kernels/kernelCrashMonitor.ts
@@ -9,6 +9,7 @@ import { IApplicationShell } from '../platform/common/application/types';
 import { Telemetry } from '../platform/common/constants';
 import { IDisposableRegistry } from '../platform/common/types';
 import { DataScience } from '../platform/common/utils/localize';
+import { noop } from '../platform/common/utils/misc';
 import { sendKernelTelemetryEvent } from '../telemetry/telemetry';
 import { endCellAndDisplayErrorsInCell } from './execution/helpers';
 import { getDisplayNameOrNameOfKernelConnection } from './helpers';
@@ -46,11 +47,13 @@ export class KernelCrashMonitor implements IExtensionSyncActivationService {
         // and the session has died, then notify the user of this dead kernel.
         // Note: We know this kernel started successfully.
         if (kernel.session.kind === 'localRaw' && kernel.status === 'dead') {
-            void this.applicationShell.showErrorMessage(
-                DataScience.kernelDiedWithoutError().format(
-                    getDisplayNameOrNameOfKernelConnection(kernel.kernelConnectionMetadata)
+            this.applicationShell
+                .showErrorMessage(
+                    DataScience.kernelDiedWithoutError().format(
+                        getDisplayNameOrNameOfKernelConnection(kernel.kernelConnectionMetadata)
+                    )
                 )
-            );
+                .then(noop, noop);
 
             await this.endCellAndDisplayErrorsInCell(kernel);
         }
@@ -59,11 +62,13 @@ export class KernelCrashMonitor implements IExtensionSyncActivationService {
         // and the session is auto restarting, then this means the kernel died.
         // notify the user of this
         if (kernel.session.kind !== 'localRaw' && kernel.status === 'autorestarting') {
-            void this.applicationShell.showErrorMessage(
-                DataScience.kernelDiedWithoutErrorAndAutoRestarting().format(
-                    getDisplayNameOrNameOfKernelConnection(kernel.kernelConnectionMetadata)
+            this.applicationShell
+                .showErrorMessage(
+                    DataScience.kernelDiedWithoutErrorAndAutoRestarting().format(
+                        getDisplayNameOrNameOfKernelConnection(kernel.kernelConnectionMetadata)
+                    )
                 )
-            );
+                .then(noop, noop);
 
             await this.endCellAndDisplayErrorsInCell(kernel);
         }

--- a/src/kernels/kernelDependencyService.node.ts
+++ b/src/kernels/kernelDependencyService.node.ts
@@ -166,15 +166,15 @@ export class KernelDependencyService implements IKernelDependencyService {
         const installedPromise = this.installer
             .isInstalled(Product.ipykernel, kernelConnection.interpreter)
             .then((installed) => installed === true);
-        void installedPromise.then((installed) => {
+        installedPromise.then((installed) => {
             if (installed) {
-                void trackPackageInstalledIntoInterpreter(
+                trackPackageInstalledIntoInterpreter(
                     this.memento,
                     Product.ipykernel,
                     kernelConnection.interpreter
-                );
+                ).catch(noop);
             }
-        });
+        }, noop);
         return Promise.race([
             installedPromise,
             createPromiseFromCancellation({ token, defaultValue: false, cancelAction: 'resolve' })

--- a/src/kernels/raw/finder/jupyterPaths.node.ts
+++ b/src/kernels/raw/finder/jupyterPaths.node.ts
@@ -16,6 +16,7 @@ import { traceDecoratorVerbose } from '../../../platform/logging';
 import { getUserHomeDir } from '../../../platform/common/utils/platform.node';
 import { fsPathToUri } from '../../../platform/vscode-path/utils';
 import { ResourceSet } from '../../../platform/vscode-path/map';
+import { noop } from '../../../platform/common/utils/misc';
 
 const winJupyterPath = path.join('AppData', 'Roaming', 'jupyter', 'kernels');
 const linuxJupyterPath = path.join('.local', 'share', 'jupyter', 'kernels');
@@ -189,14 +190,14 @@ export class JupyterPaths {
 
                 return Array.from(paths);
             })();
-        void this.cachedJupyterPaths.then((value) => {
+        this.cachedJupyterPaths.then((value) => {
             if (value.length > 0) {
-                void this.updateCachedPaths(value);
+                this.updateCachedPaths(value).then(noop, noop);
             }
             if (this.getCachedPaths().length > 0) {
                 return this.getCachedPaths();
             }
-        });
+        }, noop);
         return this.cachedJupyterPaths;
     }
 
@@ -219,9 +220,9 @@ export class JupyterPaths {
 
     private updateCachedRootPath(path: Uri | undefined) {
         if (path) {
-            void this.globalState.update(CACHE_KEY_FOR_JUPYTER_KERNELSPEC_ROOT_PATH, path.toString());
+            this.globalState.update(CACHE_KEY_FOR_JUPYTER_KERNELSPEC_ROOT_PATH, path.toString()).then(noop, noop);
         } else {
-            void this.globalState.update(CACHE_KEY_FOR_JUPYTER_KERNELSPEC_ROOT_PATH, undefined);
+            this.globalState.update(CACHE_KEY_FOR_JUPYTER_KERNELSPEC_ROOT_PATH, undefined).then(noop, noop);
         }
     }
 }

--- a/src/kernels/raw/finder/localKernelSpecFinderBase.node.ts
+++ b/src/kernels/raw/finder/localKernelSpecFinderBase.node.ts
@@ -39,7 +39,7 @@ export abstract class LocalKernelSpecFinderBase {
     }
     private set oldKernelSpecsFolder(value: string) {
         this._oldKernelSpecsFolder = value;
-        void this.globalState.update('OLD_KERNEL_SPECS_FOLDER__', value);
+        this.globalState.update('OLD_KERNEL_SPECS_FOLDER__', value).then(noop, noop);
     }
     private cache?: KernelSpecFileWithContainingInterpreter[];
     // Store our results when listing all possible kernelspecs for a resource

--- a/src/kernels/raw/launcher/kernelLauncher.node.ts
+++ b/src/kernels/raw/launcher/kernelLauncher.node.ts
@@ -20,7 +20,6 @@ import { IProcessServiceFactory, IPythonExecutionFactory } from '../../../platfo
 import { IDisposableRegistry, IConfigurationService, Resource } from '../../../platform/common/types';
 import { swallowExceptions } from '../../../platform/common/utils/decorators';
 import { DataScience } from '../../../platform/common/utils/localize';
-import { sendKernelTelemetryWhenDone } from '../../../telemetry/telemetry';
 import { sendTelemetryEvent } from '../../../telemetry';
 import { Telemetry } from '../../../webviews/webview-side/common/constants';
 import {
@@ -35,6 +34,7 @@ import { JupyterPaths } from '../finder/jupyterPaths.node';
 import { isTestExecution } from '../../../platform/common/constants';
 import { getDisplayPathFromLocalFile } from '../../../platform/common/platform/fs-paths.node';
 import { noop } from '../../../platform/common/utils/misc';
+import { KernelProcessExitedError } from '../../../platform/errors/kernelProcessExitedError';
 
 const PortFormatString = `kernelLauncherPortStart_{0}.tmp`;
 // Launches and returns a kernel process given a resource or python interpreter.
@@ -112,9 +112,27 @@ export class KernelLauncher implements IKernelLauncher {
             this.logIPyKernelPath(resource, kernelConnectionMetadata, cancelToken).catch(noop);
 
             // Should be available now, wait with a timeout
-            return await this.launchProcess(kernelConnectionMetadata, resource, workingDirectory, timeout, cancelToken);
+            try {
+                return await this.launchProcess(
+                    kernelConnectionMetadata,
+                    resource,
+                    workingDirectory,
+                    timeout,
+                    cancelToken
+                );
+            } catch (ex) {
+                if (ex instanceof KernelProcessExitedError) {
+                    throw new KernelProcessExitedError(
+                        ex.exitCode,
+                        ex.stdErr,
+                        ex.kernelConnectionMetadata,
+                        'Kernel died in launch method'
+                    );
+                }
+                throw ex;
+            }
         })();
-        sendKernelTelemetryWhenDone(resource, Telemetry.KernelLauncherPerf, promise);
+        // sendKernelTelemetryWhenDone(resource, Telemetry.KernelLauncherPerf, promise);
         return promise;
     }
 
@@ -216,6 +234,14 @@ export class KernelLauncher implements IKernelLauncher {
         } catch (ex) {
             kernelProcess.dispose();
             Cancellation.throwIfCanceled(cancelToken);
+            if (ex instanceof KernelProcessExitedError) {
+                throw new KernelProcessExitedError(
+                    ex.exitCode,
+                    ex.stdErr,
+                    ex.kernelConnectionMetadata,
+                    'Kernel died in kernelLauncher.node'
+                );
+            }
             throw ex;
         }
 

--- a/src/kernels/raw/session/hostRawNotebookProvider.node.ts
+++ b/src/kernels/raw/session/hostRawNotebookProvider.node.ts
@@ -28,7 +28,6 @@ import { IKernelLauncher, IRawNotebookProvider, IRawNotebookSupportedService } f
 import { RawJupyterSession } from './rawJupyterSession.node';
 import { Cancellation } from '../../../platform/common/cancellation';
 import { noop } from '../../../platform/common/utils/misc';
-import { KernelProcessExitedError } from '../../../platform/errors/kernelProcessExitedError';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -132,14 +131,6 @@ export class HostRawNotebookProvider implements IRawNotebookProvider {
             rawSession?.dispose().catch((error) => {
                 traceError(`Failed to dispose of raw session on launch error: ${error} `);
             });
-            if (ex instanceof KernelProcessExitedError) {
-                ex = new KernelProcessExitedError(
-                    ex.exitCode,
-                    ex.stdErr,
-                    ex.kernelConnectionMetadata,
-                    'Kernel died in hostRawNotebookProvider.node'
-                );
-            }
             // If there's an error, then reject the promise that is returned.
             // This original promise must be rejected as it is cached (check `setNotebook`).
             sessionPromise.reject(ex);

--- a/src/kernels/raw/session/rawJupyterSession.node.ts
+++ b/src/kernels/raw/session/rawJupyterSession.node.ts
@@ -27,7 +27,6 @@ import { IKernelLauncher, IKernelProcess } from '../types';
 import { RawSession } from './rawSession.node';
 import { DisplayOptions } from '../../displayOptions';
 import { noop } from '../../../platform/common/utils/misc';
-import { KernelProcessExitedError } from '../../../platform/errors/kernelProcessExitedError';
 import { KernelProgressReporter } from '../../../platform/progress/kernelProgressReporter';
 
 /*
@@ -94,15 +93,6 @@ export class RawJupyterSession extends BaseJupyterSession {
             // Listen for session status changes
             this.session?.statusChanged.connect(this.statusHandler); // NOSONAR
         } catch (error) {
-            if (error instanceof KernelProcessExitedError) {
-                error = new KernelProcessExitedError(
-                    error.exitCode,
-                    error.stdErr,
-                    error.kernelConnectionMetadata,
-                    'Kernel died in rawJuptyerSession.node'
-                );
-            }
-
             this.connected = false;
             if (isCancellationError(error) || options.token.isCancellationRequested) {
                 sendKernelTelemetryEvent(

--- a/src/kernels/raw/session/rawSocket.node.ts
+++ b/src/kernels/raw/session/rawSocket.node.ts
@@ -278,6 +278,8 @@ export class RawSocket implements IWebSocketLike, IKernelSocket, IDisposable {
                 this.postToSocket(msg.channel, data);
             });
         }
+        // Ensure we don't have any unhandled exceptions (swallow exceptions as we're not awaiting on this promise).
+        this.sendChain.catch(noop);
     }
 
     private postToSocket(channel: string, data: any) {

--- a/src/notebooks/controllers/kernelConnector.ts
+++ b/src/notebooks/controllers/kernelConnector.ts
@@ -293,6 +293,7 @@ export class KernelConnector {
             onAction
         );
         const deferred = createDeferredFromPromise(promise);
+        deferred.promise.catch(noop);
         // If the kernel gets disposed or we fail to create the kernel, then ensure we remove the cached result.
         promise
             .then((result) => {

--- a/src/notebooks/controllers/kernelConnector.ts
+++ b/src/notebooks/controllers/kernelConnector.ts
@@ -93,7 +93,7 @@ export class KernelConnector {
                 break;
             }
             case DataScience.showJupyterLogs(): {
-                void commandManager.executeCommand(Commands.ViewJupyterOutput);
+                commandManager.executeCommand(Commands.ViewJupyterOutput).then(noop, noop);
             }
         }
         return restartedKernel;

--- a/src/notebooks/controllers/kernelFilter/kernelFilterUI.ts
+++ b/src/notebooks/controllers/kernelFilter/kernelFilterUI.ts
@@ -108,7 +108,7 @@ export class KernelFilterUI implements IExtensionSyncActivationService, IDisposa
                 const hiddenConnections = items
                     .map((item) => item.connection)
                     .filter((item) => !selectedItems.has(item));
-                void this.kernelFilter.storeHiddenKernels(hiddenConnections.map((item) => item));
+                this.kernelFilter.storeHiddenKernels(hiddenConnections.map((item) => item)).then(noop, noop);
                 sendTelemetryEvent(Telemetry.JupyterKernelFilterUsed);
             },
             this,

--- a/src/notebooks/controllers/notebookControllerManager.ts
+++ b/src/notebooks/controllers/notebookControllerManager.ts
@@ -552,7 +552,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
             return;
         }
 
-        void this.initializePreferredNotebookController(document);
+        this.initializePreferredNotebookController(document).catch(noop);
         if (isPythonNotebook(getNotebookMetadata(document)) && this.extensionChecker.isPythonExtensionInstalled) {
             // If we know we're dealing with a Python notebook, load the active interpreter as a kernel asap.
             this.createActiveInterpreterController(JupyterNotebookView, document.uri).catch(noop);

--- a/src/notebooks/controllers/notebookControllerManager.ts
+++ b/src/notebooks/controllers/notebookControllerManager.ts
@@ -282,7 +282,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
             this.controllersPromise = this.loadNotebookControllersImpl(cancelToken.token)
                 .catch((e) => {
                     traceError('Error loading notebook controllers', e);
-                    if (!isCancellationError(e)) {
+                    if (!isCancellationError(e, true)) {
                         // This can happen in the tests, and these get bubbled upto VSC and are logged as unhandled exceptions.
                         // Hence swallow cancellation errors.
                         throw e;
@@ -813,7 +813,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
                 this.createNotebookController(value.connection, value.label, doNotHideInteractiveKernel);
             });
         } catch (ex) {
-            if (!isCancellationError(ex)) {
+            if (!isCancellationError(ex, true)) {
                 // This can happen in the tests, and these get bubbled upto VSC and are logged as unhandled exceptions.
                 // Hence swallow cancellation errors.
                 throw ex;
@@ -907,7 +907,7 @@ export class NotebookControllerManager implements INotebookControllerManager, IE
                     this.registeredControllers.set(controller.id, controller);
                 });
         } catch (ex) {
-            if (isCancellationError(ex)) {
+            if (isCancellationError(ex, true)) {
                 // This can happen in the tests, and these get bubbled upto VSC and are logged as unhandled exceptions.
                 // Hence swallow cancellation errors.
                 return;

--- a/src/notebooks/controllers/vscodeNotebookController.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.ts
@@ -279,7 +279,7 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
         }
 
         if (pyVersion.major < 3 || (pyVersion.major === 3 && pyVersion.minor <= 5)) {
-            void this.appShell
+            this.appShell
                 .showWarningMessage(
                     DataScience.warnWhenSelectingKernelWithUnSupportedPythonVersion(),
                     Common.learnMore()
@@ -289,7 +289,7 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
                         return;
                     }
                     return this.browser.launch('https://aka.ms/jupyterUnSupportedPythonKernelVersions');
-                });
+                }, noop);
         }
     }
     private async onDidChangeSelectedNotebooks(event: { notebook: NotebookDocument; selected: boolean }) {
@@ -494,7 +494,7 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
             }
             if (!kernelStarted) {
                 exec.start();
-                void exec.clearOutput(cell);
+                exec.clearOutput(cell).then(noop, noop);
             }
             const errorHandler = this.serviceContainer.get<IDataScienceErrorHandler>(IDataScienceErrorHandler);
             ex = WrappedError.unwrap(ex);

--- a/src/notebooks/debugger/debugCellControllers.ts
+++ b/src/notebooks/debugger/debugCellControllers.ts
@@ -9,6 +9,7 @@ import { sendTelemetryEvent } from '../../telemetry';
 import { DebuggingTelemetry } from '../../kernels/debugger/constants';
 import { cellDebugSetup } from '../../kernels/debugger/helper';
 import { IDebuggingDelegate, IKernelDebugAdapter } from '../../kernels/debugger/types';
+import { noop } from '../../platform/common/utils/misc';
 
 export class DebugCellController implements IDebuggingDelegate {
     constructor(
@@ -28,10 +29,12 @@ export class DebugCellController implements IDebuggingDelegate {
         if (request.command === 'configurationDone') {
             await cellDebugSetup(this.kernel, this.debugAdapter);
 
-            void this.commandManager.executeCommand('notebook.cell.execute', {
-                ranges: [{ start: this.debugCell.index, end: this.debugCell.index + 1 }],
-                document: this.debugCell.document.uri
-            });
+            this.commandManager
+                .executeCommand('notebook.cell.execute', {
+                    ranges: [{ start: this.debugCell.index, end: this.debugCell.index + 1 }],
+                    document: this.debugCell.document.uri
+                })
+                .then(noop, noop);
         }
     }
 }

--- a/src/notebooks/debugger/debuggingManager.ts
+++ b/src/notebooks/debugger/debuggingManager.ts
@@ -33,6 +33,7 @@ import { KernelDebugAdapter } from './kernelDebugAdapter';
 import { assertIsDebugConfig, IpykernelCheckResult } from '../../kernels/debugger/helper';
 import { IDebuggingManager, IKernelDebugAdapterConfig, KernelDebugMode } from '../../kernels/debugger/types';
 import { DebuggingManagerBase } from './debuggingManagerBase';
+import { noop } from '../../platform/common/utils/misc';
 
 /**
  * The DebuggingManager maintains the mapping between notebook documents and debug sessions.
@@ -181,7 +182,7 @@ export class DebuggingManager
         traceInfoIfCI(`Starting debugging with mode ${mode}`);
 
         if (!editor) {
-            void this.appShell.showErrorMessage(DataScience.noNotebookToDebug());
+            this.appShell.showErrorMessage(DataScience.noNotebookToDebug()).then(noop, noop);
             return;
         }
 
@@ -207,7 +208,7 @@ export class DebuggingManager
                     return;
                 case IpykernelCheckResult.Outdated:
                 case IpykernelCheckResult.Unknown: {
-                    void this.promptInstallIpykernel6();
+                    this.promptInstallIpykernel6().then(noop, noop);
                     return;
                 }
                 case IpykernelCheckResult.Ok: {
@@ -333,7 +334,7 @@ export class DebuggingManager
                     debug.resolve(session);
                     return new DebugAdapterInlineImplementation(adapter);
                 } else {
-                    void this.appShell.showInformationMessage(DataScience.kernelWasNotStarted());
+                    this.appShell.showInformationMessage(DataScience.kernelWasNotStarted()).then(noop, noop);
                 }
             }
         }

--- a/src/notebooks/debugger/debuggingManagerBase.ts
+++ b/src/notebooks/debugger/debuggingManagerBase.ts
@@ -26,6 +26,7 @@ import { Debugger } from '../../platform/debugger/debugger';
 import { KernelDebugAdapterBase } from '../../kernels/debugger/kernelDebugAdapterBase';
 import { INotebookControllerManager } from '../types';
 import { IpykernelCheckResult, isUsingIpykernel6OrLater } from '../../kernels/debugger/helper';
+import { noop } from '../../platform/common/utils/misc';
 
 /**
  * The DebuggingManager maintains the mapping between notebook documents and debug sessions.
@@ -106,7 +107,7 @@ export abstract class DebuggingManagerBase implements IDisposable {
                 traceInfoIfCI(`Debugger session is ready. Should be debugging ${session.id} now`);
             } catch (err) {
                 traceError(`Can't start debugging (${err})`);
-                void this.appShell.showErrorMessage(DataScience.cantStartDebugging());
+                this.appShell.showErrorMessage(DataScience.cantStartDebugging()).then(noop, noop);
             }
         } else {
             traceInfoIfCI(`Not starting debugging because already debugging in this notebook`);

--- a/src/notebooks/debugger/runByLineController.ts
+++ b/src/notebooks/debugger/runByLineController.ts
@@ -36,14 +36,14 @@ export class RunByLineController implements IDebuggingDelegate {
             return;
         }
 
-        void this.debugAdapter.stepIn(this.lastPausedThreadId);
+        this.debugAdapter.stepIn(this.lastPausedThreadId).then(noop, noop);
     }
 
     public stop(): void {
         traceInfoIfCI(`RunbylineController::stop()`);
         // When debugpy gets stuck, running a cell fixes it and allows us to start another debugging session
-        void this.kernel.executeHidden('pass');
-        void this.debugAdapter.disconnect();
+        this.kernel.executeHidden('pass').then(noop, noop);
+        this.debugAdapter.disconnect().then(noop, noop);
     }
 
     public getMode(): KernelDebugMode {
@@ -75,7 +75,7 @@ export class RunByLineController implements IDebuggingDelegate {
 
     private async handleStoppedEvent(threadId: number): Promise<boolean> {
         if (await this.shouldStepIn(threadId)) {
-            void this.debugAdapter.stepIn(threadId);
+            this.debugAdapter.stepIn(threadId).then(noop, noop);
             return true;
         }
 
@@ -134,14 +134,16 @@ export class RunByLineController implements IDebuggingDelegate {
             // Open variables view
             const settings = this.settings.getSettings();
             if (settings.showVariableViewWhenDebugging) {
-                void this.commandManager.executeCommand(Commands.OpenVariableView);
+                this.commandManager.executeCommand(Commands.OpenVariableView).then(noop, noop);
             }
         }
 
         // Run cell
-        void this.commandManager.executeCommand('notebook.cell.execute', {
-            ranges: [{ start: this.debugCell.index, end: this.debugCell.index + 1 }],
-            document: this.debugCell.document.uri
-        });
+        this.commandManager
+            .executeCommand('notebook.cell.execute', {
+                ranges: [{ start: this.debugCell.index, end: this.debugCell.index + 1 }],
+                document: this.debugCell.document.uri
+            })
+            .then(noop, noop);
     }
 }

--- a/src/notebooks/notebookCommandListener.ts
+++ b/src/notebooks/notebookCommandListener.ts
@@ -116,25 +116,25 @@ export class NotebookCommandListener implements IDataScienceCommandListener {
 
     private runAllCells() {
         if (this.notebooks.activeNotebookEditor) {
-            void this.commandManager.executeCommand('notebook.execute');
+            this.commandManager.executeCommand('notebook.execute').then(noop, noop);
         }
     }
 
     private addCellBelow() {
         if (this.notebooks.activeNotebookEditor) {
-            void this.commandManager.executeCommand('notebook.cell.insertCodeCellBelow');
+            this.commandManager.executeCommand('notebook.cell.insertCodeCellBelow').then(noop, noop);
         }
     }
 
     private undoCells() {
         if (this.notebooks.activeNotebookEditor) {
-            void this.commandManager.executeCommand('notebook.undo');
+            this.commandManager.executeCommand('notebook.undo').then(noop, noop);
         }
     }
 
     private redoCells() {
         if (this.notebooks.activeNotebookEditor) {
-            void this.commandManager.executeCommand('notebook.redo');
+            this.commandManager.executeCommand('notebook.redo').then(noop, noop);
         }
     }
 

--- a/src/notebooks/notebookCommandListener.ts
+++ b/src/notebooks/notebookCommandListener.ts
@@ -274,7 +274,7 @@ export class NotebookCommandListener implements IDataScienceCommandListener {
                         false
                     );
                 } else {
-                    void this.applicationShell.showErrorMessage(ex.toString());
+                    this.applicationShell.showErrorMessage(ex.toString()).then(noop, noop);
                 }
             }
         })();

--- a/src/platform/api/pythonApi.ts
+++ b/src/platform/api/pythonApi.ts
@@ -227,7 +227,7 @@ export class PythonExtensionChecker implements IPythonExtensionChecker {
     }
     private async installPythonExtension() {
         // Have the user install python
-        void this.commandManager.executeCommand('extension.open', PythonExtension);
+        this.commandManager.executeCommand('extension.open', PythonExtension).then(noop, noop);
     }
 
     private async extensionsChangeHandler(): Promise<void> {

--- a/src/platform/common/application/applicationShell.ts
+++ b/src/platform/common/application/applicationShell.ts
@@ -34,6 +34,7 @@ import {
     WorkspaceFolder,
     WorkspaceFolderPickOptions
 } from 'vscode';
+import { noop } from '../utils/misc';
 import { IApplicationShell } from './types';
 
 @injectable()
@@ -104,7 +105,7 @@ export class ApplicationShell implements IApplicationShell {
         return window.showInputBox(options, token);
     }
     public openUrl(url: string): void {
-        void env.openExternal(Uri.parse(url));
+        env.openExternal(Uri.parse(url)).then(noop, noop);
     }
 
     public setStatusBarMessage(text: string, hideAfterTimeout: number): Disposable;

--- a/src/platform/common/dataScienceSurveyBanner.node.ts
+++ b/src/platform/common/dataScienceSurveyBanner.node.ts
@@ -21,6 +21,7 @@ import {
 import * as localize from './utils/localize';
 import { MillisecondsInADay } from '../constants.node';
 import { isJupyterNotebook } from './utils';
+import { noop } from './utils/misc';
 
 export enum InsidersNotebookSurveyStateKeys {
     ShowBanner = 'ShowInsidersNotebookSurveyBanner',
@@ -205,21 +206,21 @@ export class DataScienceSurveyBanner implements IJupyterExtensionBanner, IExtens
 
         // If cell has moved to executing, update the execution count
         if (cellStateChange.state === NotebookCellExecutionState.Executing) {
-            void this.updateStateAndShowBanner(
+            this.updateStateAndShowBanner(
                 InsidersNotebookSurveyStateKeys.ExecutionCount,
                 BannerType.InsidersNotebookSurvey
-            );
-            void this.updateStateAndShowBanner(
+            ).catch(noop);
+            this.updateStateAndShowBanner(
                 ExperimentNotebookSurveyStateKeys.ExecutionCount,
                 BannerType.ExperimentNotebookSurvey
-            );
+            ).catch(noop);
         }
     }
 
     private async updateStateAndShowBanner(val: string, banner: BannerType) {
         const state = this.persistentState.createGlobalPersistentState<number>(val, 0);
         await state.updateValue(state.value + 1);
-        void this.showBanner(banner);
+        this.showBanner(banner).catch(noop);
     }
 
     private getBannerMessage(type: BannerType): string {

--- a/src/platform/common/globalActivation.ts
+++ b/src/platform/common/globalActivation.ts
@@ -90,12 +90,12 @@ export class GlobalActivation implements IExtensionSingleActivationService {
         const settings = this.configuration.getSettings(undefined);
         const ownsSelection = settings.sendSelectionToInteractiveWindow;
         const editorContext = new ContextKey(EditorContexts.OwnsSelection, this.commandManager);
-        void editorContext.set(ownsSelection).catch(noop);
+        editorContext.set(ownsSelection).catch(noop);
     };
 
     private computeZmqAvailable() {
         const zmqContext = new ContextKey(EditorContexts.ZmqAvailable, this.commandManager);
-        void zmqContext.set(this.rawSupported ? this.rawSupported.isSupported : false);
+        zmqContext.set(this.rawSupported ? this.rawSupported.isSupported : false).then(noop, noop);
     }
 
     private onChangedActiveTextEditor() {
@@ -106,9 +106,9 @@ export class GlobalActivation implements IExtensionSingleActivationService {
         if (activeEditor && activeEditor.document.languageId === PYTHON_LANGUAGE) {
             // Inform the editor context that we have cells, fire and forget is ok on the promise here
             // as we don't care to wait for this context to be set and we can't do anything if it fails
-            void editorContext.set(hasCells(activeEditor.document, this.configuration.getSettings())).catch(noop);
+            editorContext.set(hasCells(activeEditor.document, this.configuration.getSettings())).catch(noop);
         } else {
-            void editorContext.set(false).catch(noop);
+            editorContext.set(false).catch(noop);
         }
     }
 

--- a/src/platform/common/net/browser.ts
+++ b/src/platform/common/net/browser.ts
@@ -8,9 +8,10 @@
 import { injectable } from 'inversify';
 import { env, Uri } from 'vscode';
 import { IBrowserService } from '../types';
+import { noop } from '../utils/misc';
 
 export function launch(url: string) {
-    void env.openExternal(Uri.parse(url));
+    env.openExternal(Uri.parse(url)).then(noop, noop);
 }
 
 @injectable()

--- a/src/platform/common/prereleaseChecker.node.ts
+++ b/src/platform/common/prereleaseChecker.node.ts
@@ -11,6 +11,7 @@ import { GLOBAL_MEMENTO, IMemento, IsPreRelease } from '../common/types';
 import * as localize from './utils/localize';
 import { JVSC_EXTENSION_ID } from './constants';
 import * as vscode from 'vscode';
+import { noop } from './utils/misc';
 
 const PRERELEASE_DONT_ASK_FLAG = 'dontAskForPrereleaseUpgrade';
 
@@ -32,7 +33,7 @@ export class PreReleaseChecker implements IExtensionSingleActivationService {
                     const yes = localize.DataScience.usingNonPrereleaseYes();
                     const no = localize.DataScience.usingNonPrereleaseNo();
                     const dontAskAgain = localize.DataScience.usingNonPrereleaseNoAndDontAskAgain();
-                    void this.appShell
+                    this.appShell
                         .showWarningMessage(localize.DataScience.usingNonPrerelease(), yes, no, dontAskAgain)
                         .then((answer) => {
                             if (answer === yes) {
@@ -46,7 +47,7 @@ export class PreReleaseChecker implements IExtensionSingleActivationService {
                             } else if (answer == dontAskAgain) {
                                 return this.globalState.update(PRERELEASE_DONT_ASK_FLAG, true);
                             }
-                        });
+                        }, noop);
                 }
             })
             .ignoreErrors();

--- a/src/platform/common/utils/decorators.ts
+++ b/src/platform/common/utils/decorators.ts
@@ -103,6 +103,7 @@ export function makeDebounceAsyncDecorator(wait?: number) {
             const existingDeferredCompleted = existingDeferred && existingDeferred.completed;
             const deferred = (state.deferred =
                 !existingDeferred || existingDeferredCompleted ? createDeferred<any>() : existingDeferred);
+            deferred.promise.catch(noop);
             if (state.timer) {
                 clearTimeout(state.timer as any);
             }
@@ -204,7 +205,7 @@ export function displayProgress(title: string, location = ProgressLocation.Windo
             // eslint-disable-next-line no-invalid-this
             const promise = originalMethod.apply(this, args);
             if (!isTestExecution()) {
-                void window.withProgress(progressOptions, () => promise);
+                void window.withProgress(progressOptions, () => promise).then(noop, noop);
             }
             return promise;
         };

--- a/src/platform/common/utils/decorators.ts
+++ b/src/platform/common/utils/decorators.ts
@@ -203,9 +203,9 @@ export function displayProgress(title: string, location = ProgressLocation.Windo
         descriptor.value = async function (...args: any[]) {
             const progressOptions: ProgressOptions = { location, title };
             // eslint-disable-next-line no-invalid-this
-            const promise = originalMethod.apply(this, args);
+            const promise = originalMethod.apply(this, args) as Promise<string>;
             if (!isTestExecution()) {
-                void window.withProgress(progressOptions, () => promise).then(noop, noop);
+                return window.withProgress(progressOptions, () => promise);
             }
             return promise;
         };

--- a/src/platform/common/utils/decorators.ts
+++ b/src/platform/common/utils/decorators.ts
@@ -203,7 +203,7 @@ export function displayProgress(title: string, location = ProgressLocation.Windo
         descriptor.value = async function (...args: any[]) {
             const progressOptions: ProgressOptions = { location, title };
             // eslint-disable-next-line no-invalid-this
-            const promise = originalMethod.apply(this, args) as Promise<string>;
+            const promise = originalMethod.apply(this, args);
             if (!isTestExecution()) {
                 return window.withProgress(progressOptions, () => promise);
             }

--- a/src/platform/common/utils/misc.ts
+++ b/src/platform/common/utils/misc.ts
@@ -15,7 +15,10 @@ export function noop() {}
  */
 export function swallowExceptions(cb: Function) {
     try {
-        cb();
+        const result = cb();
+        if (isPromise(result)) {
+            result.catch(noop);
+        }
     } catch {
         // Ignore errors.
     }

--- a/src/platform/debugger/debugger.ts
+++ b/src/platform/debugger/debugger.ts
@@ -3,6 +3,7 @@
 
 'use strict';
 import { debug, NotebookDocument, DebugSession, DebugSessionOptions, DebugConfiguration } from 'vscode';
+import { noop } from '../../platform/common/utils/misc';
 
 export class Debugger {
     private resolveFunc?: (value: DebugSession) => void;
@@ -36,6 +37,6 @@ export class Debugger {
     }
 
     async stop() {
-        void debug.stopDebugging(await this.session);
+        void debug.stopDebugging(await this.session).then(noop, noop);
     }
 }

--- a/src/platform/devTools/clearCache.ts
+++ b/src/platform/devTools/clearCache.ts
@@ -1,5 +1,6 @@
 import { commands } from 'vscode';
 import { IExtensionContext } from '../common/types';
+import { noop } from '../common/utils/misc';
 
 export function addClearCacheCommand(context: IExtensionContext, isDevMode: boolean) {
     if (!isDevMode) {
@@ -8,11 +9,11 @@ export function addClearCacheCommand(context: IExtensionContext, isDevMode: bool
     commands.registerCommand('dataScience.ClearCache', () => {
         // eslint-disable-next-line no-restricted-syntax
         for (const key of context.globalState.keys()) {
-            void context.globalState.update(key, undefined);
+            context.globalState.update(key, undefined).then(noop, noop);
         }
         // eslint-disable-next-line no-restricted-syntax
         for (const key of context.workspaceState.keys()) {
-            void context.workspaceState.update(key, undefined);
+            context.workspaceState.update(key, undefined).then(noop, noop);
         }
     });
 }

--- a/src/platform/errors/errorHandler.ts
+++ b/src/platform/errors/errorHandler.ts
@@ -286,21 +286,24 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
             // On a self cert error, warn the user and ask if they want to change the setting
             const enableOption: string = DataScience.jupyterSelfCertEnable();
             const closeOption: string = DataScience.jupyterSelfCertClose();
-            void this.applicationShell
+            this.applicationShell
                 .showErrorMessage(DataScience.jupyterSelfCertFail().format(err.message), enableOption, closeOption)
                 .then((value) => {
                     if (value === enableOption) {
                         sendTelemetryEvent(Telemetry.SelfCertsMessageEnabled);
-                        void this.configuration.updateSetting(
-                            'allowUnauthorizedRemoteConnection',
-                            true,
-                            undefined,
-                            ConfigurationTarget.Workspace
-                        );
+                        this.configuration
+                            .updateSetting(
+                                'allowUnauthorizedRemoteConnection',
+                                true,
+                                undefined,
+                                ConfigurationTarget.Workspace
+                            )
+                            .catch(noop);
                     } else if (value === closeOption) {
                         sendTelemetryEvent(Telemetry.SelfCertsMessageClose);
                     }
-                });
+                })
+                .then(noop, noop);
             return KernelInterpreterDependencyResponse.failed;
         } else if (isCancellationError(err)) {
             // Don't show the message for cancellation errors
@@ -333,11 +336,11 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
                 kernelConnection.interpreter?.sysPrefix
             );
             if (failureInfo) {
-                void this.showMessageWithMoreInfo(failureInfo?.message, failureInfo?.moreInfoLink);
+                this.showMessageWithMoreInfo(failureInfo?.message, failureInfo?.moreInfoLink).catch(noop);
             } else {
                 // These are generic errors, we have no idea what went wrong,
                 // hence add a descriptive prefix (message), that provides more context to the user.
-                void this.showMessageWithMoreInfo(getUserFriendlyErrorMessage(err, errorContext));
+                this.showMessageWithMoreInfo(getUserFriendlyErrorMessage(err, errorContext)).catch(noop);
             }
             return KernelInterpreterDependencyResponse.failed;
         }

--- a/src/platform/errors/kernelProcessExitedError.ts
+++ b/src/platform/errors/kernelProcessExitedError.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { DataScience } from '../common/utils/localize';
 import { KernelConnectionMetadata } from '../../kernels/types';
 import { BaseKernelError } from './types';
 
@@ -9,8 +8,13 @@ export class KernelProcessExitedError extends BaseKernelError {
     constructor(
         public readonly exitCode: number = -1,
         public override readonly stdErr: string,
-        kernelConnectionMetadata: KernelConnectionMetadata
+        kernelConnectionMetadata: KernelConnectionMetadata,
+        message: string = ''
     ) {
-        super('kerneldied', DataScience.kernelDied().format(stdErr.trim()), kernelConnectionMetadata);
+        super(
+            'kerneldied',
+            message || 'Kernel Died Don with stack' + (new Error('').stack || ''),
+            kernelConnectionMetadata
+        );
     }
 }

--- a/src/platform/errors/kernelProcessExitedError.ts
+++ b/src/platform/errors/kernelProcessExitedError.ts
@@ -2,19 +2,15 @@
 // Licensed under the MIT License.
 
 import { KernelConnectionMetadata } from '../../kernels/types';
+import { DataScience } from '../common/utils/localize';
 import { BaseKernelError } from './types';
 
 export class KernelProcessExitedError extends BaseKernelError {
     constructor(
         public readonly exitCode: number = -1,
         public override readonly stdErr: string,
-        kernelConnectionMetadata: KernelConnectionMetadata,
-        message: string = ''
+        kernelConnectionMetadata: KernelConnectionMetadata
     ) {
-        super(
-            'kerneldied',
-            message || 'Kernel Died Don with stack' + (new Error('').stack || ''),
-            kernelConnectionMetadata
-        );
+        super('kerneldied', DataScience.kernelDied().format(stdErr.trim()), kernelConnectionMetadata);
     }
 }

--- a/src/platform/export/exportFileOpener.ts
+++ b/src/platform/export/exportFileOpener.ts
@@ -11,6 +11,7 @@ import { Telemetry, PYTHON_LANGUAGE } from '../common/constants';
 import { IFileSystem } from '../common/platform/types';
 import { IBrowserService } from '../common/types';
 import * as localize from '../common/utils/localize';
+import { noop } from '../common/utils/misc';
 import { ExportFormat } from './types';
 
 @injectable()
@@ -69,7 +70,7 @@ export class ExportFileOpener {
 
         if (selected === yes) {
             if (openDirectly) {
-                void this.documentManager.showTextDocument(uri);
+                this.documentManager.showTextDocument(uri).then(noop, noop);
             } else {
                 this.browserService.launch(uri.toString());
             }

--- a/src/platform/progress/kernelProgressReporter.ts
+++ b/src/platform/progress/kernelProgressReporter.ts
@@ -189,34 +189,36 @@ export class KernelProgressReporter implements IExtensionSyncActivationService {
                 return;
             }
             shownOnce = true;
-            void window.withProgress(
-                { location: ProgressLocation.Notification, title },
-                async (progress, token: CancellationToken) => {
-                    const info = KernelProgressReporter.instance!.kernelResourceProgressReporter.get(key);
-                    if (!info) {
-                        return;
-                    }
-                    info.reporter = progress;
-                    // If we have any messages, then report them.
-                    while (info.pendingProgress.length > 0) {
-                        const message = info.pendingProgress.shift();
-                        if (message === title) {
-                            info.progressList.push(message);
-                        } else if (message !== title && message) {
-                            info.progressList.push(message);
-                            progress.report({ message });
+            window
+                .withProgress(
+                    { location: ProgressLocation.Notification, title },
+                    async (progress, token: CancellationToken) => {
+                        const info = KernelProgressReporter.instance!.kernelResourceProgressReporter.get(key);
+                        if (!info) {
+                            return;
                         }
+                        info.reporter = progress;
+                        // If we have any messages, then report them.
+                        while (info.pendingProgress.length > 0) {
+                            const message = info.pendingProgress.shift();
+                            if (message === title) {
+                                info.progressList.push(message);
+                            } else if (message !== title && message) {
+                                info.progressList.push(message);
+                                progress.report({ message });
+                            }
+                        }
+                        await Promise.race([
+                            createPromiseFromCancellation({ token, cancelAction: 'resolve', defaultValue: true }),
+                            deferred.promise
+                        ]);
+                        if (KernelProgressReporter.instance!.kernelResourceProgressReporter.get(key) === info) {
+                            KernelProgressReporter.instance!.kernelResourceProgressReporter.delete(key);
+                        }
+                        KernelProgressReporter.disposables.delete(disposable);
                     }
-                    await Promise.race([
-                        createPromiseFromCancellation({ token, cancelAction: 'resolve', defaultValue: true }),
-                        deferred.promise
-                    ]);
-                    if (KernelProgressReporter.instance!.kernelResourceProgressReporter.get(key) === info) {
-                        KernelProgressReporter.instance!.kernelResourceProgressReporter.delete(key);
-                    }
-                    KernelProgressReporter.disposables.delete(disposable);
-                }
-            );
+                )
+                .then(noop, noop);
         };
 
         KernelProgressReporter.instance!.kernelResourceProgressReporter.set(key, {

--- a/src/platform/progress/statusProvider.ts
+++ b/src/platform/progress/statusProvider.ts
@@ -6,6 +6,7 @@ import { Disposable, ProgressLocation, ProgressOptions } from 'vscode';
 
 import { IApplicationShell } from '../common/application/types';
 import { createDeferred, Deferred } from '../common/utils/async';
+import { noop } from '../common/utils/misc';
 import { IStatusProvider } from './types';
 
 class StatusItem implements Disposable {
@@ -69,15 +70,17 @@ export class StatusProvider implements IStatusProvider {
         };
 
         // Set our application shell status with a busy icon
-        void this.applicationShell.withProgress(progressOptions, (_p, c) => {
-            if (c && cancel) {
-                c.onCancellationRequested(() => {
-                    cancel();
-                    statusItem.reject();
-                });
-            }
-            return statusItem.promise();
-        });
+        this.applicationShell
+            .withProgress(progressOptions, (_p, c) => {
+                if (c && cancel) {
+                    c.onCancellationRequested(() => {
+                        cancel();
+                        statusItem.reject();
+                    });
+                }
+                return statusItem.promise();
+            })
+            .then(noop, noop);
 
         return statusItem;
     }

--- a/src/platform/terminals/codeExecution/codeExecutionHelper.ts
+++ b/src/platform/terminals/codeExecution/codeExecutionHelper.ts
@@ -8,6 +8,7 @@ import { IApplicationShell, IDocumentManager } from '../../common/application/ty
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import { IServiceContainer } from '../../ioc/types';
 import { ICodeExecutionHelper } from '../types';
+import { noop } from '../../common/utils/misc';
 
 export class CodeExecutionHelperBase implements ICodeExecutionHelper {
     protected readonly documentManager: IDocumentManager;
@@ -25,15 +26,17 @@ export class CodeExecutionHelperBase implements ICodeExecutionHelper {
     public async getFileToExecute(): Promise<Uri | undefined> {
         const activeEditor = this.documentManager.activeTextEditor;
         if (!activeEditor) {
-            void this.applicationShell.showErrorMessage('No open file to run in terminal');
+            this.applicationShell.showErrorMessage('No open file to run in terminal').then(noop, noop);
             return;
         }
         if (activeEditor.document.isUntitled) {
-            void this.applicationShell.showErrorMessage('The active file needs to be saved before it can be run');
+            this.applicationShell
+                .showErrorMessage('The active file needs to be saved before it can be run')
+                .then(noop, noop);
             return;
         }
         if (activeEditor.document.languageId !== PYTHON_LANGUAGE) {
-            void this.applicationShell.showErrorMessage('The active file is not a Python source file');
+            this.applicationShell.showErrorMessage('The active file is not a Python source file').then(noop, noop);
             return;
         }
         if (activeEditor.document.isDirty) {

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -157,7 +157,6 @@ export function sendKernelTelemetryWhenDone<P extends IEventNamePropertyMapping,
                     );
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     incrementStartFailureCount(resource, eventName as any, props);
-                    return Promise.reject(ex);
                 }
             )
             .finally(() => {

--- a/src/test/common/process/pythonProcess.unit.test.ts
+++ b/src/test/common/process/pythonProcess.unit.test.ts
@@ -125,6 +125,6 @@ suite('PythonProcessService', () => {
 
         const result = procs.execModule(moduleName, args, options);
 
-        void expect(result).to.eventually.be.rejectedWith(`Module '${moduleName}' not installed`);
+        await expect(result).to.eventually.be.rejectedWith(`Module '${moduleName}' not installed`);
     });
 });

--- a/src/test/datascience/debugger.vscode.test.ts
+++ b/src/test/datascience/debugger.vscode.test.ts
@@ -5,7 +5,7 @@ import * as sinon from 'sinon';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from '../../platform/vscode-path/path';
-import { sleep } from '../core';
+import { noop, sleep } from '../core';
 import { ICommandManager, IVSCodeNotebook } from '../../platform/common/application/types';
 import { IDisposable } from '../../platform/common/types';
 import { captureScreenShot, IExtensionTestApi, waitForCondition } from '../common.node';
@@ -259,7 +259,7 @@ suite('VSCode Notebook - Run By Line', function () {
         const doc = vscodeNotebook.activeNotebookEditor?.notebook!;
         const cell = doc.getCells()[0];
 
-        void commandManager.executeCommand(Commands.RunByLine, cell);
+        commandManager.executeCommand(Commands.RunByLine, cell).then(noop, noop);
         const { debugAdapter } = await getDebugSessionAndAdapter(debuggingManager, doc);
 
         await waitForStoppedEvent(debugAdapter!);
@@ -274,7 +274,7 @@ suite('VSCode Notebook - Run By Line', function () {
         assert.isFalse(getCellOutputs(cell).includes('final output'), `Final line did run even with an interrupt`);
 
         // Start over and make sure we can execute all lines
-        void commandManager.executeCommand(Commands.RunByLine, cell);
+        commandManager.executeCommand(Commands.RunByLine, cell).then(noop, noop);
         const { debugAdapter: debugAdapter2 } = await getDebugSessionAndAdapter(debuggingManager, doc);
         await waitForStoppedEvent(debugAdapter2!);
         await waitForCondition(

--- a/src/test/datascience/editor-integration/codewatcher.unit.test.ts
+++ b/src/test/datascience/editor-integration/codewatcher.unit.test.ts
@@ -45,6 +45,7 @@ import { Commands, EditorContexts } from '../../../platform/common/constants';
 import { IDataScienceErrorHandler } from '../../../platform/errors/types';
 import { SystemVariables } from '../../../platform/common/variables/systemVariables.node';
 import { IDebugLocationTracker } from '../../../kernels/debugger/types';
+import { noop } from '../../core';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -609,7 +610,7 @@ testing3`;
             })
             .verifiable(TypeMoq.Times.exactly(2));
 
-        void codeWatcher.runAllCells();
+        codeWatcher.runAllCells().then(noop, noop);
         await codeWatcher.runAllCells();
 
         expect(funcOrder).deep.equals(expectedFuncOrder);

--- a/src/test/datascience/interactiveDebugging.vscode.common.ts
+++ b/src/test/datascience/interactiveDebugging.vscode.common.ts
@@ -25,7 +25,7 @@ import { IInteractiveWindowProvider } from '../../interactive-window/types';
 import { Commands } from '../../platform/common/constants';
 import { IVariableViewProvider } from '../../webviews/extension-side/variablesView/types';
 import { pythonIWKernelDebugAdapter } from '../../kernels/debugger/constants';
-import { isWeb } from '../../platform/common/utils/misc';
+import { isWeb, noop } from '../../platform/common/utils/misc';
 
 export type DebuggerType = 'VSCodePythonDebugger' | 'JupyterProtocolDebugger';
 
@@ -131,7 +131,7 @@ export function sharedIWDebuggerTests(
                 assert.ok(codeLenses, `No code lenses found`);
                 assert.equal(codeLenses.length, 3, `Wrong number of code lenses found`);
                 const args = codeLenses[2].command!.arguments || [];
-                void vscode.commands.executeCommand(codeLenses[2].command!.command, ...args);
+                vscode.commands.executeCommand(codeLenses[2].command!.command, ...args).then(noop, noop);
 
                 // Wait for breakpoint to be hit
                 await waitForCondition(
@@ -200,7 +200,7 @@ export function sharedIWDebuggerTests(
                 assert.ok(codeLenses, `No code lenses found`);
                 assert.equal(codeLenses.length, 3, `Wrong number of code lenses found`);
                 let args = codeLenses[2].command!.arguments || [];
-                void vscode.commands.executeCommand(codeLenses[2].command!.command, ...args);
+                vscode.commands.executeCommand(codeLenses[2].command!.command, ...args).then(noop, noop);
 
                 // Wait for breakpoint to be hit
                 await waitForCondition(
@@ -215,7 +215,7 @@ export function sharedIWDebuggerTests(
                 stopped = false;
                 // Continue and wait for stopped.
                 args = codeLenses[0].command!.arguments || [];
-                void vscode.commands.executeCommand(codeLenses[0].command!.command, ...args);
+                vscode.commands.executeCommand(codeLenses[0].command!.command, ...args).then(noop, noop);
                 await waitForCondition(
                     async () => {
                         return stoppedOnBreakpoint && stopped;
@@ -259,7 +259,7 @@ export function sharedIWDebuggerTests(
                 assert.ok(codeLenses, `No code lenses found`);
                 assert.equal(codeLenses.length, 3, `Wrong number of code lenses found`);
                 let args = codeLenses[2].command!.arguments || [];
-                void vscode.commands.executeCommand(codeLenses[2].command!.command, ...args);
+                vscode.commands.executeCommand(codeLenses[2].command!.command, ...args).then(noop, noop);
 
                 // Wait for breakpoint to be hit
                 await waitForCondition(
@@ -276,7 +276,7 @@ export function sharedIWDebuggerTests(
                 stopped = false;
                 // Continue and wait for stopped.
                 args = codeLenses[2].command!.arguments || [];
-                void vscode.commands.executeCommand(codeLenses[2].command!.command, ...args);
+                vscode.commands.executeCommand(codeLenses[2].command!.command, ...args).then(noop, noop);
                 await waitForCondition(
                     async () => {
                         return stopped;
@@ -300,7 +300,7 @@ export function sharedIWDebuggerTests(
                 stopped = false;
                 // Continue and wait for stopped.
                 args = codeLenses[2].command!.arguments || [];
-                void vscode.commands.executeCommand(codeLenses[2].command!.command, ...args);
+                vscode.commands.executeCommand(codeLenses[2].command!.command, ...args).then(noop, noop);
                 await waitForCondition(
                     async () => {
                         return stopped;
@@ -315,7 +315,7 @@ export function sharedIWDebuggerTests(
                 stopped = false;
                 // Continue and wait for stopped.
                 args = codeLenses[2].command!.arguments || [];
-                void vscode.commands.executeCommand(codeLenses[2].command!.command, ...args);
+                vscode.commands.executeCommand(codeLenses[2].command!.command, ...args).then(noop, noop);
                 await waitForCondition(
                     async () => {
                         return stopped;
@@ -362,7 +362,7 @@ export function sharedIWDebuggerTests(
                 assert.ok(codeLenses, `No code lenses found`);
                 assert.equal(codeLenses.length, 3, `Wrong number of code lenses found`);
                 let args = codeLenses[2].command!.arguments || [];
-                void vscode.commands.executeCommand(codeLenses[2].command!.command, ...args);
+                vscode.commands.executeCommand(codeLenses[2].command!.command, ...args).then(noop, noop);
 
                 // Wait for breakpoint to be hit
                 await waitForCondition(
@@ -424,7 +424,7 @@ b = 200
                 assert.ok(codeLenses, `No code lenses found`);
                 assert.equal(codeLenses.length, 3, `Wrong number of code lenses found`);
                 let args = codeLenses[2].command!.arguments || [];
-                void vscode.commands.executeCommand(codeLenses[2].command!.command, ...args);
+                vscode.commands.executeCommand(codeLenses[2].command!.command, ...args).then(noop, noop);
 
                 // Wait for breakpoint to be hit
                 await waitForCondition(
@@ -485,7 +485,7 @@ def foo():
                 assert.ok(codeLenses, `No code lenses found`);
                 assert.equal(codeLenses.length, 3, `Wrong number of code lenses found`);
                 let args = codeLenses[2].command!.arguments || [];
-                void vscode.commands.executeCommand(codeLenses[2].command!.command, ...args);
+                vscode.commands.executeCommand(codeLenses[2].command!.command, ...args).then(noop, noop);
 
                 // Wait for breakpoint to be hit
                 await waitForCondition(
@@ -510,7 +510,7 @@ def foo():
                 stoppedOnLine = false;
                 targetLine = 7;
 
-                void vscode.commands.executeCommand('workbench.action.debug.stepInto');
+                vscode.commands.executeCommand('workbench.action.debug.stepInto').then(noop, noop);
                 await waitForCondition(
                     async () => {
                         return stopped;
@@ -563,7 +563,7 @@ foo()
                 const debugCellCodeLenses = codeLenses.filter((c) => c.command?.command === Commands.DebugCell);
                 const debugCellCodeLens = debugCellCodeLenses[1];
                 let args = debugCellCodeLens.command!.arguments || [];
-                void vscode.commands.executeCommand(debugCellCodeLens.command!.command, ...args);
+                vscode.commands.executeCommand(debugCellCodeLens.command!.command, ...args).then(noop, noop);
 
                 // Wait for breakpoint to be hit
                 await waitForCondition(
@@ -588,7 +588,7 @@ foo()
                 stoppedOnLine = false;
                 targetLine = 4;
 
-                void vscode.commands.executeCommand('workbench.action.debug.stepInto');
+                vscode.commands.executeCommand('workbench.action.debug.stepInto').then(noop, noop);
                 await waitForCondition(
                     async () => {
                         return stopped;

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -414,10 +414,10 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
             .reverse()
             .find((cell) => cell.kind == NotebookCellKind.Code)!;
         await waitForExecutionCompletedSuccessfully(lastCodeCell);
-        const sysExecutable = getCellOutputs(lastCodeCell).trim().toLowerCase();
+        const sysExecutable = Uri.file(getCellOutputs(lastCodeCell).trim());
 
         assert.ok(
-            areInterpreterPathsSame(venvNoRegPath, Uri.file(sysExecutable)),
+            areInterpreterPathsSame(venvNoRegPath, sysExecutable),
             `Python paths do not match ${venvNoRegPath}, ${sysExecutable}.`
         );
     });
@@ -548,7 +548,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         nbFile = await createTemporaryNotebookFromFile(templateIPynbFile, disposables);
         await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath, venvNoRegPath, 'DoNotInstallIPyKernel');
     });
-    test('Should be prompted to re-install ipykernel when restarting a kernel from which ipykernel was uninstalled (VSCode Notebook)', async function () {
+    test.only('Should be prompted to re-install ipykernel when restarting a kernel from which ipykernel was uninstalled (VSCode Notebook)', async function () {
         if (IS_REMOTE_NATIVE_TEST()) {
             return this.skip();
         }
@@ -560,7 +560,21 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         // Un-install IpyKernel
         console.log('Step2');
         await uninstallIPyKernel(venvPythonPath.fsPath);
-
+        await sleep(5_000);
+        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
+        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
+        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
+        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
+        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
+        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
+        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
+        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
+        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
+        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
+        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
+        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
+        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
+        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
         // Now that IPyKernel is missing, if we attempt to restart a kernel, we should get a prompt.
         // Previously things just hang at weird spots, its not a likely scenario, but this test ensures the code works as expected.
 

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -548,7 +548,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         nbFile = await createTemporaryNotebookFromFile(templateIPynbFile, disposables);
         await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath, venvNoRegPath, 'DoNotInstallIPyKernel');
     });
-    test.only('Should be prompted to re-install ipykernel when restarting a kernel from which ipykernel was uninstalled (VSCode Notebook)', async function () {
+    test('Should be prompted to re-install ipykernel when restarting a kernel from which ipykernel was uninstalled (VSCode Notebook)', async function () {
         if (IS_REMOTE_NATIVE_TEST()) {
             return this.skip();
         }
@@ -561,20 +561,6 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         console.log('Step2');
         await uninstallIPyKernel(venvPythonPath.fsPath);
         await sleep(5_000);
-        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
-        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
-        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
-        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
-        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
-        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
-        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
-        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
-        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
-        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
-        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
-        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
-        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
-        console.error('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
         // Now that IPyKernel is missing, if we attempt to restart a kernel, we should get a prompt.
         // Previously things just hang at weird spots, its not a likely scenario, but this test ensures the code works as expected.
 

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -347,7 +347,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
             promptOptions.dismissPrompt = true;
             delete promptOptions.text;
             // In tests, things hang as the IW isn't focused.
-            void activeInteractiveWindow.show(false);
+            activeInteractiveWindow.show(false).then(noop, noop);
             await waitForKernelToChange({ interpreterPath: venvNoRegPath, isInteractiveController: true });
             return true;
         } as any);

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -560,7 +560,6 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         // Un-install IpyKernel
         console.log('Step2');
         await uninstallIPyKernel(venvPythonPath.fsPath);
-        await sleep(5_000);
         // Now that IPyKernel is missing, if we attempt to restart a kernel, we should get a prompt.
         // Previously things just hang at weird spots, its not a likely scenario, but this test ensures the code works as expected.
 

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -560,6 +560,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         // Un-install IpyKernel
         console.log('Step2');
         await uninstallIPyKernel(venvPythonPath.fsPath);
+
         // Now that IPyKernel is missing, if we attempt to restart a kernel, we should get a prompt.
         // Previously things just hang at weird spots, its not a likely scenario, but this test ensures the code works as expected.
 

--- a/src/test/datascience/mockJupyterRequest.ts
+++ b/src/test/datascience/mockJupyterRequest.ts
@@ -7,7 +7,7 @@ import { CancellationToken } from 'vscode-jsonrpc';
 import { ICell } from '../../platform/common/types';
 
 import { createDeferred, Deferred } from '../../platform/common/utils/async';
-import { noop } from '../../platform/common/utils/misc';
+import { noop, swallowExceptions } from '../../platform/common/utils/misc';
 import { concatMultilineString } from '../../webviews/webview-side/common';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -307,9 +307,9 @@ export class MockJupyterRequestICell implements Kernel.IFuture<any, any> {
                     .then((r) => {
                         // If there's a message, send it.
                         if (r.message && r.message.channel === 'iopub' && this.onIOPub) {
-                            void this.onIOPub(r.message as KernelMessage.IIOPubMessage);
+                            swallowExceptions(() => this.onIOPub(r.message as KernelMessage.IIOPubMessage));
                         } else if (r.message && r.message.channel === 'stdin' && this.onStdin) {
-                            void this.onStdin(r.message as KernelMessage.IStdinMessage);
+                            swallowExceptions(() => this.onStdin(r.message as KernelMessage.IStdinMessage));
                         }
 
                         // Move onto the next producer if allowed
@@ -334,7 +334,7 @@ export class MockJupyterRequestICell implements Kernel.IFuture<any, any> {
             replyProducer
                 .produceNextMessage()
                 .then((r) => {
-                    void this.onReply((<any>r.message) as KernelMessage.IShellMessage);
+                    swallowExceptions(() => this.onReply((<any>r.message) as KernelMessage.IShellMessage));
                 })
                 .ignoreErrors();
 
@@ -453,9 +453,9 @@ export class MockJupyterRequest implements Kernel.IFuture<any, any> {
                     .then((r) => {
                         // If there's a message, send it.
                         if (r.message && r.message.channel === 'iopub' && this.onIOPub) {
-                            void this.onIOPub(r.message as KernelMessage.IIOPubMessage);
+                            swallowExceptions(() => this.onIOPub(r.message as KernelMessage.IIOPubMessage));
                         } else if (r.message && r.message.channel === 'stdin' && this.onStdin) {
-                            void this.onStdin(r.message as KernelMessage.IStdinMessage);
+                            swallowExceptions(() => this.onStdin(r.message as KernelMessage.IStdinMessage));
                         }
 
                         // Move onto the next producer if allowed
@@ -480,7 +480,7 @@ export class MockJupyterRequest implements Kernel.IFuture<any, any> {
             replyProducer
                 .produceNextMessage()
                 .then((r) => {
-                    void this.onReply((<any>r.message) as KernelMessage.IShellMessage);
+                    swallowExceptions(() => this.onReply((<any>r.message) as KernelMessage.IShellMessage));
                 })
                 .ignoreErrors();
 

--- a/src/test/datascience/notebook/executionService.vscode.test.ts
+++ b/src/test/datascience/notebook/executionService.vscode.test.ts
@@ -99,7 +99,6 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
             await startJupyterServer();
             await createEmptyPythonNotebook(disposables);
             assert.isOk(vscodeNotebook.activeNotebookEditor, 'No active notebook');
-            // Verify the selected
             traceInfo(`Start Test (completed) ${this.currentTest?.title}`);
         } catch (e) {
             await captureScreenShot(this.currentTest?.title || 'unknown');

--- a/src/test/datascience/notebook/executionService.vscode.test.ts
+++ b/src/test/datascience/notebook/executionService.vscode.test.ts
@@ -45,7 +45,7 @@ import {
     createTemporaryNotebookFromFile
 } from './helper.node';
 import { openNotebook } from '../helpers.node';
-import { noop } from '../../../platform/common/utils/misc';
+import { noop, swallowExceptions } from '../../../platform/common/utils/misc';
 import { getDisplayPath } from '../../../platform/common/platform/fs-paths';
 import { ProductNames } from '../../../kernels/installer/productNames';
 import { Product } from '../../../kernels/installer/types';
@@ -99,6 +99,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
             await startJupyterServer();
             await createEmptyPythonNotebook(disposables);
             assert.isOk(vscodeNotebook.activeNotebookEditor, 'No active notebook');
+            // Verify the selected
             traceInfo(`Start Test (completed) ${this.currentTest?.title}`);
         } catch (e) {
             await captureScreenShot(this.currentTest?.title || 'unknown');
@@ -1218,7 +1219,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
                 cell = await insertMarkdownCell(`Markdown Cell ${index}`, { index: index });
             }
 
-            cellInfo.push({ runToCompletion: () => fs.unlinkSync(tmpFile), cell });
+            cellInfo.push({ runToCompletion: () => swallowExceptions(() => fs.unlinkSync(tmpFile)), cell });
         }
 
         return cellInfo;

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -54,7 +54,6 @@ import { IVSCodeNotebookController } from '../../../notebooks/controllers/types'
 import { IS_SMOKE_TEST } from '../../constants';
 import * as urlPath from '../../../platform/vscode-path/resources';
 import * as uuid from 'uuid/v4';
-import { swallowExceptions } from '../../../platform/common/utils/misc';
 import { IFileSystem, IPlatformService } from '../../../platform/common/platform/types';
 import { initialize, waitForCondition } from '../../common';
 import { VSCodeNotebook } from '../../../platform/common/application/notebook';
@@ -171,7 +170,9 @@ async function createTemporaryNotebookFromNotebook(
     await workspace.fs.writeFile(uri, Buffer.from(JSON.stringify(notebook)));
 
     disposables.push({
-        dispose: () => swallowExceptions(() => workspace.fs.delete(uri))
+        dispose: () => {
+            void workspace.fs.delete(uri).then(noop, noop);
+        }
     });
     return uri;
 }
@@ -997,7 +998,7 @@ export async function hijackPrompt(
                     }
                     clickButton.resolve(buttonToClick.text);
                 }
-                return buttonToClick.dismissPrompt ? undefined : clickButton.promise;
+                return buttonToClick.dismissPrompt ? Promise.resolve(undefined) : clickButton.promise;
             }
         }
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/test/datascience/notebook/kernelSelection.vscode.test.ts
+++ b/src/test/datascience/notebook/kernelSelection.vscode.test.ts
@@ -37,6 +37,7 @@ import {
 } from './helper.node';
 import { getOSType, OSType } from '../../../platform/common/utils/platform';
 import { getTextOutputValue } from '../../../kernels/execution/helpers';
+import { noop } from '../../core';
 
 /* eslint-disable no-invalid-this, , , @typescript-eslint/no-explicit-any */
 suite('DataScience - VSCode Notebook - Kernel Selection', function () {
@@ -331,7 +332,7 @@ suite('DataScience - VSCode Notebook - Kernel Selection', function () {
         await waitForKernelToChange({ interpreterPath: venvNoRegPythonPath });
 
         // Clear the cells & execute again
-        void commands.executeCommand('notebook.clearAllCellsOutputs');
+        commands.executeCommand('notebook.clearAllCellsOutputs').then(noop, noop);
         await waitForCondition(async () => cell.outputs.length === 0, 5_000, 'Cell did not get cleared');
         await Promise.all([
             runAllCellsInActiveNotebook(),

--- a/src/test/datascience/widgets/commUtils.ts
+++ b/src/test/datascience/widgets/commUtils.ts
@@ -7,6 +7,7 @@ import { traceInfo } from '../../../platform/logging';
 import { IDisposable, IDisposableRegistry } from '../../../platform/common/types';
 import { createDeferred } from '../../../platform/common/utils/async';
 import { IServiceContainer } from '../../../platform/ioc/types';
+import { noop } from '../../core';
 
 export function initializeWidgetComms(serviceContainer: IServiceContainer): Utils {
     const disposables = serviceContainer.get<IDisposableRegistry>(IDisposableRegistry);
@@ -51,7 +52,7 @@ export class Utils {
         };
         const editor = await this.editorPromise;
         traceInfo(`Sending message to Widget renderer ${JSON.stringify(request)}`);
-        void this.messageChannel.postMessage!(request, editor);
+        this.messageChannel.postMessage!(request, editor).then(noop, noop);
         return new Promise<string>((resolve, reject) => {
             const disposable = this.messageChannel.onDidReceiveMessage(({ message }) => {
                 traceInfo(`Received message (query) from Widget renderer ${JSON.stringify(message)}`);
@@ -76,7 +77,7 @@ export class Utils {
         };
         const editor = await this.editorPromise;
         traceInfo(`Sending message to Widget renderer ${JSON.stringify(request)}`);
-        void this.messageChannel.postMessage!(request, editor);
+        this.messageChannel.postMessage!(request, editor).then(noop, noop);
         return new Promise<void>((resolve, reject) => {
             const disposable = this.messageChannel.onDidReceiveMessage(({ message }) => {
                 traceInfo(`Received message (click) from Widget renderer ${JSON.stringify(message)}`);
@@ -102,7 +103,7 @@ export class Utils {
         };
         const editor = await this.editorPromise;
         traceInfo(`Sending message to Widget renderer ${JSON.stringify(request)}`);
-        void this.messageChannel.postMessage!(request, editor);
+        this.messageChannel.postMessage!(request, editor).then(noop, noop);
         return new Promise<void>((resolve, reject) => {
             const disposable = this.messageChannel.onDidReceiveMessage(({ message }) => {
                 traceInfo(`Received message (setValue) from Widget renderer ${JSON.stringify(message)}`);

--- a/src/test/initialize.node.ts
+++ b/src/test/initialize.node.ts
@@ -7,6 +7,7 @@ import { PythonExtension, setTestExecution } from '../platform/common/constants'
 import { activateExtension, closeActiveWindows } from './initialize';
 import { IS_REMOTE_NATIVE_TEST } from './constants';
 import { ServerConnectionType } from '../kernels/jupyter/launcher/serverConnectionType';
+import { noop } from './core';
 
 export * from './initialize';
 export * from './constants.node';
@@ -40,7 +41,7 @@ export async function initialize(): Promise<IExtensionTestApi> {
         await startJupyterServer();
     }
     if (IS_REMOTE_NATIVE_TEST()) {
-        void api.serviceContainer.get<ServerConnectionType>(ServerConnectionType).setIsLocalLaunch(false);
+        api.serviceContainer.get<ServerConnectionType>(ServerConnectionType).setIsLocalLaunch(false).then(noop, noop);
     }
     return api;
 }

--- a/src/test/initialize.ts
+++ b/src/test/initialize.ts
@@ -6,6 +6,7 @@ import { IDisposable } from '../platform/common/types';
 import { sleep } from '../platform/common/utils/async';
 import { clearPendingTimers, IExtensionTestApi } from './common';
 import { IS_SMOKE_TEST, JVSC_EXTENSION_ID_FOR_TESTS } from './constants';
+import { noop } from './core';
 
 export function isInsiders() {
     return vscode.env.appName.indexOf('Insider') > 0 || vscode.env.appName.indexOf('OSS') > 0;
@@ -57,7 +58,7 @@ async function closeWindowsInternal() {
     // If there are no editors, we can skip. This seems to time out if no editors visible.
     if (!vscode.window.visibleTextEditors || !isANotebookOpen()) {
         // Instead just post the command
-        void vscode.commands.executeCommand('workbench.action.closeAllEditors');
+        vscode.commands.executeCommand('workbench.action.closeAllEditors').then(noop, noop);
         return;
     }
 

--- a/src/webviews/extension-side/dataviewer/dataViewer.node.ts
+++ b/src/webviews/extension-side/dataviewer/dataViewer.node.ts
@@ -305,7 +305,7 @@ export class DataViewer extends WebviewPanelHost<IDataViewerMapping> implements 
                 this.dispose();
             }
             traceError(e);
-            void this.errorHandler.handleError(e);
+            this.errorHandler.handleError(e).then(noop, noop);
         } finally {
             this.sendElapsedTimeTelemetry();
         }

--- a/src/webviews/extension-side/dataviewer/dataViewerFactory.ts
+++ b/src/webviews/extension-side/dataviewer/dataViewerFactory.ts
@@ -13,6 +13,7 @@ import { ContextKey } from '../../../platform/common/contextKey';
 import { IAsyncDisposable, IAsyncDisposableRegistry, IDisposableRegistry } from '../../../platform/common/types';
 import { IServiceContainer } from '../../../platform/ioc/types';
 import { EditorContexts, Commands, Telemetry } from '../../webview-side/common/constants';
+import { noop } from '../../../platform/common/utils/misc';
 
 @injectable()
 export class DataViewerFactory implements IDataViewerFactory, IAsyncDisposable {
@@ -89,7 +90,7 @@ export class DataViewerFactory implements IDataViewerFactory, IAsyncDisposable {
         for (const viewer of this.knownViewers) {
             if (viewer.active) {
                 // There should only be one of these
-                void viewer.refreshData();
+                viewer.refreshData().then(noop, noop);
             }
         }
     }, 1000);

--- a/src/webviews/extension-side/plotting/plotViewer.node.ts
+++ b/src/webviews/extension-side/plotting/plotViewer.node.ts
@@ -22,6 +22,7 @@ import * as localize from '../../../platform/common/utils/localize';
 import { EXTENSION_ROOT_DIR } from '../../../platform/constants.node';
 import { WebviewPanelHost } from '../webviewPanelHost.node';
 import { joinPath } from '../../../platform/vscode-path/resources';
+import { noop } from '../../../platform/common/utils/misc';
 
 const plotDir = joinPath(Uri.file(EXTENSION_ROOT_DIR), 'out', 'webviews', 'webview-side', 'viewers');
 @injectable()
@@ -152,7 +153,7 @@ export class PlotViewer extends WebviewPanelHost<IPlotViewerMapping> implements 
             }
         } catch (e) {
             traceError(e);
-            void this.applicationShell.showErrorMessage(localize.DataScience.exportImageFailed().format(e));
+            this.applicationShell.showErrorMessage(localize.DataScience.exportImageFailed().format(e)).then(noop, noop);
         }
     }
 }

--- a/src/webviews/extension-side/renderer/index.ts
+++ b/src/webviews/extension-side/renderer/index.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { isTestExecution } from '../../../platform/common/constants';
 import { IDisposable } from '../../../platform/common/types';
 import { getCollectionJSON } from '../../../platform/common/utils/localize';
+import { noop } from '../../../platform/common/utils/misc';
 
 const enum MessageType {
     ExtensionInit = 1,
@@ -38,21 +39,25 @@ export class ExtensionSideRenderer implements IDisposable {
         );
 
         // broadcast extension init message
-        void this.errorRendererMessage.postMessage({
-            type: MessageType.ExtensionInit
-        });
+        this.errorRendererMessage
+            .postMessage({
+                type: MessageType.ExtensionInit
+            })
+            .then(noop, noop);
     }
 
     loadLoc(editor: vscode.NotebookEditor) {
         const locStrings = isTestExecution() ? '{}' : getCollectionJSON();
 
-        void this.errorRendererMessage.postMessage(
-            {
-                type: MessageType.LoadLoc,
-                data: locStrings
-            },
-            editor
-        );
+        this.errorRendererMessage
+            .postMessage(
+                {
+                    type: MessageType.LoadLoc,
+                    data: locStrings
+                },
+                editor
+            )
+            .then(noop, noop);
     }
 
     dispose(): void {

--- a/src/webviews/extension-side/variablesView/variableView.ts
+++ b/src/webviews/extension-side/variablesView/variableView.ts
@@ -35,6 +35,7 @@ import { DataViewerChecker } from '../dataviewer/dataViewerChecker';
 import { IJupyterVariableDataProviderFactory, IDataViewerFactory, IDataViewer } from '../dataviewer/types';
 import { WebviewViewHost } from '../webviewViewHost';
 import { swallowExceptions } from '../../../platform/common/utils/decorators';
+import { noop } from '../../../platform/common/utils/misc';
 
 // This is the client side host for the native notebook variable view webview
 // It handles passing messages to and from the react view as well as the connection
@@ -170,7 +171,7 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
         } catch (e) {
             traceError(e);
             sendTelemetryEvent(Telemetry.FailedShowDataViewer);
-            void this.appShell.showErrorMessage(localize.DataScience.showDataViewerFail());
+            this.appShell.showErrorMessage(localize.DataScience.showDataViewerFail()).then(noop, noop);
         }
     }
 

--- a/src/webviews/extension-side/variablesView/variableView.ts
+++ b/src/webviews/extension-side/variablesView/variableView.ts
@@ -34,6 +34,7 @@ import { Telemetry } from '../../webview-side/common/constants';
 import { DataViewerChecker } from '../dataviewer/dataViewerChecker';
 import { IJupyterVariableDataProviderFactory, IDataViewerFactory, IDataViewer } from '../dataviewer/types';
 import { WebviewViewHost } from '../webviewViewHost';
+import { swallowExceptions } from '../../../platform/common/utils/decorators';
 
 // This is the client side host for the native notebook variable view webview
 // It handles passing messages to and from the react view as well as the connection
@@ -151,6 +152,7 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
     }
 
     // Handle a request from the react UI to show our data viewer. Public for testing
+    @swallowExceptions()
     public async showDataViewer(request: IShowDataViewer): Promise<IDataViewer | undefined> {
         try {
             if (
@@ -174,6 +176,7 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
 
     // Variables for the current active editor are being requested, check that we have a valid active notebook
     // and use the variables interface to fetch them and pass them to the variable view UI
+    @swallowExceptions()
     private async requestVariables(args: IJupyterVariablesRequest): Promise<void> {
         const activeNotebook = this.notebookWatcher.activeKernel;
         if (activeNotebook) {


### PR DESCRIPTION
This PR fixes all of the unhandled promise rejections we have.
Also ensures we have a CI check to ensure we don't end up with new promise rejections.

Basically unhandled promises are bad and could potentially kill the process. In the Python extension we used to keep all of these clean (i.e. ensure we never had any unhandled promise rejections).
