### PR TITLE
Try number 2 for the Ensure install prompt test failure

### DIFF
--- a/src/test/datascience/helpers.ts
+++ b/src/test/datascience/helpers.ts
@@ -28,10 +28,10 @@ import { Matcher } from 'ts-mockito/lib/matcher/type/Matcher';
 
 export async function openNotebook(ipynbFile: vscode.Uri) {
     traceInfo(`Opening notebook ${getFilePath(ipynbFile)}`);
-    const nb = await vscode.workspace.openNotebookDocument(ipynbFile);
-    await vscode.window.showNotebookDocument(nb);
+    const notebook = await vscode.workspace.openNotebookDocument(ipynbFile);
+    const editor = await vscode.window.showNotebookDocument(notebook);
     traceInfo(`Opened notebook ${getFilePath(ipynbFile)}`);
-    return nb;
+    return { notebook, editor };
 }
 
 // The default base set of data science settings to use

--- a/src/test/datascience/ipywidgets/ipyWidgetScriptManager.vscode.common.test.ts
+++ b/src/test/datascience/ipywidgets/ipyWidgetScriptManager.vscode.common.test.ts
@@ -61,8 +61,8 @@ suite('IPyWidget Script Manager', function () {
             ],
             disposables
         );
-        const notebook = await openNotebook(testWidgetNb);
-        await waitForKernelToGetAutoSelected(PYTHON_LANGUAGE);
+        const { notebook, editor } = await openNotebook(testWidgetNb);
+        await waitForKernelToGetAutoSelected(editor, PYTHON_LANGUAGE);
         const cell = notebook.cellAt(0);
 
         // Execute cell. It should load and render the widget

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -45,7 +45,6 @@ import { Product, IInstaller, InstallerResponse } from '../../../../kernels/inst
 import {
     closeNotebooksAndCleanUpAfterTests,
     hijackPrompt,
-    waitForKernelToGetAutoSelected,
     runAllCellsInActiveNotebook,
     assertVSCCellIsNotRunning,
     defaultNotebookTestTimeout,
@@ -78,7 +77,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src/test/datascience/jupyter/kernels/nbWithKernel.ipynb')
     );
     const executable = getOSType() === OSType.Windows ? 'Scripts/python.exe' : 'bin/python'; // If running locally on Windows box.
-    let venvPythonPath = Uri.file(
+    let venvNoKernelPath = Uri.file(
         path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src/test/datascience/.venvnokernel', executable)
     );
     let venvNoRegPath = Uri.file(
@@ -110,7 +109,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         if (IS_REMOTE_NATIVE_TEST()) {
             return this.skip();
         }
-        if (!fs.pathExistsSync(venvPythonPath.fsPath) || !fs.pathExistsSync(venvNoRegPath.fsPath)) {
+        if (!fs.pathExistsSync(venvNoKernelPath.fsPath) || !fs.pathExistsSync(venvNoRegPath.fsPath)) {
             // Virtual env does not exist.
             return this.skip();
         }
@@ -130,14 +129,14 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         await pythonApi.refreshInterpreters({ clearCache: true });
         const interpreterService = api.serviceContainer.get<IInterpreterService>(IInterpreterService);
         const [interpreter1, interpreter2, interpreter3] = await Promise.all([
-            interpreterService.getInterpreterDetails(venvPythonPath),
+            interpreterService.getInterpreterDetails(venvNoKernelPath),
             interpreterService.getInterpreterDetails(venvNoRegPath),
             interpreterService.getInterpreterDetails(venvKernelPath)
         ]);
         if (!interpreter1 || !interpreter2 || !interpreter3) {
             throw new Error('Unable to get information for interpreter 1');
         }
-        venvPythonPath = interpreter1.uri;
+        venvNoKernelPath = interpreter1.uri;
         venvNoRegPath = interpreter2.uri;
         venvKernelPath = interpreter3.uri;
     });
@@ -156,16 +155,16 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
             fs
                 .readFileSync(nbFile.fsPath)
                 .toString('utf8')
-                .replace('<hash>', getInterpreterHash({ uri: venvPythonPath }))
+                .replace('<hash>', getInterpreterHash({ uri: venvNoKernelPath }))
         );
         await Promise.all([
             installIPyKernel(venvKernelPath.fsPath),
-            uninstallIPyKernel(venvPythonPath.fsPath),
+            uninstallIPyKernel(venvNoKernelPath.fsPath),
             uninstallIPyKernel(venvNoRegPath.fsPath)
         ]);
         await closeActiveWindows();
         await Promise.all([
-            clearInstalledIntoInterpreterMemento(memento, Product.ipykernel, venvPythonPath),
+            clearInstalledIntoInterpreterMemento(memento, Product.ipykernel, venvNoKernelPath),
             clearInstalledIntoInterpreterMemento(memento, Product.ipykernel, venvNoRegPath)
         ]);
         sinon.restore();
