### PR TITLE
Enable verbose logging for web tests

### DIFF
--- a/build/webpack/webpack.extension.web.config.js
+++ b/build/webpack/webpack.extension.web.config.js
@@ -8,9 +8,6 @@ const webpack = require('webpack');
 const constants = require('../constants');
 const CleanTerminalPlugin = require('clean-terminal-webpack-plugin');
 
-const prodEntry = {
-    extension: './src/extension.web.ts'
-};
 const devEntry = {
     extension: './src/extension.web.ts'
 };
@@ -18,10 +15,9 @@ const testEntry = {
     extension: './src/test/web/index.ts' // source of the web extension test runner
 };
 
-const isProdBuild = process.argv.includes('--mode');
 // When running web tests, the entry point for the tests and extension are the same.
 // Also, when building the production VSIX there's no need to compile the tests (faster build pipline).
-const entry = process.env.VSC_TEST_BUNDLE === 'true' ? testEntry : isProdBuild ? prodEntry : devEntry;
+const entry = process.env.VSC_TEST_BUNDLE === 'true' ? testEntry : devEntry;
 
 // tslint:disable-next-line:no-var-requires no-require-imports
 const configFileName = path.join(constants.ExtensionRootDir, 'tsconfig.extension.web.json');

--- a/build/webpack/webpack.extension.web.config.js
+++ b/build/webpack/webpack.extension.web.config.js
@@ -12,8 +12,7 @@ const prodEntry = {
     extension: './src/extension.web.ts'
 };
 const devEntry = {
-    extension: './src/extension.web.ts',
-    'test/index': './src/test/web/index.ts' // source of the web extension test runner
+    extension: './src/extension.web.ts'
 };
 const testEntry = {
     extension: './src/test/web/index.ts' // source of the web extension test runner

--- a/src/test/datascience/.vscode/settings.json
+++ b/src/test/datascience/.vscode/settings.json
@@ -22,7 +22,8 @@
     "files.autoSaveDelay": 1,
     // We don't want jupyter to start when testing (DS functionality or anything else).
     "jupyter.disableJupyterAutoStart": true,
-    "jupyter.logging.level": "debug",
+    // In web tests, VS Code will be reading this property (as we're changing the scope of this setting from machine to resource).
+    "jupyter.logging.level": "verbose",
     "python.logging.level": "debug",
     "webview.experimental.useIframes": true,
     "jupyter.interactiveWindowMode": "multiple",

--- a/src/test/datascience/widgets/commUtils.ts
+++ b/src/test/datascience/widgets/commUtils.ts
@@ -3,7 +3,7 @@
 
 import { NotebookCell, NotebookEditor, NotebookRendererMessaging, notebooks } from 'vscode';
 import { disposeAllDisposables } from '../../../platform/common/helpers';
-import { traceInfo, traceVerbose } from '../../../platform/logging';
+import { traceInfo } from '../../../platform/logging';
 import { IDisposable, IDisposableRegistry } from '../../../platform/common/types';
 import { createDeferred } from '../../../platform/common/utils/async';
 import { IServiceContainer } from '../../../platform/ioc/types';

--- a/src/test/datascience/widgets/commUtils.ts
+++ b/src/test/datascience/widgets/commUtils.ts
@@ -3,7 +3,7 @@
 
 import { NotebookCell, NotebookEditor, NotebookRendererMessaging, notebooks } from 'vscode';
 import { disposeAllDisposables } from '../../../platform/common/helpers';
-import { traceInfo } from '../../../platform/logging';
+import { traceInfo, traceVerbose } from '../../../platform/logging';
 import { IDisposable, IDisposableRegistry } from '../../../platform/common/types';
 import { createDeferred } from '../../../platform/common/utils/async';
 import { IServiceContainer } from '../../../platform/ioc/types';
@@ -22,8 +22,10 @@ export function initializeWidgetComms(serviceContainer: IServiceContainer): Util
     const disposable = messageChannel.onDidReceiveMessage(async ({ editor, message }) => {
         traceInfo(`Received message from Widget renderer ${JSON.stringify(message)}`);
         if (message && message.command === 'INIT') {
-            // disposable.dispose();
             deferred.resolve(editor);
+            // Redirect all of console.log, console.warn & console.error messages from
+            // renderer to the extension host.
+            messageChannel.postMessage({ command: 'hijackLogging' }, editor).then(noop, noop);
         }
     });
     disposables.push(disposable);

--- a/src/test/web/index.ts
+++ b/src/test/web/index.ts
@@ -1,13 +1,27 @@
 // Re-export extension entry point, so that the output from this file
 // when bundled can be used as entry point for extension as well as tests.
 // The same objects/types will be used as the module is only ever loaded once by nodejs.
+
+// First initialize the extension state.
+import { setCI, setTestExecution } from '../../platform/common/constants';
+import { setTestSettings } from '../constants';
+
+setCI(true);
+setTestExecution(true);
+setTestSettings({
+    isRemoteNativeTest: true,
+    isNonRawNativeTest: true
+});
+
+// Now import & load the rest of the extension code.
+// At this point, the necessary variables would have been initialized.
+// E.g. when extension activates, the isCI would have been set and necessary loggers setup & the like.
 import * as extension from '../../extension.web';
 import * as vscode from 'vscode';
 import type { IExtensionApi } from '../../webviews/extension-side/api/api';
 import type { IExtensionContext } from '../../platform/common/types';
 import { IExtensionTestApi } from '../common';
-import { JVSC_EXTENSION_ID, setCI, setTestExecution } from '../../platform/common/constants';
-import { setTestSettings } from '../constants';
+import { JVSC_EXTENSION_ID } from '../../platform/common/constants';
 
 let activatedResponse: undefined | IExtensionApi;
 
@@ -24,14 +38,6 @@ export async function activate(context: IExtensionContext): Promise<IExtensionAp
             mocha.setup({
                 ui: 'tdd',
                 reporter: undefined
-            });
-
-            // Can't tell if on CI or not, so assume not.
-            setCI(true);
-            setTestExecution(true);
-            setTestSettings({
-                isRemoteNativeTest: true,
-                isNonRawNativeTest: true
             });
 
             // bundles all files in the current directory matching `*.web.test` & `*.common.test`
@@ -54,6 +60,8 @@ export async function activate(context: IExtensionContext): Promise<IExtensionAp
             }
         });
     });
+
+    // Can't tell if on CI or not, so assume not.
     activatedResponse = await extension.activate(context);
     return activatedResponse;
 }

--- a/src/test/web/index.ts
+++ b/src/test/web/index.ts
@@ -61,7 +61,6 @@ export async function activate(context: IExtensionContext): Promise<IExtensionAp
         });
     });
 
-    // Can't tell if on CI or not, so assume not.
     activatedResponse = await extension.activate(context);
     return activatedResponse;
 }


### PR DESCRIPTION
Partially addresses #9807 

Today we only log the errors in web tests, and this makes it difficult to figure out what was going on when the tests failed.
I.e. a lot of contextual information is missing, information we have in other tests & not in web tests.

* Enables verbose logging for web tests
* Re-directs console log messages fromm webview out to the extension host (e.g. error messages from widget libraries or the like)