### PR TITLE
Localization-tolerant gulp clean

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -95,7 +95,7 @@ out/webviews/webview-side/viewers/ipywidgets/**
 out/webviews/webview-side/viewers/index.*.html
 out/webviews/webview-side/widgetTester/**
 out/pythonFiles/**
-!out/src/**
+out/src/**
 out/test/**
 precommit.hook
 pythonFiles/**/*.pyc
@@ -112,4 +112,4 @@ typings/**
 types/**
 test-results*
 *.zip
-!**/*.nls.bundle.*.json
+!nls.*.json

--- a/build/azure-pipeline.pre-release.yml
+++ b/build/azure-pipeline.pre-release.yml
@@ -28,8 +28,8 @@ extends:
       - script: npm ci
         displayName: Install dependencies
 
-    #   - script: gulp clean
-    #     displayName: Clean
+      - script: gulp clean
+        displayName: Clean
 
       - task: UsePythonVersion@0
         inputs:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -143,9 +143,7 @@ gulp.task('output:clean', () => del(['coverage']));
 
 gulp.task('clean:cleanExceptTests', () => del(['clean:vsix', 'out', '!out/test']));
 gulp.task('clean:vsix', () => del(['*.vsix']));
-gulp.task('clean:out', () =>
-    del(['out/**', '!out', '!out/client_renderer/**', '!out/nls.*.json', '!out/**/*.nls.metadata.json'])
-);
+gulp.task('clean:out', () => del(['out/**', '!out', '!out/client_renderer/**', '!nls.*.json']));
 
 gulp.task('clean', gulp.parallel('output:clean', 'clean:vsix', 'clean:out'));
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -143,7 +143,9 @@ gulp.task('output:clean', () => del(['coverage']));
 
 gulp.task('clean:cleanExceptTests', () => del(['clean:vsix', 'out', '!out/test']));
 gulp.task('clean:vsix', () => del(['*.vsix']));
-gulp.task('clean:out', () => del(['out/**', '!out', '!out/client_renderer/**']));
+gulp.task('clean:out', () =>
+    del(['out/**', '!out', '!out/client_renderer/**', '!out/nls.bundle.*.json', '!out/**/*.nls.metadata.json'])
+);
 
 gulp.task('clean', gulp.parallel('output:clean', 'clean:vsix', 'clean:out'));
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -144,7 +144,7 @@ gulp.task('output:clean', () => del(['coverage']));
 gulp.task('clean:cleanExceptTests', () => del(['clean:vsix', 'out', '!out/test']));
 gulp.task('clean:vsix', () => del(['*.vsix']));
 gulp.task('clean:out', () =>
-    del(['out/**', '!out', '!out/client_renderer/**', '!out/nls.bundle.*.json', '!out/**/*.nls.metadata.json'])
+    del(['out/**', '!out', '!out/client_renderer/**', '!out/nls.*.json', '!out/**/*.nls.metadata.json'])
 );
 
 gulp.task('clean', gulp.parallel('output:clean', 'clean:vsix', 'clean:out'));


### PR DESCRIPTION
Making the `gulp clean` command not delete the localization output.