### PR TITLE
Remove controllers from ThirdParty Kernels

### DIFF
--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -257,10 +257,9 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
             // When connecting, we need to update the sys info message
             this.updateSysInfoMessage(this.getSysInfoMessage(metadata, SysInfoReason.Start), false, sysInfoCell);
             const kernel = await KernelConnector.connectToNotebookKernel(
-                controller,
                 metadata,
                 this.serviceContainer,
-                { resource: this.owner, notebook: this.notebookDocument },
+                { resource: this.owner, notebook: this.notebookDocument, controller },
                 new DisplayOptions(false),
                 this.internalDisposables,
                 'jupyterExtension',

--- a/src/kernels/errors/kernelErrorHandler.ts
+++ b/src/kernels/errors/kernelErrorHandler.ts
@@ -279,6 +279,7 @@ export abstract class DataScienceErrorHandler implements IDataScienceErrorHandle
                 err instanceof InvalidRemoteJupyterServerUriHandleError
                     ? this.extensions.getExtension(err.extensionId)?.packageJSON.displayName || err.extensionId
                     : '';
+            const options = actionSource === 'jupyterExtension' ? [DataScience.selectDifferentKernel()] : [];
             const selection = await this.applicationShell.showErrorMessage(
                 err instanceof InvalidRemoteJupyterServerUriHandleError
                     ? DataScience.remoteJupyterServerProvidedBy3rdPartyExtensionNoLongerValid().format(extensionName)
@@ -286,7 +287,7 @@ export abstract class DataScienceErrorHandler implements IDataScienceErrorHandle
                 { detail: message, modal: true },
                 DataScience.removeRemoteJupyterConnectionButtonText(),
                 DataScience.changeRemoteJupyterConnectionButtonText(),
-                DataScience.selectDifferentKernel()
+                ...options
             );
             switch (selection) {
                 case DataScience.removeRemoteJupyterConnectionButtonText(): {

--- a/src/kernels/execution/kernelExecution.ts
+++ b/src/kernels/execution/kernelExecution.ts
@@ -18,10 +18,12 @@ import { captureTelemetry, Telemetry } from '../../telemetry';
 import { CellOutputDisplayIdTracker } from './cellDisplayIdTracker';
 import {
     IKernelConnectionSession,
-    IBaseKernel,
+    IThirdPartyKernel,
     InterruptResult,
     ITracebackFormatter,
-    NotebookCellRunState
+    NotebookCellRunState,
+    IKernel,
+    IBaseKernel
 } from '../../kernels/types';
 import { traceCellMessage } from './helpers';
 import { getDisplayPath } from '../../platform/common/platform/fs-paths';
@@ -32,70 +34,17 @@ import { noop } from '../../platform/common/utils/misc';
  * Separate class that deals just with kernel execution.
  * Else the `Kernel` class gets very big.
  */
-export class KernelExecution implements IDisposable {
-    private readonly documentExecutions = new WeakMap<NotebookDocument, CellExecutionQueue>();
-    private readonly executionFactory: CellExecutionFactory;
-    private readonly disposables: IDisposable[] = [];
+export class BaseKernelExecution<TKernel extends IBaseKernel = IBaseKernel> implements IDisposable {
+    protected readonly disposables: IDisposable[] = [];
     private _interruptPromise?: Promise<InterruptResult>;
     private _restartPromise?: Promise<void>;
-    private readonly _onPreExecute = new EventEmitter<NotebookCell>();
-    constructor(
-        private readonly kernel: IBaseKernel,
-        appShell: IApplicationShell,
-        private readonly interruptTimeout: number,
-        outputTracker: CellOutputDisplayIdTracker,
-        context: IExtensionContext,
-        formatters: ITracebackFormatter[]
-    ) {
-        const requestListener = new CellExecutionMessageHandlerService(
-            appShell,
-            this.kernel.controller,
-            outputTracker,
-            context,
-            formatters
-        );
-        this.disposables.push(requestListener);
-        this.executionFactory = new CellExecutionFactory(this.kernel.controller, requestListener);
+    protected get restarting() {
+        return this._restartPromise || Promise.resolve();
     }
+    constructor(protected readonly kernel: TKernel, private readonly interruptTimeout: number) {}
 
-    public get onPreExecute() {
-        return this._onPreExecute.event;
-    }
-    public get queue() {
-        const notebook = this.kernel.notebook;
-        return notebook ? this.documentExecutions.get(notebook)?.queue || [] : [];
-    }
-    public async executeCell(
-        sessionPromise: Promise<IKernelConnectionSession>,
-        cell: NotebookCell,
-        codeOverride?: string
-    ): Promise<NotebookCellRunState> {
-        traceCellMessage(cell, `KernelExecution.executeCell (1), ${getDisplayPath(cell.notebook.uri)}`);
-        if (cell.kind == NotebookCellKind.Markup) {
-            return NotebookCellRunState.Success;
-        }
-
-        // If we're restarting, wait for it to finish
-        if (this._restartPromise) {
-            await this._restartPromise;
-        }
-
-        traceCellMessage(cell, `KernelExecution.executeCell (2), ${getDisplayPath(cell.notebook.uri)}`);
-        const executionQueue = this.getOrCreateCellExecutionQueue(cell.notebook, sessionPromise);
-        executionQueue.queueCell(cell, codeOverride);
-        const result = await executionQueue.waitForCompletion([cell]);
-        traceCellMessage(cell, `KernelExecution.executeCell completed (3), ${getDisplayPath(cell.notebook.uri)}`);
-        return result[0];
-    }
     public async cancel() {
-        const notebook = this.kernel.notebook;
-        if (!notebook) {
-            return;
-        }
-        const executionQueue = this.documentExecutions.get(notebook);
-        if (executionQueue) {
-            await executionQueue.cancel(true);
-        }
+        noop();
     }
 
     /**
@@ -103,63 +52,41 @@ export class KernelExecution implements IDisposable {
      * If we don't have a kernel (Jupyter Session) available, then just abort all of the cell executions.
      */
     public async interrupt(sessionPromise?: Promise<IKernelConnectionSession>): Promise<InterruptResult> {
-        trackKernelResourceInformation(this.kernel.resourceUri, { interruptKernel: true });
-        const notebook = this.kernel.notebook;
-        const executionQueue = notebook ? this.documentExecutions.get(notebook) : undefined;
-        if (notebook && !executionQueue && this.kernel.kernelConnectionMetadata.kind !== 'connectToLiveRemoteKernel') {
-            return InterruptResult.Success;
-        }
         // Possible we don't have a notebook.
         const session = sessionPromise ? await sessionPromise.catch(() => undefined) : undefined;
+        const pendingExecutions = this.cancelPendingExecutions();
         traceInfo('Interrupt kernel execution');
-        // First cancel all the cells & then wait for them to complete.
-        // Both must happen together, we cannot just wait for cells to complete, as its possible
-        // that cell1 has started & cell2 has been queued. If Cell1 completes, then Cell2 will start.
-        // What we want is, if Cell1 completes then Cell2 should not start (it must be cancelled before hand).
-        const pendingCells = executionQueue
-            ? executionQueue.cancel().then(() => executionQueue.waitForCompletion())
-            : Promise.resolve();
 
         if (!session) {
             traceInfo('No notebook to interrupt');
             this._interruptPromise = undefined;
-            await pendingCells;
+            await pendingExecutions;
             return InterruptResult.Success;
         }
 
         // Interrupt the active execution
         const result = this._interruptPromise
             ? await this._interruptPromise
-            : await (this._interruptPromise = this.interruptExecution(session, pendingCells));
+            : await (this._interruptPromise = this.interruptExecution(session, pendingExecutions));
 
         // Done interrupting, clear interrupt promise
         this._interruptPromise = undefined;
 
         return result;
     }
+    protected async cancelPendingExecutions(): Promise<void> {
+        noop();
+    }
     /**
      * Restarts the kernel
      * If we don't have a kernel (Jupyter Session) available, then just abort all of the cell executions.
      */
     public async restart(sessionPromise?: Promise<IKernelConnectionSession>): Promise<void> {
-        trackKernelResourceInformation(this.kernel.resourceUri, { restartKernel: true });
-        const notebook = this.kernel.notebook;
-        const executionQueue = notebook ? this.documentExecutions.get(notebook) : undefined;
-        // Possible we don't have a notebook.
         const session = sessionPromise ? await sessionPromise.catch(() => undefined) : undefined;
-        traceInfo('Restart kernel execution');
-        // First cancel all the cells & then wait for them to complete.
-        // Both must happen together, we cannot just wait for cells to complete, as its possible
-        // that cell1 has started & cell2 has been queued. If Cell1 completes, then Cell2 will start.
-        // What we want is, if Cell1 completes then Cell2 should not start (it must be cancelled before hand).
-        const pendingCells = executionQueue
-            ? executionQueue.cancel(true).then(() => executionQueue.waitForCompletion())
-            : Promise.resolve();
 
         if (!session) {
             traceInfo('No notebook to interrupt');
             this._restartPromise = undefined;
-            await pendingCells;
             return;
         }
 
@@ -177,44 +104,11 @@ export class KernelExecution implements IDisposable {
         traceInfoIfCI(`Dispose KernelExecution`);
         this.disposables.forEach((d) => d.dispose());
     }
-    private getOrCreateCellExecutionQueue(
-        document: NotebookDocument,
-        sessionPromise: Promise<IKernelConnectionSession>
-    ) {
-        const existingExecutionQueue = this.documentExecutions.get(document);
-        // Re-use the existing Queue if it can be used.
-        if (existingExecutionQueue && !existingExecutionQueue.isEmpty && !existingExecutionQueue.failed) {
-            return existingExecutionQueue;
-        }
-
-        const newCellExecutionQueue = new CellExecutionQueue(
-            sessionPromise,
-            this.executionFactory,
-            this.kernel.kernelConnectionMetadata
-        );
-        this.disposables.push(newCellExecutionQueue);
-
-        // If the document is closed (user or on CI), then just stop handling the UI updates & cancel cell execution queue.
-        workspace.onDidCloseNotebookDocument(
-            async (e: NotebookDocument) => {
-                if (e === document) {
-                    if (!newCellExecutionQueue.failed || !newCellExecutionQueue.isEmpty) {
-                        await newCellExecutionQueue.cancel(true);
-                    }
-                }
-            },
-            this,
-            this.disposables
-        );
-        newCellExecutionQueue.onPreExecute((c) => this._onPreExecute.fire(c), this, this.disposables);
-        this.documentExecutions.set(document, newCellExecutionQueue);
-        return newCellExecutionQueue;
-    }
     @captureTelemetry(Telemetry.Interrupt)
     @captureTelemetry(Telemetry.InterruptJupyterTime)
     private async interruptExecution(
         session: IKernelConnectionSession,
-        pendingCells: Promise<unknown>
+        pendingExecutions: Promise<unknown>
     ): Promise<InterruptResult> {
         const restarted = createDeferred<boolean>();
         const stopWatch = new StopWatch();
@@ -240,7 +134,7 @@ export class KernelExecution implements IDisposable {
             try {
                 // Wait for all of the pending cells to finish or the timeout to fire
                 const result = await waitForPromise(
-                    Promise.race([pendingCells, restarted.promise]),
+                    Promise.race([pendingExecutions, restarted.promise]),
                     this.interruptTimeout
                 );
 
@@ -290,5 +184,165 @@ export class KernelExecution implements IDisposable {
     private async restartExecution(session: IKernelConnectionSession): Promise<void> {
         // Just use the internal session. Pending cells should have been canceled by the caller
         await session.restart();
+    }
+}
+
+export class ThirdPartyKernelExecution extends BaseKernelExecution<IThirdPartyKernel> {}
+
+/**
+ * Separate class that deals just with kernel execution.
+ * Else the `Kernel` class gets very big.
+ */
+export class KernelExecution extends BaseKernelExecution<IKernel> {
+    private readonly documentExecutions = new WeakMap<NotebookDocument, CellExecutionQueue>();
+    private readonly executionFactory: CellExecutionFactory;
+    private readonly _onPreExecute = new EventEmitter<NotebookCell>();
+    constructor(
+        kernel: IKernel,
+        appShell: IApplicationShell,
+        interruptTimeout: number,
+        outputTracker: CellOutputDisplayIdTracker,
+        context: IExtensionContext,
+        formatters: ITracebackFormatter[]
+    ) {
+        super(kernel, interruptTimeout);
+        const requestListener = new CellExecutionMessageHandlerService(
+            appShell,
+            kernel.controller,
+            outputTracker,
+            context,
+            formatters
+        );
+        this.disposables.push(requestListener);
+        this.executionFactory = new CellExecutionFactory(this.kernel.controller, requestListener);
+    }
+
+    public get onPreExecute() {
+        return this._onPreExecute.event;
+    }
+    public get queue() {
+        const notebook = this.kernel.notebook;
+        return notebook ? this.documentExecutions.get(notebook)?.queue || [] : [];
+    }
+    public async executeCell(
+        sessionPromise: Promise<IKernelConnectionSession>,
+        cell: NotebookCell,
+        codeOverride?: string
+    ): Promise<NotebookCellRunState> {
+        traceCellMessage(cell, `KernelExecution.executeCell (1), ${getDisplayPath(cell.notebook.uri)}`);
+        if (cell.kind == NotebookCellKind.Markup) {
+            return NotebookCellRunState.Success;
+        }
+
+        // If we're restarting, wait for it to finish
+        await this.restarting;
+
+        traceCellMessage(cell, `KernelExecution.executeCell (2), ${getDisplayPath(cell.notebook.uri)}`);
+        const executionQueue = this.getOrCreateCellExecutionQueue(cell.notebook, sessionPromise);
+        executionQueue.queueCell(cell, codeOverride);
+        const result = await executionQueue.waitForCompletion([cell]);
+        traceCellMessage(cell, `KernelExecution.executeCell completed (3), ${getDisplayPath(cell.notebook.uri)}`);
+        return result[0];
+    }
+    public override async cancel() {
+        await super.cancel();
+        const notebook = this.kernel.notebook;
+        if (!notebook) {
+            return;
+        }
+        const executionQueue = this.documentExecutions.get(notebook);
+        if (executionQueue) {
+            await executionQueue.cancel(true);
+        }
+    }
+
+    /**
+     * Interrupts the execution of cells.
+     * If we don't have a kernel (Jupyter Session) available, then just abort all of the cell executions.
+     */
+    public override async interrupt(sessionPromise?: Promise<IKernelConnectionSession>): Promise<InterruptResult> {
+        trackKernelResourceInformation(this.kernel.resourceUri, { interruptKernel: true });
+        const notebook = this.kernel.notebook;
+        const executionQueue = notebook ? this.documentExecutions.get(notebook) : undefined;
+        if (notebook && !executionQueue && this.kernel.kernelConnectionMetadata.kind !== 'connectToLiveRemoteKernel') {
+            return InterruptResult.Success;
+        }
+        return super.interrupt(sessionPromise);
+    }
+    protected override async cancelPendingExecutions(): Promise<void> {
+        const notebook = this.kernel.notebook;
+        const executionQueue = notebook ? this.documentExecutions.get(notebook) : undefined;
+        if (notebook && !executionQueue && this.kernel.kernelConnectionMetadata.kind !== 'connectToLiveRemoteKernel') {
+            return;
+        }
+        traceInfo('Interrupt kernel execution');
+        // First cancel all the cells & then wait for them to complete.
+        // Both must happen together, we cannot just wait for cells to complete, as its possible
+        // that cell1 has started & cell2 has been queued. If Cell1 completes, then Cell2 will start.
+        // What we want is, if Cell1 completes then Cell2 should not start (it must be cancelled before hand).
+        const pendingCells = executionQueue
+            ? executionQueue.cancel().then(() => executionQueue.waitForCompletion())
+            : Promise.resolve();
+
+        await pendingCells;
+    }
+    /**
+     * Restarts the kernel
+     * If we don't have a kernel (Jupyter Session) available, then just abort all of the cell executions.
+     */
+    public override async restart(sessionPromise?: Promise<IKernelConnectionSession>): Promise<void> {
+        trackKernelResourceInformation(this.kernel.resourceUri, { restartKernel: true });
+        const notebook = this.kernel.notebook;
+        const executionQueue = notebook ? this.documentExecutions.get(notebook) : undefined;
+        // Possible we don't have a notebook.
+        const session = sessionPromise ? await sessionPromise.catch(() => undefined) : undefined;
+        traceInfo('Restart kernel execution');
+        // First cancel all the cells & then wait for them to complete.
+        // Both must happen together, we cannot just wait for cells to complete, as its possible
+        // that cell1 has started & cell2 has been queued. If Cell1 completes, then Cell2 will start.
+        // What we want is, if Cell1 completes then Cell2 should not start (it must be cancelled before hand).
+        const pendingCells = executionQueue
+            ? executionQueue.cancel(true).then(() => executionQueue.waitForCompletion())
+            : Promise.resolve();
+
+        if (!session) {
+            traceInfo('No notebook to interrupt');
+            await pendingCells;
+        }
+
+        return super.restart(sessionPromise);
+    }
+    private getOrCreateCellExecutionQueue(
+        document: NotebookDocument,
+        sessionPromise: Promise<IKernelConnectionSession>
+    ) {
+        const existingExecutionQueue = this.documentExecutions.get(document);
+        // Re-use the existing Queue if it can be used.
+        if (existingExecutionQueue && !existingExecutionQueue.isEmpty && !existingExecutionQueue.failed) {
+            return existingExecutionQueue;
+        }
+
+        const newCellExecutionQueue = new CellExecutionQueue(
+            sessionPromise,
+            this.executionFactory,
+            this.kernel.kernelConnectionMetadata
+        );
+        this.disposables.push(newCellExecutionQueue);
+
+        // If the document is closed (user or on CI), then just stop handling the UI updates & cancel cell execution queue.
+        workspace.onDidCloseNotebookDocument(
+            async (e: NotebookDocument) => {
+                if (e === document) {
+                    if (!newCellExecutionQueue.failed || !newCellExecutionQueue.isEmpty) {
+                        await newCellExecutionQueue.cancel(true);
+                    }
+                }
+            },
+            this,
+            this.disposables
+        );
+        newCellExecutionQueue.onPreExecute((c) => this._onPreExecute.fire(c), this, this.disposables);
+        this.documentExecutions.set(document, newCellExecutionQueue);
+        return newCellExecutionQueue;
     }
 }

--- a/src/kernels/helpers.ts
+++ b/src/kernels/helpers.ts
@@ -6,7 +6,7 @@ const NamedRegexp = require('named-js-regexp') as typeof import('named-js-regexp
 import * as path from '../platform/vscode-path/path';
 import * as uriPath from '../platform/vscode-path/resources';
 import * as nbformat from '@jupyterlab/nbformat';
-import type { KernelSpec } from '@jupyterlab/services';
+import type { Kernel, KernelSpec } from '@jupyterlab/services';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import cloneDeep = require('lodash/cloneDeep');
 import * as url from 'url-parse';
@@ -1452,7 +1452,7 @@ export type SilentExecutionErrorOptions = {
 };
 
 export async function executeSilently(
-    session: IKernelConnectionSession,
+    session: IKernelConnectionSession | Kernel.IKernelConnection,
     code: string,
     errorOptions?: SilentExecutionErrorOptions
 ): Promise<nbformat.IOutput[]> {

--- a/src/kernels/kernel.ts
+++ b/src/kernels/kernel.ts
@@ -74,9 +74,6 @@ abstract class BaseKernel<TKernelExecution extends BaseKernelExecution> implemen
     get onStatusChanged(): Event<KernelMessage.Status> {
         return this._onStatusChanged.event;
     }
-    get notebook(): NotebookDocument | undefined {
-        return this._notebookDocument;
-    }
     get onRestarted(): Event<void> {
         return this._onRestarted.event;
     }
@@ -147,7 +144,6 @@ abstract class BaseKernel<TKernelExecution extends BaseKernelExecution> implemen
     constructor(
         public readonly uri: Uri,
         public readonly resourceUri: Resource,
-        private readonly _notebookDocument: NotebookDocument | undefined,
         public readonly kernelConnectionMetadata: Readonly<KernelConnectionMetadata>,
         protected readonly notebookProvider: INotebookProvider,
         protected readonly launchTimeout: number,
@@ -709,7 +705,6 @@ export class ThirdPartyKernel extends BaseKernel<ThirdPartyKernelExecution> {
     constructor(
         uri: Uri,
         resourceUri: Resource,
-        notebook: NotebookDocument | undefined,
         kernelConnectionMetadata: Readonly<KernelConnectionMetadata>,
         notebookProvider: INotebookProvider,
         launchTimeout: number,
@@ -724,7 +719,6 @@ export class ThirdPartyKernel extends BaseKernel<ThirdPartyKernelExecution> {
         super(
             uri,
             resourceUri,
-            notebook,
             kernelConnectionMetadata,
             notebookProvider,
             launchTimeout,
@@ -754,14 +748,10 @@ export class Kernel extends BaseKernel<KernelExecution> implements IKernel {
         return this._onPreExecute.event;
     }
     protected readonly _onPreExecute = new EventEmitter<NotebookCell>();
-    override get notebook(): NotebookDocument {
-        return this._notebook;
-    }
-
     constructor(
         uri: Uri,
         resourceUri: Resource,
-        private _notebook: NotebookDocument,
+        public readonly notebook: NotebookDocument,
         kernelConnectionMetadata: Readonly<KernelConnectionMetadata>,
         notebookProvider: INotebookProvider,
         launchTimeout: number,
@@ -780,7 +770,6 @@ export class Kernel extends BaseKernel<KernelExecution> implements IKernel {
         super(
             uri,
             resourceUri,
-            _notebook,
             kernelConnectionMetadata,
             notebookProvider,
             launchTimeout,

--- a/src/kernels/kernelProvider.node.ts
+++ b/src/kernels/kernelProvider.node.ts
@@ -4,7 +4,7 @@
 'use strict';
 import { inject, injectable, multiInject } from 'inversify';
 import { NotebookDocument, Uri } from 'vscode';
-import { IApplicationShell, IWorkspaceService, IVSCodeNotebook } from '../platform/common/application/types';
+import { IApplicationShell, IVSCodeNotebook } from '../platform/common/application/types';
 import { IPythonExecutionFactory } from '../platform/common/process/types.node';
 import {
     IAsyncDisposableRegistry,
@@ -40,7 +40,6 @@ export class KernelProvider extends BaseCoreKernelProvider {
         @inject(IConfigurationService) private configService: IConfigurationService,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(CellOutputDisplayIdTracker) private readonly outputTracker: CellOutputDisplayIdTracker,
-        @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IVSCodeNotebook) notebook: IVSCodeNotebook,
         @inject(IPythonExecutionFactory) private readonly pythonExecutionFactory: IPythonExecutionFactory,
         @inject(IStatusProvider) private readonly statusProvider: IStatusProvider,
@@ -74,7 +73,6 @@ export class KernelProvider extends BaseCoreKernelProvider {
             options.controller,
             this.configService,
             this.outputTracker,
-            this.workspaceService,
             this.statusProvider,
             this.context,
             this.formatters,
@@ -115,9 +113,7 @@ export class ThirdPartyKernelProvider extends BaseThirdPartyKernelProvider {
         @inject(INotebookProvider) private notebookProvider: INotebookProvider,
         @inject(IConfigurationService) private configService: IConfigurationService,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
-        @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IVSCodeNotebook) notebook: IVSCodeNotebook,
-        @inject(IPythonExecutionFactory) private readonly pythonExecutionFactory: IPythonExecutionFactory,
         @inject(IStatusProvider) private readonly statusProvider: IStatusProvider,
         @multiInject(IStartupCodeProvider) private readonly startupCodeProviders: IStartupCodeProvider[]
     ) {
@@ -144,21 +140,8 @@ export class ThirdPartyKernelProvider extends BaseThirdPartyKernelProvider {
             interruptTimeout,
             this.appShell,
             this.configService,
-            this.workspaceService,
             this.statusProvider,
-            this.startupCodeProviders,
-            () => {
-                if (kernel.session) {
-                    return sendTelemetryForPythonKernelExecutable(
-                        kernel.session,
-                        kernel.resourceUri,
-                        kernel.kernelConnectionMetadata,
-                        this.pythonExecutionFactory
-                    );
-                } else {
-                    return Promise.resolve();
-                }
-            }
+            this.startupCodeProviders
         );
         kernel.onRestarted(() => this._onDidRestartKernel.fire(kernel), this, this.disposables);
         kernel.onDisposed(() => this._onDidDisposeKernel.fire(kernel), this, this.disposables);

--- a/src/kernels/kernelProvider.node.ts
+++ b/src/kernels/kernelProvider.node.ts
@@ -138,7 +138,6 @@ export class ThirdPartyKernelProvider extends BaseThirdPartyKernelProvider {
         const kernel: IThirdPartyKernel = new ThirdPartyKernel(
             uri,
             resourceUri,
-            undefined,
             options.metadata,
             this.notebookProvider,
             waitForIdleTimeout,

--- a/src/kernels/kernelProvider.web.ts
+++ b/src/kernels/kernelProvider.web.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 import { inject, injectable, multiInject } from 'inversify';
-import { IApplicationShell, IVSCodeNotebook, IWorkspaceService } from '../platform/common/application/types';
+import { IApplicationShell, IVSCodeNotebook } from '../platform/common/application/types';
 import { InteractiveWindowView } from '../platform/common/constants';
 import { NotebookDocument, Uri } from 'vscode';
 import {
@@ -38,7 +38,6 @@ export class KernelProvider extends BaseCoreKernelProvider {
         @inject(IConfigurationService) private configService: IConfigurationService,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(CellOutputDisplayIdTracker) private readonly outputTracker: CellOutputDisplayIdTracker,
-        @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IVSCodeNotebook) notebook: IVSCodeNotebook,
         @inject(IStatusProvider) private readonly statusProvider: IStatusProvider,
         @inject(IExtensionContext) private readonly context: IExtensionContext,
@@ -71,7 +70,6 @@ export class KernelProvider extends BaseCoreKernelProvider {
             options.controller,
             this.configService,
             this.outputTracker,
-            this.workspaceService,
             this.statusProvider,
             this.context,
             this.formatters,
@@ -102,7 +100,6 @@ export class ThirdPartyKernelProvider extends BaseThirdPartyKernelProvider {
         @inject(INotebookProvider) private notebookProvider: INotebookProvider,
         @inject(IConfigurationService) private configService: IConfigurationService,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
-        @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IVSCodeNotebook) notebook: IVSCodeNotebook,
         @inject(IStatusProvider) private readonly statusProvider: IStatusProvider,
         @multiInject(IStartupCodeProvider) private readonly startupCodeProviders: IStartupCodeProvider[]
@@ -129,10 +126,8 @@ export class ThirdPartyKernelProvider extends BaseThirdPartyKernelProvider {
             interruptTimeout,
             this.appShell,
             this.configService,
-            this.workspaceService,
             this.statusProvider,
-            this.startupCodeProviders,
-            () => Promise.resolve()
+            this.startupCodeProviders
         );
         kernel.onRestarted(() => this._onDidRestartKernel.fire(kernel), this, this.disposables);
         kernel.onDisposed(() => this._onDidDisposeKernel.fire(kernel), this, this.disposables);

--- a/src/kernels/kernelProvider.web.ts
+++ b/src/kernels/kernelProvider.web.ts
@@ -15,14 +15,15 @@ import {
 import { BaseCoreKernelProvider, BaseThirdPartyKernelProvider } from './kernelProvider.base';
 import { IStatusProvider } from '../platform/progress/types';
 import { CellOutputDisplayIdTracker } from './execution/cellDisplayIdTracker';
-import { Kernel } from './kernel';
+import { Kernel, ThirdPartyKernel } from './kernel';
 import {
-    IBaseKernel,
+    IThirdPartyKernel,
     IKernel,
     INotebookProvider,
     IStartupCodeProvider,
     ITracebackFormatter,
-    KernelOptions
+    KernelOptions,
+    ThirdPartyKernelOptions
 } from './types';
 
 /**
@@ -72,7 +73,6 @@ export class KernelProvider extends BaseCoreKernelProvider {
             this.outputTracker,
             this.workspaceService,
             this.statusProvider,
-            options.creator,
             this.context,
             this.formatters,
             this.startupCodeProviders,
@@ -102,18 +102,15 @@ export class ThirdPartyKernelProvider extends BaseThirdPartyKernelProvider {
         @inject(INotebookProvider) private notebookProvider: INotebookProvider,
         @inject(IConfigurationService) private configService: IConfigurationService,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
-        @inject(CellOutputDisplayIdTracker) private readonly outputTracker: CellOutputDisplayIdTracker,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IVSCodeNotebook) notebook: IVSCodeNotebook,
         @inject(IStatusProvider) private readonly statusProvider: IStatusProvider,
-        @inject(IExtensionContext) private readonly context: IExtensionContext,
-        @multiInject(ITracebackFormatter) private readonly formatters: ITracebackFormatter[],
         @multiInject(IStartupCodeProvider) private readonly startupCodeProviders: IStartupCodeProvider[]
     ) {
         super(asyncDisposables, disposables, notebook);
     }
 
-    public getOrCreate(uri: Uri, options: KernelOptions): IBaseKernel {
+    public getOrCreate(uri: Uri, options: ThirdPartyKernelOptions): IThirdPartyKernel {
         const existingKernelInfo = this.getInternal(uri);
         if (existingKernelInfo && existingKernelInfo.options.metadata.id === options.metadata.id) {
             return existingKernelInfo.kernel;
@@ -123,7 +120,7 @@ export class ThirdPartyKernelProvider extends BaseThirdPartyKernelProvider {
         const resourceUri = uri;
         const waitForIdleTimeout = this.configService.getSettings(resourceUri).jupyterLaunchTimeout;
         const interruptTimeout = this.configService.getSettings(resourceUri).jupyterInterruptTimeout;
-        const kernel = new Kernel(
+        const kernel = new ThirdPartyKernel(
             uri,
             resourceUri,
             undefined,
@@ -132,14 +129,9 @@ export class ThirdPartyKernelProvider extends BaseThirdPartyKernelProvider {
             waitForIdleTimeout,
             interruptTimeout,
             this.appShell,
-            options.controller,
             this.configService,
-            this.outputTracker,
             this.workspaceService,
             this.statusProvider,
-            options.creator,
-            this.context,
-            this.formatters,
             this.startupCodeProviders,
             () => Promise.resolve()
         );

--- a/src/kernels/kernelProvider.web.ts
+++ b/src/kernels/kernelProvider.web.ts
@@ -123,7 +123,6 @@ export class ThirdPartyKernelProvider extends BaseThirdPartyKernelProvider {
         const kernel = new ThirdPartyKernel(
             uri,
             resourceUri,
-            undefined,
             options.metadata,
             this.notebookProvider,
             waitForIdleTimeout,

--- a/src/kernels/types.ts
+++ b/src/kernels/types.ts
@@ -131,6 +131,10 @@ export function isRemoteConnection(
 }
 
 export interface IKernel extends IBaseKernel {
+    /**
+     * Total execution count on this kernel
+     */
+    readonly executionCount: number;
     readonly notebook: NotebookDocument;
     readonly onPreExecute: Event<NotebookCell>;
     /**
@@ -154,10 +158,6 @@ export interface IKernel extends IBaseKernel {
 }
 
 export interface IBaseKernel extends IAsyncDisposable {
-    /**
-     * Total execution count on this kernel
-     */
-    readonly executionCount: number;
     readonly uri: Uri;
     /**
      * In the case of Notebooks, this is the same as the Notebook Uri.

--- a/src/notebooks/controllers/kernelConnector.ts
+++ b/src/notebooks/controllers/kernelConnector.ts
@@ -495,7 +495,7 @@ export class KernelConnector {
     public static async connectToKernel(
         metadata: KernelConnectionMetadata,
         serviceContainer: IServiceContainer,
-        resource: { resource: Uri; notebook: undefined },
+        resource: { resource: Uri },
         options: IDisplayOptions,
         disposables: IDisposable[],
         actionSource: KernelActionSource = 'jupyterExtension',

--- a/src/notebooks/controllers/remoteKernelConnectionHandler.ts
+++ b/src/notebooks/controllers/remoteKernelConnectionHandler.ts
@@ -63,8 +63,7 @@ export class RemoteKernelConnectionHandler implements IExtensionSyncActivationSe
         }
     }
     private onDidStartKernel(kernel: IKernel) {
-        // TODO@rebornix, IKernel is already created by Jupyter Extension
-        if (kernel.creator !== 'jupyterExtension' || !kernel.resourceUri) {
+        if (!kernel.resourceUri) {
             return;
         }
         const resource = kernel.resourceUri;

--- a/src/notebooks/controllers/vscodeNotebookController.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.ts
@@ -505,10 +505,9 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
 
     private async connectToKernel(doc: NotebookDocument, options: IDisplayOptions): Promise<IKernel> {
         return KernelConnector.connectToNotebookKernel(
-            this.controller,
             this.kernelConnection,
             this.serviceContainer,
-            { resource: doc.uri, notebook: doc },
+            { resource: doc.uri, notebook: doc, controller: this.controller },
             options,
             this.disposables
         );
@@ -617,8 +616,7 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
         const newKernel = this.kernelProvider.getOrCreate(document, {
             metadata: selectedKernelConnectionMetadata,
             controller: this.controller,
-            resourceUri: document.uri, // In the case of interactive window, we cannot pass the Uri of notebook, it must be the Py file or undefined.
-            creator: 'jupyterExtension'
+            resourceUri: document.uri // In the case of interactive window, we cannot pass the Uri of notebook, it must be the Py file or undefined.
         });
         traceVerbose(`KernelProvider switched kernel to id = ${newKernel.kernelConnectionMetadata.id}`);
 

--- a/src/notebooks/debugger/debuggingManagerBase.ts
+++ b/src/notebooks/debugger/debuggingManagerBase.ts
@@ -151,8 +151,7 @@ export abstract class DebuggingManagerBase implements IDisposable {
             kernel = this.kernelProvider.getOrCreate(doc, {
                 metadata: controller.connection,
                 controller: controller?.controller,
-                resourceUri: doc.uri,
-                creator: 'jupyterExtension'
+                resourceUri: doc.uri
             });
         }
         if (kernel && kernel.status === 'unknown') {
@@ -173,8 +172,7 @@ export abstract class DebuggingManagerBase implements IDisposable {
                 kernel = this.kernelProvider.getOrCreate(doc, {
                     metadata: controller.connection,
                     controller: controller?.controller,
-                    resourceUri: doc.uri,
-                    creator: 'jupyterExtension'
+                    resourceUri: doc.uri
                 });
             }
 

--- a/src/notebooks/notebookCommandListener.ts
+++ b/src/notebooks/notebookCommandListener.ts
@@ -254,12 +254,11 @@ export class NotebookCommandListener implements IDataScienceCommandListener {
                 }
                 // Wrap the restart/interrupt in a loop that allows the user to switch
                 await KernelConnector.wrapKernelMethod(
-                    controller.controller,
                     controller.connection,
                     currentContext,
                     kernel.creator,
                     this.serviceContainer,
-                    { resource: kernel.resourceUri, notebook },
+                    { resource: kernel.resourceUri, notebook, controller: controller.controller },
                     new DisplayOptions(false),
                     this.disposableRegistry
                 );

--- a/src/standalone/api/kernelApi.ts
+++ b/src/standalone/api/kernelApi.ts
@@ -6,9 +6,9 @@ import { Disposable, Event, EventEmitter, Uri } from 'vscode';
 import { KernelConnectionWrapper } from './kernelConnectionWrapper';
 import {
     IKernelProvider,
-    IBaseKernel,
     KernelConnectionMetadata as IKernelKernelConnectionMetadata,
-    IThirdPartyKernelProvider
+    IThirdPartyKernelProvider,
+    IBaseKernel
 } from '../../kernels/types';
 import { disposeAllDisposables } from '../../platform/common/helpers';
 import { traceInfo } from '../../platform/logging';
@@ -210,14 +210,13 @@ class JupyterKernelService implements IExportedKernelService {
         uri: Uri
     ): Promise<IKernelConnectionInfo> {
         await this.controllerLoader.loadControllers();
-        const controllers = this.controllerRegistration.registered;
-        const controller = controllers.find((item) => item.connection.id === spec.id);
-        if (!controller) {
+        const connections = this.controllerRegistration.all;
+        const connection = connections.find((item) => item.id === spec.id);
+        if (!connection) {
             throw new Error('Not found');
         }
         const kernel = await KernelConnector.connectToKernel(
-            controller.controller,
-            controller.connection,
+            connection,
             this.serviceContainer,
             { resource: uri, notebook: undefined },
             new DisplayOptions(false),

--- a/src/standalone/api/kernelApi.ts
+++ b/src/standalone/api/kernelApi.ts
@@ -218,7 +218,7 @@ class JupyterKernelService implements IExportedKernelService {
         const kernel = await KernelConnector.connectToKernel(
             connection,
             this.serviceContainer,
-            { resource: uri, notebook: undefined },
+            { resource: uri },
             new DisplayOptions(false),
             this.disposables,
             '3rdPartyExtension'

--- a/src/test/client/api.vscode.test.ts
+++ b/src/test/client/api.vscode.test.ts
@@ -20,6 +20,7 @@ import { IVSCodeNotebook } from '../../platform/common/application/types';
 import { IS_REMOTE_NATIVE_TEST } from '../constants.node';
 import { workspace } from 'vscode';
 import { executeSilently } from '../../kernels/helpers';
+import { getPlainTextOrStreamOutput } from '../../kernels/kernel';
 
 suite('3rd Party Kernel Service API', function () {
     let api: IExtensionTestApi;
@@ -139,7 +140,7 @@ suite('3rd Party Kernel Service API', function () {
         // Verify we can run some code against this kernel.
         const outputs = await executeSilently(kernel?.connection.connection!, '98765');
         assert.strictEqual(outputs.length, 1);
-        assert.strictEqual((outputs[0]!.data as { 'text/plain': string })['text/plain'].trim(), '98765');
+        assert.include(getPlainTextOrStreamOutput(outputs), '98765');
         await closeNotebooksAndCleanUpAfterTests(disposables);
 
         await onDidChangeKernels.assertFiredExactly(2);

--- a/src/test/kernels/jupyter/remoteKernelConnectionHandler.unit.test.ts
+++ b/src/test/kernels/jupyter/remoteKernelConnectionHandler.unit.test.ts
@@ -199,9 +199,6 @@ suite('Remote kernel connection handler', async () => {
     test('When starting a remote kernel spec ensure we track this', async () => {
         verifyRemoteKernelTracking(remoteKernelSpec, 'jupyterExtension');
     });
-    test('When starting a remote kernel spec from a 3rd party extension ensure we do not track this', async () => {
-        verifyRemoteKernelTracking(remoteKernelSpec, '3rdPartyExtension');
-    });
     test('When starting a local kernel spec ensure we do not track this', async () => {
         verifyRemoteKernelTracking(localKernelSpec, 'jupyterExtension');
     });

--- a/src/test/kernels/jupyter/remoteKernelConnectionHandler.unit.test.ts
+++ b/src/test/kernels/jupyter/remoteKernelConnectionHandler.unit.test.ts
@@ -124,7 +124,7 @@ suite('Remote kernel connection handler', async () => {
     function verifyRemoteKernelTracking(connection: KernelConnectionMetadata, source: KernelActionSource) {
         const kernel1 = mock<IKernel>();
         when(kernel1.kernelConnectionMetadata).thenReturn(connection);
-        when(kernel1.creator).thenReturn(source);
+        when(kernel1.creator).thenReturn('jupyterExtension');
         const subject = new Subject<KernelSocketInformation>();
         disposables.push(new Disposable(() => subject.unsubscribe()));
         when(kernel1.kernelSocket).thenReturn(subject);

--- a/src/test/kernels/kernelProvider.node.unit.test.ts
+++ b/src/test/kernels/kernelProvider.node.unit.test.ts
@@ -13,7 +13,7 @@ import {
     KernelOptions,
     IKernelProvider
 } from '../../kernels/types';
-import { IApplicationShell, IVSCodeNotebook, IWorkspaceService } from '../../platform/common/application/types';
+import { IApplicationShell, IVSCodeNotebook } from '../../platform/common/application/types';
 import { AsyncDisposableRegistry } from '../../platform/common/asyncDisposableRegistry';
 import { JupyterNotebookView } from '../../platform/common/constants';
 import { disposeAllDisposables } from '../../platform/common/helpers';

--- a/src/test/kernels/kernelProvider.node.unit.test.ts
+++ b/src/test/kernels/kernelProvider.node.unit.test.ts
@@ -107,13 +107,10 @@ suite('KernelProvider Node', () => {
             instance(notebookProvider),
             instance(configService),
             instance(appShell),
-            instance(outputTracker),
             instance(workspaceService),
             instance(vscNotebook),
             instance(pythonExecFactory),
             instance(statusProvider),
-            instance(context),
-            [],
             []
         );
     });
@@ -127,7 +124,6 @@ suite('KernelProvider Node', () => {
         when(metadata.id).thenReturn('xyz');
         const options: KernelOptions = {
             controller: instance(mock<NotebookController>()),
-            creator: 'jupyterExtension',
             metadata: instance(metadata),
             resourceUri: sampleUri1
         };
@@ -169,7 +165,6 @@ suite('KernelProvider Node', () => {
         when(metadata.id).thenReturn('xyz');
         const options: KernelOptions = {
             controller: instance(mock<NotebookController>()),
-            creator: '3rdPartyExtension',
             metadata: instance(metadata),
             resourceUri: uri
         };
@@ -207,7 +202,6 @@ suite('KernelProvider Node', () => {
         when(metadata.id).thenReturn('xyz');
         const options: KernelOptions = {
             controller: instance(mock<NotebookController>()),
-            creator: 'jupyterExtension',
             metadata: instance(metadata),
             resourceUri: sampleUri1
         };
@@ -227,7 +221,6 @@ suite('KernelProvider Node', () => {
         when(metadata.id).thenReturn('xyz');
         const options: KernelOptions = {
             controller: instance(mock<NotebookController>()),
-            creator: 'jupyterExtension',
             metadata: instance(metadata),
             resourceUri: sampleUri1
         };

--- a/src/test/kernels/kernelProvider.node.unit.test.ts
+++ b/src/test/kernels/kernelProvider.node.unit.test.ts
@@ -37,7 +37,6 @@ suite('KernelProvider Node', () => {
     let configService: IConfigurationService;
     let appShell: IApplicationShell;
     let outputTracker: CellOutputDisplayIdTracker;
-    let workspaceService: IWorkspaceService;
     let vscNotebook: IVSCodeNotebook;
     let statusProvider: IStatusProvider;
     let pythonExecFactory: IPythonExecutionFactory;
@@ -72,7 +71,6 @@ suite('KernelProvider Node', () => {
         configService = mock<IConfigurationService>();
         appShell = mock<IApplicationShell>();
         outputTracker = mock<CellOutputDisplayIdTracker>();
-        workspaceService = mock<IWorkspaceService>();
         vscNotebook = mock<IVSCodeNotebook>();
         statusProvider = mock<IStatusProvider>();
         context = mock<IExtensionContext>();
@@ -93,7 +91,6 @@ suite('KernelProvider Node', () => {
             instance(configService),
             instance(appShell),
             instance(outputTracker),
-            instance(workspaceService),
             instance(vscNotebook),
             instance(pythonExecFactory),
             instance(statusProvider),
@@ -107,9 +104,7 @@ suite('KernelProvider Node', () => {
             instance(notebookProvider),
             instance(configService),
             instance(appShell),
-            instance(workspaceService),
             instance(vscNotebook),
-            instance(pythonExecFactory),
             instance(statusProvider),
             []
         );


### PR DESCRIPTION
Part of https://github.com/microsoft/vscode-jupyter/issues/10832

* Split IKernel into 3rd party and regular kernels (regular = kernels used by us)
* Split IKernelProvider into 3rd party and regular provider
