### PR TITLE
Fix screen capture to work on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ nodeLanguageServer.*/**
 src/test/datascience/.venv*
 !src/test/pythonEnvironments/**/*.*
 .vscode-test-web
+testresults.json
 # translation files
 *.xlf
 *.nls.*.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -223,7 +223,7 @@
             ],
             "env": {
                 "VSC_JUPYTER_FORCE_LOGGING": "1",
-                "VSC_JUPYTER_CI_TEST_GREP": "", // Leave as `VSCode Notebook` to run only Notebook tests.
+                "VSC_JUPYTER_CI_TEST_GREP": "Ensure ipykernel install prompt is displayed every time you try to run a cell in an Interactive Window and you can switch kernels", // Leave as `VSCode Notebook` to run only Notebook tests.
                 "VSC_JUPYTER_CI_TEST_INVERT_GREP": "", // Initialize this to invert the grep (exclude tests with value defined in grep).
                 "CI_PYTHON_PATH": "", // Update with path to real python interpereter used for testing.
                 "VSC_JUPYTER_CI_RUN_NON_PYTHON_NB_TEST": "", // Initialize this to run tests again Julia & other kernels.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -223,7 +223,7 @@
             ],
             "env": {
                 "VSC_JUPYTER_FORCE_LOGGING": "1",
-                "VSC_JUPYTER_CI_TEST_GREP": "Ensure ipykernel install prompt is displayed every time you try to run a cell in an Interactive Window and you can switch kernels", // Leave as `VSCode Notebook` to run only Notebook tests.
+                "VSC_JUPYTER_CI_TEST_GREP": "", // Leave as `VSCode Notebook` to run only Notebook tests.
                 "VSC_JUPYTER_CI_TEST_INVERT_GREP": "", // Initialize this to invert the grep (exclude tests with value defined in grep).
                 "CI_PYTHON_PATH": "", // Update with path to real python interpereter used for testing.
                 "VSC_JUPYTER_CI_RUN_NON_PYTHON_NB_TEST": "", // Initialize this to run tests again Julia & other kernels.


### PR DESCRIPTION
Screen capture file names are too long. I can't open them on windows. 

This should achieve the same result (unique file names)