### PR TITLE
Variable viewer high contrast hover color fix

### DIFF
--- a/src/webviews/webview-side/interactive-common/variableExplorerCellFormatter.css
+++ b/src/webviews/webview-side/interactive-common/variableExplorerCellFormatter.css
@@ -14,19 +14,11 @@
     color: var(--vscode-editor-foreground);
 }
 
+body.vscode-high-contrast .react-grid-Row:hover {
+    filter: opacity(70%);
+}
+
 /* High contrast uses an inverse for selection highlights, so just use foreground when hovering */
-body.vscode-high-contrast .react-grid-Row:hover .react-grid-variable-explorer-cell-variable {
-    color: var(--override-selection-foreground, var(--vscode-editor-selectionForeground));
-}
-
-body.vscode-high-contrast .react-grid-Row:hover .react-grid-variable-explorer-cell-type {
-    color: var(--override-selection-foreground, var(--vscode-editor-selectionForeground));
-}
-
-body.vscode-high-contrast .react-grid-Row:hover .react-grid-variable-explorer-cell-string {
-    color: var(--override-selection-foreground, var(--vscode-editor-selectionForeground));
-}
-
-body.vscode-high-contrast .react-grid-Row:hover .react-grid-variable-explorer-cell-numeric {
-    color: var(--override-selection-foreground, var(--vscode-editor-selectionForeground));
+body.vscode-high-contrast .react-grid-Row:hover > * {
+    color: var(--vscode-editor-foreground);
 }

--- a/src/webviews/webview-side/interactive-common/variableExplorerGrid.less
+++ b/src/webviews/webview-side/interactive-common/variableExplorerGrid.less
@@ -118,21 +118,15 @@ body.vscode-high-contrast #variable-explorer-data-grid .react-grid-Cell {
 
 // HC inverts selection colors, so use the selection foreground color on hover
 body.vscode-high-contrast #variable-explorer-data-grid .react-grid-Cell:hover {
-    color: var(--override-selection-foreground, var(--vscode-editor-selectionForeground));
+    color: var(--vscode-editor-foreground);
+    filter: opacity(70%);
 }
 
 body.vscode-high-contrast #variable-explorer-data-grid .react-grid-Row:hover {
-    color: var(--override-selection-foreground, var(--vscode-editor-selectionForeground));
-}
-
-body.vscode-high-contrast #variable-explorer-data-grid .react-grid-Row:hover .react-grid-Cell {
-    color: var(--override-selection-foreground, var(--vscode-editor-selectionForeground));
-}
-
-// HC inverts selection, which messes up our icons, just keep them with the same foreground / background combo
-body.vscode-high-contrast #variable-explorer-data-grid .react-grid-Row:hover .react-grid-Cell .variable-explorer-button-cell {
     color: var(--vscode-editor-foreground);
-    background-color: var(--vscode-editor-background);
+    filter: opacity(70%);
 }
 
-
+body.vscode-high-contrast #variable-explorer-data-grid .react-grid-Row:hover > * {
+    color: var(--vscode-editor-foreground);
+}


### PR DESCRIPTION
The rows in the table of the variable viewer have a small bug in high contrast mode in which the values disappear completely when the row is hovered. This PR aims to fix that by:

- Removing some lines that seemed unnecessary to me. **Please let me know if I'm missing something.**
- Used `--vscode-editor-foreground` (which is the inverse of the high contrast background color) instead of `--vscode-editor-selectionForeground` (which is the same as the high contrast background color).
- Used opacity to make a color that could be distinct from the default foreground color, but that could remain coherent independently of the background color.

Here's a short video demonstrating the problem:

https://user-images.githubusercontent.com/417016/178050421-b199b7ee-84bb-437a-ae11-1e2c38d14eba.mov

Here's a short video demonstrating how the solution looks:

https://user-images.githubusercontent.com/417016/178050020-0c4735d2-ab9c-422d-9410-d2d0b1bef46d.mov

Feedback appreciated 👍