### PR TITLE
Validate package.nls files against a schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -220,6 +220,7 @@
                 "html-webpack-plugin": "^5.5.0",
                 "husky": "^7.0.0",
                 "jsdom": "^15.0.0",
+                "jsonschema": "^1.4.1",
                 "keyv": "^4.1.0",
                 "less": "^3.9.0",
                 "less-loader": "^10.2.0",
@@ -14550,6 +14551,15 @@
                 "graceful-fs": "^4.1.6"
             }
         },
+        "node_modules/jsonschema": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
+            "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/jsprim": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
@@ -26825,7 +26835,7 @@
                 "minimist": "~1.2.0",
                 "moment": "^2.24.0",
                 "path-browserify": "^1.0.0",
-                "url-parse": "^1.5.10"
+                "url-parse": "~1.5.1"
             }
         },
         "@jupyterlab/nbformat": {
@@ -30197,7 +30207,7 @@
             "requires": {
                 "@mapbox/node-pre-gyp": "^1.0.0",
                 "nan": "^2.15.0",
-                "simple-get": "3.1.1"
+                "simple-get": "^3.0.3"
             }
         },
         "caseless": {
@@ -36263,6 +36273,12 @@
             "requires": {
                 "graceful-fs": "^4.1.6"
             }
+        },
+        "jsonschema": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
+            "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+            "dev": true
         },
         "jsprim": {
             "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -2389,6 +2389,7 @@
         "html-webpack-plugin": "^5.5.0",
         "husky": "^7.0.0",
         "jsdom": "^15.0.0",
+        "jsonschema": "^1.4.1",
         "keyv": "^4.1.0",
         "less": "^3.9.0",
         "less-loader": "^10.2.0",


### PR DESCRIPTION
Part of https://github.com/microsoft/vscode-jupyter/issues/10729

The drawback with having the Azure pipeline fail is the fact that its not monitored and its too late in the process for something to fail (PR verifications should not allow any broken bits to get into the repo)

**This this ensures we don't break the release builds again via a PR.**
E.g. if someone makes a typo again in the package.nls file this PR will ensure its blocked.

We already have some validation for the package.nls files as we've broken builds due to faulty JSON files, looks like we need another layer of validation, hence added that.

