### PR TITLE
Exclude momentjs locale files

### DIFF
--- a/build/webpack/webpack.extension.node.config.js
+++ b/build/webpack/webpack.extension.node.config.js
@@ -120,7 +120,7 @@ const config = {
         new copyWebpackPlugin({ patterns: [{ from: './node_modules/@vscode/jupyter-ipywidgets/dist/*.js' }] }),
         new webpack.IgnorePlugin({
             resourceRegExp: /^\.\/locale$/,
-            contextRegExp: /moment$/,
+            contextRegExp: /moment$/
         })
     ],
     resolve: {

--- a/build/webpack/webpack.extension.node.config.js
+++ b/build/webpack/webpack.extension.node.config.js
@@ -117,7 +117,11 @@ const config = {
         new copyWebpackPlugin({ patterns: [{ from: './node_modules/zeromq/**/*.node' }] }),
         new copyWebpackPlugin({ patterns: [{ from: './node_modules/zeromq/**/*.json' }] }),
         new copyWebpackPlugin({ patterns: [{ from: './node_modules/node-gyp-build/**/*' }] }),
-        new copyWebpackPlugin({ patterns: [{ from: './node_modules/@vscode/jupyter-ipywidgets/dist/*.js' }] })
+        new copyWebpackPlugin({ patterns: [{ from: './node_modules/@vscode/jupyter-ipywidgets/dist/*.js' }] }),
+        new webpack.IgnorePlugin({
+            resourceRegExp: /^\.\/locale$/,
+            contextRegExp: /moment$/,
+        })
     ],
     resolve: {
         alias: {

--- a/build/webpack/webpack.extension.node.config.js
+++ b/build/webpack/webpack.extension.node.config.js
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 
+const webpack = require('webpack');
 const copyWebpackPlugin = require('copy-webpack-plugin');
 const removeFilesWebpackPlugin = require('remove-files-webpack-plugin');
 const path = require('path');

--- a/build/webpack/webpack.extension.web.config.js
+++ b/build/webpack/webpack.extension.web.config.js
@@ -103,7 +103,11 @@ const config = {
                 platform: JSON.stringify('web')
             }
         }),
-        new CleanTerminalPlugin()
+        new CleanTerminalPlugin(),
+        new webpack.IgnorePlugin({
+            resourceRegExp: /^\.\/locale$/,
+            contextRegExp: /moment$/,
+        })
     ],
     resolve: {
         extensions: ['.ts', '.js'],

--- a/build/webpack/webpack.extension.web.config.js
+++ b/build/webpack/webpack.extension.web.config.js
@@ -106,7 +106,7 @@ const config = {
         new CleanTerminalPlugin(),
         new webpack.IgnorePlugin({
             resourceRegExp: /^\.\/locale$/,
-            contextRegExp: /moment$/,
+            contextRegExp: /moment$/
         })
     ],
     resolve: {


### PR DESCRIPTION
As https://github.com/microsoft/vscode-jupyter/pull/10384 pointed it, excluding `moment` module will break the jupyter lab module. A safe way is excluding the localized files since we are not using jupyterlab on UIs.

Changes:

* Ignore localized files as suggested in Webpack offical doc https://webpack.js.org/plugins/ignore-plugin/#example-of-ignoring-moment-locales

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
