### PR TITLE
Skip unnecessary controller refreshes

### DIFF
--- a/src/notebooks/controllers/controllerLoader.ts
+++ b/src/notebooks/controllers/controllerLoader.ts
@@ -62,7 +62,11 @@ export class ControllerLoader implements IControllerLoader, IExtensionSyncActiva
         );
 
         // Make sure to reload whenever we do something that changes state
-        const forceLoad = () => this.loadControllers(true);
+        const forceLoad = () => {
+            this.loadControllers(true)
+                .then(noop)
+                .catch((ex) => traceError('Error reloading notebook controllers', ex));
+        };
         this.serverUriStorage.onDidChangeUri(forceLoad, this, this.disposables);
 
         // If we create a new kernel, we need to refresh if the kernel is remote (because
@@ -71,7 +75,7 @@ export class ControllerLoader implements IControllerLoader, IExtensionSyncActiva
         // to check for remote if the future when we support live sessions on local
         this.kernelProvider.onDidStartKernel((k) => {
             if (isRemoteConnection(k.kernelConnectionMetadata)) {
-                forceLoad().ignoreErrors();
+                forceLoad();
             }
         });
 

--- a/src/notebooks/controllers/controllerPreferredService.ts
+++ b/src/notebooks/controllers/controllerPreferredService.ts
@@ -121,20 +121,17 @@ export class ControllerPreferredService implements IControllerPreferredService, 
                     serverId
                 ));
 
-                // Also start the search to refresh the cache, don't need to await on this
-                // unless we don't find a match. It will update the cache after running
-                const ignoreCacheFindPreferredPromise = this.findPreferredKernelExactMatch(
-                    document.uri,
-                    notebookMetadata,
-                    preferredSearchToken.token,
-                    'ignoreCache',
-                    preferredInterpreter,
-                    serverId
-                );
-
                 // If we didn't find an exact match in the cache, try awaiting for the non-cache version
                 if (!preferredConnection) {
-                    ({ preferredConnection } = await ignoreCacheFindPreferredPromise);
+                    // Don't start this ahead of time to save some CPU cycles
+                    ({ preferredConnection } = await this.findPreferredKernelExactMatch(
+                        document.uri,
+                        notebookMetadata,
+                        preferredSearchToken.token,
+                        'ignoreCache',
+                        preferredInterpreter,
+                        serverId
+                    ));
                 }
 
                 // Send telemetry on looking for preferred don't await for sending it

--- a/src/platform/api/pythonApi.ts
+++ b/src/platform/api/pythonApi.ts
@@ -286,6 +286,8 @@ export class InterpreterService implements IInterpreterService {
     private readonly didChangeInterpreters = new EventEmitter<void>();
     private eventHandlerAdded?: boolean;
     private interpreterListCachePromise: Promise<PythonEnvironment[]> | undefined = undefined;
+    private refreshPromise: Promise<void> | undefined;
+    private api: PythonApi | undefined;
     constructor(
         @inject(IPythonApiProvider) private readonly apiProvider: IPythonApiProvider,
         @inject(IPythonExtensionChecker) private extensionChecker: IPythonExtensionChecker,
@@ -305,6 +307,11 @@ export class InterpreterService implements IInterpreterService {
             }
         }
         this.workspace.onDidChangeWorkspaceFolders(this.onDidChangeWorkspaceFolders, this, disposables);
+    }
+
+    public get refreshing() {
+        const refreshPromise = this.getRefreshPromise();
+        return refreshPromise !== undefined;
     }
 
     public get onDidChangeInterpreter(): Event<void> {
@@ -334,10 +341,12 @@ export class InterpreterService implements IInterpreterService {
             if (api.refreshInterpreters) {
                 const newItems = await api.refreshInterpreters({ clearCache: false });
                 this.interpreterListCachePromise = undefined;
+                this.didChangeInterpreters.fire();
                 traceVerbose(`Refreshed Environments and got ${newItems}`);
             } else if ((api as any).refreshEnvironment) {
                 const newItems = await (api as any).refreshEnvironment({ clearCache: false });
                 this.interpreterListCachePromise = undefined;
+                this.didChangeInterpreters.fire();
                 traceVerbose(`Refreshed Environments and got ${newItems}`);
             }
         } catch (ex) {
@@ -397,21 +406,41 @@ export class InterpreterService implements IInterpreterService {
         }
     }
 
+    private async getApi(): Promise<PythonApi | undefined> {
+        if (!this.extensionChecker.isPythonExtensionInstalled) {
+            return;
+        }
+        if (!this.extensionChecker.isPythonExtensionActive) {
+            return;
+        }
+        if (!this.api) {
+            this.api = await this.apiProvider.getApi();
+        }
+        return this.api;
+    }
+
+    private tryGetApi(): PythonApi | undefined {
+        if (!this.api) {
+            this.getApi().ignoreErrors();
+        }
+        return this.api;
+    }
+
     private onDidChangeWorkspaceFolders() {
         this.interpreterListCachePromise = undefined;
     }
     private async getInterpretersImpl(resource?: Uri): Promise<PythonEnvironment[]> {
         // Python uses the resource to look up the workspace folder. For Jupyter
         // we want all interpreters regardless of workspace folder so call this multiple times
+        const refreshDeferred = createDeferred<void>();
+        this.refreshPromise = refreshDeferred.promise;
         const folders = this.workspace.workspaceFolders;
         const activeInterpreterPromise = this.getActiveInterpreter(resource);
         const all = folders
             ? await Promise.all(
-                  [...folders, undefined].map((f) =>
-                      this.apiProvider.getApi().then((api) => api.getInterpreters(f?.uri))
-                  )
+                  [...folders, undefined].map((f) => this.getApi().then((api) => api?.getInterpreters(f?.uri)))
               )
-            : await Promise.all([await this.apiProvider.getApi().then((api) => api.getInterpreters(undefined))]);
+            : await Promise.all([await this.getApi().then((api) => api?.getInterpreters(undefined))]);
         const activeInterpreter = await activeInterpreterPromise;
         // Remove dupes
         const result: PythonEnvironment[] = [];
@@ -427,6 +456,9 @@ export class InterpreterService implements IInterpreterService {
                 result.push(interpreter);
             }
         });
