### PR TITLE
Remove suite only

### DIFF
--- a/src/test/client/api.vscode.test.ts
+++ b/src/test/client/api.vscode.test.ts
@@ -21,7 +21,7 @@ import { IS_REMOTE_NATIVE_TEST } from '../constants.node';
 import { workspace } from 'vscode';
 
 // eslint-disable-next-line
-suite.only('3rd Party Kernel Service API', function () {
+suite('3rd Party Kernel Service API', function () {
     let api: IExtensionTestApi;
     let vscodeNotebook: IVSCodeNotebook;
     const disposables: IDisposable[] = [];

--- a/src/test/client/api.vscode.test.ts
+++ b/src/test/client/api.vscode.test.ts
@@ -20,7 +20,6 @@ import { IVSCodeNotebook } from '../../platform/common/application/types';
 import { IS_REMOTE_NATIVE_TEST } from '../constants.node';
 import { workspace } from 'vscode';
 
-// eslint-disable-next-line
 suite('3rd Party Kernel Service API', function () {
     let api: IExtensionTestApi;
     let vscodeNotebook: IVSCodeNotebook;


### PR DESCRIPTION
Remove the `suite.only` and `eslint-disable-next-line`

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
