### PR TITLE
Exception in .vscodeignore for nls.bundle.*.json

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -112,3 +112,4 @@ typings/**
 types/**
 test-results*
 *.zip
+!**/*.nls.bundle.*.json


### PR DESCRIPTION
Hoping this will include the `nls.bundle.*.json` file in the VSIX