@@ -183,7 +182,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
     suiteTeardown(async function () {
         // Make sure to put ipykernel back
         try {
-            await installIPyKernel(venvPythonPath.fsPath);
+            await installIPyKernel(venvNoKernelPath.fsPath);
             await uninstallIPyKernel(venvNoRegPath.fsPath);
         } catch (ex) {
             // Don't fail test
@@ -201,11 +200,11 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
     });
 
     test(`Ensure prompt is displayed when ipykernel module is not found and it gets installed for '${path.basename(
-        venvPythonPath.fsPath
-    )}'`, async () => openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath));
+        venvNoKernelPath.fsPath
+    )}'`, async () => openNotebookAndInstallIpyKernelWhenRunningCell(venvNoKernelPath));
     test(`Ensure prompt is displayed when ipykernel module is not found and it gets installed for '${path.basename(
         venvNoRegPath.fsPath
-    )}'`, async () => openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath));
+    )}'`, async () => openNotebookAndInstallIpyKernelWhenRunningCell(venvNoKernelPath));
     test('Ensure ipykernel install prompt is displayed every time you try to run a cell in a Notebook', async function () {
         if (IS_REMOTE_NATIVE_TEST()) {
             return this.skip();
@@ -219,13 +218,13 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
             disposables
         );
 
-        await openNotebook(nbFile);
-        await waitForKernelToGetAutoSelected();
-        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
+        const { notebook, editor } = await openNotebook(nbFile);
+        await waitForKernelToChange({ interpreterPath: venvNoKernelPath }, editor);
+        const cell = notebook.cellAt(0)!;
         assert.equal(cell.outputs.length, 0);
 
         // The prompt should be displayed when we run a cell.
-        await runAllCellsInActiveNotebook(true);
+        await runAllCellsInActiveNotebook(true, editor);
         await waitForCondition(async () => prompt.displayed.then(() => true), delayForUITest, 'Prompt not displayed');
 
         // Once ipykernel prompt has been dismissed, execution should stop due to missing dependencies.
@@ -240,7 +239,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
 
         // Execute notebook once again & we should get another prompted to install ipykernel.
         let previousPromptDisplayCount = prompt.getDisplayCount();
-        await runAllCellsInActiveNotebook(true);
+        await runAllCellsInActiveNotebook(true, editor);
         await waitForCondition(
             async () => prompt.getDisplayCount() > previousPromptDisplayCount,
             delayForUITest,
@@ -256,7 +255,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
 
         // Execute a cell this time & we should get yet another prompted to install ipykernel.
         previousPromptDisplayCount = prompt.getDisplayCount();
-        await runAllCellsInActiveNotebook(true);
+        await runAllCellsInActiveNotebook(true, editor);
         await waitForCondition(
             async () => prompt.getDisplayCount() > previousPromptDisplayCount,
             delayForUITest,
@@ -299,7 +298,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
             source,
             disposables,
             pythonApiProvider,
-            venvPythonPath
+            venvNoKernelPath
         );
         const notebookDocument = workspace.notebookDocuments.find(
             (doc) => doc.uri.toString() === activeInteractiveWindow?.notebookUri?.toString()
@@ -307,20 +306,20 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
 
         // The prompt should be displayed when we run a cell.
         await waitForCondition(async () => prompt.displayed.then(() => true), delayForUITest, 'Prompt not displayed');
-        await verifyIPyKernelPromptDisplayed(prompt, venvPythonPath.fsPath);
-        await verifyErrorInCellOutput(notebookDocument, venvPythonPath.fsPath);
+        await verifyIPyKernelPromptDisplayed(prompt, venvNoKernelPath.fsPath);
+        await verifyErrorInCellOutput(notebookDocument, venvNoKernelPath.fsPath);
 
         // Submitting code again should display the same prompt again.
         prompt.reset();
         await activeInteractiveWindow.addCode(source, untitledPythonFile.uri, 0).catch(noop);
-        await verifyIPyKernelPromptDisplayed(prompt, venvPythonPath.fsPath);
-        await verifyErrorInCellOutput(notebookDocument, venvPythonPath.fsPath);
+        await verifyIPyKernelPromptDisplayed(prompt, venvNoKernelPath.fsPath);
+        await verifyErrorInCellOutput(notebookDocument, venvNoKernelPath.fsPath);
 
         // Submitting code again should display the same prompt again.
         prompt.reset();
         await activeInteractiveWindow.addCode(source, untitledPythonFile.uri, 0).catch(noop);
-        await verifyIPyKernelPromptDisplayed(prompt, venvPythonPath.fsPath);
-        await verifyErrorInCellOutput(notebookDocument, venvPythonPath.fsPath);
+        await verifyIPyKernelPromptDisplayed(prompt, venvNoKernelPath.fsPath);
+        await verifyErrorInCellOutput(notebookDocument, venvNoKernelPath.fsPath);
 
         await sleep(1_000);
 
@@ -349,7 +348,10 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
             delete promptOptions.result;
             // In tests, things hang as the IW isn't focused.
             activeInteractiveWindow.show(false).then(noop, noop);
-            await waitForKernelToChange({ interpreterPath: venvNoRegPath, isInteractiveController: true });
+            await waitForKernelToChange(
+                { interpreterPath: venvNoRegPath, isInteractiveController: true },
+                activeInteractiveWindow.notebookEditor
+            );
             return true;
         } as any);
         disposables.push({ dispose: () => stub.restore() });
@@ -369,11 +371,11 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
             waitForCondition(
                 () =>
                     prompt.messages.some((message) =>
-                        message.includes(path.basename(path.dirname(path.dirname(venvPythonPath.fsPath))))
+                        message.includes(path.basename(path.dirname(path.dirname(venvNoKernelPath.fsPath))))
                     ),
                 delayForUITest,
                 `Prompts '${prompt.messages}' do not include ${path.basename(
-                    path.dirname(path.dirname(venvPythonPath.fsPath))
+                    path.dirname(path.dirname(venvNoKernelPath.fsPath))
                 )}`
             ),
             // Verify the the name of the new env is included in the prompt displayed (instead of the old message);
@@ -436,17 +438,17 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         const { activeInteractiveWindow } = await submitFromPythonFileUsingCodeWatcher(
             source,
             disposables,
-            venvPythonPath
+            venvNoKernelPath
         );
         const notebookDocument = workspace.notebookDocuments.find(
             (doc) => doc.uri.toString() === activeInteractiveWindow?.notebookUri?.toString()
         )!;
 
-        await verifyIPyKernelPromptDisplayed(prompt, venvPythonPath.fsPath);
+        await verifyIPyKernelPromptDisplayed(prompt, venvNoKernelPath.fsPath);
         await sleep(500);
-        await verifyIPyKernelPromptDisplayed(prompt, venvPythonPath.fsPath);
+        await verifyIPyKernelPromptDisplayed(prompt, venvNoKernelPath.fsPath);
         await sleep(500);
-        await verifyIPyKernelPromptDisplayed(prompt, venvPythonPath.fsPath);
+        await verifyIPyKernelPromptDisplayed(prompt, venvNoKernelPath.fsPath);
 
         // Now lets install, all cells should run successfully.
         prompt.clickButton(Common.install());
@@ -478,27 +480,27 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         const { activeInteractiveWindow } = await submitFromPythonFileUsingCodeWatcher(
             source,
             disposables,
-            venvPythonPath
+            venvNoKernelPath
         );
         const notebookDocument = workspace.notebookDocuments.find(
             (doc) => doc.uri.toString() === activeInteractiveWindow?.notebookUri?.toString()
         )!;
 
         // Verify and wait a few seconds, in the past we'd get a couple of prompts.
-        await verifyIPyKernelPromptDisplayed(prompt, venvPythonPath.fsPath);
+        await verifyIPyKernelPromptDisplayed(prompt, venvNoKernelPath.fsPath);
         await sleep(500);
-        await verifyIPyKernelPromptDisplayed(prompt, venvPythonPath.fsPath);
+        await verifyIPyKernelPromptDisplayed(prompt, venvNoKernelPath.fsPath);
         await sleep(500);
-        await verifyIPyKernelPromptDisplayed(prompt, venvPythonPath.fsPath);
+        await verifyIPyKernelPromptDisplayed(prompt, venvNoKernelPath.fsPath);
 
         // Verify all cells have errors.
         const [cell1, cell2, cell3] = notebookDocument!
             .getCells()
             .filter((cell) => cell.kind === NotebookCellKind.Code);
         await Promise.all([
-            verifyErrorInCellOutput(notebookDocument, venvPythonPath.fsPath, cell1),
-            verifyErrorInCellOutput(notebookDocument, venvPythonPath.fsPath, cell2),
-            verifyErrorInCellOutput(notebookDocument, venvPythonPath.fsPath, cell3)
+            verifyErrorInCellOutput(notebookDocument, venvNoKernelPath.fsPath, cell1),
+            verifyErrorInCellOutput(notebookDocument, venvNoKernelPath.fsPath, cell2),
+            verifyErrorInCellOutput(notebookDocument, venvNoKernelPath.fsPath, cell3)
         ]);
     });
 
