### PR TITLE
Remove noop from external dependencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -265,7 +265,7 @@ module.exports = {
         ],
         'react/jsx-uses-vars': 'error',
         'react/jsx-uses-react': 'error',
-        'no-restricted-imports': ['error', { paths: ['lodash', 'rxjs'] }],
+        'no-restricted-imports': ['error', { paths: ['lodash', 'rxjs', 'lodash/noop'] }],
         'import/no-restricted-paths': [
             'error',
             {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -265,7 +265,7 @@ module.exports = {
         ],
         'react/jsx-uses-vars': 'error',
         'react/jsx-uses-react': 'error',
-        'no-restricted-imports': ['error', { paths: ['lodash', 'rxjs', 'lodash/noop'] }],
+        'no-restricted-imports': ['error', { paths: ['lodash', 'rxjs', 'lodash/noop', 'rxjs/util/noop'] }],
         'import/no-restricted-paths': [
             'error',
             {

--- a/src/kernels/execution/notebookUpdater.ts
+++ b/src/kernels/execution/notebookUpdater.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import noop = require('lodash/noop');
 import { isPromise } from 'rxjs/internal-compatibility';
 import { NotebookDocument, NotebookEditor, workspace, WorkspaceEdit, window } from 'vscode';
 import { createDeferred } from '../../platform/common/utils/async';
+import { noop } from '../../platform/common/utils/misc';
 
 /**
  * Use this class to perform updates on all cells.

--- a/src/notebooks/controllers/remoteSwitcher.ts
+++ b/src/notebooks/controllers/remoteSwitcher.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import noop = require('lodash/noop');
 import { StatusBarAlignment, StatusBarItem } from 'vscode';
 import { IExtensionSingleActivationService } from '../../platform/activation/types';
 import {
@@ -19,6 +18,7 @@ import { INotebookControllerManager } from '../types';
 import { IJupyterServerUriStorage } from '../../kernels/jupyter/types';
 import { Settings } from '../../platform/common/constants';
 import { isJupyterNotebook } from '../../platform/common/utils';
+import { noop } from '../../platform/common/utils/misc';
 
 @injectable()
 export class RemoteSwitcher implements IExtensionSingleActivationService {

--- a/src/platform/api/pythonApi.ts
+++ b/src/platform/api/pythonApi.ts
@@ -18,7 +18,6 @@ import {
 } from './types';
 import * as localize from '../common/utils/localize';
 import { injectable, inject } from 'inversify';
-import { noop } from 'rxjs/util/noop';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { IWorkspaceService, IApplicationShell, ICommandManager } from '../common/application/types';
 import { isCI, PythonExtension, Telemetry } from '../common/constants';
@@ -30,6 +29,7 @@ import { IInterpreterSelector, IInterpreterQuickPickItem } from '../interpreter/
 import { IInterpreterService } from '../interpreter/contracts';
 import { areInterpreterPathsSame } from '../pythonEnvironments/info/interpreter';
 import { TraceOptions } from '../logging/types';
+import { noop } from '../common/utils/misc';
 
 export function deserializePythonEnvironment(
     pythonVersion: Partial<PythonEnvironment_PythonApi> | undefined

--- a/src/test/datascience/helpers.ts
+++ b/src/test/datascience/helpers.ts
@@ -6,7 +6,6 @@ import { assert } from 'chai';
 import * as vscode from 'vscode';
 import { getFilePath } from '../../platform/common/platform/fs-paths';
 import { traceInfo } from '../../platform/logging';
-import noop = require('lodash/noop');
 import { IPythonApiProvider } from '../../platform/api/types';
 import { IJupyterSettings, Resource } from '../../platform/common/types';
 import { InteractiveWindow } from '../../interactive-window/interactiveWindow';
@@ -20,7 +19,7 @@ import {
 import { IDataScienceCodeLensProvider } from '../../interactive-window/editor-integration/types';
 import { IInteractiveWindowProvider, IInteractiveWindow } from '../../interactive-window/types';
 import { Commands } from '../../platform/common/constants';
-import { sleep } from '../core';
+import { noop, sleep } from '../core';
 import { arePathsSame } from '../../platform/common/platform/fileUtils';
 import { IS_REMOTE_NATIVE_TEST } from '../constants';
 import { isWeb } from '../../platform/common/utils/misc';

--- a/src/test/datascience/mockCommandManager.ts
+++ b/src/test/datascience/mockCommandManager.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
-import noop = require('lodash/noop');
 import { Disposable, TextEditor, TextEditorEdit } from 'vscode';
 
 import { ICommandNameArgumentTypeMapping } from '../../platform/common/application/commands';
 import { ICommandManager } from '../../platform/common/application/types';
+import { noop } from '../core';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, , no-multi-str,  */
 export class MockCommandManager implements ICommandManager {

--- a/src/test/datascience/raw-kernel/rawKernel.functional.test.ts
+++ b/src/test/datascience/raw-kernel/rawKernel.functional.test.ts
@@ -8,7 +8,6 @@ suite('Dummy13', () => {
     });
 });
 // import { assert } from 'chai';
-// import { noop } from 'jquery';
 // import * as portfinder from 'portfinder';
 // import * as uuid from 'uuid/v4';
 // import { IPythonExtensionChecker } from '../../../platform/api/types';


### PR DESCRIPTION
Re https://github.com/microsoft/vscode-jupyter/issues/10307

We don't need external modules to offer noop ;) 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
