### PR TITLE
Ensures string variables appear within single quotes in the variable viewer

### DIFF
--- a/news/1 Enhancements/10225.md
+++ b/news/1 Enhancements/10225.md
@@ -1,0 +1,1 @@
+The Variable Viewer now shows strings wrapped in single quotes.

--- a/src/kernels/variables/kernelVariables.ts
+++ b/src/kernels/variables/kernelVariables.ts
@@ -24,7 +24,7 @@ import {
 // kernels will add the ansi encoding.
 const TypeRegex = /.*?\[.*?;31mType:.*?\[0m\s+(\w+)/;
 const ValueRegex = /.*?\[.*?;31mValue:.*?\[0m\s+(.*)/;
-const StringFormRegex = /.*?\[.*?;31mString form:.*?\[0m\s*?([\s\S]+?)\n(.*\[.*;31m?)/;
+const StringFormRegex = /.*?\[.*?;31mString form:.*?\[0m\s+?([\s\S]+?)\n(.*\[.*;31m?)/;
 const DocStringRegex = /.*?\[.*?;31mDocstring:.*?\[0m\s+(.*)/;
 const CountRegex = /.*?\[.*?;31mLength:.*?\[0m\s+(.*)/;
 const ShapeRegex = /^\s+\[(\d+) rows x (\d+) columns\]/m;

--- a/src/test/datascience/variableView/variableView.vscode.test.ts
+++ b/src/test/datascience/variableView/variableView.vscode.test.ts
@@ -97,8 +97,8 @@ suite('DataScience - VariableView', function () {
 
         // Parse the HTML for our expected variables
         const expectedVariables = [
-            { name: 'test', type: 'str', length: '11', value: ' MYTESTVALUE' },
-            { name: 'test2', type: 'str', length: '12', value: ' MYTESTVALUE2' }
+            { name: 'test', type: 'str', length: '11', value: 'MYTESTVALUE' },
+            { name: 'test2', type: 'str', length: '12', value: 'MYTESTVALUE2' }
         ];
         await waitForVariablesToMatch(expectedVariables, variableView);
 
@@ -142,7 +142,7 @@ suite('DataScience - VariableView', function () {
         await runCell(cell2);
 
         // Parse the HTML for our expected variables
-        const expectedVariables = [{ name: 'test2', type: 'str', length: '12', value: ' MYTESTVALUE2' }];
+        const expectedVariables = [{ name: 'test2', type: 'str', length: '12', value: 'MYTESTVALUE2' }];
         await waitForVariablesToMatch(expectedVariables, variableView);
     });
 
@@ -162,7 +162,7 @@ suite('DataScience - VariableView', function () {
         await Promise.all([runCell(cell), waitForExecutionCompletedSuccessfully(cell)]);
 
         // Parse the HTML for our expected variables
-        const expectedVariables = [{ name: 'test', type: 'str', length: '11', value: ' MYTESTVALUE' }];
+        const expectedVariables = [{ name: 'test', type: 'str', length: '11', value: 'MYTESTVALUE' }];
         await waitForVariablesToMatch(expectedVariables, variableView);
 
         // Now create a second document
@@ -183,8 +183,8 @@ suite('DataScience - VariableView', function () {
 
         // Parse the HTML for our expected variables
         const expectedVariables2 = [
-            { name: 'test2', type: 'str', length: '12', value: ' MYTESTVALUE2' },
-            { name: 'test3', type: 'str', length: '12', value: ' MYTESTVALUE3' }
+            { name: 'test2', type: 'str', length: '12', value: 'MYTESTVALUE2' },
+            { name: 'test3', type: 'str', length: '12', value: 'MYTESTVALUE3' }
         ];
         await waitForVariablesToMatch(expectedVariables2, variableView);
     });
@@ -222,13 +222,13 @@ myClass = MyClass()
         // If the value can change (ordering or python version), then omit the value to not check it
         const expectedVariables = [
             { name: 'myClass', type: 'MyClass', length: '' },
-            { name: 'myDataframe', type: 'DataFrame', length: '(3, 1)', value: '\n     0\n0  1.0\n1  2.0\n2  3.0' },
+            { name: 'myDataframe', type: 'DataFrame', length: '(3, 1)', value: '     0\n0  1.0\n1  2.0\n2  3.0' },
             { name: 'mynpArray', type: 'ndarray', length: '(3,)' },
             {
                 name: 'mySeries',
                 type: 'Series',
                 length: '(3,)',
-                value: '\n0    1.0\n1    2.0\n2    3.0\nName: 0, dtype: float64'
+                value: '0    1.0\n1    2.0\n2    3.0\nName: 0, dtype: float64'
             }
         ];
 
@@ -261,13 +261,13 @@ mySet = {1, 2, 3}
         // Parse the HTML for our expected variables
         // If the value can change (ordering or python version), then omit the value to not check it
         const expectedVariables = [
-            { name: 'myComplex', type: 'complex', length: '', value: ' (1+1j)' },
-            { name: 'myDict', type: 'dict', length: '1', value: " {'a': 1}" },
-            { name: 'myFloat', type: 'float', length: '', value: ' 9999.9999' },
-            { name: 'myInt', type: 'int', length: '', value: ' 99999999' },
-            { name: 'myList', type: 'list', length: '3', value: ' [1, 2, 3]' },
-            { name: 'mySet', type: 'set', length: '3', value: ' {1, 2, 3}' },
-            { name: 'myTuple', type: 'tuple', length: '3', value: ' (1, 2, 3)' }
+            { name: 'myComplex', type: 'complex', length: '', value: '(1+1j)' },
+            { name: 'myDict', type: 'dict', length: '1', value: "{'a': 1}" },
+            { name: 'myFloat', type: 'float', length: '', value: '9999.9999' },
+            { name: 'myInt', type: 'int', length: '', value: '99999999' },
+            { name: 'myList', type: 'list', length: '3', value: '[1, 2, 3]' },
+            { name: 'mySet', type: 'set', length: '3', value: '{1, 2, 3}' },
+            { name: 'myTuple', type: 'tuple', length: '3', value: '(1, 2, 3)' }
         ];
 
         await waitForVariablesToMatch(expectedVariables, variableView);
@@ -295,8 +295,8 @@ mySet = {1, 2, 3}
 
         // Parse the HTML for our expected variables
         const expectedVariables = [
-            { name: 'test', type: 'list', length: '3', value: ' [1, 2, 3]' },
-            { name: 'test2', type: 'list', length: '3', value: ' [1, 2, 3]' }
+            { name: 'test', type: 'list', length: '3', value: '[1, 2, 3]' },
+            { name: 'test2', type: 'list', length: '3', value: '[1, 2, 3]' }
         ];
         await waitForVariablesToMatch(expectedVariables, variableView);
 

--- a/src/webviews/webview-side/interactive-common/variableExplorer.tsx
+++ b/src/webviews/webview-side/interactive-common/variableExplorer.tsx
@@ -348,6 +348,14 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
                 } else if (variable.count) {
                     newSize = variable.count.toString();
                 }
+                let value = variable.value;
+                if (variable.type === 'str' && variable.value) {
+                    if (variable.value[0] === ' ') {
+                        value = `'${variable.value.slice(1)}'`;
+                    } else {
+                        value = `'${variable.value}'`;
+                    }
+                }
                 return {
                     buttons: {
                         name: variable.name,
@@ -359,9 +367,7 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
                     type: variable.type,
                     size: newSize,
                     index,
-                    value: variable.value
-                        ? variable.value
-                        : getLocString('DataScience.variableLoadingValue', 'Loading...')
+                    value: value ? value : getLocString('DataScience.variableLoadingValue', 'Loading...')
                 };
             }
         }

--- a/src/webviews/webview-side/interactive-common/variableExplorer.tsx
+++ b/src/webviews/webview-side/interactive-common/variableExplorer.tsx
@@ -350,11 +350,7 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
                 }
                 let value = variable.value;
                 if (variable.type === 'str' && variable.value) {
-                    if (variable.value[0] === ' ') {
-                        value = `'${variable.value.slice(1)}'`;
-                    } else {
-                        value = `'${variable.value}'`;
-                    }
+                    value = `'${variable.value}'`;
                 }
                 return {
                     buttons: {


### PR DESCRIPTION
This PR changes the way strings are rendered in the variable viewer to wrap them in single quotes. Looks as follows:

<img width="453" alt="Screen Shot 2022-07-07 at 7 51 21 PM" src="https://user-images.githubusercontent.com/417016/177889936-bb45a4cd-8828-4e61-9ec9-fbc245e2a2e9.png">

I'm achieving this by detecting the string type on the component that renders the string, and wrapping the value in quotes.

**IMPORTANT:** For some reason, all of the variable values are received with an empty space up front.

This PR aims to:
Fix #10225

Feedback appreciated!