### PR TITLE
Drop fnv algorithm on Web first.

### DIFF
--- a/src/platform/common/crypto.node.ts
+++ b/src/platform/common/crypto.node.ts
@@ -5,14 +5,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { injectable } from 'inversify';
-import { IHashFormat } from './types';
+import { ICryptoUtils, IHashFormat } from './types';
 import { CryptoUtils } from './crypto';
+import { traceError } from '../logging';
 
 /**
  * Implements tools related to cryptography
  */
 @injectable()
-export class CryptoUtilsNode extends CryptoUtils {
+export class CryptoUtilsNode extends CryptoUtils implements ICryptoUtils {
     public override createHash<E extends keyof IHashFormat>(
         data: string,
         hashFormat: E,
@@ -21,7 +22,14 @@ export class CryptoUtilsNode extends CryptoUtils {
         if (algorithm === 'FNV') {
             // eslint-disable-next-line @typescript-eslint/no-require-imports
             const fnv = require('@enonic/fnv-plus');
-            let hash = fnv.fast1a32hex(data) as string;
+            const hash = fnv.fast1a32hex(data) as string;
+            if (hashFormat === 'number') {
+                const result = parseInt(hash, 16);
+                if (isNaN(result)) {
+                    traceError(`Number hash for data '${data}' is NaN`);
+                }
+                return result as any;
+            }
             return hash as any;
         }
 

--- a/src/platform/common/crypto.node.ts
+++ b/src/platform/common/crypto.node.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { injectable } from 'inversify';
+import { IHashFormat } from './types';
+import { CryptoUtils } from './crypto';
+
+/**
+ * Implements tools related to cryptography
+ */
+@injectable()
+export class CryptoUtilsNode extends CryptoUtils {
+    public override createHash<E extends keyof IHashFormat>(
+        data: string,
+        hashFormat: E,
+        algorithm: 'SHA512' | 'SHA256' | 'FNV' = 'FNV'
+    ): IHashFormat[E] {
+        if (algorithm === 'FNV') {
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            const fnv = require('@enonic/fnv-plus');
+            let hash = fnv.fast1a32hex(data) as string;
+            return hash as any;
+        }
+
+        return super.createHash(data, hashFormat, algorithm);
+    }
+}

--- a/src/platform/common/crypto.ts
+++ b/src/platform/common/crypto.ts
@@ -17,14 +17,10 @@ export class CryptoUtils implements ICryptoUtils {
     public createHash<E extends keyof IHashFormat>(
         data: string,
         hashFormat: E,
-        algorithm: 'SHA512' | 'SHA256' | 'FNV' = 'FNV'
+        algorithm: 'SHA512' | 'SHA256' = 'SHA256'
     ): IHashFormat[E] {
         let hash: string;
-        if (algorithm === 'FNV') {
-            // eslint-disable-next-line @typescript-eslint/no-require-imports
-            const fnv = require('@enonic/fnv-plus');
-            hash = fnv.fast1a32hex(data) as string;
-        } else if (algorithm === 'SHA256') {
+        if (algorithm === 'SHA256') {
             hash = hashjs.sha256().update(data).digest('hex');
         } else {
             hash = hashjs.sha512().update(data).digest('hex');

--- a/src/platform/common/serviceRegistry.node.ts
+++ b/src/platform/common/serviceRegistry.node.ts
@@ -28,6 +28,7 @@ import {
     IVSCodeNotebook
 } from './application/types';
 import { AsyncDisposableRegistry } from './asyncDisposableRegistry';
+import { CryptoUtils } from './crypto';
 import { CryptoUtilsNode } from './crypto.node';
 import { ExperimentService } from './experiments/service';
 import { FeatureDeprecationManager } from './featureDeprecationManager';
@@ -73,6 +74,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<ILanguageService>(ILanguageService, LanguageService);
     serviceManager.addSingleton<IBrowserService>(IBrowserService, BrowserService);
     serviceManager.addSingleton<IHttpClient>(IHttpClient, HttpClient);
+    serviceManager.addSingleton<CryptoUtils>(CryptoUtils, CryptoUtils);
     serviceManager.addSingleton<ICryptoUtils>(ICryptoUtils, CryptoUtilsNode);
     serviceManager.addSingleton<IExperimentService>(IExperimentService, ExperimentService);
     serviceManager.addSingleton<ITerminalManager>(ITerminalManager, TerminalManager);

--- a/src/platform/common/serviceRegistry.node.ts
+++ b/src/platform/common/serviceRegistry.node.ts
@@ -28,7 +28,7 @@ import {
     IVSCodeNotebook
 } from './application/types';
 import { AsyncDisposableRegistry } from './asyncDisposableRegistry';
-import { CryptoUtils } from './crypto';
+import { CryptoUtilsNode } from './crypto.node';
 import { ExperimentService } from './experiments/service';
 import { FeatureDeprecationManager } from './featureDeprecationManager';
 import { BrowserService } from './net/browser';
@@ -73,7 +73,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<ILanguageService>(ILanguageService, LanguageService);
     serviceManager.addSingleton<IBrowserService>(IBrowserService, BrowserService);
     serviceManager.addSingleton<IHttpClient>(IHttpClient, HttpClient);
-    serviceManager.addSingleton<ICryptoUtils>(ICryptoUtils, CryptoUtils);
+    serviceManager.addSingleton<ICryptoUtils>(ICryptoUtils, CryptoUtilsNode);
     serviceManager.addSingleton<IExperimentService>(IExperimentService, ExperimentService);
     serviceManager.addSingleton<ITerminalManager>(ITerminalManager, TerminalManager);
 

--- a/src/test/common/crypto.unit.test.ts
+++ b/src/test/common/crypto.unit.test.ts
@@ -6,20 +6,20 @@
 import { assert, expect } from 'chai';
 import * as fs from 'fs-extra';
 import * as path from '../../platform/vscode-path/path';
-import { CryptoUtils } from '../../platform/common/crypto';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants.node';
+import { CryptoUtilsNode } from '../../platform/common/crypto.node';
 
 const RANDOM_WORDS = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src', 'test', 'common', 'randomWords.txt');
 
 // eslint-disable-next-line
 suite('Crypto Utils', async () => {
-    let crypto: CryptoUtils;
+    let crypto: CryptoUtilsNode;
     let wordsText: string;
     suiteSetup(async () => {
         wordsText = await fs.readFile(RANDOM_WORDS, 'utf8');
     });
     setup(() => {
-        crypto = new CryptoUtils();
+        crypto = new CryptoUtilsNode();
     });
     async function getRandomWords(): Promise<string[]> {
         return wordsText.split('\n');


### PR DESCRIPTION
First step for https://github.com/microsoft/vscode-jupyter/issues/10358, dropping the fnv hash algorithm for the Web platform. Migration for the desktop version can come later.


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
