### PR TITLE
Guard against loading python extension when checking interpreter packages.

### DIFF
--- a/news/2 Fixes/10615.md
+++ b/news/2 Fixes/10615.md
@@ -1,0 +1,1 @@
+Don't prompt to install python extension on just trying to check the packages that are in an interpreter.

--- a/src/platform/interpreter/interpreterPackages.node.ts
+++ b/src/platform/interpreter/interpreterPackages.node.ts
@@ -61,6 +61,9 @@ export class InterpreterPackages implements IInterpreterPackages {
         return InterpreterPackages._instance;
     }
     public getPackageVersions(interpreter: PythonEnvironment): Promise<Map<string, string>> {
+        if (!this.pythonExtensionChecker.isPythonExtensionInstalled) {
+            return Promise.resolve(new Map<string, string>());
+        }
         const key = getComparisonKey(interpreter.uri);
         let deferred = this.interpreterInformation.get(key);
         if (!deferred) {
@@ -71,6 +74,9 @@ export class InterpreterPackages implements IInterpreterPackages {
         return deferred.promise;
     }
     public async getPackageVersion(interpreter: PythonEnvironment, packageName: string): Promise<string | undefined> {
+        if (!this.pythonExtensionChecker.isPythonExtensionInstalled) {
+            return Promise.resolve(undefined);
+        }
         const packages = await this.getPackageVersions(interpreter);
         const telemetrySafeString = getTelemetrySafeHashedString(packageName.toLocaleLowerCase());
         if (!packages.has(telemetrySafeString)) {


### PR DESCRIPTION
Fixes #10615

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