@@ -508,14 +510,14 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         }
 
         // Verify we can open a notebook, run a cell and ipykernel prompt should be displayed.
-        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath);
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvNoKernelPath);
         await closeNotebooksAndCleanUpAfterTests();
 
         // Un-install IpyKernel
-        await uninstallIPyKernel(venvPythonPath.fsPath);
+        await uninstallIPyKernel(venvNoKernelPath.fsPath);
 
         nbFile = await createTemporaryNotebookFromFile(templateIPynbFile, disposables);
-        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath);
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvNoKernelPath);
     });
     test('Ensure ipykernel install prompt is displayed even selecting another kernel which too does not have IPyKernel installed (VSCode Notebook)', async function () {
         if (IS_REMOTE_NATIVE_TEST()) {
@@ -523,15 +525,15 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         }
 
         // Verify we can open a notebook, run a cell and ipykernel prompt should be displayed.
-        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath);
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvNoKernelPath);
         await closeNotebooksAndCleanUpAfterTests();
 
         // Un-install IpyKernel
-        await uninstallIPyKernel(venvPythonPath.fsPath);
+        await uninstallIPyKernel(venvNoKernelPath.fsPath);
         await uninstallIPyKernel(venvNoRegPath.fsPath);
 
         nbFile = await createTemporaryNotebookFromFile(templateIPynbFile, disposables);
