### PR TITLE
Change the logic for when we show the "Install Python (Extension)" commands

### DIFF
--- a/news/1 Enhancements/10583.md
+++ b/news/1 Enhancements/10583.md
@@ -1,0 +1,1 @@
+Change the logic to show our "Install Python (Extension)" commands in the kernel picker more often.

--- a/src/notebooks/languages/helpers.ts
+++ b/src/notebooks/languages/helpers.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { NotebookCellKind, NotebookDocument } from 'vscode';
+import { getLanguageInNotebookMetadata } from '../../kernels/helpers';
+import { getNotebookMetadata } from '../../platform/common/utils';
+import { traceWarning } from '../../platform/logging';
+
+// Get the language of the notebook document, preference given to metadata over the language of
+// the first cell
+export function getLanguageOfNotebookDocument(doc: NotebookDocument): string | undefined {
+    // If the document has been closed, accessing cell information can fail.
+    // Ignore such exceptions.
+    try {
+        // Give preference to the language information in the metadata.
+        const language = getLanguageInNotebookMetadata(getNotebookMetadata(doc));
+        // Fall back to the language of the first code cell in the notebook.
+        return language || doc.getCells().find((cell) => cell.kind === NotebookCellKind.Code)?.document.languageId;
+    } catch (ex) {
+        traceWarning('Failed to determine language of first cell', ex);
+    }
+}


### PR DESCRIPTION
Fixes #10583

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
