### PR TITLE
fix test coverage filter

### DIFF
--- a/src/test/coverage.node.ts
+++ b/src/test/coverage.node.ts
@@ -19,7 +19,7 @@ export function setupCoverage() {
     const nyc = new NYC({
         cwd: path.join(EXTENSION_ROOT_DIR_FOR_TESTS),
         extension: ['.ts'],
-        include: ['**/src/platform/**/*.ts', '**/out/platform/**/*.js'],
+        include: ['**/src/**/*.ts', '**/out/**/*.js'],
         exclude: ['**/test/**', '.vscode-test/**', '**/ipywidgets/**', '**/node_modules/**'],
         reporter: reports,
         'report-dir': path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'coverage'),


### PR DESCRIPTION
Currently we only generate coverage for platform folder.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
