### PR TITLE
Better CI Job labels

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -358,13 +358,13 @@ jobs:
         python: [nonConda, conda]
         pythonVersion: ['3.9', '3.10']
         webOrDesktop: ['']
-        # We're not running CI on macOS for now because it's one less matrix entry to lower the number of runners used,
-        # macOS runners are expensive, and we assume that Ubuntu is enough to cover the UNIX case.
-        os: [ubuntu-latest]
         # Whether we're using stable (<empty>) or pre-release versions of Python packages.
         # When installing pre-release versions, we're only focused on jupyter & related packages.
         # Not pre-release versions of pandas, numpy or other such packages that are not core to Jupyter.
         packageVersion: ['']
+        # We're not running CI on macOS for now because it's one less matrix entry to lower the number of runners used,
+        # macOS runners are expensive, and we assume that Ubuntu is enough to cover the UNIX case.
+        os: [ubuntu-latest]
         # More details on includes/excludes can be found here https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-additional-values-into-combinations
         # Basically with exclude, you can exclude any of the combinations from the result matrix.
         # & with include, you can include additional items to the result matrix.

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -371,13 +371,13 @@ jobs:
           - jupyter: remote # We don't care how remote is started (we only want to test connecting to it)
             python: nonConda
             pythonVersion: '3.9'
-            os: ubuntu-latest
             webOrDesktop: 'desktop'
+            os: ubuntu-latest
           - jupyter: remote
             python: nonConda
             pythonVersion: '3.9'
-            os: ubuntu-latest
             webOrDesktop: 'web'
+            os: ubuntu-latest
           - jupyter: raw
             python: noPython
             os: ubuntu-latest
@@ -388,13 +388,13 @@ jobs:
           - jupyter: local
             python: nonConda
             pythonVersion: '3.9'
-            os: ubuntu-latest
             packageVersion: 'prerelease'
+            os: ubuntu-latest
           - jupyter: raw
             python: nonConda
             pythonVersion: '3.9'
-            os: ubuntu-latest
             packageVersion: 'prerelease'
+            os: ubuntu-latest
         exclude:
           - python: conda # Conda does't seem to support 3.10 yet.
             pythonVersion: '3.10'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -357,6 +357,7 @@ jobs:
         jupyter: [raw, local]
         python: [nonConda, conda]
         pythonVersion: ['3.9', '3.10']
+        webOrDesktop: ['']
         # We're not running CI on macOS for now because it's one less matrix entry to lower the number of runners used,
         # macOS runners are expensive, and we assume that Ubuntu is enough to cover the UNIX case.
         os: [ubuntu-latest]


### PR DESCRIPTION
This basically makes it easy to read the Job labels & figure out which one is web and which runs against pre-release bits

# Before
![Screen Shot 2022-07-07 at 09 30 36](https://user-images.githubusercontent.com/1948812/177659723-d67c6e18-558a-4d68-ba22-a6878c9e6d2d.png)

# Now (with changes)
![Screen Shot 2022-07-07 at 09 33 28](https://user-images.githubusercontent.com/1948812/177659871-4986faa6-eaea-4a97-812b-1fe1b140ef42.png)

