### PR TITLE
Vertical alignment on the variable viewer column headers

### DIFF
--- a/src/webviews/webview-side/interactive-common/variableExplorerGrid.less
+++ b/src/webviews/webview-side/interactive-common/variableExplorerGrid.less
@@ -40,6 +40,7 @@
     padding: 2px;
     font-family: var(--vscode-font-family);
     border-right: 1px solid var(--vscode-menu-border);
+    padding-top: 4px;
 }
 
 .react-grid-Header {


### PR DESCRIPTION
This PR adds some padding at the top of the column headers in the variable viewer table. Looks as follows:

<img width="773" alt="Screen Shot 2022-07-07 at 4 49 18 PM" src="https://user-images.githubusercontent.com/417016/177868993-49093578-d139-426d-a68a-f4cf60530106.png">

You can compare that screenshot with the screenshot available in the related issue.
Fixes #10228 
