### PR TITLE
Hotfix: Stop using vscode-nls for some key localizations

### DIFF
--- a/news/2 Fixes/10752.md
+++ b/news/2 Fixes/10752.md
@@ -1,0 +1,1 @@
+Stopped using localization in certain phrases that would break some of the extension features while we investigate the underlying reason.

--- a/news/2 Fixes/10752.md
+++ b/news/2 Fixes/10752.md
@@ -1,1 +1,1 @@
-Stopped using localization in certain phrases that would break some of the extension features while we investigate the underlying reason.
+Temporarily disable localising certain phrases that would break some of the extension features while we investigate the underlying reason.

--- a/package.json
+++ b/package.json
@@ -593,7 +593,7 @@
             },
             {
                 "command": "jupyter.importnotebook",
-                "title": "%jupyter.command.jupyter.importnotebook.title%",
+                "title": "Import Jupyter Notebook",
                 "category": "Jupyter",
                 "enablement": "isWorkspaceTrusted && !jupyter.webExtension"
             },
@@ -605,19 +605,19 @@
             },
             {
                 "command": "jupyter.exportoutputasnotebook",
-                "title": "%jupyter.command.jupyter.exportoutputasnotebook.title%",
+                "title": "Export Interactive Window as Jupyter Notebook",
                 "category": "Jupyter",
                 "enablement": "isWorkspaceTrusted && !jupyter.webExtension"
             },
             {
                 "command": "jupyter.exportfileasnotebook",
-                "title": "%jupyter.command.jupyter.exportfileasnotebook.title%",
+                "title": "Export Current Python File as Jupyter Notebook",
                 "category": "Jupyter",
                 "enablement": "isWorkspaceTrusted && !jupyter.webExtension"
             },
             {
                 "command": "jupyter.exportfileandoutputasnotebook",
-                "title": "%jupyter.command.jupyter.exportfileandoutputasnotebook.title%",
+                "title": "Export Current Python File and Output as Jupyter Notebook",
                 "category": "Jupyter",
                 "enablement": "isWorkspaceTrusted && !jupyter.webExtension"
             },
