### PR TITLE
Break out of switch when generating ipynb

### DIFF
--- a/build/webTestReporter.js
+++ b/build/webTestReporter.js
@@ -113,6 +113,7 @@ exports.dumpTestSummary = () => {
             switch (output.event) {
                 case 'pass': {
                     passedCount++;
+                    break;
                 }
                 case 'suite': {
                     indent += 1;


### PR DESCRIPTION
The markdown content in the Ipynb was weired, found that we weren't breaking in a switch statement.