### PR TITLE
Adding more padding to each cell in the variable viewer

### DIFF
--- a/src/webviews/webview-side/interactive-common/variableExplorerGrid.less
+++ b/src/webviews/webview-side/interactive-common/variableExplorerGrid.less
@@ -40,7 +40,7 @@
     padding: 2px;
     font-family: var(--vscode-font-family);
     border-right: 1px solid var(--vscode-menu-border);
-    padding-top: 4px;
+    padding: 4px 8px;
 }
 
 .react-grid-Header {
@@ -69,7 +69,7 @@
     background-color: transparent;
     color: var(--vscode-editor-foreground);
     border-style: none;
-    padding: 0 2px;
+    padding: 0 8px;
 }
 
 #variable-explorer-data-grid .react-grid-Cell:hover {


### PR DESCRIPTION
As the issue #10206 says:

> Hovering over the right half of the sort indicator ("triangle") shows the column resize cursor and when clicking there the column is actually resized.

This PR solves that by increasing the padding on the cells. Rather than fixing this only in the headers, I decided to increase the horizontal padding on all the variable viewer cells in order to keep them looking more harmonious together.

Here's how it looks:


https://user-images.githubusercontent.com/417016/178078880-2de262fd-4133-4406-be73-535f90a34f60.mov

Let me know if you know of a better approach!

Fixes #10206