### PR TITLE
Output metadata Id on new output

### DIFF
--- a/src/kernels/execution/helpers.ts
+++ b/src/kernels/execution/helpers.ts
@@ -35,6 +35,7 @@ import {
     kernelConnectionMetadataHasKernelModel,
     getKernelRegistrationInfo
 } from '../helpers';
+import * as uuid from 'uuid/v4';
 
 export enum CellOutputMimeTypes {
     error = 'application/vnd.code.notebook.error',
@@ -219,6 +220,7 @@ export function cellOutputToVSCCellOutput(output: nbformat.IOutput): NotebookCel
 function getOutputMetadata(output: nbformat.IOutput): CellOutputMetadata {
     // Add on transient data if we have any. This should be removed by our save functions elsewhere.
     const metadata: CellOutputMetadata = {
+        id: uuid(),
         outputType: output.output_type
     };
     if (output.transient) {
@@ -353,6 +355,7 @@ export type CellOutputMetadata = {
      * Whether to display the open plot icon.
      */
     __displayOpenPlotIcon?: boolean;
+    id?: string;
 };
 
 export function translateCellErrorOutput(output: NotebookCellOutput): nbformat.IError {

--- a/src/kernels/execution/helpers.ts
+++ b/src/kernels/execution/helpers.ts
@@ -355,6 +355,9 @@ export type CellOutputMetadata = {
      * Whether to display the open plot icon.
      */
     __displayOpenPlotIcon?: boolean;
+    /**
+     * A unique identifier to track a specific output.
+     */
     id?: string;
 };
 

--- a/src/webviews/extension-side/plotView/helpers.ts
+++ b/src/webviews/extension-side/plotView/helpers.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { NotebookCellOutput } from 'vscode';
+import { CellOutputMetadata } from '../../../kernels/execution/helpers';
+
+export function getCellOutputMetadata(cell?: NotebookCellOutput): CellOutputMetadata | undefined {
+    if (cell && cell.metadata !== undefined) {
+        return cell.metadata as CellOutputMetadata;
+    }
+}

--- a/src/webviews/extension-side/plotView/plotSaveHandler.node.ts
+++ b/src/webviews/extension-side/plotView/plotSaveHandler.node.ts
@@ -7,6 +7,7 @@ import { getDisplayPath } from '../../../platform/common/platform/fs-paths';
 import { IFileSystemNode } from '../../../platform/common/platform/types.node';
 import { DataScience } from '../../../platform/common/utils/localize';
 import { saveSvgToPdf } from '../plotting/plotViewer.node';
+import { getCellOutputMetadata } from './helpers';
 
 const svgMimeType = 'image/svg+xml';
 const imageExtensionForMimeType: Record<string, string> = {
@@ -96,7 +97,8 @@ export class PlotSaveHandler {
 function getOutputItem(notebook: NotebookDocument, outputId: string, mimeType: string): NotebookCellOutput | undefined {
     for (const cell of notebook.getCells()) {
         for (const output of cell.outputs) {
-            if (output.id !== outputId) {
+            const metadata = getCellOutputMetadata(output);
+            if (metadata && metadata.id !== outputId) {
                 continue;
             }
             if (output.items.find((item) => item.mime === mimeType)) {

--- a/src/webviews/extension-side/plotView/plotViewHandler.node.ts
+++ b/src/webviews/extension-side/plotView/plotViewHandler.node.ts
@@ -4,6 +4,7 @@ import { NotebookCellOutputItem, NotebookDocument } from 'vscode';
 import { traceError } from '../../../platform/logging';
 import { getDisplayPath } from '../../../platform/common/platform/fs-paths';
 import { IPlotViewerProvider } from '../plotting/types';
+import { getCellOutputMetadata } from './helpers';
 
 const svgMimeType = 'image/svg+xml';
 const pngMimeType = 'image/png';
@@ -44,7 +45,8 @@ function getOutputItem(
 ): NotebookCellOutputItem | undefined {
     for (const cell of notebook.getCells()) {
         for (const output of cell.outputs) {
-            if (output.id !== outputId) {
+            const metadata = getCellOutputMetadata(output);
+            if (metadata && metadata.id !== outputId) {
                 continue;
             }
             return output.items.find((item) => item.mime === mimeType);


### PR DESCRIPTION
This PR migrates off of the `output.id` used to view and save plots to the new `output.metadata.id`.

For this PR to work, the following two PRs would need to be merged:

- https://github.com/microsoft/vscode-notebook-renderers/pull/114
- [coming soon]

Fixes #9629