### PR TITLE
Do not show modal error everytime for widget error

### DIFF
--- a/src/kernels/ipywidgets/commonMessageCoordinator.ts
+++ b/src/kernels/ipywidgets/commonMessageCoordinator.ts
@@ -57,7 +57,7 @@ export class CommonMessageCoordinator {
     private jupyterOutput: IOutputChannel;
     private readonly configService: IConfigurationService;
     private webview: IWebviewCommunication | undefined;
-    private modulesForWhichWeHaveDisplayedWisdgetErrorMessage = new Set<string>();
+    private modulesForWhichWeHaveDisplayedWidgetErrorMessage = new Set<string>();
 
     public constructor(
         private readonly document: NotebookDocument,

--- a/src/kernels/ipywidgets/commonMessageCoordinator.ts
+++ b/src/kernels/ipywidgets/commonMessageCoordinator.ts
@@ -177,8 +177,8 @@ export class CommonMessageCoordinator {
                     payload.moduleVersion
                 );
                 this.appShell.showErrorMessage(errorMessage).then(noop, noop);
-            } else if (!cdnsEnabled && !this.modulesForWhichWeHaveDisplayedWisdgetErrorMessage.has(key)) {
-                this.modulesForWhichWeHaveDisplayedWisdgetErrorMessage.add(key);
+            } else if (!cdnsEnabled && !this.modulesForWhichWeHaveDisplayedWidgetErrorMessage.has(key)) {
+                this.modulesForWhichWeHaveDisplayedWidgetErrorMessage.add(key);
                 const moreInfo = Common.moreInfo();
                 const enableDownloads = DataScience.enableCDNForWidgetsButton();
                 errorMessage = DataScience.enableCDNForWidgetsSetting().format(


### PR DESCRIPTION
Basically if we have a widget that registers 20 scripts for a single cell output, then the webview attempts to load the scripts 20 times & for each failure we send a message to the extension host
& on the extension host we display 20 modal dialogs (for the same kernel session) if CDN isn't configured

This PR ensures we display the message for the kernel only once,
E.g. when using widgets like gmaps one will end up getting around 30 modal dialogs, perhaps more (I gave up and had to kill VS Code, restarting VS Code was easier than hitting cancel 30+ times)