@@ -635,8 +635,8 @@
             },
             {
                 "command": "jupyter.interruptkernel",
-                "title": "%jupyter.command.jupyter.interruptkernel.title%",
-                "shortTitle": "%jupyter.command.jupyter.interruptkernel.shorttitle%",
+                "title": "Interrupt Kernel",
+                "shortTitle": "Interrupt",
                 "category": "Jupyter",
                 "icon": {
                     "light": "resources/light/interrupt.svg",
@@ -646,7 +646,7 @@
             },
             {
                 "command": "jupyter.restartkernel",
-                "title": "%jupyter.command.jupyter.restartkernel.title%",
+                "title": "Restart Kernel",
                 "shortTitle": "%jupyter.command.jupyter.restartkernel.shorttitle%",
                 "category": "Jupyter",
                 "icon": {
@@ -657,8 +657,8 @@
             },
             {
                 "command": "jupyter.notebookeditor.interruptkernel",
-                "title": "%jupyter.command.jupyter.interruptkernel.title%",
-                "shortTitle": "%jupyter.command.jupyter.interruptkernel.shorttitle%",
+                "title": "Interrupt Kernel",
+                "shortTitle": "Interrupt",
                 "category": "Notebook",
                 "icon": {
                     "light": "resources/light/interrupt.svg",
@@ -668,7 +668,7 @@
             },
             {
                 "command": "jupyter.notebookeditor.restartkernel",
-                "title": "%jupyter.command.jupyter.restartkernel.title%",
+                "title": "Restart Kernel",
                 "shortTitle": "%jupyter.command.jupyter.restartkernel.shorttitle%",
                 "category": "Notebook",
                 "icon": {
@@ -686,38 +686,38 @@
             },
             {
                 "command": "jupyter.notebookeditor.addcellbelow",
-                "title": "%jupyter.command.jupyter.notebookeditor.addcellbelow.title%",
+                "title": "Add Empty Cell to Notebook File",
                 "category": "Notebook",
                 "enablement": "!jupyter.webExtension"
             },
             {
                 "command": "jupyter.notebookeditor.removeallcells",
-                "title": "%jupyter.command.jupyter.notebookeditor.removeallcells.title%",
+                "title": "Delete All Notebook Editor Cells",
                 "category": "Notebook",
                 "enablement": "!jupyter.webExtension"
             },
             {
                 "command": "jupyter.notebookeditor.expandallcells",
-                "title": "%jupyter.command.jupyter.notebookeditor.expandallcells.title%",
+                "title": "Expand All Notebook Cells",
                 "category": "Notebook",
                 "enablement": "!jupyter.webExtension"
             },
             {
                 "command": "jupyter.notebookeditor.collapseallcells",
-                "title": "%jupyter.command.jupyter.notebookeditor.collapseallcells.title%",
+                "title": "Collapse All Notebook Cells",
                 "category": "Notebook",
                 "enablement": "!jupyter.webExtension"
             },
             {
                 "command": "jupyter.expandallcells",
-                "title": "%jupyter.command.jupyter.expandallcells.title%",
+                "title": "Expand All Interactive Cells",
                 "shortTitle": "%jupyter.command.jupyter.expandallcells.shorttitle%",
                 "category": "Jupyter",
                 "icon": "$(expand-all)"
             },
             {
                 "command": "jupyter.collapseallcells",
-                "title": "%jupyter.command.jupyter.collapseallcells.title%",
+                "title": "Collapse All Interactive Cells",
                 "shortTitle": "%jupyter.command.jupyter.collapseallcells.shorttitle%",
                 "category": "Jupyter",
                 "icon": "$(collapse-all)"
@@ -811,8 +811,8 @@
             },
             {
                 "command": "jupyter.interactive.exportasnotebook",
-                "title": "%DataScience.exportDialogTitle%",
-                "shortTitle": "%DataScience.exportAsNotebook.shorttitle%",
+                "title": "Export to Jupyter Notebook",
+                "shortTitle": "Save",
                 "icon": "$(save-as)",
                 "enablement": "notebookType == interactive",
                 "category": "Jupyter"
@@ -916,13 +916,13 @@
             "editor/title": [
                 {
                     "command": "jupyter.notebookeditor.restartkernel",
-                    "title": "%jupyter.command.jupyter.restartkernel.title%",
+                    "title": "Restart Kernel",
                     "group": "navigation@1",
                     "when": "notebookKernel =~ /^ms-toolsai.jupyter\\// && notebookType == 'jupyter-notebook' && isWorkspaceTrusted && jupyter.notebookeditor.canrestartNotebookkernel && config.notebook.globalToolbar != true"
                 },
                 {
                     "command": "jupyter.notebookeditor.interruptkernel",
-                    "title": "%jupyter.command.jupyter.interruptkernel.title%",
+                    "title": "Interrupt Kernel",
                     "group": "overflow@1",
                     "when": "notebookKernel =~ /^ms-toolsai.jupyter\\// && notebookType == 'jupyter-notebook' && isWorkspaceTrusted && jupyter.notebookeditor.canInterruptNotebookKernel && config.notebook.globalToolbar != true"
                 },
@@ -1335,31 +1335,31 @@
                 },
                 {
                     "command": "jupyter.importnotebook",
-                    "title": "%jupyter.command.jupyter.importnotebook.title%",
+                    "title": "Import Jupyter Notebook",
                     "category": "Jupyter",
                     "when": "isWorkspaceTrusted"
                 },
                 {
                     "command": "jupyter.exportfileasnotebook",
-                    "title": "%jupyter.command.jupyter.exportfileasnotebook.title%",
+                    "title": "Export Current Python File as Jupyter Notebook",
                     "category": "Jupyter",
                     "when": "jupyter.hascodecells && jupyter.ispythonorinteractiveeactive && !notebookEditorFocused && isWorkspaceTrusted"
                 },
                 {
                     "command": "jupyter.exportfileandoutputasnotebook",
-                    "title": "%jupyter.command.jupyter.exportfileandoutputasnotebook.title%",
+                    "title": "Export Current Python File and Output as Jupyter Notebook",
                     "category": "Jupyter",
                     "when": "jupyter.hascodecells && jupyter.ispythonorinteractiveeactive && !notebookEditorFocused && isWorkspaceTrusted"
                 },
                 {
                     "command": "jupyter.interruptkernel",
-                    "title": "%jupyter.command.jupyter.interruptkernel.title%",
+                    "title": "Interrupt Kernel",
                     "category": "Jupyter",
                     "when": "jupyter.ispythonorinteractiveeactive && isWorkspaceTrusted"
                 },
                 {
                     "command": "jupyter.restartkernel",
-                    "title": "%jupyter.command.jupyter.restartkernel.title%",
+                    "title": "Restart Kernel",
                     "category": "Jupyter",
                     "when": "jupyter.ispythonorinteractiveeactive && isWorkspaceTrusted"
                 },
@@ -1377,57 +1377,57 @@
                 },
                 {
                     "command": "jupyter.notebookeditor.removeallcells",
-                    "title": "%jupyter.command.jupyter.notebookeditor.removeallcells.title%",
+                    "title": "Delete All Notebook Editor Cells",
                     "category": "Notebook",
                     "when": "jupyter.havenativecells && jupyter.isnativeactive && isWorkspaceTrusted"
                 },
                 {
                     "command": "jupyter.notebookeditor.interruptkernel",
-                    "title": "%jupyter.command.jupyter.interruptkernel.title%",
+                    "title": "Interrupt Kernel",
                     "category": "Notebook",
                     "when": "notebookType == 'jupyter-notebook' && isWorkspaceTrusted"
                 },
                 {
                     "command": "jupyter.notebookeditor.restartkernel",
-                    "title": "%jupyter.command.jupyter.restartkernel.title%",
+                    "title": "Restart Kernel",
                     "category": "Notebook",
                     "when": "jupyter.isnativeactive && isWorkspaceTrusted"
                 },
                 {
                     "command": "jupyter.notebookeditor.addcellbelow",
-                    "title": "%jupyter.command.jupyter.notebookeditor.addcellbelow.title%",
+                    "title": "Add Empty Cell to Notebook File",
                     "category": "Notebook",
                     "when": "jupyter.isnativeactive && isWorkspaceTrusted"
                 },
                 {
                     "command": "jupyter.notebookeditor.expandallcells",
-                    "title": "%jupyter.command.jupyter.expandallcells.title%",
+                    "title": "Expand All Interactive Cells",
                     "category": "Notebook",
                     "when": "notebookEditorFocused && notebookType == 'jupyter-notebook'"
                 },
                 {
                     "command": "jupyter.notebookeditor.collapseallcells",
-                    "title": "%jupyter.command.jupyter.collapseallcells.title%",
+                    "title": "Collapse All Interactive Cells",
                     "category": "Notebook",
                     "when": "notebookEditorFocused && notebookType == 'jupyter-notebook'"
                 },
                 {
                     "command": "jupyter.expandallcells",
-                    "title": "%jupyter.command.jupyter.expandallcells.title%",
+                    "title": "Expand All Interactive Cells",
                     "shortTitle": "%jupyter.command.jupyter.expandallcells.shorttitle%",
                     "category": "Jupyter",
                     "when": "jupyter.isinteractiveactive"
                 },
                 {
                     "command": "jupyter.collapseallcells",
-                    "title": "%jupyter.command.jupyter.collapseallcells.title%",
+                    "title": "Collapse All Interactive Cells",
                     "shortTitle": "%jupyter.command.jupyter.collapseallcells.shorttitle%",
                     "category": "Jupyter",
                     "when": "jupyter.isinteractiveactive"
                 },
                 {
                     "command": "jupyter.exportoutputasnotebook",
-                    "title": "%jupyter.command.jupyter.exportoutputasnotebook.title%",
+                    "title": "Export Interactive Window as Jupyter Notebook",
                     "category": "Jupyter",
                     "when": "jupyter.isinteractiveactive"
                 },


### PR DESCRIPTION
This PR undoes localization on some localization keys that are breaking the related features of the `vscode-jupyter` extension.

Last week we released version 6.100 of the `vscode-jupyter`. Unbeknown to us, the extension shipped with some of its features broken. Customers began reporting that some of the commands, like the one for restarting kernels and the one for interrupting kernels, were missing from the UI.

In the developer tools of VSCode (version 1.69.0 and above), when 6.100 is loaded, we see a large influx of error messages:

<img width="607" alt="Screen Shot 2022-07-11 at 8 17 20 PM" src="https://user-images.githubusercontent.com/417016/178379870-c629a695-e29b-42fb-abaf-c2244596c903.png">

While debugging, we realized that:

- Version 5.100 does not have the issue, even though it shipped with the localization code (though it didn't ship with the new localizations themselves, only with the code that uses them).
- Version 6.100 does not include localization changes to the related localization IDs.
- The problem doesn't reproduce building a .VSIX of the extension locally.
- Changing the problematic entries in the `package.json` to use existing keys pointing to other localized phrases bypasses the problem.
- Changing the problematic entries in the `package.json` to use plain strings also bypasses the problem.

This PR aims to replace all of the problematic localizations for plain text English strings in order to deliver a hotfix for 6.100.

The changes included in this PR do make all of the errors shown in the screenshot go away.

(Once released)
Fixes #10752