### PR TITLE
Ignore husky from builds

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,6 +12,7 @@ docs/**
 .gitignore
 .gitmodules
 .huskyrc.json
+.husky/**
 .npmrc
 .nvmrc
 .nycrc


### PR DESCRIPTION
`.husky` directory is being shipped in the vsix.