### PR TITLE
Webpack loader must be in  module -> rules -> use: <here>

### DIFF
--- a/build/webpack/webpack.extension.node.config.js
+++ b/build/webpack/webpack.extension.node.config.js
@@ -26,12 +26,6 @@ const config = {
     module: {
         rules: [
             {
-                loader: 'vscode-nls-dev/lib/webpack-loader',
-                options: {
-                    base: constants.ExtensionRootDir
-                }
-            },
-            {
                 // JupyterServices imports node-fetch.
                 test: /@jupyterlab[\\\/]services[\\\/].*js$/,
                 use: [
@@ -43,6 +37,12 @@ const config = {
             {
                 test: /\.ts$/,
                 use: [
+                    {
+                        loader: 'vscode-nls-dev/lib/webpack-loader',
+                        options: {
+                            base: constants.ExtensionRootDir
+                        }
+                    },
                     {
                         loader: path.join(__dirname, 'loaders', 'externalizeDependencies.js')
                     }


### PR DESCRIPTION
An oversight from me, since this is clearly stated in the guide: https://github.com/microsoft/vscode-engineering/wiki/Extensions-Localization#verification