### PR TITLE
Cleared inherited horizontal padding on the react-grid-Cell

### DIFF
--- a/src/webviews/webview-side/interactive-common/variableExplorerGrid.less
+++ b/src/webviews/webview-side/interactive-common/variableExplorerGrid.less
@@ -68,6 +68,7 @@
     background-color: transparent;
     color: var(--vscode-editor-foreground);
     border-style: none;
+    padding: 0 2px;
 }
 
 #variable-explorer-data-grid .react-grid-Cell:hover {


### PR DESCRIPTION
As shown on #10230 , there's a slight misalignment between the column names and the column values in the variable viewer. This PR ensures the values are aligned with the column titles.

Here's how it looks:
<img width="782" alt="Screen Shot 2022-07-06 at 8 48 11 PM" src="https://user-images.githubusercontent.com/417016/177666864-89211694-e8c8-43e0-8b9d-04491bb548f3.png">

Feedback appreciated!
If approved:
Fixes #10230