### PR TITLE
Adjust a translation per recommendation from the localization team

### DIFF
--- a/src/platform/common/utils/localize.ts
+++ b/src/platform/common/utils/localize.ts
@@ -312,10 +312,7 @@ export namespace DataScience {
             'Raw kernel process exited before connecting.'
         );
     export const unknownMimeTypeFormat = () =>
-        localize(
-            { key: 'DataScience.unknownMimeTypeFormat', comment: ['{Locked="Mime type"}'] },
-            'Mime type {0} is not currently supported'
-        );
+        localize('DataScience.unknownMimeTypeFormat', 'MIME type {0} is not currently supported');
     export const exportDialogTitle = () =>
         localize(
             { key: 'DataScience.exportDialogTitle', comment: ['{Locked="Notebook"}'] },


### PR DESCRIPTION
The localization team has told me that we shouldn't lock `Mime type` as we are doing here.

I've removed the comment and fixed the casing (`MIME` is the [correct casing](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types))