### PR TITLE
Fix variable viewer reload issues

### DIFF
--- a/news/2 Fixes/10240.md
+++ b/news/2 Fixes/10240.md
@@ -1,0 +1,1 @@
+Fix problem with variable view not refreshing when switching between tabs.

--- a/news/2 Fixes/10413.md
+++ b/news/2 Fixes/10413.md
@@ -1,0 +1,1 @@
+Fix problem with continuous progress bar in the 'Jupyter:Variables' window by making the jupyter extension load when this view is visible.

--- a/package.json
+++ b/package.json
@@ -71,7 +71,10 @@
         "onCommand:jupyter.runInDedicatedExtensionHost",
         "onWalkthrough:jupyterWelcome",
         "onNotebook:jupyter-notebook",
-        "onNotebook:interactive"
+        "onNotebook:interactive",
+        "onView:jupyterViewVariables",
+        "onWebviewPanel:jupyter-variables",
+        "onWebviewPanel:jupyter"
     ],
     "main": "./out/extension.node.js",
     "browser": "./out/extension.web.bundle.js",

--- a/src/kernels/types.ts
+++ b/src/kernels/types.ts
@@ -123,6 +123,10 @@ export function isLocalConnection(
 }
 
 export interface IKernel extends IAsyncDisposable {
+    /**
+     * Total execution count on this kernel
+     */
+    readonly executionCount: number;
     readonly uri: Uri;
     /**
      * In the case of Notebooks, this is the same as the Notebook Uri.

--- a/src/kernels/variables/debuggerVariables.ts
+++ b/src/kernels/variables/debuggerVariables.ts
@@ -76,7 +76,7 @@ export class DebuggerVariables
         }
 
         const result: IJupyterVariablesResponse = {
-            executionCount: request.executionCount,
+            executionCount: kernel ? kernel.executionCount : request.executionCount,
             pageStartIndex: 0,
             pageResponse: [],
             totalCount: 0,

--- a/src/kernels/variables/kernelVariables.ts
+++ b/src/kernels/variables/kernelVariables.ts
@@ -170,10 +170,14 @@ export class KernelVariables implements IJupyterVariables {
     ): Promise<IJupyterVariablesResponse> {
         // See if we already have the name list
         let list = this.cachedVariables.get(kernel.uri.toString());
-        if (!list || list.currentExecutionCount !== request.executionCount) {
+        if (
+            !list ||
+            list.currentExecutionCount !== request.executionCount ||
+            list.currentExecutionCount !== kernel.executionCount
+        ) {
             // Refetch the list of names from the notebook. They might have changed.
             list = {
-                currentExecutionCount: request.executionCount,
+                currentExecutionCount: kernel.executionCount,
                 variables: (await this.getVariableNamesAndTypesFromKernel(kernel)).map((v) => {
                     return {
                         name: v.name,
@@ -194,7 +198,7 @@ export class KernelVariables implements IJupyterVariables {
             : [];
 
         const result: IJupyterVariablesResponse = {
-            executionCount: request.executionCount,
+            executionCount: kernel.executionCount,
             pageStartIndex: -1,
             pageResponse: [],
             totalCount: 0,


### PR DESCRIPTION
Fixes #10240 
Fixes #10413

Package.json needed more activation events.
Variable requests when the window first reopens start with an execution count of zero. This was being propagated to each response regardless of what the execution count of the kernel actually was.