### PR TITLE
Move KernelConnector. 

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -7682,7 +7682,7 @@ No properties for event
 
 ## Locations Used
 
-[src/kernels/kernelConnector.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/kernels/kernelConnector.ts)
+[src/notebooks/controllers/kernelConnector.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/notebooks/controllers/kernelConnector.ts)
 ```typescript
         const rawNotebookProvider = serviceContainer.tryGet<IRawNotebookProvider>(IRawNotebookProvider);
         const rawLocalKernel = rawNotebookProvider?.isSupported && isLocal;

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -63,7 +63,7 @@ import { generateInteractiveCode } from './helpers';
 import { IVSCodeNotebookController } from '../notebooks/controllers/types';
 import { DisplayOptions } from '../kernels/displayOptions';
 import { getInteractiveCellMetadata } from './helpers';
-import { KernelConnector } from '../kernels/kernelConnector';
+import { KernelConnector } from '../notebooks/controllers/kernelConnector';
 import { getFilePath } from '../platform/common/platform/fs-paths';
 import {
     ICodeGeneratorFactory,

--- a/src/kernels/kernelCommandListener.ts
+++ b/src/kernels/kernelCommandListener.ts
@@ -16,7 +16,7 @@ import { IKernel, IKernelProvider } from './types';
 import { IInteractiveWindowProvider } from '../interactive-window/types';
 import { IDataScienceErrorHandler } from '../platform/errors/types';
 import { DisplayOptions } from './displayOptions';
-import { KernelConnector } from './kernelConnector';
+import { KernelConnector } from '../notebooks/controllers/kernelConnector';
 import { getDisplayPath } from '../platform/common/platform/fs-paths';
 import { endCellAndDisplayErrorsInCell } from './execution/helpers';
 import { getAssociatedNotebookDocument } from './helpers';

--- a/src/notebooks/controllers/kernelConnector.ts
+++ b/src/notebooks/controllers/kernelConnector.ts
@@ -11,28 +11,28 @@ import {
     KernelInterpreterDependencyResponse,
     KernelAction,
     KernelActionSource
-} from './types';
+} from '../../kernels/types';
 import { Memento, NotebookDocument, NotebookController, Uri } from 'vscode';
-import { ICommandManager, IApplicationShell } from '../platform/common/application/types';
-import { traceVerbose, traceWarning } from '../platform/logging';
-import { Resource, IMemento, GLOBAL_MEMENTO, IDisplayOptions, IDisposable } from '../platform/common/types';
-import { createDeferred, createDeferredFromPromise, Deferred } from '../platform/common/utils/async';
-import { DataScience } from '../platform/common/utils/localize';
-import { sendKernelTelemetryEvent } from '../telemetry/telemetry';
-import { IServiceContainer } from '../platform/ioc/types';
-import { Telemetry, Commands } from '../webviews/webview-side/common/constants';
-import { clearInstalledIntoInterpreterMemento } from './installer/productInstaller';
-import { Product } from './installer/types';
-import { INotebookControllerManager, INotebookEditorProvider } from '../notebooks/types';
-import { selectKernel } from '../notebooks/controllers/kernelSelector';
-import { KernelDeadError } from '../platform/errors/kernelDeadError';
-import { noop } from '../platform/common/utils/misc';
-import { IDataScienceErrorHandler } from '../platform/errors/types';
-import { IStatusProvider } from '../platform/progress/types';
-import { IRawNotebookProvider } from './raw/types';
-import { IVSCodeNotebookController } from '../notebooks/controllers/types';
-import { getDisplayNameOrNameOfKernelConnection } from './helpers';
-import { isCancellationError } from '../platform/common/cancellation';
+import { ICommandManager, IApplicationShell } from '../../platform/common/application/types';
+import { traceVerbose, traceWarning } from '../../platform/logging';
+import { Resource, IMemento, GLOBAL_MEMENTO, IDisplayOptions, IDisposable } from '../../platform/common/types';
+import { createDeferred, createDeferredFromPromise, Deferred } from '../../platform/common/utils/async';
+import { DataScience } from '../../platform/common/utils/localize';
+import { sendKernelTelemetryEvent } from '../../telemetry/telemetry';
+import { IServiceContainer } from '../../platform/ioc/types';
+import { Telemetry, Commands } from '../../webviews/webview-side/common/constants';
+import { clearInstalledIntoInterpreterMemento } from '../../kernels/installer/productInstaller';
+import { Product } from '../../kernels/installer/types';
+import { INotebookControllerManager, INotebookEditorProvider } from '../types';
+import { selectKernel } from './kernelSelector';
+import { KernelDeadError } from '../../platform/errors/kernelDeadError';
+import { noop } from '../../platform/common/utils/misc';
+import { IDataScienceErrorHandler } from '../../platform/errors/types';
+import { IStatusProvider } from '../../platform/progress/types';
+import { IRawNotebookProvider } from '../../kernels/raw/types';
+import { IVSCodeNotebookController } from './types';
+import { getDisplayNameOrNameOfKernelConnection } from '../../kernels/helpers';
+import { isCancellationError } from '../../platform/common/cancellation';
 
 /**
  * Class used for connecting a controller to an instance of an IKernel

--- a/src/notebooks/controllers/vscodeNotebookController.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.ts
@@ -84,7 +84,7 @@ import {
     sendNotebookOrKernelLanguageTelemetry
 } from '../../platform/common/utils';
 import { ConsoleForegroundColors, TraceOptions } from '../../platform/logging/types';
-import { KernelConnector } from '../../kernels/kernelConnector';
+import { KernelConnector } from './kernelConnector';
 import { IVSCodeNotebookController } from './types';
 import { ILocalResourceUriConverter } from '../../kernels/ipywidgets-message-coordination/types';
 import { isCancellationError } from '../../platform/common/cancellation';

--- a/src/platform/api/kernelApi.ts
+++ b/src/platform/api/kernelApi.ts
@@ -26,7 +26,7 @@ import {
     WebSocketData
 } from './extension';
 import { JupyterNotebookView, Telemetry } from '../common/constants';
-import { KernelConnector } from '../../kernels/kernelConnector';
+import { KernelConnector } from '../../notebooks/controllers/kernelConnector';
 import { DisplayOptions } from '../../kernels/displayOptions';
 import { IServiceContainer } from '../ioc/types';
 import { IExportedKernelServiceFactory } from './types';


### PR DESCRIPTION
For #10152 

KernelConnector class finds kernels for notebook controllers. Thought it make sense to just move this.
 