-        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath, venvNoRegPath);
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvNoKernelPath, venvNoRegPath);
     });
     test('Ensure ipykernel install prompt is not displayed after selecting another kernel which has IPyKernel installed (VSCode Notebook)', async function () {
         if (IS_REMOTE_NATIVE_TEST()) {
@@ -539,15 +541,15 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         }
 
         // Verify we can open a notebook, run a cell and ipykernel prompt should be displayed.
-        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath);
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvNoKernelPath);
         await closeNotebooksAndCleanUpAfterTests();
 
         // Un-install IpyKernel
-        await uninstallIPyKernel(venvPythonPath.fsPath);
+        await uninstallIPyKernel(venvNoKernelPath.fsPath);
         await installIPyKernel(venvNoRegPath.fsPath);
 
         nbFile = await createTemporaryNotebookFromFile(templateIPynbFile, disposables);
-        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath, venvNoRegPath, 'DoNotInstallIPyKernel');
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvNoKernelPath, venvNoRegPath, 'DoNotInstallIPyKernel');
     });
     test('Should be prompted to re-install ipykernel when restarting a kernel from which ipykernel was uninstalled (VSCode Notebook)', async function () {
         if (IS_REMOTE_NATIVE_TEST()) {
@@ -556,11 +558,11 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
 
         // Verify we can open a notebook, run a cell and ipykernel prompt should be displayed.
         console.log('Step1');
-        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath);
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvNoKernelPath);
 
         // Un-install IpyKernel
         console.log('Step2');
-        await uninstallIPyKernel(venvPythonPath.fsPath);
+        await uninstallIPyKernel(venvNoKernelPath.fsPath);
 
         // Now that IPyKernel is missing, if we attempt to restart a kernel, we should get a prompt.
         // Previously things just hang at weird spots, its not a likely scenario, but this test ensures the code works as expected.
@@ -587,10 +589,10 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
             return this.skip();
         }
         // Verify we can open a notebook, run a cell and ipykernel prompt should be displayed.
