### PR TITLE
Update eslintrc import restriction rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -316,6 +316,20 @@ module.exports = {
                         message: 'Only modules from ./src/platform, ./src/telemetry, ./src/kernels and ./src/notebooks can be imported into ./src/interactive-window.'
                     },
                     {
+                        target: './src/**[!test,standalone,webviews]**/**/*.ts',
+                        from: './src/webviews/**/*.ts',
+                        except: [
+                            '**/src/webviews/webview-side/common/constants.ts',
+                            '**/src/webviews/types',
+                        ],
+                        message: 'Importing modules from ./src/webviews into core components (platform, kernels, notebooks, interactive-window) is not allowed.'
+                    },
+                    {
+                        target: './src/**[!test,standalone]**/*.ts',
+                        from: './src/standalone/**/*.ts',
+                        message: 'Importing modules from ./src/standalone into other components is not allowed.'
+                    },
+                    {
                         target: './src/telemetry/**/**[!types]**.ts',
                         from: './src/**[!telemetry,platform]**/**/*.ts',
                         message: 'Importing non-platform modules into telemetry files is not allowed.'

--- a/src/extension.node.ts
+++ b/src/extension.node.ts
@@ -73,6 +73,7 @@ import { registerTypes as registerInteractiveTypes } from './interactive-window/
 import { registerTypes as registerStandaloneTypes } from './standalone/serviceRegistry.node';
 import { registerTypes as registerTelemetryTypes } from './telemetry/serviceRegistry.node';
 import { registerTypes as registerIntellisenseTypes } from './intellisense/serviceRegistry.node';
+import { registerTypes as registerWebviewTypes } from './webviews/extension-side/serviceRegistry.node';
 import { IExtensionActivationManager } from './platform/activation/types';
 import { isCI, isTestExecution, JUPYTER_OUTPUT_CHANNEL, STANDARD_OUTPUT_CHANNEL } from './platform/common/constants';
 import { getDisplayPath } from './platform/common/platform/fs-paths';
@@ -320,6 +321,7 @@ async function activateLegacy(
     registerInteractiveTypes(serviceManager);
     registerStandaloneTypes(context, serviceManager, isDevMode);
     registerIntellisenseTypes(serviceManager, isDevMode);
+    registerWebviewTypes(serviceManager);
 
     // We need to setup this property before any telemetry is sent
     const fs = serviceManager.get<IFileSystemNode>(IFileSystemNode);

--- a/src/extension.web.ts
+++ b/src/extension.web.ts
@@ -71,6 +71,7 @@ import { registerTypes as registerInteractiveTypes } from './interactive-window/
 import { registerTypes as registerIntellisenseTypes } from './intellisense/serviceRegistry.web';
 import { registerTypes as registerTerminalTypes } from './platform/terminals/serviceRegistry.web';
 import { registerTypes as registerStandaloneTypes } from './standalone/serviceRegistry.web';
+import { registerTypes as registerWebviewTypes } from './webviews/extension-side/serviceRegistry.web';
 import { IExtensionActivationManager } from './platform/activation/types';
 import { isCI, isTestExecution, JUPYTER_OUTPUT_CHANNEL, STANDARD_OUTPUT_CHANNEL } from './platform/common/constants';
 import { getJupyterOutputChannel } from './standalone/devTools/jupyterOutputChannel';
@@ -291,6 +292,7 @@ async function activateLegacy(
     registerIntellisenseTypes(serviceManager, isDevMode);
     registerTerminalTypes(serviceManager);
     registerStandaloneTypes(context, serviceManager, isDevMode);
+    registerWebviewTypes(serviceManager);
 
     // Load the two data science experiments that we need to register types
     // Await here to keep the register method sync

--- a/src/platform/messageTypes.ts
+++ b/src/platform/messageTypes.ts
@@ -7,10 +7,12 @@ import { NativeKeyboardCommandTelemetry, NativeMouseCommandTelemetry } from '../
 import {
     IVariableExplorerHeight,
     CommonActionType
+    // eslint-disable-next-line
 } from '../webviews/webview-side/interactive-common/redux/reducers/types';
+// eslint-disable-next-line
+import { BaseReduxActionPayload } from '../webviews/types';
 import { WidgetScriptSource } from '../kernels/ipywidgets/types';
 import { KernelConnectionMetadata, KernelSocketOptions } from '../kernels/types';
-import { BaseReduxActionPayload } from '../webviews/types';
 import { ICell } from './common/types';
 import { IJupyterVariable, IJupyterVariablesRequest, IJupyterVariablesResponse } from '../kernels/variables/types';
 

--- a/src/platform/serviceRegistry.node.ts
+++ b/src/platform/serviceRegistry.node.ts
@@ -16,13 +16,21 @@ import { StatusProvider } from './progress/statusProvider';
 import { IStatusProvider } from './progress/types';
 import { ApplicationShell } from './common/application/applicationShell';
 import { CommandManager } from './common/application/commandManager';
-import { ICommandManager, IWorkspaceService, IApplicationShell } from './common/application/types';
+import {
+    ICommandManager,
+    IWorkspaceService,
+    IApplicationShell,
+    IWebviewViewProvider,
+    IWebviewPanelProvider
+} from './common/application/types';
 import { ConfigurationService } from './common/configuration/service.node';
 import { IFileSystem } from './common/platform/types';
 import { IFileSystemNode } from './common/platform/types.node';
 import { FileSystem } from './common/platform/fileSystem.node';
 import { WorkspaceService } from './common/application/workspace.node';
 import { OutputCommandListener } from './logging/outputCommandListener';
+import { WebviewViewProvider } from './webviews/webviewViewProvider';
+import { WebviewPanelProvider } from './webviews/webviewPanelProvider';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<FileSystem>(FileSystem, FileSystem);
@@ -51,4 +59,7 @@ export function registerTypes(serviceManager: IServiceManager) {
         PreReleaseChecker
     );
     serviceManager.addSingleton<IDataScienceCommandListener>(IDataScienceCommandListener, OutputCommandListener);
+
+    serviceManager.add<IWebviewViewProvider>(IWebviewViewProvider, WebviewViewProvider);
+    serviceManager.add<IWebviewPanelProvider>(IWebviewPanelProvider, WebviewPanelProvider);
 }

--- a/src/platform/serviceRegistry.web.ts
+++ b/src/platform/serviceRegistry.web.ts
@@ -9,7 +9,9 @@ import {
     ICommandManager,
     IWorkspaceService,
     IApplicationShell,
-    IApplicationEnvironment
+    IApplicationEnvironment,
+    IWebviewViewProvider,
+    IWebviewPanelProvider
 } from './common/application/types';
 import { ConfigurationService } from './common/configuration/service.web';
 import { registerTypes as registerApiTypes } from './api/serviceRegistry.web';
@@ -26,6 +28,8 @@ import { OutputCommandListener } from './logging/outputCommandListener';
 import { IFileSystem } from './common/platform/types';
 import { FileSystem } from './common/platform/fileSystem';
 import { KernelProgressReporter } from './progress/kernelProgressReporter';
+import { WebviewPanelProvider } from './webviews/webviewPanelProvider';
+import { WebviewViewProvider } from './webviews/webviewViewProvider';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IFileSystem>(IFileSystem, FileSystem);
@@ -45,4 +49,8 @@ export function registerTypes(serviceManager: IServiceManager) {
         IExtensionSyncActivationService,
         KernelProgressReporter
     );
+
+    // Webview Provider
+    serviceManager.add<IWebviewViewProvider>(IWebviewViewProvider, WebviewViewProvider);
+    serviceManager.add<IWebviewPanelProvider>(IWebviewPanelProvider, WebviewPanelProvider);
 }

--- a/src/standalone/import-export/exportCommands.ts
+++ b/src/standalone/import-export/exportCommands.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { NotebookDocument, QuickPickItem, QuickPickOptions, Uri } from 'vscode';
-import { getLocString } from '../../webviews/webview-side/react-common/locReactSide';
+import * as localize from '../../platform/common/utils/localize';
 import { ICommandNameArgumentTypeMapping } from '../../platform/common/application/commands';
 import { IApplicationShell, ICommandManager, IVSCodeNotebook } from '../../platform/common/application/types';
 import { traceInfo } from '../../platform/logging';
@@ -188,7 +188,7 @@ export class ExportCommands implements IDisposable {
             ignoreFocusOut: false,
             matchOnDescription: true,
             matchOnDetail: true,
-            placeHolder: getLocString('DataScience.exportAsQuickPickPlaceholder', 'Export As...')
+            placeHolder: localize.DataScience.exportAsQuickPickPlaceholder()
         };
 
         return this.applicationShell.showQuickPick(items, options);

--- a/src/standalone/serviceRegistry.node.ts
+++ b/src/standalone/serviceRegistry.node.ts
@@ -7,38 +7,12 @@ import {
     IExtensionSingleActivationService,
     IExtensionSyncActivationService
 } from '../platform/activation/types';
-import { IWebviewViewProvider, IWebviewPanelProvider } from '../platform/common/application/types';
 import { IServiceManager } from '../platform/ioc/types';
-import { INotebookWatcher, IVariableViewProvider } from '../webviews/extension-side/variablesView/types';
-import { VariableViewActivationService } from '../webviews/extension-side/variablesView/variableViewActivationService';
-import { VariableViewProvider } from '../webviews/extension-side/variablesView/variableViewProvider';
-import { WebviewPanelProvider } from '../platform/webviews/webviewPanelProvider';
-import { WebviewViewProvider } from '../platform/webviews/webviewViewProvider';
-import { JupyterVariableDataProvider } from '../webviews/extension-side/dataviewer/jupyterVariableDataProvider';
-import { JupyterVariableDataProviderFactory } from '../webviews/extension-side/dataviewer/jupyterVariableDataProviderFactory';
-import {
-    IDataViewer,
-    IDataViewerDependencyService,
-    IDataViewerFactory,
-    IJupyterVariableDataProvider,
-    IJupyterVariableDataProviderFactory
-} from '../webviews/extension-side/dataviewer/types';
 import { INotebookExporter, INotebookImporter } from '../kernels/jupyter/types';
 import { JupyterExporter } from './import-export/jupyterExporter';
 import { JupyterImporter } from './import-export/jupyterImporter.node';
 import { CommandRegistry as ExportCommandRegistry } from './import-export/commandRegistry';
 import { ServerPreload } from './serverPreload/serverPreload.node';
-import { RendererCommunication } from '../webviews/extension-side/plotView/rendererCommunication.node';
-import { PlotSaveHandler } from '../webviews/extension-side/plotView/plotSaveHandler.node';
-import { PlotViewHandler } from '../webviews/extension-side/plotView/plotViewHandler.node';
-import { DataViewerCommandRegistry } from '../webviews/extension-side/dataviewer/dataViewerCommandRegistry';
-import { DataViewer } from '../webviews/extension-side/dataviewer/dataViewer';
-import { IPlotViewer, IPlotViewerProvider } from '../webviews/extension-side/plotting/types';
-import { PlotViewer } from '../webviews/extension-side/plotting/plotViewer.node';
-import { DataViewerDependencyService } from '../webviews/extension-side/dataviewer/dataViewerDependencyService.node';
-import { PlotViewerProvider } from '../webviews/extension-side/plotting/plotViewerProvider.node';
-import { DataViewerFactory } from '../webviews/extension-side/dataviewer/dataViewerFactory';
-import { NotebookWatcher } from '../webviews/extension-side/variablesView/notebookWatcher';
 import { ExtensionSideRenderer, IExtensionSideRenderer } from './renderer';
 import { ExtensionRecommendationService } from './recommendation/extensionRecommendation.node';
 import { ActiveEditorContextService } from './context/activeEditorContext';
@@ -61,10 +35,6 @@ export function registerTypes(context: IExtensionContext, serviceManager: IServi
         IExtensionSingleActivationService,
         WorkspaceActivation
     );
-    serviceManager.addSingleton<IExtensionSingleActivationService>(
-        IExtensionSyncActivationService,
-        RendererCommunication
-    );
     serviceManager.addSingleton<IExtensionSyncActivationService>(
         IExtensionSyncActivationService,
         ExtensionRecommendationService
@@ -80,37 +50,6 @@ export function registerTypes(context: IExtensionContext, serviceManager: IServi
     serviceManager.addSingleton<AmlComputeContext>(AmlComputeContext, AmlComputeContext);
     serviceManager.addSingleton<IImportTracker>(IImportTracker, ImportTracker);
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, ImportTracker);
-    serviceManager.add<IDataViewer>(IDataViewer, DataViewer);
-    serviceManager.addSingleton<IDataViewerFactory>(IDataViewerFactory, DataViewerFactory);
-    serviceManager.add<IPlotViewer>(IPlotViewer, PlotViewer);
-    serviceManager.addSingleton<IPlotViewerProvider>(IPlotViewerProvider, PlotViewerProvider);
-    serviceManager.addSingleton<PlotSaveHandler>(PlotSaveHandler, PlotSaveHandler);
-    serviceManager.addSingleton<PlotViewHandler>(PlotViewHandler, PlotViewHandler);
-
-    serviceManager.addSingleton<IDataViewerDependencyService>(
-        IDataViewerDependencyService,
-        DataViewerDependencyService
-    );
-    serviceManager.addSingleton<IExtensionSingleActivationService>(
-        IExtensionSingleActivationService,
-        DataViewerCommandRegistry
-    );
-
-    serviceManager.add<IWebviewViewProvider>(IWebviewViewProvider, WebviewViewProvider);
-    serviceManager.add<IWebviewPanelProvider>(IWebviewPanelProvider, WebviewPanelProvider);
-
-    // Variable View
-    serviceManager.addSingleton<INotebookWatcher>(INotebookWatcher, NotebookWatcher);
-    serviceManager.addSingleton<IExtensionSingleActivationService>(
-        IExtensionSingleActivationService,
-        VariableViewActivationService
-    );
-    serviceManager.addSingleton<IVariableViewProvider>(IVariableViewProvider, VariableViewProvider);
-    serviceManager.add<IJupyterVariableDataProvider>(IJupyterVariableDataProvider, JupyterVariableDataProvider);
-    serviceManager.addSingleton<IJupyterVariableDataProviderFactory>(
-        IJupyterVariableDataProviderFactory,
-        JupyterVariableDataProviderFactory
-    );
 
     // Import/Export
     serviceManager.add<INotebookExporter>(INotebookExporter, JupyterExporter);

--- a/src/standalone/serviceRegistry.web.ts
+++ b/src/standalone/serviceRegistry.web.ts
@@ -2,30 +2,12 @@
 // Licensed under the MIT License.
 'use strict';
 
-import { IWebviewViewProvider, IWebviewPanelProvider } from '../platform/common/application/types';
 import { IServiceManager } from '../platform/ioc/types';
-import { WebviewViewProvider } from '../platform/webviews/webviewViewProvider';
-import { WebviewPanelProvider } from '../platform/webviews/webviewPanelProvider';
 import { IExtensionActivationManager, IExtensionSingleActivationService } from '../platform/activation/types';
-import { VariableViewActivationService } from '../webviews/extension-side/variablesView/variableViewActivationService';
-import { INotebookWatcher, IVariableViewProvider } from '../webviews/extension-side/variablesView/types';
-import { VariableViewProvider } from '../webviews/extension-side/variablesView/variableViewProvider';
-import { JupyterVariableDataProvider } from '../webviews/extension-side/dataviewer/jupyterVariableDataProvider';
-import { JupyterVariableDataProviderFactory } from '../webviews/extension-side/dataviewer/jupyterVariableDataProviderFactory';
-import {
-    IDataViewer,
-    IDataViewerFactory,
-    IJupyterVariableDataProvider,
-    IJupyterVariableDataProviderFactory
-} from '../webviews/extension-side/dataviewer/types';
-import { DataViewerCommandRegistry } from '../webviews/extension-side/dataviewer/dataViewerCommandRegistry';
 import { CommandRegistry as ExportCommandRegistry } from './import-export/commandRegistry';
-import { NotebookWatcher } from '../webviews/extension-side/variablesView/notebookWatcher';
-import { DataViewerFactory } from '../webviews/extension-side/dataviewer/dataViewerFactory';
 import { ExtensionSideRenderer, IExtensionSideRenderer } from './renderer';
 import { ActiveEditorContextService } from './context/activeEditorContext';
 import { GlobalActivation } from './activation/globalActivation';
-import { DataViewer } from '../webviews/extension-side/dataviewer/dataViewer';
 import { INotebookExporter } from '../kernels/jupyter/types';
 import { JupyterExporter } from './import-export/jupyterExporter';
 import { JupyterKernelServiceFactory } from './api/kernelApi';
@@ -40,30 +22,6 @@ export function registerTypes(context: IExtensionContext, serviceManager: IServi
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,
         ActiveEditorContextService
-    );
-
-    serviceManager.add<IWebviewViewProvider>(IWebviewViewProvider, WebviewViewProvider);
-    serviceManager.add<IWebviewPanelProvider>(IWebviewPanelProvider, WebviewPanelProvider);
-
-    // Data viewer
-    serviceManager.add<IDataViewer>(IDataViewer, DataViewer);
-    serviceManager.addSingleton<IDataViewerFactory>(IDataViewerFactory, DataViewerFactory);
-    serviceManager.addSingleton<IExtensionSingleActivationService>(
-        IExtensionSingleActivationService,
-        DataViewerCommandRegistry
-    );
-
-    // Variables view
-    serviceManager.addSingleton<INotebookWatcher>(INotebookWatcher, NotebookWatcher);
-    serviceManager.addSingleton<IExtensionSingleActivationService>(
-        IExtensionSingleActivationService,
-        VariableViewActivationService
-    );
-    serviceManager.addSingleton<IVariableViewProvider>(IVariableViewProvider, VariableViewProvider);
-    serviceManager.add<IJupyterVariableDataProvider>(IJupyterVariableDataProvider, JupyterVariableDataProvider);
-    serviceManager.addSingleton<IJupyterVariableDataProviderFactory>(
-        IJupyterVariableDataProviderFactory,
-        JupyterVariableDataProviderFactory
     );
 
     serviceManager.addSingleton<IExtensionSingleActivationService>(

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -18,6 +18,7 @@ import { EnvironmentType, PythonEnvironment } from '../platform/pythonEnvironmen
 import { TelemetryErrorProperties, ErrorCategory } from '../platform/errors/types';
 import { ExportFormat } from '../notebooks/export/types';
 import { InterruptResult, KernelConnectionMetadata, KernelInterpreterDependencyResponse } from '../kernels/types';
+// eslint-disable-next-line
 import { IExportedKernelService } from '../standalone/api/extension';
 import { PreferredKernelExactMatchReason } from '../notebooks/controllers/notebookControllerManager';
 import { SelectJupyterUriCommandSource } from '../kernels/jupyter/serverSelector';

--- a/src/webviews/extension-side/serviceRegistry.node.ts
+++ b/src/webviews/extension-side/serviceRegistry.node.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+
+import { IExtensionSingleActivationService, IExtensionSyncActivationService } from '../../platform/activation/types';
+import { IServiceManager } from '../../platform/ioc/types';
+import { DataViewer } from './dataviewer/dataViewer';
+import { DataViewerCommandRegistry } from './dataviewer/dataViewerCommandRegistry';
+import { DataViewerDependencyService } from './dataviewer/dataViewerDependencyService.node';
+import { DataViewerFactory } from './dataviewer/dataViewerFactory';
+import { JupyterVariableDataProvider } from './dataviewer/jupyterVariableDataProvider';
+import { JupyterVariableDataProviderFactory } from './dataviewer/jupyterVariableDataProviderFactory';
+import {
+    IDataViewer,
+    IDataViewerDependencyService,
+    IDataViewerFactory,
+    IJupyterVariableDataProvider,
+    IJupyterVariableDataProviderFactory
+} from './dataviewer/types';
+import { PlotViewer } from './plotting/plotViewer.node';
+import { PlotViewerProvider } from './plotting/plotViewerProvider.node';
+import { IPlotViewer, IPlotViewerProvider } from './plotting/types';
+import { PlotSaveHandler } from './plotView/plotSaveHandler.node';
+import { PlotViewHandler } from './plotView/plotViewHandler.node';
+import { RendererCommunication } from './plotView/rendererCommunication.node';
+import { NotebookWatcher } from './variablesView/notebookWatcher';
+import { INotebookWatcher, IVariableViewProvider } from './variablesView/types';
+import { VariableViewActivationService } from './variablesView/variableViewActivationService';
+import { VariableViewProvider } from './variablesView/variableViewProvider';
+
+export function registerTypes(serviceManager: IServiceManager) {
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSyncActivationService,
+        RendererCommunication
+    );
+
+    // Data Viewer
+    serviceManager.add<IDataViewer>(IDataViewer, DataViewer);
+    serviceManager.addSingleton<IDataViewerFactory>(IDataViewerFactory, DataViewerFactory);
+    serviceManager.addSingleton<IDataViewerDependencyService>(
+        IDataViewerDependencyService,
+        DataViewerDependencyService
+    );
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSingleActivationService,
+        DataViewerCommandRegistry
+    );
+
+    // Plot Viewer
+    serviceManager.add<IPlotViewer>(IPlotViewer, PlotViewer);
+    serviceManager.addSingleton<IPlotViewerProvider>(IPlotViewerProvider, PlotViewerProvider);
+    serviceManager.addSingleton<PlotSaveHandler>(PlotSaveHandler, PlotSaveHandler);
+    serviceManager.addSingleton<PlotViewHandler>(PlotViewHandler, PlotViewHandler);
+
+    // Variable View
+    serviceManager.addSingleton<INotebookWatcher>(INotebookWatcher, NotebookWatcher);
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSingleActivationService,
+        VariableViewActivationService
+    );
+    serviceManager.addSingleton<IVariableViewProvider>(IVariableViewProvider, VariableViewProvider);
+    serviceManager.add<IJupyterVariableDataProvider>(IJupyterVariableDataProvider, JupyterVariableDataProvider);
+    serviceManager.addSingleton<IJupyterVariableDataProviderFactory>(
+        IJupyterVariableDataProviderFactory,
+        JupyterVariableDataProviderFactory
+    );
+}

