### PR TITLE
Split IJupyterSession into Raw and Jupyter

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1553,7 +1553,7 @@ No properties for event
     @captureTelemetry(Telemetry.Interrupt)
     @captureTelemetry(Telemetry.InterruptJupyterTime)
     private async interruptExecution(
-        session: IJupyterSession,
+        session: IKernelConnectionSession,
 ```
 
 </details>
@@ -5806,7 +5806,7 @@ No properties for event
     @captureTelemetry(Telemetry.Interrupt)
     @captureTelemetry(Telemetry.InterruptJupyterTime)
     private async interruptExecution(
-        session: IJupyterSession,
+        session: IKernelConnectionSession,
         pendingCells: Promise<unknown>
 ```
 
@@ -8151,7 +8151,7 @@ No properties for event
 
     @captureTelemetry(Telemetry.RestartKernel)
     @captureTelemetry(Telemetry.RestartJupyterTime)
-    private async restartExecution(session: IJupyterSession): Promise<void> {
+    private async restartExecution(session: IKernelConnectionSession): Promise<void> {
         // Just use the internal session. Pending cells should have been canceled by the caller
         await session.restart();
 ```
@@ -8180,7 +8180,7 @@ No properties for event
 
     @captureTelemetry(Telemetry.RestartKernel)
     @captureTelemetry(Telemetry.RestartJupyterTime)
-    private async restartExecution(session: IJupyterSession): Promise<void> {
+    private async restartExecution(session: IKernelConnectionSession): Promise<void> {
         // Just use the internal session. Pending cells should have been canceled by the caller
 ```
 

--- a/src/interactive-window/debugger/jupyter/kernelDebugAdapter.ts
+++ b/src/interactive-window/debugger/jupyter/kernelDebugAdapter.ts
@@ -7,7 +7,7 @@ import { KernelMessage } from '@jupyterlab/services';
 import * as path from '../../../platform/vscode-path/path';
 import { DebugAdapterTracker, DebugSession, NotebookDocument, Uri } from 'vscode';
 import { DebugProtocol } from 'vscode-debugprotocol';
-import { IJupyterSession, IKernel } from '../../../kernels/types';
+import { IKernel, IKernelConnectionSession } from '../../../kernels/types';
 import { IPlatformService } from '../../../platform/common/platform/types';
 import { IDumpCellResponse, IDebugLocationTrackerFactory } from '../../../kernels/debugger/types';
 import { traceError, traceInfo, traceInfoIfCI } from '../../../platform/logging';
@@ -27,7 +27,7 @@ export class KernelDebugAdapter extends KernelDebugAdapterBase {
     constructor(
         session: DebugSession,
         notebookDocument: NotebookDocument,
-        jupyterSession: IJupyterSession,
+        jupyterSession: IKernelConnectionSession,
         kernel: IKernel | undefined,
         platformService: IPlatformService,
         debugLocationTrackerFactory?: IDebugLocationTrackerFactory

--- a/src/kernels/common/baseJupyterSession.ts
+++ b/src/kernels/common/baseJupyterSession.ts
@@ -20,7 +20,7 @@ import { JupyterWaitForIdleError } from '../errors/jupyterWaitForIdleError';
 import { KernelInterruptTimeoutError } from '../errors/kernelInterruptTimeoutError';
 import { SessionDisposedError } from '../../platform/errors/sessionDisposedError';
 import {
-    IJupyterServerSession,
+    IJupyterKernelConnectionSession,
     ISessionWithSocket,
     KernelConnectionMetadata,
     KernelSocketInformation,
@@ -139,7 +139,7 @@ export abstract class BaseJupyterSession implements IBaseKernelConnectionSession
             traceInfo(`Unhandled message found: ${m.header.msg_type}`);
         };
     }
-    public isServerSession(): this is IJupyterServerSession {
+    public isServerSession(): this is IJupyterKernelConnectionSession {
         return false;
     }
     public async dispose(): Promise<void> {

--- a/src/kernels/common/baseJupyterSession.ts
+++ b/src/kernels/common/baseJupyterSession.ts
@@ -21,10 +21,10 @@ import { KernelInterruptTimeoutError } from '../errors/kernelInterruptTimeoutErr
 import { SessionDisposedError } from '../../platform/errors/sessionDisposedError';
 import {
     IJupyterServerSession,
-    IJupyterSession,
     ISessionWithSocket,
     KernelConnectionMetadata,
-    KernelSocketInformation
+    KernelSocketInformation,
+    IBaseKernelConnectionSession
 } from '../types';
 import { ChainingExecuteRequester } from './chainingExecuteRequester';
 import { getResourceType } from '../../platform/common/utils';
@@ -70,7 +70,7 @@ export class JupyterSessionStartError extends WrappedError {
     }
 }
 
-export abstract class BaseJupyterSession implements IJupyterSession {
+export abstract class BaseJupyterSession implements IBaseKernelConnectionSession {
     /**
      * Keep a single instance of KernelConnectionWrapper.
      * This way when sessions change, we still have a single Kernel.IKernelConnection proxy (wrapper),
@@ -129,7 +129,6 @@ export abstract class BaseJupyterSession implements IJupyterSession {
     private previousAnyMessageHandler?: IDisposable;
 
     constructor(
-        public readonly kind: 'localRaw' | 'remoteJupyter' | 'localJupyter',
         protected resource: Resource,
         protected readonly kernelConnectionMetadata: KernelConnectionMetadata,
         public workingDirectory: Uri,

--- a/src/kernels/debugger/kernelDebugAdapterBase.ts
+++ b/src/kernels/debugger/kernelDebugAdapterBase.ts
@@ -23,7 +23,7 @@ import {
     workspace
 } from 'vscode';
 import { DebugProtocol } from 'vscode-debugprotocol';
-import { IJupyterSession, IKernel } from '../types';
+import { IKernelConnectionSession, IKernel } from '../types';
 import { IPlatformService } from '../../platform/common/platform/types';
 import { DebuggingTelemetry } from './constants';
 import {
@@ -60,7 +60,7 @@ export abstract class KernelDebugAdapterBase implements DebugAdapter, IKernelDeb
     constructor(
         protected session: DebugSession,
         protected notebookDocument: NotebookDocument,
-        protected readonly jupyterSession: IJupyterSession,
+        protected readonly jupyterSession: IKernelConnectionSession,
         private readonly kernel: IKernel | undefined,
         private readonly platformService: IPlatformService
     ) {

--- a/src/kernels/execution/cellExecution.ts
+++ b/src/kernels/execution/cellExecution.ts
@@ -30,7 +30,7 @@ import { getDisplayNameOrNameOfKernelConnection, isPythonKernelConnection } from
 import { isCancellationError } from '../../platform/common/cancellation';
 import { activeNotebookCellExecution, CellExecutionMessageHandler } from './cellExecutionMessageHandler';
 import { CellExecutionMessageHandlerService } from './cellExecutionMessageHandlerService';
-import { IJupyterSession, KernelConnectionMetadata, NotebookCellRunState } from '../../kernels/types';
+import { IKernelConnectionSession, KernelConnectionMetadata, NotebookCellRunState } from '../../kernels/types';
 import { NotebookCellStateTracker, traceCellMessage } from './helpers';
 
 export class CellExecutionFactory {
@@ -133,7 +133,7 @@ export class CellExecution implements IDisposable {
     ) {
         return new CellExecution(cell, code, metadata, controller, requestListener);
     }
-    public async start(session: IJupyterSession) {
+    public async start(session: IKernelConnectionSession) {
         if (this.cancelHandled) {
             traceCellMessage(this.cell, 'Not starting as it was cancelled');
             return;
@@ -311,12 +311,12 @@ export class CellExecution implements IDisposable {
         return !this.cell.document.isClosed;
     }
 
-    private async execute(code: string, session: IJupyterSession) {
+    private async execute(code: string, session: IKernelConnectionSession) {
         traceCellMessage(this.cell, 'Send code for execution');
         await this.executeCodeCell(code, session);
     }
 
-    private async executeCodeCell(code: string, session: IJupyterSession) {
+    private async executeCodeCell(code: string, session: IKernelConnectionSession) {
         // Skip if no code to execute
         if (code.trim().length === 0 || this.cell.document.isClosed) {
             traceCellMessage(this.cell, 'Empty cell execution');

--- a/src/kernels/execution/cellExecutionQueue.ts
+++ b/src/kernels/execution/cellExecutionQueue.ts
@@ -6,7 +6,7 @@ import { traceInfo, traceError } from '../../platform/logging';
 import { noop } from '../../platform/common/utils/misc';
 import { traceCellMessage } from './helpers';
 import { CellExecution, CellExecutionFactory } from './cellExecution';
-import { IJupyterSession, KernelConnectionMetadata, NotebookCellRunState } from '../../kernels/types';
+import { IKernelConnectionSession, KernelConnectionMetadata, NotebookCellRunState } from '../../kernels/types';
 
 /**
  * A queue responsible for execution of cells.
@@ -36,7 +36,7 @@ export class CellExecutionQueue implements Disposable {
         return this.queueOfCellsToExecute.map((cell) => cell.cell);
     }
     constructor(
-        private readonly session: Promise<IJupyterSession>,
+        private readonly session: Promise<IKernelConnectionSession>,
         private readonly executionFactory: CellExecutionFactory,
         readonly metadata: Readonly<KernelConnectionMetadata>
     ) {}

--- a/src/kernels/helpers.ts
+++ b/src/kernels/helpers.ts
@@ -16,8 +16,8 @@ import {
     LiveRemoteKernelConnectionMetadata,
     PythonKernelConnectionMetadata,
     IJupyterKernelSpec,
-    IJupyterSession,
-    IKernel
+    IKernel,
+    IKernelConnectionSession
 } from './types';
 import { Uri, workspace } from 'vscode';
 import { IWorkspaceService } from '../platform/common/application/types';
@@ -1454,7 +1454,7 @@ export type SilentExecutionErrorOptions = {
 };
 
 export async function executeSilently(
-    session: IJupyterSession,
+    session: IKernelConnectionSession,
     code: string,
     errorOptions?: SilentExecutionErrorOptions
 ): Promise<nbformat.IOutput[]> {

--- a/src/kernels/jupyter/launcher/jupyterNotebookProvider.ts
+++ b/src/kernels/jupyter/launcher/jupyterNotebookProvider.ts
@@ -8,7 +8,7 @@ import {
     ConnectNotebookProviderOptions,
     GetServerOptions,
     IJupyterConnection,
-    IJupyterSession,
+    IKernelConnectionSession,
     isLocalConnection,
     NotebookCreationOptions
 } from '../../types';
@@ -34,7 +34,7 @@ export class JupyterNotebookProvider implements IJupyterNotebookProvider {
         return connection;
     }
 
-    public async createNotebook(options: NotebookCreationOptions): Promise<IJupyterSession> {
+    public async createNotebook(options: NotebookCreationOptions): Promise<IKernelConnectionSession> {
         const kernelConnection = options.kernelConnection;
         // Make sure we have a server
         const serverOptions: GetServerOptions = isLocalConnection(kernelConnection)

--- a/src/kernels/jupyter/launcher/liveshare/hostJupyterServer.ts
+++ b/src/kernels/jupyter/launcher/liveshare/hostJupyterServer.ts
@@ -27,7 +27,7 @@ import {
     isLocalConnection,
     IJupyterConnection,
     KernelActionSource,
-    IJupyterSession
+    IJupyterKernelConnectionSession
 } from '../../../types';
 import { JupyterSessionManager } from '../../session/jupyterSessionManager';
 import { noop } from '../../../../platform/common/utils/misc';
@@ -41,7 +41,7 @@ import { RemoteJupyterServerConnectionError } from '../../../../platform/errors/
 export class HostJupyterServer implements INotebookServer {
     private connectionInfoDisconnectHandler: IDisposable | undefined;
     private serverExitCode: number | undefined;
-    private sessions = new Set<Promise<IJupyterSession>>();
+    private sessions = new Set<Promise<IJupyterKernelConnectionSession>>();
     private disposed = false;
     constructor(
         @inject(IAsyncDisposableRegistry) private readonly asyncRegistry: IAsyncDisposableRegistry,
@@ -89,10 +89,10 @@ export class HostJupyterServer implements INotebookServer {
         cancelToken: CancellationToken,
         ui: IDisplayOptions,
         actionSource: KernelActionSource
-    ): Promise<IJupyterSession> {
+    ): Promise<IJupyterKernelConnectionSession> {
         this.throwIfDisposedOrCancelled(cancelToken);
         // Compute launch information from the resource and the notebook metadata
-        const sessionPromise = createDeferred<IJupyterSession>();
+        const sessionPromise = createDeferred<IJupyterKernelConnectionSession>();
         // Save the Session
         this.trackDisposable(sessionPromise.promise);
         const startNewSession = async () => {
@@ -141,7 +141,7 @@ export class HostJupyterServer implements INotebookServer {
         cancelToken: CancellationToken,
         ui: IDisplayOptions,
         creator: KernelActionSource
-    ): Promise<IJupyterSession> {
+    ): Promise<IJupyterKernelConnectionSession> {
         this.throwIfDisposedOrCancelled(cancelToken);
         traceInfoIfCI(
             `HostJupyterServer.createNotebook for ${getDisplayPath(resource)} with ui.disableUI=${
@@ -254,7 +254,7 @@ export class HostJupyterServer implements INotebookServer {
         // Default is just say session was disposed
         return new SessionDisposedError();
     }
-    private trackDisposable(sessionPromise: Promise<IJupyterSession>) {
+    private trackDisposable(sessionPromise: Promise<IJupyterKernelConnectionSession>) {
         sessionPromise
             .then((session) => {
                 session.onDidDispose(() => this.sessions.delete(sessionPromise), this, this.disposables);

--- a/src/kernels/jupyter/launcher/notebookProvider.ts
+++ b/src/kernels/jupyter/launcher/notebookProvider.ts
@@ -10,7 +10,7 @@ import { Telemetry } from '../../../telemetry';
 import {
     ConnectNotebookProviderOptions,
     GetServerOptions,
-    IJupyterSession,
+    IKernelConnectionSession,
     INotebookProvider,
     INotebookProviderConnection,
     isLocalConnection,
@@ -60,7 +60,7 @@ export class NotebookProvider implements INotebookProvider {
             throw new Error('Python Extension is not installed');
         }
     }
-    public async create(options: NotebookCreationOptions): Promise<IJupyterSession> {
+    public async create(options: NotebookCreationOptions): Promise<IKernelConnectionSession> {
         const kernelConnection = options.kernelConnection;
         const isLocal = isLocalConnection(kernelConnection);
         const rawLocalKernel = this.rawNotebookProvider?.isSupported && isLocal;

--- a/src/kernels/jupyter/session/jupyterSession.ts
+++ b/src/kernels/jupyter/session/jupyterSession.ts
@@ -21,7 +21,7 @@ import {
     IJupyterConnection,
     ISessionWithSocket,
     KernelActionSource,
-    IJupyterServerSession
+    IJupyterKernelConnectionSession
 } from '../../types';
 import { DisplayOptions } from '../../displayOptions';
 import { IBackupFile, IJupyterBackingFileCreator, IJupyterKernelService, IJupyterRequestCreator } from '../types';
@@ -30,7 +30,7 @@ import { generateBackingIPyNbFileName } from './backingFileCreator.base';
 import { noop } from '../../../platform/common/utils/misc';
 
 // function is
-export class JupyterSession extends BaseJupyterSession implements IJupyterServerSession {
+export class JupyterSession extends BaseJupyterSession implements IJupyterKernelConnectionSession {
     public readonly kind: 'remoteJupyter' | 'localJupyter';
 
     constructor(
@@ -53,7 +53,7 @@ export class JupyterSession extends BaseJupyterSession implements IJupyterServer
         this.kind = connInfo.localLaunch ? 'localJupyter' : 'remoteJupyter';
     }
 
-    public override isServerSession(): this is IJupyterServerSession {
+    public override isServerSession(): this is IJupyterKernelConnectionSession {
         return true;
     }
 

--- a/src/kernels/jupyter/session/jupyterSession.ts
+++ b/src/kernels/jupyter/session/jupyterSession.ts
@@ -31,7 +31,7 @@ import { noop } from '../../../platform/common/utils/misc';
 
 // function is
 export class JupyterSession extends BaseJupyterSession implements IJupyterServerSession {
-    public override readonly kind: 'remoteJupyter' | 'localJupyter';
+    public readonly kind: 'remoteJupyter' | 'localJupyter';
 
     constructor(
         resource: Resource,
@@ -49,14 +49,7 @@ export class JupyterSession extends BaseJupyterSession implements IJupyterServer
         private readonly requestCreator: IJupyterRequestCreator,
         private readonly sessionCreator: KernelActionSource
     ) {
-        super(
-            connInfo.localLaunch ? 'localJupyter' : 'remoteJupyter',
-            resource,
-            kernelConnectionMetadata,
-            workingDirectory,
-            interruptTimeout
-        );
-
+        super(resource, kernelConnectionMetadata, workingDirectory, interruptTimeout);
         this.kind = connInfo.localLaunch ? 'localJupyter' : 'remoteJupyter';
     }
 

--- a/src/kernels/jupyter/types.ts
+++ b/src/kernels/jupyter/types.ts
@@ -16,12 +16,13 @@ import {
     IJupyterConnection,
     ConnectNotebookProviderOptions,
     NotebookCreationOptions,
-    IJupyterSession,
+    IJupyterKernelConnectionSession,
     IJupyterKernelSpec,
     GetServerOptions,
     IKernelSocket,
     KernelActionSource,
-    LiveRemoteKernelConnectionMetadata
+    LiveRemoteKernelConnectionMetadata,
+    IKernelConnectionSession
 } from '../types';
 import { ClassType } from '../../platform/ioc/types';
 
@@ -52,7 +53,7 @@ export interface INotebookServer extends IAsyncDisposable {
         cancelToken: CancellationToken,
         ui: IDisplayOptions,
         creator: KernelActionSource
-    ): Promise<IJupyterSession>;
+    ): Promise<IKernelConnectionSession>;
     readonly connection: IJupyterConnection;
 }
 
@@ -65,7 +66,7 @@ export interface INotebookServerFactory {
 export const IJupyterNotebookProvider = Symbol('IJupyterNotebookProvider');
 export interface IJupyterNotebookProvider {
     connect(options: ConnectNotebookProviderOptions): Promise<IJupyterConnection>;
-    createNotebook(options: NotebookCreationOptions): Promise<IJupyterSession>;
+    createNotebook(options: NotebookCreationOptions): Promise<IKernelConnectionSession>;
 }
 
 export type INotebookServerLocalOptions = {
@@ -121,7 +122,7 @@ export interface IJupyterSessionManager extends IAsyncDisposable {
         ui: IDisplayOptions,
         cancelToken: CancellationToken,
         creator: KernelActionSource
-    ): Promise<IJupyterSession>;
+    ): Promise<IJupyterKernelConnectionSession>;
     getKernelSpecs(): Promise<IJupyterKernelSpec[]>;
     getRunningKernels(): Promise<IJupyterKernel[]>;
     getRunningSessions(): Promise<Session.IModel[]>;

--- a/src/kernels/kernel.base.ts
+++ b/src/kernels/kernel.base.ts
@@ -43,8 +43,8 @@ import {
 import { sendTelemetryEvent, Telemetry } from '../telemetry';
 import { executeSilently, getDisplayNameOrNameOfKernelConnection, isPythonKernelConnection } from './helpers';
 import {
-    IJupyterSession,
     IKernel,
+    IKernelConnectionSession,
     INotebookProvider,
     InterruptResult,
     isLocalConnection,
@@ -106,7 +106,7 @@ export abstract class BaseKernel implements IKernel {
     get executionCount(): number {
         return this._visibleExecutionCount;
     }
-    protected _session?: IJupyterSession;
+    protected _session?: IKernelConnectionSession;
     /**
      * If the session died, then ensure the status is set to `dead`.
      * We need to provide an accurate status.
@@ -114,7 +114,7 @@ export abstract class BaseKernel implements IKernel {
      * If a jupyter kernel dies after it has started, then status is set to `dead`.
      */
     private isKernelDead?: boolean;
-    public get session(): IJupyterSession | undefined {
+    public get session(): IKernelConnectionSession | undefined {
         return this._session;
     }
     protected _disposed?: boolean;
@@ -126,8 +126,8 @@ export abstract class BaseKernel implements IKernel {
     private readonly _onStarted = new EventEmitter<void>();
     protected readonly _onDisposed = new EventEmitter<void>();
     protected readonly _onPreExecute = new EventEmitter<NotebookCell>();
-    protected _jupyterSessionPromise?: Promise<IJupyterSession>;
-    private readonly hookedSessionForEvents = new WeakSet<IJupyterSession>();
+    protected _jupyterSessionPromise?: Promise<IKernelConnectionSession>;
+    private readonly hookedSessionForEvents = new WeakSet<IKernelConnectionSession>();
     protected eventHooks: ((ev: 'willInterrupt' | 'willRestart') => Promise<void>)[] = [];
     protected restarting?: Deferred<void>;
     protected startCancellation = new CancellationTokenSource();
@@ -344,7 +344,7 @@ export abstract class BaseKernel implements IKernel {
     }
     protected async startJupyterSession(
         options: IDisplayOptions = new DisplayOptions(false)
-    ): Promise<IJupyterSession> {
+    ): Promise<IKernelConnectionSession> {
         traceVerbose(`Start Jupyter Session in kernel.ts with disableUI = ${options.disableUI}`);
         this._startedAtLeastOnce = true;
         if (!options.disableUI) {
@@ -395,7 +395,7 @@ export abstract class BaseKernel implements IKernel {
         return this._jupyterSessionPromise;
     }
 
-    private async createJupyterSession(stopWatch: StopWatch): Promise<IJupyterSession> {
+    private async createJupyterSession(stopWatch: StopWatch): Promise<IKernelConnectionSession> {
         let disposables: Disposable[] = [];
         try {
             // No need to block kernel startup on UI updates.
@@ -439,11 +439,14 @@ export abstract class BaseKernel implements IKernel {
             // Else we just pollute the logs with lots of noise.
             if (this.startupUI.disableUI) {
                 traceVerbose(
-                    `failed to create IJupyterSession in kernel, UI Disabled = ${this.startupUI.disableUI}`,
+                    `failed to create IJupyterKernelConnectionSession in kernel, UI Disabled = ${this.startupUI.disableUI}`,
                     ex
                 );
             } else if (!this.startCancellation.token && !isCancellationError(ex)) {
-                traceError(`failed to create IJupyterSession in kernel, UI Disabled = ${this.startupUI.disableUI}`, ex);
+                traceError(
+                    `failed to create IJupyterKernelConnectionSession in kernel, UI Disabled = ${this.startupUI.disableUI}`,
+                    ex
+                );
             }
             Cancellation.throwIfCanceled(this.startCancellation.token);
             if (ex instanceof JupyterConnectError) {
@@ -489,7 +492,7 @@ export abstract class BaseKernel implements IKernel {
 
     protected abstract sendTelemetryForPythonKernelExecutable(): Promise<void>;
 
-    protected async initializeAfterStart(session: IJupyterSession | undefined) {
+    protected async initializeAfterStart(session: IKernelConnectionSession | undefined) {
         traceVerbose(`Started running kernel initialization for ${getDisplayPath(this.uri)}`);
         if (!session) {
             traceVerbose('Not running kernel initialization');
@@ -723,7 +726,7 @@ export abstract class BaseKernel implements IKernel {
     protected abstract getUpdateWorkingDirectoryAndPathCode(launchingFile?: Resource): Promise<string[]>;
 
     private async executeSilently(
-        session: IJupyterSession | undefined,
+        session: IKernelConnectionSession | undefined,
         code: string[],
         errorOptions?: SilentExecutionErrorOptions
     ) {

--- a/src/kernels/raw/session/hostRawNotebookProvider.node.ts
+++ b/src/kernels/raw/session/hostRawNotebookProvider.node.ts
@@ -22,7 +22,7 @@ import { DataScience } from '../../../platform/common/utils/localize';
 import { trackKernelResourceInformation } from '../../telemetry/helper';
 import { captureTelemetry, sendTelemetryEvent, Telemetry } from '../../../telemetry';
 import { isPythonKernelConnection } from '../../helpers';
-import { IJupyterSession, KernelConnectionMetadata } from '../../types';
+import { IRawKernelConnectionSession, KernelConnectionMetadata } from '../../types';
 import { IKernelLauncher, IRawNotebookProvider, IRawNotebookSupportedService } from '../types';
 import { RawJupyterSession } from './rawJupyterSession.node';
 import { Cancellation } from '../../../platform/common/cancellation';
@@ -36,7 +36,7 @@ export class HostRawNotebookProvider implements IRawNotebookProvider {
     public get id(): string {
         return this._id;
     }
-    private sessions = new Set<Promise<IJupyterSession>>();
+    private sessions = new Set<Promise<IRawKernelConnectionSession>>();
     private _id = uuid();
     private disposed = false;
     constructor(
@@ -72,9 +72,9 @@ export class HostRawNotebookProvider implements IRawNotebookProvider {
         kernelConnection: KernelConnectionMetadata,
         ui: IDisplayOptions,
         cancelToken: vscode.CancellationToken
-    ): Promise<IJupyterSession> {
+    ): Promise<IRawKernelConnectionSession> {
         traceInfo(`Creating raw notebook for resource '${getDisplayPath(resource)}'`);
-        const sessionPromise = createDeferred<IJupyterSession>();
+        const sessionPromise = createDeferred<IRawKernelConnectionSession>();
         this.trackDisposable(sessionPromise.promise);
         let rawSession: RawJupyterSession | undefined;
 
@@ -138,7 +138,7 @@ export class HostRawNotebookProvider implements IRawNotebookProvider {
         return sessionPromise.promise;
     }
 
-    private trackDisposable(sessionPromise: Promise<IJupyterSession>) {
+    private trackDisposable(sessionPromise: Promise<IRawKernelConnectionSession>) {
         void sessionPromise
             .then((session) => {
                 session.onDidDispose(

--- a/src/kernels/raw/session/rawJupyterSession.node.ts
+++ b/src/kernels/raw/session/rawJupyterSession.node.ts
@@ -21,7 +21,7 @@ import { sendKernelTelemetryEvent } from '../../telemetry/sendKernelTelemetryEve
 import { trackKernelResourceInformation } from '../../telemetry/helper';
 import { sendTelemetryEvent, captureTelemetry, Telemetry } from '../../../telemetry';
 import { getDisplayNameOrNameOfKernelConnection } from '../../../kernels/helpers';
-import { ISessionWithSocket, KernelConnectionMetadata } from '../../../kernels/types';
+import { IRawKernelConnectionSession, ISessionWithSocket, KernelConnectionMetadata } from '../../../kernels/types';
 import { BaseJupyterSession } from '../../common/baseJupyterSession';
 import { IKernelLauncher, IKernelProcess } from '../types';
 import { RawSession } from './rawSession.node';
@@ -30,13 +30,14 @@ import { noop } from '../../../platform/common/utils/misc';
 import { KernelProgressReporter } from '../../../platform/progress/kernelProgressReporter';
 
 /*
-RawJupyterSession is the implementation of IJupyterSession that instead of
+RawJupyterSession is the implementation of IJupyterKernelConnectionSession that instead of
 connecting to JupyterLab services it instead connects to a kernel directly
 through ZMQ.
-It's responsible for translating our IJupyterSession interface into the
+It's responsible for translating our IJupyterKernelConnectionSession interface into the
 jupyterlabs interface as well as starting up and connecting to a raw session
 */
-export class RawJupyterSession extends BaseJupyterSession {
+export class RawJupyterSession extends BaseJupyterSession implements IRawKernelConnectionSession {
+    public readonly kind = 'localRaw';
     private processExitHandler = new WeakMap<RawSession, IDisposable>();
     private terminatingStatus?: KernelMessage.Status;
     public get atleastOneCellExecutedSuccessfully() {
@@ -59,7 +60,7 @@ export class RawJupyterSession extends BaseJupyterSession {
         kernelConnection: KernelConnectionMetadata,
         private readonly launchTimeout: number
     ) {
-        super('localRaw', resource, kernelConnection, workingDirectory, interruptTimeout);
+        super(resource, kernelConnection, workingDirectory, interruptTimeout);
     }
 
     public async waitForIdle(timeout: number): Promise<void> {

--- a/src/kernels/raw/types.ts
+++ b/src/kernels/raw/types.ts
@@ -5,7 +5,7 @@
 import { CancellationToken, Event } from 'vscode';
 import { IAsyncDisposable, IDisplayOptions, IDisposable, Resource } from '../../platform/common/types';
 import {
-    IJupyterSession,
+    IKernelConnectionSession,
     INotebookProviderConnection,
     KernelConnectionMetadata,
     LocalKernelConnectionMetadata,
@@ -95,5 +95,5 @@ export interface IRawNotebookProvider extends IAsyncDisposable {
         kernelConnection: KernelConnectionMetadata,
         ui: IDisplayOptions,
         cancelToken: CancellationToken
-    ): Promise<IJupyterSession>;
+    ): Promise<IKernelConnectionSession>;
 }

--- a/src/kernels/types.ts
+++ b/src/kernels/types.ts
@@ -270,7 +270,7 @@ export interface IBaseKernelConnectionSession extends IAsyncDisposable {
     readonly status: KernelMessage.Status;
     readonly kernelId: string;
     readonly kernelSocket: Observable<KernelSocketInformation | undefined>;
-    isServerSession(): this is IJupyterServerSession;
+    isServerSession(): this is IJupyterKernelConnectionSession;
     onSessionStatusChanged: Event<KernelMessage.Status>;
     onDidDispose: Event<void>;
     interrupt(): Promise<void>;
@@ -303,19 +303,15 @@ export interface IBaseKernelConnectionSession extends IAsyncDisposable {
 
 export interface IJupyterKernelConnectionSession extends IBaseKernelConnectionSession {
     readonly kind: 'remoteJupyter' | 'localJupyter';
-}
-export interface IRawKernelConnectionSession extends IBaseKernelConnectionSession {
-    readonly kind: 'localRaw';
-}
-export type IKernelConnectionSession = IJupyterKernelConnectionSession | IRawKernelConnectionSession;
-
-export interface IJupyterServerSession extends IJupyterKernelConnectionSession {
-    readonly kind: 'remoteJupyter' | 'localJupyter';
     invokeWithFileSynced(contents: string, handler: (file: IBackupFile) => Promise<void>): Promise<void>;
     createTempfile(ext: string): Promise<string>;
     deleteTempfile(file: string): Promise<void>;
     getContents(file: string, format: Contents.FileFormat): Promise<Contents.IModel>;
 }
+export interface IRawKernelConnectionSession extends IBaseKernelConnectionSession {
+    readonly kind: 'localRaw';
+}
+export type IKernelConnectionSession = IJupyterKernelConnectionSession | IRawKernelConnectionSession;
 
 export type ISessionWithSocket = Session.ISessionConnection & {
     /**

--- a/src/kernels/variables/kernelVariables.ts
+++ b/src/kernels/variables/kernelVariables.ts
@@ -9,7 +9,7 @@ import { Experiments } from '../../platform/common/experiments/groups';
 import { IConfigurationService, IExperimentService, IDisposableRegistry } from '../../platform/common/types';
 import { createDeferred } from '../../platform/common/utils/async';
 import { getKernelConnectionLanguage, isPythonKernelConnection } from '../helpers';
-import { IJupyterSession, IKernel } from '../types';
+import { IKernel, IKernelConnectionSession } from '../types';
 import {
     IJupyterVariable,
     IJupyterVariables,
@@ -294,7 +294,7 @@ export class KernelVariables implements IJupyterVariables {
     }
 
     private inspect(
-        session: IJupyterSession,
+        session: IKernelConnectionSession,
         code: string,
         offsetInCode = 0,
         cancelToken?: CancellationToken

--- a/src/standalone/intellisense/pythonKernelCompletionProvider.ts
+++ b/src/standalone/intellisense/pythonKernelCompletionProvider.ts
@@ -20,7 +20,7 @@ import { IConfigurationService, IDisposableRegistry } from '../../platform/commo
 import { waitForPromise } from '../../platform/common/utils/async';
 import { isNotebookCell } from '../../platform/common/utils/misc';
 import { StopWatch } from '../../platform/common/utils/stopWatch';
-import { IJupyterSession, IKernelProvider } from '../../kernels/types';
+import { IKernelConnectionSession, IKernelProvider } from '../../kernels/types';
 import { INotebookCompletionProvider, INotebookEditorProvider } from '../../notebooks/types';
 import { mapJupyterKind } from './conversion';
 import { isTestExecution, Settings } from '../../platform/common/constants';
@@ -156,7 +156,7 @@ export class PythonKernelCompletionProvider implements CompletionItemProvider {
         );
     }
     public async getJupyterCompletion(
-        session: IJupyterSession,
+        session: IKernelConnectionSession,
         cellCode: string,
         offsetInCode: number,
         cancelToken?: CancellationToken

--- a/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
+++ b/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { anything, instance, mock, when } from 'ts-mockito';
 import * as vscode from 'vscode';
 import { PythonExtensionChecker } from '../../../platform/api/pythonApi';
-import { IJupyterSession, KernelConnectionMetadata } from '../../../platform/../kernels/types';
+import { IJupyterKernelConnectionSession, KernelConnectionMetadata } from '../../../platform/../kernels/types';
 import { NotebookProvider } from '../../../kernels/jupyter/launcher/notebookProvider';
 import { DisplayOptions } from '../../../kernels/displayOptions';
 import { IJupyterNotebookProvider } from '../../../kernels/jupyter/types';
@@ -47,7 +47,7 @@ suite('DataScience - NotebookProvider', () => {
     });
     teardown(() => disposeAllDisposables(disposables));
     test('NotebookProvider getOrCreateNotebook jupyter provider does not have notebook already', async () => {
-        const mockSession = mock<IJupyterSession>();
+        const mockSession = mock<IJupyterKernelConnectionSession>();
         instance(mockSession as any).then = undefined;
         when(jupyterNotebookProvider.createNotebook(anything())).thenResolve(instance(mockSession));
         when(jupyterNotebookProvider.connect(anything())).thenResolve({} as any);
@@ -65,7 +65,7 @@ suite('DataScience - NotebookProvider', () => {
     });
 
     test('NotebookProvider getOrCreateNotebook second request should return the notebook already cached', async () => {
-        const mockSession = mock<IJupyterSession>();
+        const mockSession = mock<IJupyterKernelConnectionSession>();
         instance(mockSession as any).then = undefined;
         when(jupyterNotebookProvider.createNotebook(anything())).thenResolve(instance(mockSession));
         when(jupyterNotebookProvider.connect(anything())).thenResolve({} as any);

--- a/src/test/datascience/mockJupyterServer.ts
+++ b/src/test/datascience/mockJupyterServer.ts
@@ -2,14 +2,14 @@
 // Licensed under the MIT License.
 import { Uri } from 'vscode';
 import { INotebookServer } from '../../kernels/jupyter/types';
-import { IJupyterConnection, IJupyterSession } from '../../kernels/types';
+import { IJupyterConnection, IJupyterKernelConnectionSession } from '../../kernels/types';
 import { TemporaryFile } from '../../platform/common/platform/types';
 
 export class MockJupyterServer implements INotebookServer {
     constructor(public connection: IJupyterConnection) {}
     private notebookFile: TemporaryFile | undefined;
 
-    public async createNotebook(_resource: Uri): Promise<IJupyterSession> {
+    public async createNotebook(_resource: Uri): Promise<IJupyterKernelConnectionSession> {
         throw new Error('Not implemented');
     }
     public async dispose(): Promise<void> {

--- a/src/test/datascience/notebook/executionService.mock.vscode.test.ts
+++ b/src/test/datascience/notebook/executionService.mock.vscode.test.ts
@@ -27,7 +27,7 @@
 // import { INotebookControllerManager } from '../../../notebooks/types';
 // import { IKernelProvider } from '../../../platform/../kernels/types';
 // import {
-//     IJupyterSession,
+//     IJupyterKernelConnectionSession,
 //     INotebook,
 //     INotebookProvider,
 //     KernelSocketInformation
@@ -101,7 +101,7 @@
 //         traceInfo(`Ended Test (completed) ${this.currentTest?.title}`);
 //     });
 //     suiteTeardown(() => closeNotebooksAndCleanUpAfterTests(disposables));
-//     function createKernelWithMockJupyterSession(notebook: NotebookDocument, session: IJupyterSession) {
+//     function createKernelWithMockJupyterSession(notebook: NotebookDocument, session: IJupyterKernelConnectionSession) {
 //         const controller = controllerManager.getSelectedNotebookController(notebook);
 //         if (!controller) {
 //             return;

--- a/src/test/kernels/kernelAutoRestartMonitor.unit.test.ts
+++ b/src/test/kernels/kernelAutoRestartMonitor.unit.test.ts
@@ -6,7 +6,7 @@ import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { EventEmitter } from 'vscode';
 import { getDisplayNameOrNameOfKernelConnection } from '../../kernels/helpers';
 import { KernelAutoRestartMonitor } from '../../kernels/kernelAutoRestartMonitor.node';
-import { IJupyterSession, IKernel, IKernelProvider, KernelConnectionMetadata } from '../../kernels/types';
+import { IKernel, IKernelConnectionSession, IKernelProvider, KernelConnectionMetadata } from '../../kernels/types';
 import { disposeAllDisposables } from '../../platform/common/helpers';
 import { IDisposable } from '../../platform/common/types';
 import { DataScience } from '../../platform/common/utils/localize';
@@ -66,7 +66,7 @@ suite('Jupyter Execution', async () => {
         );
 
         const kernel = mock<IKernel>();
-        const session = mock<IJupyterSession>();
+        const session = mock<IKernelConnectionSession>();
         const disposable = mock<IDisposable>();
         when(kernel.kernelConnectionMetadata).thenReturn(connectionMetadata);
         when(kernel.session).thenReturn(instance(session));


### PR DESCRIPTION
Minor refactor to split the interface into two, 
* Also `IJupyterSession` is confusing name, as we use the term `JupyterSession` mosly when dealing with non-raw (real jupyter sessions). 
Note: We already had two separate interfaces, but we never really made it clear (i.e. we had a seprate interface for Jupyter sessions that inherited `IJupyterSession`).

* Pre for local live kernels (easier when we have two distinct interfaces)
