### PR TITLE
Service registration refactor part 2

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -8185,7 +8185,7 @@ No properties for event
 
 ## Locations Used
 
-[src/platform/common/globalActivation.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/platform/common/globalActivation.ts)
+[src/webviews/extension-side/globalActivation.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/webviews/extension-side/globalActivation.ts)
 ```typescript
                     resultSettings[k] = currentValue;
                 }
@@ -8990,7 +8990,7 @@ No properties for event
 
 ## Locations Used
 
-[src/platform/common/importTracker.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/platform/common/importTracker.node.ts)
+[src/webviews/extension-side/importTracker.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/webviews/extension-side/importTracker.node.ts)
 ```typescript
         // Hash the package name so that we will never accidentally see a
         // user's private package name.
@@ -9030,7 +9030,7 @@ No properties for event
 
 ## Locations Used
 
-[src/platform/common/importTracker.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/platform/common/importTracker.node.ts)
+[src/webviews/extension-side/importTracker.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/webviews/extension-side/importTracker.node.ts)
 ```typescript
         }
     }
@@ -9042,7 +9042,7 @@ No properties for event
 ```
 
 
-[src/platform/common/importTracker.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/platform/common/importTracker.node.ts)
+[src/webviews/extension-side/importTracker.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/webviews/extension-side/importTracker.node.ts)
 ```typescript
         this.lookForImports(lines);
     }
@@ -9054,7 +9054,7 @@ No properties for event
 ```
 
 
-[src/platform/common/importTracker.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/platform/common/importTracker.node.ts)
+[src/webviews/extension-side/importTracker.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/webviews/extension-side/importTracker.node.ts)
 ```typescript
         this.lookForImports(result);
     }

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -5831,7 +5831,7 @@ No properties for event
 
 ## Locations Used
 
-[src/platform/errors/jupyterInvalidKernelError.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/platform/errors/jupyterInvalidKernelError.ts)
+[src/kernels/errors/jupyterInvalidKernelError.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/kernels/errors/jupyterInvalidKernelError.ts)
 ```typescript
             DataScience.kernelInvalid().format(getDisplayNameOrNameOfKernelConnection(kernelConnectionMetadata)),
             kernelConnectionMetadata
@@ -6326,7 +6326,7 @@ No properties for event
 
 ## Locations Used
 
-[src/platform/errors/jupyterWaitForIdleError.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/platform/errors/jupyterWaitForIdleError.ts)
+[src/kernels/errors/jupyterWaitForIdleError.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/kernels/errors/jupyterWaitForIdleError.ts)
 ```typescript
 export class JupyterWaitForIdleError extends BaseKernelError {
     constructor(kernelConnectionMetadata: KernelConnectionMetadata) {

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -4152,7 +4152,7 @@ No properties for event
 ```
 
 
-[src/platform/errors/errorHandler.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/platform/errors/errorHandler.ts)
+[src/kernels/errors/kernelErrorHandler.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/kernels/errors/kernelErrorHandler.ts)
 ```typescript
                             )
                             .catch(noop);
@@ -4216,7 +4216,7 @@ No properties for event
 ```
 
 
-[src/platform/errors/errorHandler.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/platform/errors/errorHandler.ts)
+[src/kernels/errors/kernelErrorHandler.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/kernels/errors/kernelErrorHandler.ts)
 ```typescript
                 .showErrorMessage(DataScience.jupyterSelfCertFail().format(err.message), enableOption, closeOption)
                 .then((value) => {

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -3050,7 +3050,7 @@ No description provided
 
 ## Locations Used
 
-[src/platform/common/extensionRecommendation.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/platform/common/extensionRecommendation.node.ts)
+[src/webviews/extension-side/extensionRecommendation.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/webviews/extension-side/extensionRecommendation.node.ts)
 ```typescript
             `[${extensionInfo.displayName}](${extensionInfo.extensionLink})`,
             language
@@ -3062,7 +3062,7 @@ No description provided
 ```
 
 
-[src/platform/common/extensionRecommendation.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/platform/common/extensionRecommendation.node.ts)
+[src/webviews/extension-side/extensionRecommendation.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/webviews/extension-side/extensionRecommendation.node.ts)
 ```typescript
         );
         switch (selection) {
@@ -3074,7 +3074,7 @@ No description provided
 ```
 
 
-[src/platform/common/extensionRecommendation.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/platform/common/extensionRecommendation.node.ts)
+[src/webviews/extension-side/extensionRecommendation.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/webviews/extension-side/extensionRecommendation.node.ts)
 ```typescript
                 break;
             }
@@ -3086,7 +3086,7 @@ No description provided
 ```
 
 
-[src/platform/common/extensionRecommendation.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/platform/common/extensionRecommendation.node.ts)
+[src/webviews/extension-side/extensionRecommendation.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/webviews/extension-side/extensionRecommendation.node.ts)
 ```typescript
                 break;
             }
@@ -3098,7 +3098,7 @@ No description provided
 ```
 
 
-[src/platform/common/extensionRecommendation.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/platform/common/extensionRecommendation.node.ts)
+[src/webviews/extension-side/extensionRecommendation.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/webviews/extension-side/extensionRecommendation.node.ts)
 ```typescript
                 break;
             }

--- a/src/interactive-window/debugger/interactiveWindowDebugger.node.ts
+++ b/src/interactive-window/debugger/interactiveWindowDebugger.node.ts
@@ -11,7 +11,7 @@ import { IConfigurationService } from '../../platform/common/types';
 import { DataScience } from '../../platform/common/utils/localize';
 import { Identifiers } from '../../platform/common/constants';
 import { Telemetry } from '../../telemetry';
-import { JupyterDebuggerNotInstalledError } from '../../platform/errors/jupyterDebuggerNotInstalledError';
+import { JupyterDebuggerNotInstalledError } from '../../kernels/errors/jupyterDebuggerNotInstalledError';
 import { getPlainTextOrStreamOutput } from '../../kernels/kernel.base';
 import { IKernel, isLocalConnection } from '../../kernels/types';
 import { IInteractiveWindowDebugger } from '../types';

--- a/src/kernels/common/baseJupyterSession.ts
+++ b/src/kernels/common/baseJupyterSession.ts
@@ -15,9 +15,9 @@ import { createDeferred, sleep, waitForPromise } from '../../platform/common/uti
 import * as localize from '../../platform/common/utils/localize';
 import { noop } from '../../platform/common/utils/misc';
 import { sendTelemetryEvent, Telemetry } from '../../telemetry';