+        // We are definitely ready after we get all of the interpreters
+        refreshDeferred.resolve();
+        this.refreshPromise = undefined;
         return result;
     }
 
@@ -435,17 +467,9 @@ export class InterpreterService implements IInterpreterService {
         if (this.eventHandlerAdded) {
             return;
         }
-        // Python may not be installed or active
-        if (!this.extensionChecker.isPythonExtensionInstalled) {
-            return;
-        }
-        if (!this.extensionChecker.isPythonExtensionActive) {
-            return;
-        }
-        this.apiProvider
-            .getApi()
+        this.getApi()
             .then((api) => {
-                if (!this.eventHandlerAdded) {
+                if (!this.eventHandlerAdded && api) {
                     this.eventHandlerAdded = true;
                     api.onDidChangeInterpreter(
                         () => {
@@ -467,5 +491,18 @@ export class InterpreterService implements IInterpreterService {
                 }
             })
             .catch(noop);
+    }
+    private getRefreshPromise(): Promise<void> | undefined {
+        if (!this.refreshPromise) {
+            const api = this.tryGetApi();
+            if (!api) {
+                this.refreshPromise = this.getApi().then((api) =>
+                    api?.getRefreshPromise ? api.getRefreshPromise() : undefined
+                );
+            } else {
+                this.refreshPromise = api.getRefreshPromise ? api.getRefreshPromise() : undefined;
+            }
+        }
+        return this.refreshPromise;
     }
 }

--- a/src/platform/api/pythonApi.ts
+++ b/src/platform/api/pythonApi.ts
@@ -500,7 +500,7 @@ export class InterpreterService implements IInterpreterService {
             }
         }
         if (!this.canFindRefreshPromise) {
-            return Promise.resolve(); // If no getRefreshPromise, then we're always refreshing. Meaning always out of date.
+            return undefined; // If API isn't supported, then just assume we're not in the middle of a refresh.
         } else {
             const api = this.tryGetApi();
             const apiRefreshPromise = api?.getRefreshPromise ? api.getRefreshPromise() : undefined;

--- a/src/platform/api/types.ts
+++ b/src/platform/api/types.ts
@@ -81,6 +81,15 @@ export interface IInterpreterQuickPickItem_PythonApi extends QuickPickItem {
      */
     interpreter: PythonEnvironment_PythonApi;
 }
+export enum ProgressReportStage {
+    discoveryStarted = 'discoveryStarted',
+    allPathsDiscovered = 'allPathsDiscovered',
+    discoveryFinished = 'discoveryFinished'
+}
+
+export type ProgressNotificationEvent = {
+    stage: ProgressReportStage;
+};
 
 export type PythonApi = {
     /**
@@ -157,6 +166,10 @@ export type PythonApi = {
      * @param resource
      */
     setActiveInterpreter(interpreterPath: string, resource?: Resource): Promise<void>;
+    /***
+     * Returns a promise if a refresh is going on.
+     */
+    getRefreshPromise?(): Promise<void> | undefined;
 };
 
 export type RefreshInterpretersOptions = {

--- a/src/platform/api/types.ts
+++ b/src/platform/api/types.ts
@@ -81,15 +81,6 @@ export interface IInterpreterQuickPickItem_PythonApi extends QuickPickItem {
      */
     interpreter: PythonEnvironment_PythonApi;
 }
-export enum ProgressReportStage {
-    discoveryStarted = 'discoveryStarted',
-    allPathsDiscovered = 'allPathsDiscovered',
-    discoveryFinished = 'discoveryFinished'
-}
-
-export type ProgressNotificationEvent = {
-    stage: ProgressReportStage;
-};
 
 export type PythonApi = {
     /**

--- a/src/platform/interpreter/contracts.ts
+++ b/src/platform/interpreter/contracts.ts
@@ -9,4 +9,5 @@ export interface IInterpreterService {
     getInterpreters(resource?: Uri): Promise<PythonEnvironment[]>;
     getActiveInterpreter(resource?: Uri): Promise<PythonEnvironment | undefined>;
     getInterpreterDetails(pythonPath: Uri, resource?: Uri): Promise<undefined | PythonEnvironment>;
+    refreshing: boolean;
 }

--- a/src/test/interpreters/interpreterService.node.ts
+++ b/src/test/interpreters/interpreterService.node.ts
@@ -26,6 +26,9 @@ export class InterpreterService implements IInterpreterService {
     private readonly customInterpretersPerUri = new Map<string, Uri>();
     constructor(@inject(IPythonExtensionChecker) private readonly extensionChecker: IPythonExtensionChecker) {}
 
+    public get refreshing() {
+        return false;
+    }
     public async getInterpreters(_resource?: Uri): Promise<PythonEnvironment[]> {
         this.validatePythonExtension();
         if (interpretersCache) {


### PR DESCRIPTION
For #10399 

Was running some poor mans profiling (just trace statements in the debugger) and noticed we spend a lot of time continually refreshing the kernel list. 

This PR attempts to minimize some of the refreshes that occur. 
