### PR TITLE
Update to latest middleware layer to handle fragment URI changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "@nteract/messaging": "^7.0.0",
                 "@vscode/extension-telemetry": "^0.6.2",
                 "@vscode/jupyter-ipywidgets": "^1.0.9",
-                "@vscode/jupyter-lsp-middleware": "^0.2.48",
+                "@vscode/jupyter-lsp-middleware": "^0.2.49",
                 "ajv-keywords": "^3.5.2",
                 "ansi-to-html": "^0.6.7",
                 "arch": "^2.1.0",
@@ -282,7 +282,7 @@
                 "yargs-parser": "^13.1.2"
             },
             "engines": {
-                "vscode": "^1.69.0-insider"
+                "vscode": "^1.70.0-insider"
             },
             "optionalDependencies": {
                 "canvas": "^2.7.0",
@@ -4623,11 +4623,11 @@
             "hasInstallScript": true
         },
         "node_modules/@vscode/jupyter-lsp-middleware": {
-            "version": "0.2.48",
-            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.48.tgz",
-            "integrity": "sha512-1fe0EWq47hAsZyeOcjmNuKV0uP91n1+kFjfoLWCtPrHOUPq0o7LZ3VY67I0axKwASndFvUjB8VHvks7sCxwlVw==",
+            "version": "0.2.49",
+            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.49.tgz",
+            "integrity": "sha512-JpzXThToxqEPGQFi8XhHeq/r7TQBg1bkTlqci7FQhC0cEI/WIk7iI/b4PrFuL2qfCQhfMRWvyHkXhMyDpgFk9g==",
             "dependencies": {
-                "@vscode/lsp-notebook-concat": "^0.1.15",
+                "@vscode/lsp-notebook-concat": "^0.1.16",
                 "fast-myers-diff": "^3.0.1",
                 "sha.js": "^2.4.11",
                 "vscode-languageclient": "^8.0.2-next.4",
@@ -4639,9 +4639,9 @@
             }
         },
         "node_modules/@vscode/lsp-notebook-concat": {
-            "version": "0.1.15",
-            "resolved": "https://registry.npmjs.org/@vscode/lsp-notebook-concat/-/lsp-notebook-concat-0.1.15.tgz",
-            "integrity": "sha512-u1yJcTWrhTF+sdTXKdz1u1TLEGZluiU6aqChtYYiBv+WXPnW1yxY5+9A6py1QohdMq9RrqX8c5nGkQ71P3mmFA==",
+            "version": "0.1.16",
+            "resolved": "https://registry.npmjs.org/@vscode/lsp-notebook-concat/-/lsp-notebook-concat-0.1.16.tgz",
+            "integrity": "sha512-jN2ut22GR/xelxHx2W9U+uZoylHGCezsNmsMYn20LgVHTcJMGL+4bL5PJeh63yo6P5XjAPtoeeymvp5EafJV+w==",
             "dependencies": {
                 "object-hash": "^3.0.0",
                 "vscode-languageserver-protocol": "^3.17.2-next.5",
@@ -26835,7 +26835,7 @@
                 "minimist": "~1.2.0",
                 "moment": "^2.24.0",
                 "path-browserify": "^1.0.0",
-                "url-parse": "~1.5.1"
+                "url-parse": "^1.5.10"
             }
         },
         "@jupyterlab/nbformat": {
@@ -28502,11 +28502,11 @@
             "integrity": "sha512-xx2aAtvoXz+yFGm3zSvAJLIDBiMehcj8Xw31n2gwv8lYGKllyqeEXIqZtN8kZfi4xR5GHUmKsH6EsvpCNAwXQw=="
         },
         "@vscode/jupyter-lsp-middleware": {
-            "version": "0.2.48",
-            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.48.tgz",
-            "integrity": "sha512-1fe0EWq47hAsZyeOcjmNuKV0uP91n1+kFjfoLWCtPrHOUPq0o7LZ3VY67I0axKwASndFvUjB8VHvks7sCxwlVw==",
+            "version": "0.2.49",
+            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.49.tgz",
+            "integrity": "sha512-JpzXThToxqEPGQFi8XhHeq/r7TQBg1bkTlqci7FQhC0cEI/WIk7iI/b4PrFuL2qfCQhfMRWvyHkXhMyDpgFk9g==",
             "requires": {
-                "@vscode/lsp-notebook-concat": "^0.1.15",
+                "@vscode/lsp-notebook-concat": "^0.1.16",
                 "fast-myers-diff": "^3.0.1",
                 "sha.js": "^2.4.11",
                 "vscode-languageclient": "^8.0.2-next.4",
@@ -28515,9 +28515,9 @@
             }
         },
         "@vscode/lsp-notebook-concat": {
-            "version": "0.1.15",
-            "resolved": "https://registry.npmjs.org/@vscode/lsp-notebook-concat/-/lsp-notebook-concat-0.1.15.tgz",
-            "integrity": "sha512-u1yJcTWrhTF+sdTXKdz1u1TLEGZluiU6aqChtYYiBv+WXPnW1yxY5+9A6py1QohdMq9RrqX8c5nGkQ71P3mmFA==",
+            "version": "0.1.16",
+            "resolved": "https://registry.npmjs.org/@vscode/lsp-notebook-concat/-/lsp-notebook-concat-0.1.16.tgz",
+            "integrity": "sha512-jN2ut22GR/xelxHx2W9U+uZoylHGCezsNmsMYn20LgVHTcJMGL+4bL5PJeh63yo6P5XjAPtoeeymvp5EafJV+w==",
             "requires": {
                 "object-hash": "^3.0.0",
                 "vscode-languageserver-protocol": "^3.17.2-next.5",
@@ -30207,7 +30207,7 @@
             "requires": {
                 "@mapbox/node-pre-gyp": "^1.0.0",
                 "nan": "^2.15.0",
-                "simple-get": "^3.0.3"
+                "simple-get": "3.1.1"
             }
         },
         "caseless": {

--- a/package.json
+++ b/package.json
@@ -2191,7 +2191,7 @@
         "@nteract/messaging": "^7.0.0",
         "@vscode/extension-telemetry": "^0.6.2",
         "@vscode/jupyter-ipywidgets": "^1.0.9",
-        "@vscode/jupyter-lsp-middleware": "^0.2.48",
+        "@vscode/jupyter-lsp-middleware": "^0.2.49",
         "ajv-keywords": "^3.5.2",
         "ansi-to-html": "^0.6.7",
         "arch": "^2.1.0",


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/141717

The lsp-notebook-concat layer was using implicit knowledge of how fragments are laid out in order to determine cell order. 

The fragment format is changing.

This change should allow the concat piece to work with the new format and the old.

Longer term, we won't be using the middleware layer anymore.