### PR TITLE
fail test run if too many skipped

### DIFF
--- a/build/webTestReporter.js
+++ b/build/webTestReporter.js
@@ -13,7 +13,6 @@ const core = require('@actions/core');
 const hashjs = require('hash.js');
 const glob = require('glob');
 const { ExtensionRootDir } = require('./constants');
-const { reporter } = require('gulp-typescript');
 
 const settingsFile = path.join(__dirname, '..', 'src', 'test', 'datascience', '.vscode', 'settings.json');
 const webTestSummaryJsonFile = path.join(__dirname, '..', 'testresults.json');
@@ -111,7 +110,6 @@ exports.dumpTestSummary = () => {
             }
             runner.emit(output.event, output, output.err);
 
-            core.info(`${output.event} ${output.title}`);
             switch (output.event) {
                 case 'pass': {
                     passedCount++;
@@ -203,11 +201,11 @@ exports.dumpTestSummary = () => {
             }
         });
 
-        core.info(`Passed: ${passedCount}, Skipped: ${skippedTests.length}`);
         if (reportWriter.failures.length) {
             core.setFailed(`${reportWriter.failures.length} tests failed.`);
-        } else if (passedCount < skippedTests.length) {
-            core.setFailed('Failing check, not enough passing tests or too many skipped');
+        } else if (passedCount < 3) {
+            // the non-python suite only has 4 tests passing currently, so that's the highest bar we can use.
+            core.setFailed('Not enough tests were run - are too many being skipped?');
         }
 
         // Write output into an ipynb file with the failures & corresponding console output & screenshot.

--- a/build/webTestReporter.js
+++ b/build/webTestReporter.js
@@ -87,7 +87,7 @@ exports.dumpTestSummary = () => {
         let indent = 0;
         let executionCount = 0;
         const skippedTests = [];
-        const passedCount = 0;
+        let passedCount = 0;
         mocha.reporters.Base.useColors = true;
         colors.enable();
         summary.forEach((output) => {
@@ -111,6 +111,7 @@ exports.dumpTestSummary = () => {
             }
             runner.emit(output.event, output, output.err);
 
+            core.info(`${output.event} ${output.title}`);
             switch (output.event) {
                 case 'pass': {
                     passedCount++;
@@ -202,9 +203,10 @@ exports.dumpTestSummary = () => {
             }
         });
 
+        core.info(`Passed: ${passedCount}, Skipped: ${skippedTests.length}`);
         if (reportWriter.failures.length) {
             core.setFailed(`${reportWriter.failures.length} tests failed.`);
-        } else if (passedCount < skippedTests) {
+        } else if (passedCount < skippedTests.length) {
             core.setFailed('Failing check, not enough passing tests or too many skipped');
         }
 

--- a/src/test/datascience/notebook/executionService.vscode.test.ts
+++ b/src/test/datascience/notebook/executionService.vscode.test.ts
@@ -68,8 +68,7 @@ import { InteractiveWindowMessages } from '../../../messageTypes';
 const expectedPromptMessageSuffix = `requires ${ProductNames.get(Product.ipykernel)!} to be installed.`;
 
 /* eslint-disable @typescript-eslint/no-explicit-any, no-invalid-this */
-// eslint-disable-next-line no-only-tests/no-only-tests
-suite.only('DataScience - VSCode Notebook - (Execution) (slow)', function () {
+suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
     let api: IExtensionTestApi;
     const disposables: IDisposable[] = [];
     let vscodeNotebook: IVSCodeNotebook;

--- a/src/test/datascience/notebook/executionService.vscode.test.ts
+++ b/src/test/datascience/notebook/executionService.vscode.test.ts
@@ -68,7 +68,8 @@ import { InteractiveWindowMessages } from '../../../messageTypes';
 const expectedPromptMessageSuffix = `requires ${ProductNames.get(Product.ipykernel)!} to be installed.`;
 
 /* eslint-disable @typescript-eslint/no-explicit-any, no-invalid-this */
-suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
+// eslint-disable-next-line no-only-tests/no-only-tests
+suite.only('DataScience - VSCode Notebook - (Execution) (slow)', function () {
     let api: IExtensionTestApi;
     const disposables: IDisposable[] = [];
     let vscodeNotebook: IVSCodeNotebook;


### PR DESCRIPTION
fail the CI check if we didn't run enough tests.
The non-python suite only has 4 tests passing (and 4 skipped!), so we can't check for any more than that or that suite would fail, but that suite should fail for any instance of `.only`, which is what we want to catch with this.