-        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath);
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvNoKernelPath);
 
         // Un-install IpyKernel
-        await uninstallIPyKernel(venvPythonPath.fsPath);
+        await uninstallIPyKernel(venvNoKernelPath.fsPath);
 
         // Now that IPyKernel is missing, if we attempt to restart a kernel, we should get a prompt.
         // Previously things just hang at weird spots, its not a likely scenario, but this test ensures the code works as expected.
@@ -639,9 +641,11 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
             disposables
         );
 
+        const { editor } = await openNotebook(nbFile);
+
         // Hijack the select kernel functionality so it selects the correct kernel
         const stub = sinon.stub(kernelSelector, 'selectKernel').callsFake(async function () {
-            await waitForKernelToChange({ interpreterPath: venvKernelPath });
+            await waitForKernelToChange({ interpreterPath: venvKernelPath }, editor);
             return true;
         } as any);
         const disposable = { dispose: () => stub.restore() };
@@ -649,17 +653,16 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
             disposables.push(disposable);
         }
 
-        await openNotebook(nbFile);
-        await waitForKernelToGetAutoSelected();
-        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
+        await waitForKernelToChange({ interpreterPath: venvNoKernelPath }, editor);
+        const cell = editor.notebook.cellAt(0)!;
         assert.equal(cell.outputs.length, 0);
 
         // Insert another cell so we can test run all
         const cell2 = await insertCodeCell('print("foo")');
 
         // The prompt should be displayed when we run a cell.
-        const runPromise = runAllCellsInActiveNotebook();
-        await waitForCondition(async () => prompt.displayed.then(() => true), delayForUITest, 'Prompt not displayed');
+        const runPromise = runAllCellsInActiveNotebook(false, editor);
+        await waitForCondition(async () => prompt.displayed.then(() => true), 10_000, 'Prompt not displayed');
 
         // Now the run should finish
         await runPromise;
@@ -673,11 +676,11 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
         const promptToInstall = await clickInstallFromIPyKernelPrompt();
         const kernelStartSpy = sinon.spy(Kernel.prototype, 'start');
         console.log('Step1');
-        await uninstallIPyKernel(venvPythonPath.fsPath);
+        await uninstallIPyKernel(venvNoKernelPath.fsPath);
         console.log('Step2');
-        await openNotebook(nbFile);
+        const { editor } = await openNotebook(nbFile);
         console.log('Step3');
