### PR TITLE
increase execution count for cells added from the input box

### DIFF
--- a/src/interactive-window/editor-integration/codeGenerator.ts
+++ b/src/interactive-window/editor-integration/codeGenerator.ts
@@ -39,6 +39,10 @@ export class CodeGenerator implements IInteractiveWindowCodeGenerator {
         this.documentManager.onDidChangeTextDocument(this.onChangedDocument, this, this.disposables);
     }
 
+    bumpExecutionCount(): void {
+        this.executionCount += 1;
+    }
+
     public dispose() {
         if (this.disposed) {
             return;

--- a/src/interactive-window/editor-integration/types.ts
+++ b/src/interactive-window/editor-integration/types.ts
@@ -110,6 +110,7 @@ export type InteractiveCellMetadata = {
 };
 
 export interface IInteractiveWindowCodeGenerator extends IDisposable {
+    bumpExecutionCount(): void;
     reset(): void;
     generateCode(
         metadata: Pick<InteractiveCellMetadata, 'interactive' | 'id' | 'interactiveWindowCellMarker'>,


### PR DESCRIPTION
Fixes #10631

When a cell is added from the input box, we don't have enough information to fully generate the code, but we still need to bump the execution count so that the traceback formatter can find the correct code when adding links to stack traces
