### PR TITLE
Using monospace in the values of the variable viewer

### DIFF
--- a/src/webviews/webview-side/interactive-common/variableExplorerGrid.less
+++ b/src/webviews/webview-side/interactive-common/variableExplorerGrid.less
@@ -70,6 +70,7 @@
     color: var(--vscode-editor-foreground);
     border-style: none;
     padding: 0 2px;
+    font-family: monospace;
 }
 
 #variable-explorer-data-grid .react-grid-Cell:hover {


### PR DESCRIPTION
This PR changes the font family of the cells in the table of the variable viewer to use monospace. Looks as follows:

<img width="569" alt="Screen Shot 2022-07-07 at 5 00 14 PM" src="https://user-images.githubusercontent.com/417016/177870854-984c24ac-552f-4ea5-9c32-13948ed637a5.png">

You can compare that screenshot with the screenshot available in the related issue.
Fixes #10223
