### PR TITLE
Add API to get notebook URI connected to a text document URI

### DIFF
--- a/src/platform/api/types.ts
+++ b/src/platform/api/types.ts
@@ -142,6 +142,9 @@ export type PythonApi = {
     ): Promise<string[] | undefined>;
 
     registerJupyterPythonPathFunction(func: (uri: Uri) => Promise<string | undefined>): void;
+
+    registerGetNotebookUriForTextDocumentUriFunction(func: (textDocumentUri: Uri) => Uri | undefined): void;
+
     /**
      * This API will re-trigger environment discovery. Extensions can wait on the returned
      * promise to get the updated interpreters list. If there is a refresh already going on

--- a/src/platform/api/types.ts
+++ b/src/platform/api/types.ts
@@ -141,8 +141,19 @@ export type PythonApi = {
         interpreter?: PythonEnvironment_PythonApi
     ): Promise<string[] | undefined>;
 
+    /**
+     * Call to provide a function that the Python extension can call to request the Python
+     * path to use for a particular notebook.
+     * @param func : The function that Python should call when requesting the Python path.
+     */
     registerJupyterPythonPathFunction(func: (uri: Uri) => Promise<string | undefined>): void;
 
+    /**
+     * Call to provide a function that the Python extension can call to request the notebook
+     * document URI related to a particular text document URI, or undefined if there is no
+     * associated notebook.
+     * @param func : The function that Python should call when requesting the notebook URI.
+     */
     registerGetNotebookUriForTextDocumentUriFunction(func: (textDocumentUri: Uri) => Uri | undefined): void;
 
     /**

--- a/src/standalone/intellisense/notebookPythonPathService.node.ts
+++ b/src/standalone/intellisense/notebookPythonPathService.node.ts
@@ -47,6 +47,11 @@ export class NotebookPythonPathService implements IExtensionSingleActivationServ
             if (api.registerJupyterPythonPathFunction !== undefined) {
                 api.registerJupyterPythonPathFunction((uri) => this._jupyterPythonPathFunction(uri));
             }
+            if (api.registerGetNotebookUriForTextDocumentUriFunction !== undefined) {
+                api.registerGetNotebookUriForTextDocumentUriFunction((uri) =>
+                    this._getNotebookUriForTextDocumentUri(uri)
+                );
+            }
         });
     }
 
@@ -137,5 +142,15 @@ export class NotebookPythonPathService implements IExtensionSingleActivationServ
         traceVerbose(`_jupyterPythonPathFunction: Giving Pylance "${pythonPath}" as python path for "${uri}"`);
 
         return pythonPath;
+    }
+
+    private _getNotebookUriForTextDocumentUri(textDocumentUri: Uri): Uri | undefined {
+        if (textDocumentUri.scheme !== 'vscode-interactive-input') {
+            return undefined;
+        }
+
+        const notebookPath = `${textDocumentUri.fsPath.replace('\\InteractiveInput-', 'Interactive-')}.interactive`;
+        const notebookUri = textDocumentUri.with({ scheme: 'vscode-interactive', path: notebookPath });
+        return notebookUri;
     }
 }


### PR DESCRIPTION
Part of https://github.com/microsoft/vscode-jupyter/issues/10630. Also requires changes in Python and Pylance.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [X] Title summarizes what is changing.
-   [X] ~Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).~
-   [X] Appropriate comments and documentation strings in the code.
-   [X] ~Has sufficient logging.~
-   [X] ~Has telemetry for feature-requests.~
-   [X] ~Unit tests & system/integration tests are added/updated.~
-   [X] ~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [X] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