-import { JupyterInvalidKernelError } from '../../platform/errors/jupyterInvalidKernelError';
-import { JupyterWaitForIdleError } from '../../platform/errors/jupyterWaitForIdleError';
-import { KernelInterruptTimeoutError } from '../../platform/errors/kernelInterruptTimeoutError';
+import { JupyterInvalidKernelError } from '../errors/jupyterInvalidKernelError';
+import { JupyterWaitForIdleError } from '../errors/jupyterWaitForIdleError';
+import { KernelInterruptTimeoutError } from '../errors/kernelInterruptTimeoutError';
 import { SessionDisposedError } from '../../platform/errors/sessionDisposedError';
 import {
     IJupyterServerSession,

--- a/src/kernels/errors/invalidRemoteJupyterServerUriHandleError.ts
+++ b/src/kernels/errors/invalidRemoteJupyterServerUriHandleError.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { computeServerId, generateUriFromRemoteProvider } from '../../kernels/jupyter/jupyterUtils';
-import { BaseError } from './types';
+import { computeServerId, generateUriFromRemoteProvider } from '../jupyter/jupyterUtils';
+import { BaseError } from '../../platform/errors/types';
 
 export class InvalidRemoteJupyterServerUriHandleError extends BaseError {
     public readonly serverId: string;

--- a/src/kernels/errors/jupyterDebuggerNotInstalledError.ts
+++ b/src/kernels/errors/jupyterDebuggerNotInstalledError.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 'use strict';
 
-import { DataScience } from '../common/utils/localize';
-import { KernelConnectionMetadata } from '../../kernels/types';
-import { BaseKernelError } from './types';
+import { DataScience } from '../../platform/common/utils/localize';
+import { KernelConnectionMetadata } from '../types';
+import { BaseKernelError } from '../../platform/errors/types';
 
 export class JupyterDebuggerNotInstalledError extends BaseKernelError {
     constructor(debuggerPkg: string, message: string | undefined, kernelConnectionMetadata: KernelConnectionMetadata) {

--- a/src/kernels/errors/jupyterInvalidKernelError.ts
+++ b/src/kernels/errors/jupyterInvalidKernelError.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { DataScience } from '../common/utils/localize';
+import { DataScience } from '../../platform/common/utils/localize';
 import { sendTelemetryEvent, Telemetry } from '../../telemetry';
-import { getDisplayNameOrNameOfKernelConnection } from '../../kernels/helpers';
-import { KernelConnectionMetadata } from '../../kernels/types';
-import { BaseKernelError } from './types';
+import { getDisplayNameOrNameOfKernelConnection } from '../helpers';
+import { KernelConnectionMetadata } from '../types';
+import { BaseKernelError } from '../../platform/errors/types';
 
 export class JupyterInvalidKernelError extends BaseKernelError {
     constructor(kernelConnectionMetadata: KernelConnectionMetadata) {

--- a/src/kernels/errors/jupyterKernelDependencyError.ts
+++ b/src/kernels/errors/jupyterKernelDependencyError.ts
@@ -3,10 +3,10 @@
 
 'use strict';
 
-import { DataScience } from '../common/utils/localize';
-import { getDisplayNameOrNameOfKernelConnection } from '../../kernels/helpers';
-import { KernelConnectionMetadata, KernelInterpreterDependencyResponse } from '../../kernels/types';
-import { BaseKernelError } from './types';
+import { DataScience } from '../../platform/common/utils/localize';
+import { getDisplayNameOrNameOfKernelConnection } from '../helpers';
+import { KernelConnectionMetadata, KernelInterpreterDependencyResponse } from '../types';
+import { BaseKernelError } from '../../platform/errors/types';
 
 export class JupyterKernelDependencyError extends BaseKernelError {
     constructor(

--- a/src/kernels/errors/jupyterWaitForIdleError.ts
+++ b/src/kernels/errors/jupyterWaitForIdleError.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 'use strict';
 
-import { DataScience } from '../common/utils/localize';
+import { DataScience } from '../../platform/common/utils/localize';
 import { sendTelemetryEvent, Telemetry } from '../../telemetry';
-import { KernelConnectionMetadata } from '../../kernels/types';
-import { BaseKernelError } from './types';
+import { KernelConnectionMetadata } from '../types';
+import { BaseKernelError } from '../../platform/errors/types';
 
 export class JupyterWaitForIdleError extends BaseKernelError {
     constructor(kernelConnectionMetadata: KernelConnectionMetadata) {

--- a/src/kernels/errors/kernelConnectionTimeoutError.ts
+++ b/src/kernels/errors/kernelConnectionTimeoutError.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { DataScience } from '../common/utils/localize';
-import { getDisplayNameOrNameOfKernelConnection } from '../../kernels/helpers';
-import { KernelConnectionMetadata } from '../../kernels/types';
-import { BaseKernelError } from './types';
+import { DataScience } from '../../platform/common/utils/localize';
+import { getDisplayNameOrNameOfKernelConnection } from '../helpers';
+import { KernelConnectionMetadata } from '../types';
+import { BaseKernelError } from '../../platform/errors/types';
 
 export class KernelConnectionTimeoutError extends BaseKernelError {
     constructor(kernelConnection: KernelConnectionMetadata) {

--- a/src/kernels/errors/kernelDeadError.ts
+++ b/src/kernels/errors/kernelDeadError.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { DataScience } from '../common/utils/localize';
-import { getDisplayNameOrNameOfKernelConnection } from '../../kernels/helpers';
-import { KernelConnectionMetadata } from '../../kernels/types';
-import { WrappedKernelError } from './types';
+import { DataScience } from '../../platform/common/utils/localize';
+import { getDisplayNameOrNameOfKernelConnection } from '../helpers';
+import { KernelConnectionMetadata } from '../types';
+import { WrappedKernelError } from '../../platform/errors/types';
 
 export class KernelDeadError extends WrappedKernelError {
     constructor(kernelConnectionMetadata: KernelConnectionMetadata) {

--- a/src/kernels/errors/kernelDiedError.ts
+++ b/src/kernels/errors/kernelDiedError.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { KernelConnectionMetadata } from '../../kernels/types';
-import { WrappedKernelError } from './types';
+import { KernelConnectionMetadata } from '../types';
+import { WrappedKernelError } from '../../platform/errors/types';
 
 export class KernelDiedError extends WrappedKernelError {
     constructor(

--- a/src/kernels/errors/kernelErrorHandler.ts
+++ b/src/kernels/errors/kernelErrorHandler.ts
@@ -4,10 +4,10 @@ import { inject, injectable, optional } from 'inversify';
 import { JupyterInstallError } from '../../platform/errors/jupyterInstallError';
 import { JupyterSelfCertsError } from '../../platform/errors/jupyterSelfCertsError';
 import { CancellationTokenSource, ConfigurationTarget, workspace } from 'vscode';
-import { KernelConnectionTimeoutError } from '../../platform/errors/kernelConnectionTimeoutError';
-import { KernelDiedError } from '../../platform/errors/kernelDiedError';
-import { KernelPortNotUsedTimeoutError } from '../../platform/errors/kernelPortNotUsedTimeoutError';
-import { KernelProcessExitedError } from '../../platform/errors/kernelProcessExitedError';
+import { KernelConnectionTimeoutError } from './kernelConnectionTimeoutError';
+import { KernelDiedError } from './kernelDiedError';
+import { KernelPortNotUsedTimeoutError } from './kernelPortNotUsedTimeoutError';
+import { KernelProcessExitedError } from './kernelProcessExitedError';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../../platform/common/application/types';
 import { traceError, traceVerbose, traceWarning } from '../../platform/logging';
 import {
@@ -37,7 +37,7 @@ import {
     getErrorMessageFromPythonTraceback
 } from '../../platform/errors/errorUtils';
 import { JupyterConnectError } from '../../platform/errors/jupyterConnectError';
-import { JupyterKernelDependencyError } from '../../platform/errors/jupyterKernelDependencyError';
+import { JupyterKernelDependencyError } from './jupyterKernelDependencyError';
 import {
     WrappedError,
     BaseKernelError,
@@ -47,7 +47,7 @@ import {
 } from '../../platform/errors/types';
 import { noop } from '../../platform/common/utils/misc';
 import { EnvironmentType } from '../../platform/pythonEnvironments/info';
-import { KernelDeadError } from '../../platform/errors/kernelDeadError';
+import { KernelDeadError } from './kernelDeadError';
 import { DisplayOptions } from '../displayOptions';
 import {
     IJupyterInterpreterDependencyManager,
@@ -60,8 +60,8 @@ import { isCancellationError } from '../../platform/common/cancellation';
 import { JupyterExpiredCertsError } from '../../platform/errors/jupyterExpiredCertsError';
 import { computeServerId } from '../jupyter/jupyterUtils';
 import { RemoteJupyterServerConnectionError } from '../../platform/errors/remoteJupyterServerConnectionError';
-import { RemoteJupyterServerUriProviderError } from '../../platform/errors/remoteJupyterServerUriProviderError';
-import { InvalidRemoteJupyterServerUriHandleError } from '../../platform/errors/invalidRemoteJupyterServerUriHandleError';
+import { RemoteJupyterServerUriProviderError } from './remoteJupyterServerUriProviderError';
+import { InvalidRemoteJupyterServerUriHandleError } from './invalidRemoteJupyterServerUriHandleError';
 
 @injectable()
 export class DataScienceErrorHandler implements IDataScienceErrorHandler {

--- a/src/kernels/errors/kernelInterruptTimeoutError.ts
+++ b/src/kernels/errors/kernelInterruptTimeoutError.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { DataScience } from '../common/utils/localize';
-import { KernelConnectionMetadata } from '../../kernels/types';
-import { BaseKernelError } from './types';
+import { DataScience } from '../../platform/common/utils/localize';
+import { KernelConnectionMetadata } from '../types';
+import { BaseKernelError } from '../../platform/errors/types';
 
 export class KernelInterruptTimeoutError extends BaseKernelError {
     constructor(kernelConnection: KernelConnectionMetadata) {

--- a/src/kernels/errors/kernelPortNotUsedTimeoutError.ts
+++ b/src/kernels/errors/kernelPortNotUsedTimeoutError.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { DataScience } from '../common/utils/localize';
-import { getDisplayNameOrNameOfKernelConnection } from '../../kernels/helpers';
-import { KernelConnectionMetadata } from '../../kernels/types';
-import { BaseKernelError } from './types';
+import { DataScience } from '../../platform/common/utils/localize';
+import { getDisplayNameOrNameOfKernelConnection } from '../helpers';
+import { KernelConnectionMetadata } from '../types';
+import { BaseKernelError } from '../../platform/errors/types';
 
 export class KernelPortNotUsedTimeoutError extends BaseKernelError {
     constructor(kernelConnection: KernelConnectionMetadata) {

--- a/src/kernels/errors/kernelProcessExitedError.ts
+++ b/src/kernels/errors/kernelProcessExitedError.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { KernelConnectionMetadata } from '../../kernels/types';
-import { DataScience } from '../common/utils/localize';
-import { BaseKernelError } from './types';
+import { KernelConnectionMetadata } from '../types';
+import { DataScience } from '../../platform/common/utils/localize';
+import { BaseKernelError } from '../../platform/errors/types';
 
 export class KernelProcessExitedError extends BaseKernelError {
     constructor(

--- a/src/kernels/errors/remoteJupyterServerUriProviderError.ts
+++ b/src/kernels/errors/remoteJupyterServerUriProviderError.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { computeServerId, generateUriFromRemoteProvider } from '../../kernels/jupyter/jupyterUtils';
-import { BaseError } from './types';
+import { computeServerId, generateUriFromRemoteProvider } from '../jupyter/jupyterUtils';
+import { BaseError } from '../../platform/errors/types';
 
 export class RemoteJupyterServerUriProviderError extends BaseError {
     public readonly serverId: string;

--- a/src/kernels/jupyter/jupyterConnection.ts
+++ b/src/kernels/jupyter/jupyterConnection.ts
@@ -5,7 +5,7 @@ import { inject, injectable } from 'inversify';
 import { IExtensionSyncActivationService } from '../../platform/activation/types';
 import { IDisposableRegistry } from '../../platform/common/types';
 import { noop } from '../../platform/common/utils/misc';
-import { RemoteJupyterServerUriProviderError } from '../../platform/errors/remoteJupyterServerUriProviderError';
+import { RemoteJupyterServerUriProviderError } from '../errors/remoteJupyterServerUriProviderError';
 import { BaseError } from '../../platform/errors/types';
 import { IJupyterConnection } from '../types';
 import { computeServerId, createRemoteConnectionInfo, extractJupyterServerHandleAndId } from './jupyterUtils';

--- a/src/kernels/jupyter/jupyterKernelService.node.ts
+++ b/src/kernels/jupyter/jupyterKernelService.node.ts
@@ -26,7 +26,7 @@ import { IEnvironmentVariablesService } from '../../platform/common/variables/ty
 import { IEnvironmentActivationService } from '../../platform/interpreter/activation/types';
 import { PythonEnvironment } from '../../platform/pythonEnvironments/info';
 import { captureTelemetry, sendTelemetryEvent, Telemetry } from '../../telemetry';
-import { JupyterKernelDependencyError } from '../../platform/errors/jupyterKernelDependencyError';
+import { JupyterKernelDependencyError } from '../errors/jupyterKernelDependencyError';
 import { getKernelRegistrationInfo, cleanEnvironment } from '../helpers';
 import { JupyterPaths } from '../raw/finder/jupyterPaths.node';
 import {

--- a/src/kernels/jupyter/jupyterUriProviderRegistration.ts
+++ b/src/kernels/jupyter/jupyterUriProviderRegistration.ts
@@ -7,7 +7,7 @@ import { GLOBAL_MEMENTO, IDisposableRegistry, IExtensions, IMemento } from '../.
 import { swallowExceptions } from '../../platform/common/utils/decorators';
 import * as localize from '../../platform/common/utils/localize';
 import { noop } from '../../platform/common/utils/misc';
-import { InvalidRemoteJupyterServerUriHandleError } from '../../platform/errors/invalidRemoteJupyterServerUriHandleError';
+import { InvalidRemoteJupyterServerUriHandleError } from '../errors/invalidRemoteJupyterServerUriHandleError';
 import { JupyterUriProviderWrapper } from './jupyterUriProviderWrapper';
 import {
     IJupyterServerUri,

--- a/src/kernels/jupyter/launcher/jupyterExecution.ts
+++ b/src/kernels/jupyter/launcher/jupyterExecution.ts
@@ -10,7 +10,7 @@ import { traceInfo } from '../../../platform/logging';
 import { IDisposableRegistry, IConfigurationService, Resource } from '../../../platform/common/types';
 import { DataScience } from '../../../platform/common/utils/localize';
 import { JupyterSelfCertsError } from '../../../platform/errors/jupyterSelfCertsError';
-import { JupyterWaitForIdleError } from '../../../platform/errors/jupyterWaitForIdleError';
+import { JupyterWaitForIdleError } from '../../errors/jupyterWaitForIdleError';
 import { IInterpreterService } from '../../../platform/interpreter/contracts';
 import { PythonEnvironment } from '../../../platform/pythonEnvironments/info';
 import { sendTelemetryEvent, captureTelemetry, Telemetry } from '../../../telemetry';

--- a/src/kernels/jupyter/serviceRegistry.node.ts
+++ b/src/kernels/jupyter/serviceRegistry.node.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IExtensionSingleActivationService, IExtensionSyncActivationService } from '../../platform/activation/types';
+import { IDataScienceErrorHandler } from '../../platform/errors/types';
 import { IServiceManager } from '../../platform/ioc/types';
+import { DataScienceErrorHandler } from '../errors/kernelErrorHandler';
 import { IRemoteKernelFinder } from '../raw/types';
 import { INotebookProvider } from '../types';
 import { JupyterCommandLineSelectorCommand } from './commands/commandLineSelector';
@@ -149,4 +151,5 @@ export function registerTypes(serviceManager: IServiceManager, _isDevMode: boole
         JupyterRemoteCachedKernelValidator
     );
     serviceManager.addSingleton<JupyterDetectionTelemetry>(IExtensionSyncActivationService, JupyterDetectionTelemetry);
+    serviceManager.addSingleton<IDataScienceErrorHandler>(IDataScienceErrorHandler, DataScienceErrorHandler);
 }

--- a/src/kernels/jupyter/serviceRegistry.web.ts
+++ b/src/kernels/jupyter/serviceRegistry.web.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IExtensionSingleActivationService, IExtensionSyncActivationService } from '../../platform/activation/types';
+import { IDataScienceErrorHandler } from '../../platform/errors/types';
 import { IServiceManager } from '../../platform/ioc/types';
+import { DataScienceErrorHandler } from '../errors/kernelErrorHandler';
 import { IRemoteKernelFinder } from '../raw/types';
 import { INotebookProvider } from '../types';
 import { JupyterCommandLineSelectorCommand } from './commands/commandLineSelector';
@@ -81,4 +83,5 @@ export function registerTypes(serviceManager: IServiceManager, _isDevMode: boole
         IJupyterRemoteCachedKernelValidator,
         JupyterRemoteCachedKernelValidator
     );
+    serviceManager.addSingleton<IDataScienceErrorHandler>(IDataScienceErrorHandler, DataScienceErrorHandler);
 }

--- a/src/kernels/jupyter/session/jupyterSession.ts
+++ b/src/kernels/jupyter/session/jupyterSession.ts
@@ -10,7 +10,7 @@ import { traceVerbose, traceError, traceInfo } from '../../../platform/logging';
 import { Resource, IOutputChannel, IDisplayOptions } from '../../../platform/common/types';
 import { waitForCondition } from '../../../platform/common/utils/async';
 import { DataScience } from '../../../platform/common/utils/localize';
-import { JupyterInvalidKernelError } from '../../../platform/errors/jupyterInvalidKernelError';
+import { JupyterInvalidKernelError } from '../../errors/jupyterInvalidKernelError';
 import { SessionDisposedError } from '../../../platform/errors/sessionDisposedError';
 import { captureTelemetry, Telemetry } from '../../../telemetry';
 import { BaseJupyterSession, JupyterSessionStartError } from '../../common/baseJupyterSession';

--- a/src/kernels/port/portAttributeProvider.node.ts
+++ b/src/kernels/port/portAttributeProvider.node.ts
@@ -4,11 +4,11 @@
 import { inject, injectable } from 'inversify';
 import { workspace } from 'vscode';
 import { CancellationToken, PortAttributes, PortAttributesProvider, PortAutoForwardAction } from 'vscode';
-import { NotebookStarter } from '../../../kernels/jupyter/launcher/notebookStarter.node';
-import { KernelLauncher } from '../../../kernels/raw/launcher/kernelLauncher.node';
-import { IExtensionSyncActivationService } from '../../activation/types';
-import { traceError } from '../../logging';
-import { IDisposableRegistry } from '../types';
+import { NotebookStarter } from '../jupyter/launcher/notebookStarter.node';
+import { KernelLauncher } from '../raw/launcher/kernelLauncher.node';
+import { IExtensionSyncActivationService } from '../../platform/activation/types';
+import { traceError } from '../../platform/logging';
+import { IDisposableRegistry } from '../../platform/common/types';
 
 @injectable()
 export class PortAttributesProviders implements PortAttributesProvider, IExtensionSyncActivationService {

--- a/src/kernels/raw/launcher/kernelProcess.node.ts
+++ b/src/kernels/raw/launcher/kernelProcess.node.ts
@@ -52,9 +52,9 @@ import { Resource, IOutputChannel, IJupyterSettings } from '../../../platform/co
 import { createDeferred } from '../../../platform/common/utils/async';
 import { DataScience } from '../../../platform/common/utils/localize';
 import { noop, swallowExceptions } from '../../../platform/common/utils/misc';
-import { KernelDiedError } from '../../../platform/errors/kernelDiedError';
-import { KernelPortNotUsedTimeoutError } from '../../../platform/errors/kernelPortNotUsedTimeoutError';
-import { KernelProcessExitedError } from '../../../platform/errors/kernelProcessExitedError';
+import { KernelDiedError } from '../../errors/kernelDiedError';
+import { KernelPortNotUsedTimeoutError } from '../../errors/kernelPortNotUsedTimeoutError';
+import { KernelProcessExitedError } from '../../errors/kernelProcessExitedError';
 import { captureTelemetry, Telemetry } from '../../../telemetry';
 import { PythonKernelInterruptDaemon } from '../finder/pythonKernelInterruptDaemon.node';
 import { TraceOptions } from '../../../platform/logging/types';

--- a/src/kernels/raw/session/rawSession.node.ts
+++ b/src/kernels/raw/session/rawSession.node.ts
@@ -8,7 +8,7 @@ import '../../../platform/common/extensions';
 import { traceVerbose, traceInfoIfCI, traceError, traceWarning } from '../../../platform/logging';
 import { IDisposable, Resource } from '../../../platform/common/types';
 import { createDeferred, sleep } from '../../../platform/common/utils/async';
-import { KernelConnectionTimeoutError } from '../../../platform/errors/kernelConnectionTimeoutError';
+import { KernelConnectionTimeoutError } from '../../errors/kernelConnectionTimeoutError';
 import { sendTelemetryEvent, Telemetry } from '../../../telemetry';
 import { ISessionWithSocket, KernelConnectionMetadata, KernelSocketInformation } from '../../types';
 import { IKernelProcess } from '../types';

--- a/src/kernels/serviceRegistry.node.ts
+++ b/src/kernels/serviceRegistry.node.ts
@@ -42,10 +42,14 @@ import { ServerConnectionType } from './jupyter/launcher/serverConnectionType';
 import { CellOutputDisplayIdTracker } from './execution/cellDisplayIdTracker';
 import { DebugLocationTrackerFactory } from './debugger/debugLocationTrackerFactory';
 import { Activation } from './activation.node';
+import { PortAttributesProviders } from './port/portAttributeProvider.node';
 
 export function registerTypes(serviceManager: IServiceManager, isDevMode: boolean) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, Activation);
-
+    serviceManager.addSingleton<IExtensionSyncActivationService>(
+        IExtensionSyncActivationService,
+        PortAttributesProviders
+    );
     serviceManager.addSingleton<IRawNotebookSupportedService>(
         IRawNotebookSupportedService,
         RawNotebookSupportedService

--- a/src/notebooks/controllers/kernelConnector.ts
+++ b/src/notebooks/controllers/kernelConnector.ts
@@ -26,7 +26,7 @@ import { clearInstalledIntoInterpreterMemento } from '../../kernels/installer/pr
 import { Product } from '../../kernels/installer/types';
 import { INotebookControllerManager, INotebookEditorProvider } from '../types';
 import { selectKernel } from './kernelSelector';
-import { KernelDeadError } from '../../platform/errors/kernelDeadError';
+import { KernelDeadError } from '../../kernels/errors/kernelDeadError';
 import { noop } from '../../platform/common/utils/misc';
 import { IDataScienceErrorHandler } from '../../platform/errors/types';
 import { IStatusProvider } from '../../platform/progress/types';

--- a/src/notebooks/controllers/vscodeNotebookController.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.ts
@@ -73,7 +73,7 @@ import {
     LocalKernelSpecConnectionMetadata,
     PythonKernelConnectionMetadata
 } from '../../kernels/types';
-import { KernelDeadError } from '../../platform/errors/kernelDeadError';
+import { KernelDeadError } from '../../kernels/errors/kernelDeadError';
 import { DisplayOptions } from '../../kernels/displayOptions';
 import {
     getNotebookMetadata,

--- a/src/platform/common/serviceRegistry.node.ts
+++ b/src/platform/common/serviceRegistry.node.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IExtensionSingleActivationService, IExtensionSyncActivationService } from '../activation/types';
+import { IExtensionSingleActivationService } from '../activation/types';
 import { IExperimentService, IHttpClient } from '../common/types';
 import { IServiceManager } from '../ioc/types';
 import { ActiveResourceService } from './application/activeResource.node';

--- a/src/platform/common/serviceRegistry.node.ts
+++ b/src/platform/common/serviceRegistry.node.ts
@@ -3,8 +3,6 @@
 import { IExtensionSingleActivationService, IExtensionSyncActivationService } from '../activation/types';
 import { IExperimentService, IHttpClient } from '../common/types';
 import { IServiceManager } from '../ioc/types';
-import { ImportTracker } from './importTracker.node';
-import { IImportTracker } from '../../telemetry/types';
 import { ActiveResourceService } from './application/activeResource.node';
 import { ApplicationEnvironment } from './application/applicationEnvironment.node';
 import { ClipboardService } from './application/clipboard';
@@ -81,8 +79,6 @@ export function registerTypes(serviceManager: IServiceManager) {
 
     serviceManager.addSingleton<IAsyncDisposableRegistry>(IAsyncDisposableRegistry, AsyncDisposableRegistry);
     serviceManager.addSingleton<IMultiStepInputFactory>(IMultiStepInputFactory, MultiStepInputFactory);
-    serviceManager.addSingleton<IImportTracker>(IImportTracker, ImportTracker);
-    serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, ImportTracker);
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,
         LanguageInitializer

--- a/src/platform/common/serviceRegistry.node.ts
+++ b/src/platform/common/serviceRegistry.node.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { IExtensionSingleActivationService, IExtensionSyncActivationService } from '../activation/types';
 import { IExperimentService, IHttpClient } from '../common/types';
-import { AmlComputeContext } from './amlContext.node';
 import { IServiceManager } from '../ioc/types';
 import { ImportTracker } from './importTracker.node';
 import { IImportTracker } from '../../telemetry/types';
@@ -96,16 +95,10 @@ export function registerTypes(serviceManager: IServiceManager) {
         IExtensionSingleActivationService,
         RunInDedicatedExtensionHostCommandHandler
     );
-    serviceManager.addSingleton<IExtensionSingleActivationService>(
-        IExtensionSingleActivationService,
-        AmlComputeContext
-    );
     serviceManager.addSingleton<IExtensionSyncActivationService>(
         IExtensionSyncActivationService,
         PortAttributesProviders
     );
-    serviceManager.addSingleton<AmlComputeContext>(AmlComputeContext, AmlComputeContext);
-
     registerPlatformTypes(serviceManager);
     processRegisterTypes(serviceManager);
     variableRegisterTypes(serviceManager);

--- a/src/platform/common/serviceRegistry.node.ts
+++ b/src/platform/common/serviceRegistry.node.ts
@@ -45,7 +45,6 @@ import {
     IsWindows
 } from './types';
 import { IMultiStepInputFactory, MultiStepInputFactory } from './utils/multiStepInput';
-import { PortAttributesProviders } from './net/portAttributeProvider.node';
 import { LanguageInitializer } from '../../telemetry/languageInitializer';
 import { registerTypes as registerPlatformTypes } from './platform/serviceRegistry.node';
 import { registerTypes as processRegisterTypes } from './process/serviceRegistry.node';
@@ -90,10 +89,6 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,
         RunInDedicatedExtensionHostCommandHandler
-    );
-    serviceManager.addSingleton<IExtensionSyncActivationService>(
-        IExtensionSyncActivationService,
-        PortAttributesProviders
     );
     registerPlatformTypes(serviceManager);
     processRegisterTypes(serviceManager);

--- a/src/platform/common/serviceRegistry.node.ts
+++ b/src/platform/common/serviceRegistry.node.ts
@@ -54,7 +54,6 @@ import { registerTypes as registerPlatformTypes } from './platform/serviceRegist
 import { registerTypes as processRegisterTypes } from './process/serviceRegistry.node';
 import { registerTypes as variableRegisterTypes } from './variables/serviceRegistry.node';
 import { RunInDedicatedExtensionHostCommandHandler } from './application/commands/runInDedicatedExtensionHost.node';
-import { ActiveEditorContextService } from './activeEditorContext';
 import { TerminalManager } from './application/terminalManager.node';
 
 // eslint-disable-next-line
@@ -106,10 +105,6 @@ export function registerTypes(serviceManager: IServiceManager) {
         PortAttributesProviders
     );
     serviceManager.addSingleton<AmlComputeContext>(AmlComputeContext, AmlComputeContext);
-    serviceManager.addSingleton<IExtensionSingleActivationService>(
-        IExtensionSingleActivationService,
-        ActiveEditorContextService
-    );
 
     registerPlatformTypes(serviceManager);
     processRegisterTypes(serviceManager);

--- a/src/platform/common/serviceRegistry.web.ts
+++ b/src/platform/common/serviceRegistry.web.ts
@@ -26,8 +26,6 @@ import { ClipboardService } from './application/clipboard';
 import { AsyncDisposableRegistry } from './asyncDisposableRegistry';
 import { IMultiStepInputFactory, MultiStepInputFactory } from './utils/multiStepInput';
 import { BrowserService } from './net/browser';
-import { ActiveEditorContextService } from './activeEditorContext';
-import { IExtensionSingleActivationService } from '../activation/types';
 import { DebugService } from './application/debugService';
 import { HttpClient } from './net/httpClient';
 
@@ -47,10 +45,6 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IMultiStepInputFactory>(IMultiStepInputFactory, MultiStepInputFactory);
     serviceManager.addSingleton<IBrowserService>(IBrowserService, BrowserService);
     serviceManager.addSingleton<IHttpClient>(IHttpClient, HttpClient);
-    serviceManager.addSingleton<IExtensionSingleActivationService>(
-        IExtensionSingleActivationService,
-        ActiveEditorContextService
-    );
 
     registerPlatformTypes(serviceManager);
 }

--- a/src/platform/serviceRegistry.node.ts
+++ b/src/platform/serviceRegistry.node.ts
@@ -10,7 +10,6 @@ import { registerTypes as registerActivationTypes } from './activation/serviceRe
 import { registerTypes as registerDevToolTypes } from './devTools/serviceRegistry';
 import { DataScienceStartupTime } from './common/constants';
 import { IExtensionSingleActivationService, IExtensionSyncActivationService } from './activation/types';
-import { ExtensionRecommendationService } from './common/extensionRecommendation.node';
 import { GlobalActivation } from './common/globalActivation';
 import { PreReleaseChecker } from './common/prereleaseChecker.node';
 import { IConfigurationService, IDataScienceCommandListener, IExtensionContext } from './common/types';
@@ -74,10 +73,6 @@ export function registerTypes(context: IExtensionContext, serviceManager: IServi
     serviceManager.addSingleton<ExportUtilBase>(ExportUtilBase, ExportUtilBase);
     serviceManager.addSingleton<ExportUtil>(ExportUtil, ExportUtil);
     serviceManager.addSingleton<IExportDialog>(IExportDialog, ExportDialog);
-    serviceManager.addSingleton<IExtensionSyncActivationService>(
-        IExtensionSyncActivationService,
-        ExtensionRecommendationService
-    );
     serviceManager.addSingleton<IExtensionSyncActivationService>(
         IExtensionSyncActivationService,
         KernelProgressReporter

--- a/src/platform/serviceRegistry.node.ts
+++ b/src/platform/serviceRegistry.node.ts
@@ -10,7 +10,6 @@ import { registerTypes as registerActivationTypes } from './activation/serviceRe
 import { registerTypes as registerDevToolTypes } from './devTools/serviceRegistry';
 import { DataScienceStartupTime } from './common/constants';
 import { IExtensionSingleActivationService, IExtensionSyncActivationService } from './activation/types';
-import { GlobalActivation } from './common/globalActivation';
 import { PreReleaseChecker } from './common/prereleaseChecker.node';
 import { IConfigurationService, IDataScienceCommandListener, IExtensionContext } from './common/types';
 import { ExportBase } from './export/exportBase.node';
@@ -57,7 +56,6 @@ export function registerTypes(context: IExtensionContext, serviceManager: IServi
     // Root platform types
     serviceManager.addSingletonInstance<number>(DataScienceStartupTime, Date.now());
 
-    serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, GlobalActivation);
     serviceManager.addSingleton<IStatusProvider>(IStatusProvider, StatusProvider);
     serviceManager.addSingleton<ProgressReporter>(ProgressReporter, ProgressReporter);
     serviceManager.addSingleton<IFileConverter>(IFileConverter, FileConverter);

--- a/src/platform/serviceRegistry.node.ts
+++ b/src/platform/serviceRegistry.node.ts
@@ -14,8 +14,6 @@ import { ExtensionRecommendationService } from './common/extensionRecommendation
 import { GlobalActivation } from './common/globalActivation';
 import { PreReleaseChecker } from './common/prereleaseChecker.node';
 import { IConfigurationService, IDataScienceCommandListener, IExtensionContext } from './common/types';
-import { DataScienceErrorHandler } from './errors/errorHandler';
-import { IDataScienceErrorHandler } from './errors/types';
 import { ExportBase } from './export/exportBase.node';
 import { ExportDialog } from './export/exportDialog';
 import { ExportFileOpener } from './export/exportFileOpener';
@@ -59,7 +57,6 @@ export function registerTypes(context: IExtensionContext, serviceManager: IServi
 
     // Root platform types
     serviceManager.addSingletonInstance<number>(DataScienceStartupTime, Date.now());
-    serviceManager.addSingleton<IDataScienceErrorHandler>(IDataScienceErrorHandler, DataScienceErrorHandler);
 
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, GlobalActivation);
     serviceManager.addSingleton<IStatusProvider>(IStatusProvider, StatusProvider);

--- a/src/platform/serviceRegistry.web.ts
+++ b/src/platform/serviceRegistry.web.ts
@@ -22,8 +22,6 @@ import { ProgressReporter } from './progress/progressReporter';
 import { StatusProvider } from './progress/statusProvider';
 import { IStatusProvider } from './progress/types';
 import { WorkspaceService } from './common/application/workspace.web';
-import { DataScienceErrorHandler } from './errors/errorHandler';
-import { IDataScienceErrorHandler } from './errors/types';
 import { GlobalActivation } from './common/globalActivation';
 import { IExtensionSingleActivationService, IExtensionSyncActivationService } from './activation/types';
 import { OutputCommandListener } from './logging/outputCommandListener';
@@ -49,7 +47,6 @@ export function registerTypes(context: IExtensionContext, serviceManager: IServi
     serviceManager.addSingleton<IApplicationEnvironment>(IApplicationEnvironment, ApplicationEnvironment);
     serviceManager.addSingleton<IConfigurationService>(IConfigurationService, ConfigurationService);
     serviceManager.addSingleton<IStatusProvider>(IStatusProvider, StatusProvider);
-    serviceManager.addSingleton<IDataScienceErrorHandler>(IDataScienceErrorHandler, DataScienceErrorHandler);
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, GlobalActivation);
     serviceManager.addSingleton<IDataScienceCommandListener>(IDataScienceCommandListener, OutputCommandListener);
     serviceManager.addSingleton<ExportFileOpener>(ExportFileOpener, ExportFileOpener);

--- a/src/platform/serviceRegistry.web.ts
+++ b/src/platform/serviceRegistry.web.ts
@@ -22,8 +22,7 @@ import { ProgressReporter } from './progress/progressReporter';
 import { StatusProvider } from './progress/statusProvider';
 import { IStatusProvider } from './progress/types';
 import { WorkspaceService } from './common/application/workspace.web';
-import { GlobalActivation } from './common/globalActivation';
-import { IExtensionSingleActivationService, IExtensionSyncActivationService } from './activation/types';
+import { IExtensionSyncActivationService } from './activation/types';
 import { OutputCommandListener } from './logging/outputCommandListener';
 import { ExportDialog } from './export/exportDialog';
 import { ExportFormat, IExport, IExportBase, IExportDialog, IFileConverter, INbConvertExport } from './export/types';
@@ -47,7 +46,6 @@ export function registerTypes(context: IExtensionContext, serviceManager: IServi
     serviceManager.addSingleton<IApplicationEnvironment>(IApplicationEnvironment, ApplicationEnvironment);
     serviceManager.addSingleton<IConfigurationService>(IConfigurationService, ConfigurationService);
     serviceManager.addSingleton<IStatusProvider>(IStatusProvider, StatusProvider);
-    serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, GlobalActivation);
     serviceManager.addSingleton<IDataScienceCommandListener>(IDataScienceCommandListener, OutputCommandListener);
     serviceManager.addSingleton<ExportFileOpener>(ExportFileOpener, ExportFileOpener);
     serviceManager.addSingleton<IExportBase>(IExportBase, ExportBase);

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -23,9 +23,6 @@ import { PreferredKernelExactMatchReason } from '../notebooks/controllers/notebo
 import { SelectJupyterUriCommandSource } from '../kernels/jupyter/serverSelector';
 import { TerminalShellType } from '../platform/terminals/types';
 
-export const IImportTracker = Symbol('IImportTracker');
-export interface IImportTracker {}
-
 export type ResourceSpecificTelemetryProperties = Partial<{
     resourceType: 'notebook' | 'interactive';
     /**

--- a/src/test/datascience/datascience.unit.test.ts
+++ b/src/test/datascience/datascience.unit.test.ts
@@ -13,7 +13,7 @@ import { WorkspaceService } from '../../platform/common/application/workspace.no
 import { JupyterSettings } from '../../platform/common/configSettings';
 import { ConfigurationService } from '../../platform/common/configuration/service.node';
 import { IConfigurationService, IWatchableJupyterSettings } from '../../platform/common/types';
-import { GlobalActivation } from '../../platform/common/globalActivation';
+import { GlobalActivation } from '../../webviews/extension-side/globalActivation';
 import { DataScienceCodeLensProvider } from '../../interactive-window/editor-integration/codelensprovider';
 import { RawNotebookSupportedService } from '../../kernels/raw/session/rawNotebookSupportedService.node';
 import { IDataScienceCodeLensProvider } from '../../interactive-window/editor-integration/types';

--- a/src/test/datascience/errorHandler.unit.test.ts
+++ b/src/test/datascience/errorHandler.unit.test.ts
@@ -22,7 +22,7 @@ import { DataScienceErrorHandler } from '../../kernels/errors/kernelErrorHandler
 import { JupyterConnectError } from '../../platform/errors/jupyterConnectError';
 import { JupyterInstallError } from '../../platform/errors/jupyterInstallError';
 import { JupyterSelfCertsError } from '../../platform/errors/jupyterSelfCertsError';
-import { KernelDiedError } from '../../platform/errors/kernelDiedError';
+import { KernelDiedError } from '../../kernels/errors/kernelDiedError';
 import {
     IJupyterInterpreterDependencyManager,
     IJupyterServerUriStorage,
@@ -33,7 +33,7 @@ import { getOSType, OSType } from '../../platform/common/utils/platform';
 import { RemoteJupyterServerConnectionError } from '../../platform/errors/remoteJupyterServerConnectionError';
 import { computeServerId, generateUriFromRemoteProvider } from '../../kernels/jupyter/jupyterUtils';
 import { Commands } from '../../platform/common/constants';
-import { RemoteJupyterServerUriProviderError } from '../../platform/errors/remoteJupyterServerUriProviderError';
+import { RemoteJupyterServerUriProviderError } from '../../kernels/errors/remoteJupyterServerUriProviderError';
 
 suite('DataScience Error Handler Unit Tests', () => {
     let applicationShell: IApplicationShell;

--- a/src/test/datascience/errorHandler.unit.test.ts
+++ b/src/test/datascience/errorHandler.unit.test.ts
@@ -18,7 +18,7 @@ import {
 } from '../../platform/../kernels/types';
 import { PythonEnvironment, EnvironmentType } from '../../platform/pythonEnvironments/info';
 import { JupyterInterpreterService } from '../../kernels/jupyter/interpreter/jupyterInterpreterService.node';
-import { DataScienceErrorHandler } from '../../platform/errors/errorHandler';
+import { DataScienceErrorHandler } from '../../kernels/errors/kernelErrorHandler';
 import { JupyterConnectError } from '../../platform/errors/jupyterConnectError';
 import { JupyterInstallError } from '../../platform/errors/jupyterInstallError';
 import { JupyterSelfCertsError } from '../../platform/errors/jupyterSelfCertsError';

--- a/src/test/datascience/extensionRecommendation.unit.test.ts
+++ b/src/test/datascience/extensionRecommendation.unit.test.ts
@@ -12,7 +12,7 @@ import { Common } from '../../platform/common/utils/localize';
 import { VSCodeNotebookController } from '../../notebooks/controllers/vscodeNotebookController';
 import { INotebookControllerManager } from '../../notebooks/types';
 import { IJupyterKernelSpec } from '../../kernels/types';
-import { ExtensionRecommendationService } from '../../platform/common/extensionRecommendation.node';
+import { ExtensionRecommendationService } from '../../webviews/extension-side/extensionRecommendation.node';
 import { JupyterNotebookView } from '../../platform/common/constants';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/src/test/datascience/jupyter/serverSelector.unit.test.ts
+++ b/src/test/datascience/jupyter/serverSelector.unit.test.ts
@@ -23,7 +23,7 @@ import { JupyterServerUriStorage } from '../../../kernels/jupyter/launcher/serve
 import { JupyterServerSelector } from '../../../kernels/jupyter/serverSelector';
 import { JupyterUriProviderRegistration } from '../../../kernels/jupyter/jupyterUriProviderRegistration';
 import { Settings } from '../../../platform/common/constants';
-import { DataScienceErrorHandler } from '../../../platform/errors/errorHandler';
+import { DataScienceErrorHandler } from '../../../kernels/errors/kernelErrorHandler';
 import { IDisposable } from '../../../platform/common/types';
 import { disposeAllDisposables } from '../../../platform/common/helpers';
 import { ServerConnectionType } from '../../../kernels/jupyter/launcher/serverConnectionType';

--- a/src/test/datascience/kernelLauncher.vscode.test.ts
+++ b/src/test/datascience/kernelLauncher.vscode.test.ts
@@ -15,7 +15,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import { traceInfo } from '../../platform/logging';
 import { IS_REMOTE_NATIVE_TEST } from '../constants.node';
 import { initialize } from '../initialize.node';
-import { PortAttributesProviders } from '../../platform/common/net/portAttributeProvider.node';
+import { PortAttributesProviders } from '../../kernels/port/portAttributeProvider.node';
 import { IDisposable } from '../../platform/common/types';
 import { disposeAllDisposables } from '../../platform/common/helpers';
 import { CancellationTokenSource, PortAutoForwardAction } from 'vscode';

--- a/src/test/telemetry/importTracker.unit.test.ts
+++ b/src/test/telemetry/importTracker.unit.test.ts
@@ -19,7 +19,7 @@ import { disposeAllDisposables } from '../../platform/common/helpers';
 import { IDisposable } from '../../platform/common/types';
 import { EventName } from '../../telemetry/constants';
 import { getTelemetrySafeHashedString } from '../../telemetry/helpers';
-import { ImportTracker } from '../../platform/common/importTracker.node';
+import { ImportTracker } from '../../webviews/extension-side/importTracker.node';
 import { createDocument } from '../datascience/editor-integration/helpers';
 
 suite('Import Tracker', () => {

--- a/src/webviews/extension-side/activeEditorContext.ts
+++ b/src/webviews/extension-side/activeEditorContext.ts
@@ -5,16 +5,16 @@
 import { inject, injectable, optional } from 'inversify';
 import { NotebookEditor, TextEditor } from 'vscode';
 import { IKernel, IKernelProvider } from '../../kernels/types';
-import { IExtensionSingleActivationService } from '../activation/types';
-import { ICommandManager, IDocumentManager, IVSCodeNotebook } from './application/types';
-import { EditorContexts, PYTHON_LANGUAGE } from './constants';
-import { ContextKey } from './contextKey';
-import { IDisposable, IDisposableRegistry } from './types';
-import { isNotebookCell, noop } from './utils/misc';
+import { IExtensionSingleActivationService } from '../../platform/activation/types';
+import { ICommandManager, IDocumentManager, IVSCodeNotebook } from '../../platform/common/application/types';
+import { EditorContexts, PYTHON_LANGUAGE } from '../../platform/common/constants';
+import { ContextKey } from '../../platform/common/contextKey';
+import { IDisposable, IDisposableRegistry } from '../../platform/common/types';
+import { isNotebookCell, noop } from '../../platform/common/utils/misc';
 import { InteractiveWindowView, JupyterNotebookView } from '../../platform/common/constants';
 import { INotebookControllerManager } from '../../notebooks/types';
 import { IInteractiveWindowProvider, IInteractiveWindow } from '../../interactive-window/types';
-import { getNotebookMetadata, isJupyterNotebook, isPythonNotebook } from './utils';
+import { getNotebookMetadata, isJupyterNotebook, isPythonNotebook } from '../../platform/common/utils';
 import { getAssociatedNotebookDocument } from '../../kernels/helpers';
 
 @injectable()

--- a/src/webviews/extension-side/amlContext.node.ts
+++ b/src/webviews/extension-side/amlContext.node.ts
@@ -3,7 +3,7 @@
 
 import { injectable } from 'inversify';
 import { env } from 'vscode';
-import { IExtensionSingleActivationService } from '../activation/types';
+import { IExtensionSingleActivationService } from '../../platform/activation/types';
 import { setSharedProperty } from '../../telemetry';
 
 const amlComputeRemoteName = 'amlext';

--- a/src/webviews/extension-side/extensionRecommendation.node.ts
+++ b/src/webviews/extension-side/extensionRecommendation.node.ts
@@ -3,14 +3,14 @@
 
 import { inject, injectable, named } from 'inversify';
 import { Memento, NotebookDocument } from 'vscode';
-import { IExtensionSyncActivationService } from '../activation/types';
-import { IApplicationShell, ICommandManager, IVSCodeNotebook } from '../common/application/types';
-import { disposeAllDisposables } from '../common/helpers';
-import { GLOBAL_MEMENTO, IDisposable, IDisposableRegistry, IExtensions, IMemento } from '../common/types';
-import { Common, DataScience } from './utils/localize';
-import { noop } from './utils/misc';
+import { IExtensionSyncActivationService } from '../../platform/activation/types';
+import { IApplicationShell, ICommandManager, IVSCodeNotebook } from '../../platform/common/application/types';
+import { disposeAllDisposables } from '../../platform/common/helpers';
+import { GLOBAL_MEMENTO, IDisposable, IDisposableRegistry, IExtensions, IMemento } from '../../platform/common/types';
+import { Common, DataScience } from '../../platform/common/utils/localize';
+import { noop } from '../../platform/common/utils/misc';
 import { sendTelemetryEvent } from '../../telemetry';
-import { Telemetry } from './constants';
+import { Telemetry } from '../../platform/common/constants';
 import {
     getKernelConnectionLanguage,
     getLanguageInNotebookMetadata,
@@ -18,7 +18,7 @@ import {
 } from '../../kernels/helpers';
 import { INotebookControllerManager } from '../../notebooks/types';
 import { IVSCodeNotebookController } from '../../notebooks/controllers/types';
-import { getNotebookMetadata, isJupyterNotebook } from './utils';
+import { getNotebookMetadata, isJupyterNotebook } from '../../platform/common/utils';
 
 const mementoKeyToNeverPromptExtensionAgain = 'JVSC_NEVER_PROMPT_EXTENSIONS_LIST';
 const knownExtensionsToRecommend = new Map<string, { displayName: string; extensionLink: string }>([

--- a/src/webviews/extension-side/globalActivation.ts
+++ b/src/webviews/extension-side/globalActivation.ts
@@ -4,22 +4,22 @@
 import type { JSONObject } from '@lumino/coreutils';
 import { inject, injectable, multiInject, optional } from 'inversify';
 import * as vscode from 'vscode';
-import { ICommandManager, IDocumentManager, IWorkspaceService } from './application/types';
-import { PYTHON_FILE_ANY_SCHEME, PYTHON_LANGUAGE } from './constants';
-import { ContextKey } from './contextKey';
-import './extensions';
+import { ICommandManager, IDocumentManager, IWorkspaceService } from '../../platform/common/application/types';
+import { PYTHON_FILE_ANY_SCHEME, PYTHON_LANGUAGE } from '../../platform/common/constants';
+import { ContextKey } from '../../platform/common/contextKey';
+import '../../platform/common/extensions';
 import {
     IConfigurationService,
     IDataScienceCommandListener,
     IDisposable,
     IDisposableRegistry,
     IExtensionContext
-} from './types';
-import { debounceAsync, swallowExceptions } from './utils/decorators';
-import { noop } from './utils/misc';
+} from '../../platform/common/types';
+import { debounceAsync, swallowExceptions } from '../../platform/common/utils/decorators';
+import { noop } from '../../platform/common/utils/misc';
 import { sendTelemetryEvent } from '../../telemetry';
-import { EditorContexts, Telemetry } from './constants';
-import { IExtensionSingleActivationService } from '../activation/types';
+import { EditorContexts, Telemetry } from '../../platform/common/constants';
+import { IExtensionSingleActivationService } from '../../platform/activation/types';
 import { IDataScienceCodeLensProvider } from '../../interactive-window/editor-integration/types';
 import { IRawNotebookSupportedService } from '../../kernels/raw/types';
 import { hasCells } from '../../interactive-window/editor-integration/cellFactory';

--- a/src/webviews/extension-side/importTracker.node.ts
+++ b/src/webviews/extension-side/importTracker.node.ts
@@ -4,19 +4,19 @@
 
 import type * as nbformat from '@jupyterlab/nbformat';
 import { inject, injectable } from 'inversify';
-import * as path from '../vscode-path/path';
+import * as path from '../../platform/vscode-path/path';
 import { NotebookCellExecutionStateChangeEvent, NotebookCellKind, NotebookDocument, TextDocument } from 'vscode';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
-import { IExtensionSingleActivationService } from '../activation/types';
-import { IDocumentManager, IVSCodeNotebook } from './application/types';
-import { isCI, isTestExecution, PYTHON_LANGUAGE } from './constants';
-import './extensions';
-import { disposeAllDisposables } from './helpers';
-import { IDisposable, IDisposableRegistry } from './types';
-import { noop } from './utils/misc';
+import { IExtensionSingleActivationService } from '../../platform/activation/types';
+import { IDocumentManager, IVSCodeNotebook } from '../../platform/common/application/types';
+import { isCI, isTestExecution, PYTHON_LANGUAGE } from '../../platform/common/constants';
+import '../../platform/common/extensions';
+import { disposeAllDisposables } from '../../platform/common/helpers';
+import { IDisposable, IDisposableRegistry } from '../../platform/common/types';
+import { noop } from '../../platform/common/utils/misc';
 import { EventName } from '../../telemetry/constants';
 import { getTelemetrySafeHashedString } from '../../telemetry/helpers';
-import { getAssociatedJupyterNotebook, isJupyterNotebook, splitMultilineString } from './utils';
+import { getAssociatedJupyterNotebook, isJupyterNotebook, splitMultilineString } from '../../platform/common/utils';
 
 /*
 Python has a fairly rich import statement. Originally the matching regexp was kept simple for
@@ -46,6 +46,9 @@ const MAX_DOCUMENT_LINES = 1000;
 // Capture isTestExecution on module load so that a test can turn it off and still
 // have this value set.
 const testExecution = isTestExecution();
+
+export const IImportTracker = Symbol('IImportTracker');
+export interface IImportTracker {}
 
 @injectable()
 export class ImportTracker implements IExtensionSingleActivationService, IDisposable {

--- a/src/webviews/extension-side/serviceRegistry.node.ts
+++ b/src/webviews/extension-side/serviceRegistry.node.ts
@@ -37,6 +37,7 @@ import { DataViewerFactory } from './dataviewer/dataViewerFactory';
 import { NotebookWatcher } from './variablesView/notebookWatcher';
 import { ExtensionSideRenderer, IExtensionSideRenderer } from './renderer';
 import { ExtensionRecommendationService } from './extensionRecommendation.node';
+import { ActiveEditorContextService } from './activeEditorContext';
 
 export function registerTypes(serviceManager: IServiceManager, _isDevMode: boolean) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, ServerPreload);
@@ -47,6 +48,10 @@ export function registerTypes(serviceManager: IServiceManager, _isDevMode: boole
     serviceManager.addSingleton<IExtensionSyncActivationService>(
         IExtensionSyncActivationService,
         ExtensionRecommendationService
+    );
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSingleActivationService,
+        ActiveEditorContextService
     );
 
     serviceManager.add<IDataViewer>(IDataViewer, DataViewer);

--- a/src/webviews/extension-side/serviceRegistry.node.ts
+++ b/src/webviews/extension-side/serviceRegistry.node.ts
@@ -40,8 +40,10 @@ import { ExtensionRecommendationService } from './extensionRecommendation.node';
 import { ActiveEditorContextService } from './activeEditorContext';
 import { AmlComputeContext } from './amlContext.node';
 import { IImportTracker, ImportTracker } from './importTracker.node';
+import { GlobalActivation } from './globalActivation';
 
 export function registerTypes(serviceManager: IServiceManager, _isDevMode: boolean) {
+    serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, GlobalActivation);
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, ServerPreload);
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSyncActivationService,

--- a/src/webviews/extension-side/serviceRegistry.node.ts
+++ b/src/webviews/extension-side/serviceRegistry.node.ts
@@ -36,12 +36,17 @@ import { PlotViewerProvider } from './plotting/plotViewerProvider.node';
 import { DataViewerFactory } from './dataviewer/dataViewerFactory';
 import { NotebookWatcher } from './variablesView/notebookWatcher';
 import { ExtensionSideRenderer, IExtensionSideRenderer } from './renderer';
+import { ExtensionRecommendationService } from './extensionRecommendation.node';
 
 export function registerTypes(serviceManager: IServiceManager, _isDevMode: boolean) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, ServerPreload);
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSyncActivationService,
         RendererCommunication
+    );
+    serviceManager.addSingleton<IExtensionSyncActivationService>(
+        IExtensionSyncActivationService,
+        ExtensionRecommendationService
     );
 
     serviceManager.add<IDataViewer>(IDataViewer, DataViewer);

--- a/src/webviews/extension-side/serviceRegistry.node.ts
+++ b/src/webviews/extension-side/serviceRegistry.node.ts
@@ -38,6 +38,7 @@ import { NotebookWatcher } from './variablesView/notebookWatcher';
 import { ExtensionSideRenderer, IExtensionSideRenderer } from './renderer';
 import { ExtensionRecommendationService } from './extensionRecommendation.node';
 import { ActiveEditorContextService } from './activeEditorContext';
+import { AmlComputeContext } from './amlContext.node';
 
 export function registerTypes(serviceManager: IServiceManager, _isDevMode: boolean) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, ServerPreload);
@@ -53,7 +54,12 @@ export function registerTypes(serviceManager: IServiceManager, _isDevMode: boole
         IExtensionSingleActivationService,
         ActiveEditorContextService
     );
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSingleActivationService,
+        AmlComputeContext
+    );
 
+    serviceManager.addSingleton<AmlComputeContext>(AmlComputeContext, AmlComputeContext);
     serviceManager.add<IDataViewer>(IDataViewer, DataViewer);
     serviceManager.addSingleton<IDataViewerFactory>(IDataViewerFactory, DataViewerFactory);
     serviceManager.add<IPlotViewer>(IPlotViewer, PlotViewer);

--- a/src/webviews/extension-side/serviceRegistry.node.ts
+++ b/src/webviews/extension-side/serviceRegistry.node.ts
@@ -39,6 +39,7 @@ import { ExtensionSideRenderer, IExtensionSideRenderer } from './renderer';
 import { ExtensionRecommendationService } from './extensionRecommendation.node';
 import { ActiveEditorContextService } from './activeEditorContext';
 import { AmlComputeContext } from './amlContext.node';
+import { IImportTracker, ImportTracker } from './importTracker.node';
 
 export function registerTypes(serviceManager: IServiceManager, _isDevMode: boolean) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, ServerPreload);
@@ -58,8 +59,9 @@ export function registerTypes(serviceManager: IServiceManager, _isDevMode: boole
         IExtensionSingleActivationService,
         AmlComputeContext
     );
-
     serviceManager.addSingleton<AmlComputeContext>(AmlComputeContext, AmlComputeContext);
+    serviceManager.addSingleton<IImportTracker>(IImportTracker, ImportTracker);
+    serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, ImportTracker);
     serviceManager.add<IDataViewer>(IDataViewer, DataViewer);
     serviceManager.addSingleton<IDataViewerFactory>(IDataViewerFactory, DataViewerFactory);
     serviceManager.add<IPlotViewer>(IPlotViewer, PlotViewer);

--- a/src/webviews/extension-side/serviceRegistry.web.ts
+++ b/src/webviews/extension-side/serviceRegistry.web.ts
@@ -22,8 +22,14 @@ import { CommandRegistry as ExportCommandRegistry } from './import-export/comman
 import { NotebookWatcher } from './variablesView/notebookWatcher';
 import { DataViewerFactory } from './dataviewer/dataViewerFactory';
 import { ExtensionSideRenderer, IExtensionSideRenderer } from './renderer';
+import { ActiveEditorContextService } from './activeEditorContext';
 
 export function registerTypes(serviceManager: IServiceManager, _isDevMode: boolean) {
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSingleActivationService,
+        ActiveEditorContextService
+    );
+
     serviceManager.add<IWebviewViewProvider>(IWebviewViewProvider, WebviewViewProvider);
     serviceManager.add<IWebviewPanelProvider>(IWebviewPanelProvider, WebviewPanelProvider);
 

--- a/src/webviews/extension-side/serviceRegistry.web.ts
+++ b/src/webviews/extension-side/serviceRegistry.web.ts
@@ -23,8 +23,10 @@ import { NotebookWatcher } from './variablesView/notebookWatcher';
 import { DataViewerFactory } from './dataviewer/dataViewerFactory';
 import { ExtensionSideRenderer, IExtensionSideRenderer } from './renderer';
 import { ActiveEditorContextService } from './activeEditorContext';
+import { GlobalActivation } from './globalActivation';
 
 export function registerTypes(serviceManager: IServiceManager, _isDevMode: boolean) {
+    serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, GlobalActivation);
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,
         ActiveEditorContextService


### PR DESCRIPTION
Re #10152. Continue to move service registration into feature component from platform. This PR itself is a bit large but they are mostly moving files.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
