### PR TITLE
Fix problem with asking for widget permission without modal

### DIFF
--- a/src/kernels/ipywidgets-message-coordination/commonMessageCoordinator.ts
+++ b/src/kernels/ipywidgets-message-coordination/commonMessageCoordinator.ts
@@ -187,20 +187,22 @@ export class CommonMessageCoordinator {
                     payload.moduleName,
                     payload.moduleVersion
                 );
-                this.appShell.showErrorMessage(errorMessage, ...[enableDownloads, moreInfo]).then((selection) => {
-                    switch (selection) {
-                        case moreInfo:
-                            this.appShell.openUrl('https://aka.ms/PVSCIPyWidgets');
-                            break;
-                        case enableDownloads:
-                            this.commandManager
-                                .executeCommand(Commands.EnableLoadingWidgetsFrom3rdPartySource)
-                                .then(noop, noop);
-                            break;
-                        default:
-                            break;
-                    }
-                }, noop);
+                this.appShell
+                    .showErrorMessage(errorMessage, { modal: true }, ...[enableDownloads, moreInfo])
+                    .then((selection) => {
+                        switch (selection) {
+                            case moreInfo:
+                                this.appShell.openUrl('https://aka.ms/PVSCIPyWidgets');
+                                break;
+                            case enableDownloads:
+                                this.commandManager
+                                    .executeCommand(Commands.EnableLoadingWidgetsFrom3rdPartySource)
+                                    .then(noop, noop);
+                                break;
+                            default:
+                                break;
+                        }
+                    }, noop);
             }
             traceError(`Widget load failure ${errorMessage}`, payload);
 


### PR DESCRIPTION
Widgets really only work if the user says 'yes' on the widget notification. This makes sure we ask modally.

As a result of that, we can't stick the markdown in the message but instead put it on the button.