### PR TITLE
Cache kernels for a specific version of extension

### DIFF
--- a/src/kernels/kernelFinder.base.ts
+++ b/src/kernels/kernelFinder.base.ts
@@ -282,6 +282,15 @@ export abstract class BaseKernelFinder implements IKernelFinder {
                 key,
                 { kernels: [], extensionVersion: '' }
             );
+
+            /**
+             * The cached list of raw kernels is pointing to kernelSpec.json files in the extensions directory.
+             * Assume you have version 1 of extension installed.
+             * Now you update to version 2, at this point the cache still points to version 1 and the kernelSpec.json files are in the directory version 1.
+             * Those files in directory for version 1 could get deleted by VS Code at any point in time, as thats an old version of the extension and user has now installed version 2.
+             * Hence its wrong and buggy to use those files.
+             * To ensure we don't run into weird issues with the use of cached kernelSpec.json files, we ensure the cache is tied to each version of the extension.
+             */
             if (values && isArray(values.kernels) && values.extensionVersion === this.env.extensionVersion) {
                 results = values.kernels.map(deserializeKernelConnection);
                 this.cache.set(kind, results);

--- a/src/kernels/kernelFinder.base.ts
+++ b/src/kernels/kernelFinder.base.ts
@@ -25,10 +25,11 @@ import {
     isLocalConnection,
     KernelConnectionMetadata
 } from './types';
+import { IApplicationEnvironment } from '../platform/common/application/types';
 
 // Two cache keys so we can get local and remote separately (exported for tests)
-export const LocalKernelSpecsCacheKey = 'JUPYTER_LOCAL_KERNELSPECS_V3';
-export const RemoteKernelSpecsCacheKey = 'JUPYTER_REMOTE_KERNELSPECS_V3';
+export const LocalKernelSpecsCacheKey = 'JUPYTER_LOCAL_KERNELSPECS_V4';
+export const RemoteKernelSpecsCacheKey = 'JUPYTER_REMOTE_KERNELSPECS_V4';
 
 export abstract class BaseKernelFinder implements IKernelFinder {
     private startTimeForFetching?: StopWatch;
@@ -42,7 +43,8 @@ export abstract class BaseKernelFinder implements IKernelFinder {
         private readonly remoteKernelFinder: IRemoteKernelFinder | undefined,
         private readonly globalState: Memento,
         protected readonly serverUriStorage: IJupyterServerUriStorage,
-        protected readonly serverConnectionType: IServerConnectionType
+        protected readonly serverConnectionType: IServerConnectionType,
+        private readonly env: IApplicationEnvironment
     ) {}
 
     @traceDecoratorVerbose('Rank Kernels', TraceOptions.BeforeCall | TraceOptions.Arguments)
@@ -271,14 +273,17 @@ export abstract class BaseKernelFinder implements IKernelFinder {
         cancelToken?: CancellationToken
     ): Promise<KernelConnectionMetadata[]> {
         let results: KernelConnectionMetadata[] = this.cache.get(kind) || [];
-        const key = kind === 'local' ? LocalKernelSpecsCacheKey : RemoteKernelSpecsCacheKey;
+        const key = this.getCacheKey(kind);
 
         // If not in memory, check memento
         if (!results || results.length === 0) {
             // Check memento too
-            const values = this.globalState.get<KernelConnectionMetadata[]>(key, []);
-            if (values && isArray(values)) {
-                results = values.map(deserializeKernelConnection);
+            const values = this.globalState.get<{ kernels: KernelConnectionMetadata[]; extensionVersion: string }>(
+                key,
+                { kernels: [], extensionVersion: '' }
+            );
+            if (values && isArray(values.kernels) && values.extensionVersion === this.env.extensionVersion) {
+                results = values.kernels.map(deserializeKernelConnection);
                 this.cache.set(kind, results);
             }
         }
@@ -304,9 +309,36 @@ export abstract class BaseKernelFinder implements IKernelFinder {
     }
 
     protected async writeToCache(kind: 'local' | 'remote', values: KernelConnectionMetadata[]) {
-        const key = kind === 'local' ? LocalKernelSpecsCacheKey : RemoteKernelSpecsCacheKey;
+        const key = this.getCacheKey(kind);
         this.cache.set(kind, values);
         const serialized = values.map(serializeKernelConnection);
-        return this.globalState.update(key, serialized);
+        await Promise.all([
+            this.removeOldCachedItems(),
+            ,
+            this.globalState.update(key, { kernels: serialized, extensionVersion: this.env.extensionVersion })
+        ]);
+    }
+    /**
+     * The old cached items can be quite large and we should clear them if we no longer need them.
+     */
+    private async removeOldCachedItems(): Promise<void> {
+        await Promise.all(
+            [
+                'JUPYTER_LOCAL_KERNELSPECS',
+                'JUPYTER_LOCAL_KERNELSPECS_V1',
+                'JUPYTER_LOCAL_KERNELSPECS_V2',
+                'JUPYTER_LOCAL_KERNELSPECS_V3',
+                'JUPYTER_REMOTE_KERNELSPECS',
+                'JUPYTER_REMOTE_KERNELSPECS_V1',
+                'JUPYTER_REMOTE_KERNELSPECS_V2',
+                'JUPYTER_REMOTE_KERNELSPECS_V3'
+            ]
+                .filter((key) => LocalKernelSpecsCacheKey !== key && RemoteKernelSpecsCacheKey !== key) // Exclude latest cache key
+                .filter((key) => this.globalState.get(key, undefined) !== undefined)
+                .map((key) => this.globalState.update(key, undefined).then(noop, noop))
+        );
+    }
+    private getCacheKey(kind: 'local' | 'remote') {
+        return kind === 'local' ? LocalKernelSpecsCacheKey : RemoteKernelSpecsCacheKey;
     }
 }

--- a/src/kernels/kernelFinder.node.ts
+++ b/src/kernels/kernelFinder.node.ts
@@ -9,6 +9,7 @@ import { PreferredRemoteKernelIdProvider } from './jupyter/preferredRemoteKernel
 import { ILocalKernelFinder, IRemoteKernelFinder } from './raw/types';
 import { INotebookProvider, KernelConnectionMetadata } from './types';
 import { IFileSystem } from '../platform/common/platform/types';
+import { IApplicationEnvironment } from '../platform/common/application/types';
 
 @injectable()
 export class KernelFinder extends BaseKernelFinder {
@@ -22,7 +23,8 @@ export class KernelFinder extends BaseKernelFinder {
         @inject(IJupyterServerUriStorage) serverUriStorage: IJupyterServerUriStorage,
         @inject(IServerConnectionType) serverConnectionType: IServerConnectionType,
         @inject(IJupyterRemoteCachedKernelValidator)
-        protected readonly cachedRemoteKernelValidator: IJupyterRemoteCachedKernelValidator
+        protected readonly cachedRemoteKernelValidator: IJupyterRemoteCachedKernelValidator,
+        @inject(IApplicationEnvironment) env: IApplicationEnvironment
     ) {
         super(
             preferredRemoteFinder,
@@ -31,7 +33,8 @@ export class KernelFinder extends BaseKernelFinder {
             remoteKernelFinder,
             globalState,
             serverUriStorage,
-            serverConnectionType
+            serverConnectionType,
+            env
         );
     }
 

--- a/src/kernels/kernelFinder.web.ts
+++ b/src/kernels/kernelFinder.web.ts
@@ -8,6 +8,7 @@ import { BaseKernelFinder } from './kernelFinder.base';
 import { PreferredRemoteKernelIdProvider } from './jupyter/preferredRemoteKernelIdProvider';
 import { IRemoteKernelFinder } from './raw/types';
 import { INotebookProvider, KernelConnectionMetadata } from './types';
+import { IApplicationEnvironment } from '../platform/common/application/types';
 
 @injectable()
 export class KernelFinder extends BaseKernelFinder {
@@ -19,7 +20,8 @@ export class KernelFinder extends BaseKernelFinder {
         @inject(IJupyterServerUriStorage) serverUriStorage: IJupyterServerUriStorage,
         @inject(IServerConnectionType) serverConnectionType: IServerConnectionType,
         @inject(IJupyterRemoteCachedKernelValidator)
-        protected readonly cachedRemoteKernelValidator: IJupyterRemoteCachedKernelValidator
+        protected readonly cachedRemoteKernelValidator: IJupyterRemoteCachedKernelValidator,
+        @inject(IApplicationEnvironment) env: IApplicationEnvironment
     ) {
         super(
             preferredRemoteFinder,
@@ -28,7 +30,8 @@ export class KernelFinder extends BaseKernelFinder {
             remoteKernelFinder,
             globalState,
             serverUriStorage,
-            serverConnectionType
+            serverConnectionType,
+            env
         );
     }
     protected async isValidCachedKernel(kernel: KernelConnectionMetadata): Promise<boolean> {

--- a/src/platform/common/application/applicationEnvironment.base.ts
+++ b/src/platform/common/application/applicationEnvironment.base.ts
@@ -34,6 +34,10 @@ export abstract class BaseApplicationEnvironment implements IApplicationEnvironm
         // eslint-disable-next-line
         return this.packageJson.displayName;
     }
+    public get extensionVersion(): string {
+        // eslint-disable-next-line
+        return this.packageJson.version;
+    }
     /**
      * At the time of writing this API, the vscode.env.shell isn't officially released in stable version of VS Code.
      * Using this in stable version seems to throw errors in VSC with messages being displayed to the user about use of

--- a/src/platform/common/application/types.ts
+++ b/src/platform/common/application/types.ts
@@ -963,6 +963,12 @@ export interface IApplicationEnvironment {
      * @readonly
      */
     readonly extensionName: string;
+    /**
+     * The extension name.
+     *
+     * @readonly
+     */
+    readonly extensionVersion: string;
 
     /**
      * The application root folder from which the editor is running.

--- a/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/localKernelFinder.unit.test.ts
@@ -58,6 +58,7 @@ import { IJupyterRemoteCachedKernelValidator, IServerConnectionType } from '../.
 import { uriEquals } from '../helpers';
 import { IPythonExecutionFactory, IPythonExecutionService } from '../../../platform/common/process/types.node';
 import { getUserHomeDir } from '../../../platform/common/utils/platform.node';
+import { IApplicationEnvironment } from '../../../platform/common/application/types';
 
 [false, true].forEach((isWindows) => {
     suite(`Local Kernel Finder ${isWindows ? 'Windows' : 'Unix'}`, () => {
@@ -133,6 +134,8 @@ import { getUserHomeDir } from '../../../platform/common/utils/platform.node';
             fs = mock(FileSystem);
             when(fs.delete(anything())).thenResolve();
             when(fs.exists(anything())).thenResolve(true);
+            const env = mock<IApplicationEnvironment>();
+            when(env.extensionVersion).thenReturn('');
             const workspaceService = mock(WorkspaceService);
             const testWorkspaceFolder = Uri.file(path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'datascience'));
 
@@ -264,7 +267,8 @@ import { getUserHomeDir } from '../../../platform/common/utils/platform.node';
                 instance(fs),
                 instance(serverUriStorage),
                 instance(connectionType),
-                instance(cachedRemoteKernelValidator)
+                instance(cachedRemoteKernelValidator),
+                instance(env)
             );
         }
         teardown(() => {


### PR DESCRIPTION
Related to #10359

Found a problem in our code:
* The cached list of raw kernels is pointing to kernelspec.json files in the extensions directory.
* So assume you have version 1 of extension installed
* Now you update to version 2, at this point the cache still points to version 1 and the kernelspec.json files are in the directory version 1.
* Those files in directory for version 1 could get deleted by VS Code at any point in time, as thats an old version of the extension and user has now installed version 2.

This PR ensures we don't use the cache when users updated their exensions from version 1 to version 2, else they end up using kernelspecs.json files that could get deleted at some point in time.
At worst this adds a slight delay in loading the kernels, however we have a lot of other cache points for interpeters and the liek to ensure this delay in loading kernels isn't too slow.