### PR TITLE
nit: command source

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -2964,7 +2964,7 @@ No properties for event
 
 ## Locations Used
 
-[src/webviews/extension-side/plotting/plotViewerProvider.node.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/webviews/extension-side/plotting/plotViewerProvider.node.ts)
+[src/webviews/extension-side/plotting/plotViewerProvider.ts](https://github.com/microsoft/vscode-jupyter/tree/main/src/webviews/extension-side/plotting/plotViewerProvider.ts)
 ```typescript
             this.currentViewer = this.serviceContainer.get<IPlotViewer>(IPlotViewer);
             this.currentViewerClosed = this.currentViewer.closed(this.closedViewer);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -14,9 +14,8 @@ import {
     ViewColumn
 } from 'vscode';
 import { IShowDataViewerFromVariablePanel } from './messageTypes';
-import { Commands as DSCommands } from './platform/common/constants';
+import { Commands as DSCommands, CommandSource } from './platform/common/constants';
 import { PythonEnvironment } from './platform/pythonEnvironments/info';
-import { CommandSource } from './platform/testing/common/constants';
 import { Channel } from './platform/common/application/types';
 import { SelectJupyterUriCommandSource } from './kernels/jupyter/serverSelector';
 

--- a/src/interactive-window/commands/commandRegistry.ts
+++ b/src/interactive-window/commands/commandRegistry.ts
@@ -36,7 +36,13 @@ import { IConfigurationService, IDisposable, IDisposableRegistry } from '../../p
 import { DataScience } from '../../platform/common/utils/localize';
 import { isUri, noop } from '../../platform/common/utils/misc';
 import { captureTelemetry } from '../../telemetry';
-import { Commands, JVSC_EXTENSION_ID, PYTHON_LANGUAGE, Telemetry } from '../../platform/common/constants';
+import {
+    Commands,
+    CommandSource,
+    JVSC_EXTENSION_ID,
+    PYTHON_LANGUAGE,
+    Telemetry
+} from '../../platform/common/constants';
 import { IDataScienceCodeLensProvider, ICodeWatcher } from '../editor-integration/types';
 import { IInteractiveWindowProvider } from '../types';
 import * as urlPath from '../../platform/vscode-path/resources';
@@ -47,7 +53,6 @@ import { ExportFormat, IExportDialog, IFileConverter } from '../../notebooks/exp
 import { openAndShowNotebook } from '../../platform/common/utils/notebooks';
 import { JupyterInstallError } from '../../platform/errors/jupyterInstallError';
 import { traceError, traceInfo } from '../../platform/logging';
-import { CommandSource } from '../../platform/testing/common/constants';
 import { generateCellsFromDocument } from '../editor-integration/cellFactory';
 import { IDataScienceErrorHandler } from '../../kernels/errors/types';
 import { INotebookEditorProvider } from '../../notebooks/types';

--- a/src/platform/common/constants.ts
+++ b/src/platform/common/constants.ts
@@ -188,6 +188,13 @@ export const VSCodeKnownNotebookLanguages: string[] = [
     'ocaml'
 ];
 
+export enum CommandSource {
+    auto = 'auto',
+    ui = 'ui',
+    codelens = 'codelens',
+    commandPalette = 'commandpalette'
+}
+
 export namespace Commands {
     export const RunAllCells = 'jupyter.runallcells';
     export const RunAllCellsAbove = 'jupyter.runallcellsabove';

--- a/src/platform/testing/common/constants.ts
+++ b/src/platform/testing/common/constants.ts
@@ -1,6 +1,0 @@
-export enum CommandSource {
-    auto = 'auto',
-    ui = 'ui',
-    codelens = 'codelens',
-    commandPalette = 'commandpalette'
-}


### PR DESCRIPTION
`CommandSource` is accidentally placed in a `test/*` folder. Moved it to common constants.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