-        await waitForKernelToGetAutoSelected();
+        await waitForKernelToChange({ interpreterPath: venvNoKernelPath }, editor);
         console.log('Step4');
         await waitForCondition(
             async () => kernelStartSpy.callCount > 0,
@@ -707,7 +710,7 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
 
         // If we try to run a cell, verify a prompt is displayed.
         console.log('Step7');
-        await openNotebookAndInstallIpyKernelWhenRunningCell(venvPythonPath);
+        await openNotebookAndInstallIpyKernelWhenRunningCell(venvNoKernelPath);
     });
 
     async function verifyErrorInCellOutput(notebook: NotebookDocument, venvPath: string, cell?: NotebookCell) {
@@ -788,8 +791,8 @@ suite('DataScience Install IPyKernel (slow) (install)', function () {
                     (item) => item.uri.fsPath.toLowerCase() === nbFile.fsPath.toLowerCase()
                 )
             ) {
-                await openNotebook(nbFile);
-                await waitForKernelToChange({ interpreterPath });
+                const { editor } = await openNotebook(nbFile);
+                await waitForKernelToChange({ interpreterPath }, editor);
             }
             console.log('Stepb');
 

--- a/src/test/datascience/notebook/ipywidget.vscode.common.test.ts
+++ b/src/test/datascience/notebook/ipywidget.vscode.common.test.ts
@@ -70,8 +70,8 @@ suite('DataScience - VSCode Notebook - Standard', function () {
     });
     suiteTeardown(() => closeNotebooksAndCleanUpAfterTests(disposables));
     test('Can run a widget notebook (webview-test)', async function () {
-        const notebook = await openNotebook(testWidgetNb);
-        await waitForKernelToGetAutoSelected(PYTHON_LANGUAGE);
+        const { notebook, editor } = await openNotebook(testWidgetNb);
+        await waitForKernelToGetAutoSelected(editor, PYTHON_LANGUAGE);
         const cell = notebook.cellAt(0);
 
         // This flag will be resolved when the widget loads
@@ -90,9 +90,9 @@ suite('DataScience - VSCode Notebook - Standard', function () {
         );
     });
     test('Can run a widget notebook twice (webview-test)', async function () {
-        let notebook = await openNotebook(testWidgetNb);
-        await waitForKernelToGetAutoSelected(PYTHON_LANGUAGE);
-        let cell = notebook.cellAt(0);
+        let open = await openNotebook(testWidgetNb);
+        await waitForKernelToGetAutoSelected(open.editor, PYTHON_LANGUAGE);
+        let cell = open.notebook.cellAt(0);
 
         // Execute cell. It should load and render the widget
         await runCell(cell);
@@ -103,9 +103,9 @@ suite('DataScience - VSCode Notebook - Standard', function () {
         // Close notebook and open again.
         await closeNotebooks();
 
-        notebook = await openNotebook(testWidgetNb);
-        await waitForKernelToGetAutoSelected(PYTHON_LANGUAGE);
-        cell = notebook.cellAt(0);
+        open = await openNotebook(testWidgetNb);
+        await waitForKernelToGetAutoSelected(open.editor, PYTHON_LANGUAGE);
+        cell = open.notebook.cellAt(0);
 
         // This flag will be resolved when the widget loads
         const flag = createDeferred<boolean>();

--- a/src/test/datascience/notebook/nonPythonKernels.vscode.test.ts
+++ b/src/test/datascience/notebook/nonPythonKernels.vscode.test.ts
@@ -100,12 +100,12 @@ suite('DataScience - VSCode Notebook - Kernels (non-python-kernel) (slow)', () =
         if (!testJavaKernels) {
             return this.skip();
         }
-        await openNotebook(testJavaNb);
-        await waitForKernelToGetAutoSelected('java');
+        const { editor } = await openNotebook(testJavaNb);
+        await waitForKernelToGetAutoSelected(editor, 'java');
     });
     test('Automatically pick julia kernel when opening a Julia Notebook', async () => {
-        await openNotebook(testJuliaNb);
-        await waitForKernelToGetAutoSelected('julia');
+        const { editor } = await openNotebook(testJuliaNb);
+        await waitForKernelToGetAutoSelected(editor, 'julia');
     });
     test('Automatically pick csharp kernel when opening a csharp notebook', async function () {
         // The .NET interactive CLI does not work if you do not have Jupyter installed.
@@ -116,8 +116,8 @@ suite('DataScience - VSCode Notebook - Kernels (non-python-kernel) (slow)', () =
         if (!pythonChecker.isPythonExtensionInstalled) {
             return this.skip();
         }
-        await openNotebook(testCSharpNb);
-        await waitForKernelToGetAutoSelected('c#');
+        const { editor } = await openNotebook(testCSharpNb);
+        await waitForKernelToGetAutoSelected(editor, 'c#');
     });
     test('New notebook will have a Julia cell if last notebook was a julia nb', async function () {
         return this.skip();
@@ -148,7 +148,7 @@ suite('DataScience - VSCode Notebook - Kernels (non-python-kernel) (slow)', () =
                 .cellAt(0)
                 .document.languageId.toLowerCase()}`
         );
-        await waitForKernelToGetAutoSelected('julia');
+        await waitForKernelToGetAutoSelected(undefined, 'julia');
 
         // Lets try opening a python nb & validate that.
         await closeNotebooks();
@@ -156,16 +156,16 @@ suite('DataScience - VSCode Notebook - Kernels (non-python-kernel) (slow)', () =
         const pythonChecker = api.serviceContainer.get<IPythonExtensionChecker>(IPythonExtensionChecker);
         if (pythonChecker.isPythonExtensionInstalled) {
             // Now open an existing python notebook & confirm kernel is set to Python.
-            await openNotebook(testEmptyPythonNb);
-            await waitForKernelToGetAutoSelected('python');
+            const { editor } = await openNotebook(testEmptyPythonNb);
+            await waitForKernelToGetAutoSelected(editor, 'python');
         }
     });
     test('Can run a Julia notebook', async function () {
         this.timeout(60_000); // Can be slow to start Julia kernel on CI.
-        await openNotebook(testJuliaNb);
-        await waitForKernelToGetAutoSelected('julia');
+        const { editor } = await openNotebook(testJuliaNb);
+        await waitForKernelToGetAutoSelected(editor, 'julia');
         await insertCodeCell('123456', { language: 'julia', index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
+        const cell = editor.notebook.cellAt(0)!;
         // Wait till execution count changes and status is success.
         await Promise.all([
             runCell(cell),
@@ -181,8 +181,8 @@ suite('DataScience - VSCode Notebook - Kernels (non-python-kernel) (slow)', () =
             return this.skip();
         }
         this.timeout(30_000); // Can be slow to start csharp kernel on CI.
-        await openNotebook(testCSharpNb);
-        await waitForKernelToGetAutoSelected('c#');
+        const { editor } = await openNotebook(testCSharpNb);
+        await waitForKernelToGetAutoSelected(editor, 'c#');
         await runAllCellsInActiveNotebook();
 
         const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;

--- a/src/test/datascience/notebook/remoteNotebookEditor.vscode.common.test.ts
+++ b/src/test/datascience/notebook/remoteNotebookEditor.vscode.common.test.ts
@@ -111,11 +111,11 @@ suite('DataScience - VSCode Notebook - Remote Execution', function () {
         this.skip();
         const previousList = globalMemento.get<{}[]>(Settings.JupyterServerUriList, []);
         const encryptedStorageSpiedStore = sinon.spy(encryptedStorage, 'store');
-        await openNotebook(ipynbFile);
-        await waitForKernelToGetAutoSelected(PYTHON_LANGUAGE);
+        const { editor } = await openNotebook(ipynbFile);
+        await waitForKernelToGetAutoSelected(editor, PYTHON_LANGUAGE);
         await deleteAllCellsAndWait();
         await insertCodeCell('print("123412341234")', { index: 0 });
-        const cell = vscodeNotebook.activeNotebookEditor?.notebook.cellAt(0)!;
+        const cell = editor.notebook.cellAt(0)!;
         await Promise.all([runAllCellsInActiveNotebook(), waitForExecutionCompletedSuccessfully(cell)]);
 
         // Wait for MRU to get updated & encrypted storage to get updated.
@@ -161,15 +161,15 @@ suite('DataScience - VSCode Notebook - Remote Execution', function () {
 
     test('Remote kernels support completions', async function () {
         setIntellisenseTimeout(30000);
-        await openNotebook(ipynbFile);
-        await waitForKernelToGetAutoSelected(PYTHON_LANGUAGE);
+        const { editor } = await openNotebook(ipynbFile);
+        await waitForKernelToGetAutoSelected(editor, PYTHON_LANGUAGE);
         let nbEditor = vscodeNotebook.activeNotebookEditor!;
         assert.isOk(nbEditor, 'No active notebook');
         // Cell 1 = `a = "Hello World"`
         // Cell 2 = `print(a)`
         let cell2 = nbEditor.notebook.getCells()![1]!;
         await Promise.all([
-            runAllCellsInActiveNotebook(),
+            runAllCellsInActiveNotebook(false, editor),
             waitForExecutionCompletedSuccessfully(cell2),
             waitForTextOutput(cell2, 'Hello World', 0, false)
         ]);
@@ -206,8 +206,8 @@ export async function runCellAndVerifyUpdateOfPreferredRemoteKernelId(
         PreferredRemoteKernelIdProvider
     );
 
-    await openNotebook(ipynbFile);
-    await waitForKernelToGetAutoSelected(PYTHON_LANGUAGE, true);
+    const { editor } = await openNotebook(ipynbFile);
+    await waitForKernelToGetAutoSelected(editor, PYTHON_LANGUAGE, true);
     let nbEditor = window.activeNotebookEditor!;
     assert.isOk(nbEditor, 'No active notebook');
     // Cell 1 = `a = "Hello World"`
@@ -241,8 +241,8 @@ export async function reopeningNotebookUsesSameRemoteKernel(ipynbFile: Uri, serv
     // It should connect to the same live kernel. Don't force it to pick it.
     // Second cell should display the value of existing variable from previous execution.
 
-    await openNotebook(ipynbFile);
-    await waitForKernelToGetAutoSelected(PYTHON_LANGUAGE, true, 100_000, true);
+    const { editor } = await openNotebook(ipynbFile);
+    await waitForKernelToGetAutoSelected(editor, PYTHON_LANGUAGE, true, 100_000, true);
     nbEditor = window.activeNotebookEditor!;
     assert.isOk(nbEditor, 'No active notebook');
 

--- a/src/test/datascience/notebook/remoteNotebookEditor.vscode.test.ts
+++ b/src/test/datascience/notebook/remoteNotebookEditor.vscode.test.ts
@@ -15,7 +15,7 @@ import { traceInfoIfCI, traceInfo } from '../../../platform/logging';
 import { captureScreenShot, IExtensionTestApi, initialize, waitForCondition } from '../../common';
 import { openNotebook } from '../helpers';
 import { JupyterServer } from '../jupyterServer.node';
-import { closeNotebooksAndCleanUpAfterTests, hijackPrompt } from './helper';
+import { changeShowOnlyOneTypeOfKernel, closeNotebooksAndCleanUpAfterTests, hijackPrompt } from './helper';
 import {
     createEmptyPythonNotebook,
     createTemporaryNotebook,
@@ -95,6 +95,7 @@ suite('DataScience - VSCode Notebook - (Remote Execution)', function () {
     });
     teardown(async function () {
         traceInfo(`Ended Test ${this.currentTest?.title}`);
+        await changeShowOnlyOneTypeOfKernel(false);
         if (this.currentTest?.isFailed()) {
             await captureScreenShot(this);
         }
@@ -158,6 +159,7 @@ suite('DataScience - VSCode Notebook - (Remote Execution)', function () {
     });
 
     test('Local and Remote kernels are not listed', async function () {
+        await changeShowOnlyOneTypeOfKernel(true);
         await controllerLoader.loadControllers();
         const controllers = controllerRegistration.registered;
         assert.ok(
@@ -234,8 +236,8 @@ suite('DataScience - VSCode Notebook - (Remote Execution)', function () {
     });
 
     test('Remote kernels support intellisense', async function () {
-        await openNotebook(ipynbFile);
-        await waitForKernelToGetAutoSelected(PYTHON_LANGUAGE);
+        const { editor } = await openNotebook(ipynbFile);
+        await waitForKernelToGetAutoSelected(editor, PYTHON_LANGUAGE);
         let nbEditor = vscodeNotebook.activeNotebookEditor!;
         assert.isOk(nbEditor, 'No active notebook');
         // Cell 1 = `a = "Hello World"`
@@ -271,9 +273,9 @@ suite('DataScience - VSCode Notebook - (Remote Execution)', function () {
             { result: DataScience.jupyterSelfCertEnable(), clickImmediately: true }
         );
         await startJupyterServer(undefined, true);
-        await openNotebook(ipynbFile);
+        const { editor } = await openNotebook(ipynbFile);
         await waitForCondition(() => prompt.displayed, defaultNotebookTestTimeout, 'Prompt not displayed');
-        await waitForKernelToGetAutoSelected(PYTHON_LANGUAGE, true);
+        await waitForKernelToGetAutoSelected(editor, PYTHON_LANGUAGE, true);
         let nbEditor = vscodeNotebook.activeNotebookEditor!;
         assert.isOk(nbEditor, 'No active notebook');
         // Cell 1 = `a = "Hello World"`


### PR DESCRIPTION
Fixes #10734 

On my local machine at least, the 'activeNotebookEditor' was consistently not being set when opening different windows. 

Specifying it explicitly fixes it for me locally plus makes the tests run faster. Not sure we need to validate active notebook editor is correct (as VS code may decide to change focus behavior), so this seems good to me in general.

