### PR TITLE
Also allowing nls.metadata.header.json

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -97,6 +97,7 @@ out/webviews/webview-side/widgetTester/**
 out/pythonFiles/**
 out/src/**
 !out/src/**/*.nls.metadata.json
+!out/src/**/*.nls.metadata.header.json
 out/test/**
 precommit.hook
 pythonFiles/**/*.pyc


### PR DESCRIPTION
My previous PR https://github.com/microsoft/vscode-jupyter/pull/10411 did something effective: Now this file exists `.vscode/extensions/ms-toolsai.jupyter-2022.6.1001631438/out/src/platform/common/utils/localize.nls.metadata.json`.

However, it is still saying that it can't load properly `Failed to load message bundle for file /Users/user/.vscode/extensions/ms-toolsai.jupyter-2022.6.1001631438/out/src/platform/common/utils/localize`

Reading through the `vscode-nls`'s source code, I found out they also read this header files that they load from the localizations repo, I believe. Here's where the header file is loaded: https://github.com/microsoft/vscode-nls/blob/172e6fcaa6c5576562ae830da00f6383a30bbda6/src/node/main.ts#L365

Since I still don't see that header file in our build, I'm making another exception in the .vscodeignore