### PR TITLE
use correct env variable to check

### DIFF
--- a/src/test/testHooks.node.ts
+++ b/src/test/testHooks.node.ts
@@ -26,8 +26,8 @@ export const rootHooks: Mocha.RootHookObject = {
     afterEach(this: Context) {
         if (
             !IS_CI_SERVER ||
-            !process.env.GITHUB_HEAD_REF ||
-            process.env.GITHUB_HEAD_REF !== 'main' ||
+            !process.env.GITHUB_REF_NAME ||
+            process.env.GITHUB_REF_NAME !== 'main' ||
             (process.env.VSC_JUPYTER_WARMUP && process.env.VSC_JUPYTER_WARMUP == 'true')
         ) {
             return;


### PR DESCRIPTION
Now that we have a run with the env variable dump, adjust the check to look for the correct variable