### PR TITLE
Ensure we select remote kernels in tests

### DIFF
--- a/src/test/datascience/helpers.ts
+++ b/src/test/datascience/helpers.ts
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { assert } from 'chai';
 import * as vscode from 'vscode';
 import { getFilePath } from '../../platform/common/platform/fs-paths';
 import { traceInfo } from '../../platform/logging';
@@ -21,6 +22,9 @@ import { IInteractiveWindowProvider, IInteractiveWindow } from '../../interactiv
 import { Commands } from '../../platform/common/constants';
 import { sleep } from '../core';
 import { arePathsSame } from '../../platform/common/platform/fileUtils';
+import { IS_REMOTE_NATIVE_TEST } from '../constants';
+import { isWeb } from '../../platform/common/utils/misc';
+import { INotebookControllerManager } from '../../notebooks/types';
 
 export async function openNotebook(ipynbFile: vscode.Uri) {
     traceInfo(`Opening notebook ${getFilePath(ipynbFile)}`);
@@ -134,7 +138,8 @@ export async function submitFromPythonFile(
         untitledPythonFile.uri
     )) as InteractiveWindow;
     await activeInteractiveWindow.addCode(source, untitledPythonFile.uri, 0).catch(noop);
-    await waitForInteractiveWindow(activeInteractiveWindow);
+    const notebook = await waitForInteractiveWindow(activeInteractiveWindow);
+    await verifySelectedControllerIsRemoteForRemoteTests(notebook);
     return { activeInteractiveWindow, untitledPythonFile };
 }
 
@@ -271,4 +276,26 @@ export async function waitForCodeLenses(document: vscode.Uri, command: string) {
     );
 
     return codeLenses;
+}
+
+export async function verifySelectedControllerIsRemoteForRemoteTests(notebook?: vscode.NotebookDocument) {
+    if (!IS_REMOTE_NATIVE_TEST() || !isWeb()) {
+        return;
+    }
+    notebook = notebook || vscode.window.activeNotebookEditor!.notebook;
+    const api = await initialize();
+    const controller = api.serviceContainer
+        .get<INotebookControllerManager>(INotebookControllerManager)
+        .getSelectedNotebookController(notebook);
+    if (!controller) {
+        return;
+    }
+    if (
+        controller.connection.kind !== 'connectToLiveRemoteKernel' &&
+        controller.connection.kind !== 'startUsingRemoteKernelSpec'
+    ) {
+        assert.fail(
+            `Notebook Controller is not a remote controller, it is ${controller.connection.kind}:${controller.id}`
+        );
+    }
 }

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -62,6 +62,7 @@ import { initialize, waitForCondition } from '../../common';
 import { VSCodeNotebook } from '../../../platform/common/application/notebook';
 import { IDebuggingManager, IKernelDebugAdapter } from '../../../kernels/debugger/types';
 import { PythonKernelCompletionProvider } from '../../../intellisense/pythonKernelCompletionProvider';
+import { verifySelectedControllerIsRemoteForRemoteTests } from '../helpers';
 
 // Running in Conda environments, things can be a little slower.
 export const defaultNotebookTestTimeout = 60_000;
@@ -242,6 +243,7 @@ export async function createEmptyPythonNotebook(
     assert.isOk(vscodeNotebook.activeNotebookEditor, 'No active notebook');
     if (!dontWaitForKernel) {
         await waitForKernelToGetAutoSelected();
+        await verifySelectedControllerIsRemoteForRemoteTests();
     }
     await deleteAllCellsAndWait();
     return vscodeNotebook.activeNotebookEditor!.notebook;


### PR DESCRIPTION
Fixes #9859

All this PR does is, ensures our tests will always use Remote Kernel specs/sessions when running tests against remote servers.
At one point in time the tests were using local kernlespecs even when we were running remote tests, this ensures we verify the selected controller.