### PR TITLE
Fixing bundle destination paths

### DIFF
--- a/build/azure-pipeline.pre-release.yml
+++ b/build/azure-pipeline.pre-release.yml
@@ -23,7 +23,7 @@ extends:
   template: azure-pipelines/extension/pre-release.yml@templates
   parameters:
     locTsConfigs: $(Build.SourcesDirectory)/tsconfig.json
-    locBundleDestination: $(Build.SourcesDirectory)/out/client
+    locBundleDestination: $(Build.SourcesDirectory)/out
     buildSteps:
       - script: npm ci
         displayName: Install dependencies

--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -19,7 +19,7 @@ extends:
   parameters:
     publishExtension: true
     locTsConfigs: $(Build.SourcesDirectory)/tsconfig.json
-    locBundleDestination: $(Build.SourcesDirectory)/out/client
+    locBundleDestination: $(Build.SourcesDirectory)/out
     buildSteps:
       - script: npm ci
         displayName: Install dependencies


### PR DESCRIPTION
Although localization is generally working, I'm getting `Failed to load message bundle` in several cases. Upon reading [the guide](https://github.com/microsoft/vscode-engineering/wiki/Extensions-Localization#verification), it says:

> This is likely because the path to the tsconfig(s) isn't correct. Double check that the path actually points to where the tsconfig.json is. Keep in mind that $(Build.SourcesDirectory) points to your repo root so if you have multiple extensions in your repo, you need to add the additional paths to point to the root of the extension.
> 
> I've also seen things like the CleanWebpackPlugin which ensures a clean out/dist dir before bundling interfere because first we add the nls files to your output folder and then we compile your extension.

So, I wonder if this would help.