### PR TITLE
Change pylanceHandlesNotebooks default to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -1970,12 +1970,9 @@
                 },
                 "jupyter.pylanceHandlesNotebooks": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Determines if pylance's experimental notebook support is used or not.",
-                    "scope": "machine",
-                    "tags": [
-                        "experimental"
-                    ]
+                    "scope": "machine"
                 },
                 "jupyter.pythonCompletionTriggerCharacters": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -1971,7 +1971,7 @@
                 "jupyter.pylanceHandlesNotebooks": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Determines if pylance's experimental notebook support is used or not.",
+                    "description": "Determines if Pylance manages notebook concat doc creation.",
                     "scope": "machine"
                 },
                 "jupyter.pythonCompletionTriggerCharacters": {

--- a/src/platform/common/configSettings.ts
+++ b/src/platform/common/configSettings.ts
@@ -94,7 +94,7 @@ export class JupyterSettings implements IWatchableJupyterSettings {
     public verboseLogging: boolean = false;
     public showVariableViewWhenDebugging: boolean = true;
     public newCellOnRunLast: boolean = true;
-    public pylanceHandlesNotebooks: boolean = false;
+    public pylanceHandlesNotebooks: boolean = true;
     public pylanceLspNotebooksEnabled: boolean = false;
     public pythonCompletionTriggerCharacters: string = '';
     public logKernelOutputSeparately: boolean = false;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pylance-release/issues/2963

The pylanceHandlesNotebooks experiment is finished and was successful, so changing the setting to be on by default.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [X] Title summarizes what is changing.
-   [X] ~Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).~
-   [X] ~Appropriate comments and documentation strings in the code.~
-   [X] ~Has sufficient logging.~
-   [X] ~Has telemetry for feature-requests.~
-   [X] ~Unit tests & system/integration tests are added/updated.~
-   [X] ~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [X] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