--- a/src/webviews/extension-side/serviceRegistry.web.ts
+++ b/src/webviews/extension-side/serviceRegistry.web.ts
@@ -1,0 +1,40 @@
+import { VariableViewActivationService } from './variablesView/variableViewActivationService';
+import { INotebookWatcher, IVariableViewProvider } from './variablesView/types';
+import { VariableViewProvider } from './variablesView/variableViewProvider';
+import { JupyterVariableDataProvider } from './dataviewer/jupyterVariableDataProvider';
+import { JupyterVariableDataProviderFactory } from './dataviewer/jupyterVariableDataProviderFactory';
+import {
+    IDataViewer,
+    IDataViewerFactory,
+    IJupyterVariableDataProvider,
+    IJupyterVariableDataProviderFactory
+} from './dataviewer/types';
+import { DataViewerCommandRegistry } from './dataviewer/dataViewerCommandRegistry';
+import { NotebookWatcher } from './variablesView/notebookWatcher';
+import { DataViewerFactory } from './dataviewer/dataViewerFactory';
+import { DataViewer } from './dataviewer/dataViewer';
+import { IServiceManager } from '../../platform/ioc/types';
+import { IExtensionSingleActivationService } from '../../platform/activation/types';
+
+export function registerTypes(serviceManager: IServiceManager) {
+    // Data viewer
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSingleActivationService,
+        DataViewerCommandRegistry
+    );
+    serviceManager.add<IDataViewer>(IDataViewer, DataViewer);
+    serviceManager.addSingleton<IDataViewerFactory>(IDataViewerFactory, DataViewerFactory);
+
+    // Variables view
+    serviceManager.addSingleton<INotebookWatcher>(INotebookWatcher, NotebookWatcher);
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSingleActivationService,
+        VariableViewActivationService
+    );
+    serviceManager.addSingleton<IVariableViewProvider>(IVariableViewProvider, VariableViewProvider);
+    serviceManager.add<IJupyterVariableDataProvider>(IJupyterVariableDataProvider, JupyterVariableDataProvider);
+    serviceManager.addSingleton<IJupyterVariableDataProviderFactory>(
+        IJupyterVariableDataProviderFactory,
+        JupyterVariableDataProviderFactory
+    );
+}


### PR DESCRIPTION
Re #10152 

After experimenting moving all `webviews` into `standalone/webviews` I found that change is siganificantly large and I'm also not seeing obvious benefits of doing that. If I want to find a feature related to webview, it's kind of weird that I need to go to `standalone` and then `webviews`, and lastly have to browse in both `extension-side` and `webview-side`.

`webviews` is still probably a good top component, where all features related to webview just go into that. Other features go into `standalone`.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
