### PR TITLE
Adding the whole src to see if that makes a difference

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -95,9 +95,7 @@ out/webviews/webview-side/viewers/ipywidgets/**
 out/webviews/webview-side/viewers/index.*.html
 out/webviews/webview-side/widgetTester/**
 out/pythonFiles/**
-out/src/**
-!out/src/**/*.nls.metadata.json
-!out/src/**/*.nls.metadata.header.json
+!out/src/**
 out/test/**
 precommit.hook
 pythonFiles/**/*.pyc


### PR DESCRIPTION
The built extension still doesn't include the `nls.metadata.header.json` file, so I'm adding the whole `src` folder to see if I can back-track a cleaner solution from that position.