### PR TITLE
Idea to bypass unexpected usages of the localize function

### DIFF
--- a/src/platform/common/utils/localize.ts
+++ b/src/platform/common/utils/localize.ts
@@ -14,7 +14,7 @@ nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFo
 // - Only use this nlsLocalize function, but name it `localize`.
 // - Change the signature of the localize properties in this file to not be functions but constants.
 //   - Instead of `Common.bannerLabelYes()`, make them `Common.bannerLabelYes`.
-const standardLocalize = nls.loadMessageBundle();
+let localize = nls.loadMessageBundle();
 
 // Embed all known translations so we can use them on the web too
 const packageBaseNlsJson = require('../../../../package.nls.json');
@@ -38,7 +38,9 @@ export function localizeReplacement(key: string | nls.LocalizeInfo, defaultValue
 }
 
 const osType = getOSType();
-const localize = osType === OSType.Unknown ? localizeReplacement : standardLocalize;
+if (osType === OSType.Unknown) {
+    localize = localizeReplacement;
+}
 
 // External callers of localize use these tables to retrieve localized values.
 


### PR DESCRIPTION
This is an idea to bypass the type checks that were complaining that we were using the exported localize function in unexpected ways. I don't know if this will work, but something has to work, since the alternative is to have a full copy of this file for each: Node and the web.