### PR TITLE
fix flaky debugging tests

### DIFF
--- a/src/interactive-window/editor-integration/cellFactory.ts
+++ b/src/interactive-window/editor-integration/cellFactory.ts
@@ -10,6 +10,7 @@ import { ICell, ICellRange, IJupyterSettings } from '../../platform/common/types
 import { noop } from '../../platform/common/utils/misc';
 import { createJupyterCellFromVSCNotebookCell } from '../../kernels/execution/helpers';
 import { appendLineFeed, parseForComments, generateMarkdownFromCodeLines } from '../../platform/common/utils';
+import { traceInfoIfCI } from '../../platform/logging';
 
 export function createCodeCell(): nbformat.ICodeCell;
 // eslint-disable-next-line @typescript-eslint/unified-signatures
@@ -137,6 +138,7 @@ export function generateCellRangesFromDocument(document: TextDocument, settings?
     for (let index = 0; index < document.lineCount; index += 1) {
         const line = document.lineAt(index);
         if (matcher.isCell(line.text)) {
+            traceInfoIfCI(`${line.text} is a cell marker`);
             if (cells.length > 0) {
                 const previousCell = cells[cells.length - 1];
                 previousCell.range = new Range(previousCell.range.start, document.lineAt(index - 1).range.end);
@@ -146,6 +148,8 @@ export function generateCellRangesFromDocument(document: TextDocument, settings?
                 range: line.range,
                 cell_type: matcher.getCellType(line.text)
             });
+        } else {
+            traceInfoIfCI(`${line.text} is a not cell marker`);
         }
     }
 

--- a/src/interactive-window/editor-integration/cellFactory.ts
+++ b/src/interactive-window/editor-integration/cellFactory.ts
@@ -10,7 +10,6 @@ import { ICell, ICellRange, IJupyterSettings } from '../../platform/common/types
 import { noop } from '../../platform/common/utils/misc';
 import { createJupyterCellFromVSCNotebookCell } from '../../kernels/execution/helpers';
 import { appendLineFeed, parseForComments, generateMarkdownFromCodeLines } from '../../platform/common/utils';
-import { traceInfoIfCI } from '../../platform/logging';
 
 export function createCodeCell(): nbformat.ICodeCell;
 // eslint-disable-next-line @typescript-eslint/unified-signatures
@@ -138,7 +137,6 @@ export function generateCellRangesFromDocument(document: TextDocument, settings?
     for (let index = 0; index < document.lineCount; index += 1) {
         const line = document.lineAt(index);
         if (matcher.isCell(line.text)) {
-            traceInfoIfCI(`${line.text} is a cell marker`);
             if (cells.length > 0) {
                 const previousCell = cells[cells.length - 1];
                 previousCell.range = new Range(previousCell.range.start, document.lineAt(index - 1).range.end);
@@ -148,8 +146,6 @@ export function generateCellRangesFromDocument(document: TextDocument, settings?
                 range: line.range,
                 cell_type: matcher.getCellType(line.text)
             });
-        } else {
-            traceInfoIfCI(`${line.text} is a not cell marker`);
         }
     }
 

--- a/src/interactive-window/editor-integration/codeLensFactory.ts
+++ b/src/interactive-window/editor-integration/codeLensFactory.ts
@@ -109,6 +109,7 @@ export class CodeLensFactory implements ICodeLensFactory {
             // Because we have all new ranges, we need to recompute ALL of our code lenses.
             cache.documentLenses = [];
             cache.gotoCellLens = [];
+            cache.cachedDocumentVersion = document.version;
             needUpdate = true;
         }
 
@@ -142,7 +143,6 @@ export class CodeLensFactory implements ICodeLensFactory {
                 });
                 firstCell = false;
             });
-            traceInfoIfCI(`Cached ${cache.documentLenses.length} code lenses`);
         } else {
             traceInfoIfCI(
                 `NOT Generating new code lenses for version ${document.version} of document ${document.uri} - needUpdate: ${needUpdate}, cellRanges.length: ${cache.cellRanges.length}`
@@ -170,7 +170,6 @@ export class CodeLensFactory implements ICodeLensFactory {
             }
         }
 
-        cache.cachedDocumentVersion = document.version;
         return cache;
     }
     private getDocumentExecutionCounts(key: string): number[] {

--- a/src/interactive-window/editor-integration/codeLensFactory.ts
+++ b/src/interactive-window/editor-integration/codeLensFactory.ts
@@ -144,7 +144,9 @@ export class CodeLensFactory implements ICodeLensFactory {
                 firstCell = false;
             });
         } else {
-            traceInfoIfCI(`NOT Generating new code lenses for version ${document.version} of document ${document.uri}`);
+            traceInfoIfCI(
+                `NOT Generating new code lenses for version ${document.version} of document ${document.uri} - needUpdate: ${needUpdate}, cellRanges.length: ${cache.cellRanges.length}`
+            );
         }
 
         // Generate the goto cell lenses if necessary

--- a/src/interactive-window/editor-integration/codeLensFactory.ts
+++ b/src/interactive-window/editor-integration/codeLensFactory.ts
@@ -109,7 +109,6 @@ export class CodeLensFactory implements ICodeLensFactory {
             // Because we have all new ranges, we need to recompute ALL of our code lenses.
             cache.documentLenses = [];
             cache.gotoCellLens = [];
-            cache.cachedDocumentVersion = document.version;
             needUpdate = true;
         }
 
@@ -138,11 +137,12 @@ export class CodeLensFactory implements ICodeLensFactory {
                 commands.forEach((c) => {
                     const codeLens = this.createCodeLens(document, r, c, firstCell);
                     if (codeLens) {
-                        cache?.documentLenses.push(codeLens); // NOSONAR
+                        cache!.documentLenses.push(codeLens); // NOSONAR
                     }
                 });
                 firstCell = false;
             });
+            traceInfoIfCI(`Cached ${cache.documentLenses.length} code lenses`);
         } else {
             traceInfoIfCI(
                 `NOT Generating new code lenses for version ${document.version} of document ${document.uri} - needUpdate: ${needUpdate}, cellRanges.length: ${cache.cellRanges.length}`
@@ -169,6 +169,8 @@ export class CodeLensFactory implements ICodeLensFactory {
                 });
             }
         }
+
+        cache.cachedDocumentVersion = document.version;
         return cache;
     }
     private getDocumentExecutionCounts(key: string): number[] {

--- a/src/interactive-window/editor-integration/codelensprovider.ts
+++ b/src/interactive-window/editor-integration/codelensprovider.ts
@@ -166,6 +166,13 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
                     }
                     return false;
                 });
+            } else {
+                traceInfoIfCI(
+                    `Detected debugging context because activeDebugSession is name:"${this.debugService.activeDebugSession.name}", type: "${this.debugService.activeDebugSession.type}", ` +
+                        `but fell through with debugLocation: ${JSON.stringify(
+                            debugLocation
+                        )}, and doument.uri: ${document.uri.toString()}`
+                );
             }
         } else {
             return lenses.filter((lens) => {

--- a/src/interactive-window/editor-integration/codelensprovider.ts
+++ b/src/interactive-window/editor-integration/codelensprovider.ts
@@ -129,7 +129,7 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
         }
 
         const result = this.adjustDebuggingLenses(document, codeLenses);
-        traceInfoIfCI(`CodeLensProvider: returning ${result.map((x) => x.command?.title).join(', ')}`);
+        traceInfoIfCI(`CodeLensProvider: returning ${result.length} code lenses`);
         return result;
     }
 

--- a/src/interactive-window/editor-integration/codelensprovider.ts
+++ b/src/interactive-window/editor-integration/codelensprovider.ts
@@ -128,9 +128,7 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
             return [];
         }
 
-        const result = this.adjustDebuggingLenses(document, codeLenses);
-        traceInfoIfCI(`CodeLensProvider: returning ${result.length} code lenses`);
-        return result;
+        return this.adjustDebuggingLenses(document, codeLenses);
     }
 
     // Adjust what code lenses are visible or not given debug mode and debug context location

--- a/src/interactive-window/editor-integration/codelensprovider.ts
+++ b/src/interactive-window/editor-integration/codelensprovider.ts
@@ -128,7 +128,9 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
             return [];
         }
 
-        return this.adjustDebuggingLenses(document, codeLenses);
+        const result = this.adjustDebuggingLenses(document, codeLenses);
+        traceInfoIfCI(`CodeLensProvider: returning ${result.map((x) => x.command?.title).join(', ')}`);
+        return result;
     }
 
     // Adjust what code lenses are visible or not given debug mode and debug context location

--- a/src/interactive-window/editor-integration/codelensprovider.ts
+++ b/src/interactive-window/editor-integration/codelensprovider.ts
@@ -169,7 +169,7 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
                     `Detected debugging context because activeDebugSession is name:"${this.debugService.activeDebugSession.name}", type: "${this.debugService.activeDebugSession.type}", ` +
                         `but fell through with debugLocation: ${JSON.stringify(
                             debugLocation
-                        )}, and doument.uri: ${document.uri.toString()}`
+                        )}, and document.uri: ${document.uri.toString()}`
                 );
             }
         } else {

--- a/src/kernels/helpers.ts
+++ b/src/kernels/helpers.ts
@@ -176,6 +176,7 @@ export function rankKernels(
     }
 
     traceInfoIfCI(`preferredInterpreterKernelSpecIndex = ${preferredInterpreterKernelSpec?.id}`);
+    traceInfoIfCI(`filtering kernels: ${JSON.stringify(kernels)}`);
 
     // Figure out our possible language from the metadata
     const actualNbMetadataLanguage: string | undefined =
@@ -196,6 +197,10 @@ export function rankKernels(
             return false;
         }
         // Return everything else
+        if (kernel.kind !== 'connectToLiveRemoteKernel' && kernel.kernelSpec.language) {
+            traceInfoIfCI(`including Kernel with language ${kernel.kernelSpec.language} as a possible match`);
+        }
+
         return true;
     });
 
@@ -226,7 +231,7 @@ export function rankKernels(
             preferredRemoteKernelId
         )
     );
-
+    traceInfoIfCI(`ranked kernels: ${JSON.stringify(kernels)}`);
     return kernels;
 }
 

--- a/src/kernels/helpers.ts
+++ b/src/kernels/helpers.ts
@@ -176,7 +176,6 @@ export function rankKernels(
     }
 
     traceInfoIfCI(`preferredInterpreterKernelSpecIndex = ${preferredInterpreterKernelSpec?.id}`);
-    traceInfoIfCI(`filtering kernels: ${JSON.stringify(kernels)}`);
 
     // Figure out our possible language from the metadata
     const actualNbMetadataLanguage: string | undefined =
@@ -197,10 +196,6 @@ export function rankKernels(
             return false;
         }
         // Return everything else
-        if (kernel.kind !== 'connectToLiveRemoteKernel' && kernel.kernelSpec.language) {
-            traceInfoIfCI(`including Kernel with language ${kernel.kernelSpec.language} as a possible match`);
-        }
-
         return true;
     });
 
@@ -231,7 +226,6 @@ export function rankKernels(
             preferredRemoteKernelId
         )
     );
-    traceInfoIfCI(`ranked kernels: ${JSON.stringify(kernels)}`);
     return kernels;
 }
 

--- a/src/test/datascience/helpers.ts
+++ b/src/test/datascience/helpers.ts
@@ -267,9 +267,10 @@ export async function waitForLastCellToComplete(
 ) {
     const notebookDocument = await waitForInteractiveWindow(interactiveWindow);
     let codeCell: vscode.NotebookCell | undefined;
+    let codeCells: vscode.NotebookCell[] = [];
     await waitForCondition(
         async () => {
-            const codeCells = notebookDocument?.getCells().filter((c) => c.kind === vscode.NotebookCellKind.Code);
+            codeCells = notebookDocument?.getCells().filter((c) => c.kind === vscode.NotebookCellKind.Code);
             codeCell = codeCells && codeCells.length ? codeCells[codeCells.length - 1] : undefined;
             return codeCell && (numberOfCells === -1 || numberOfCells === codeCells!.length) ? true : false;
         },
@@ -281,7 +282,7 @@ export async function waitForLastCellToComplete(
     } else {
         await waitForExecutionCompletedSuccessfully(codeCell!);
     }
-    traceInfoIfCI(`finished waiting for last cell to complete of ${numberOfCells} cells`);
+    traceInfoIfCI(`finished waiting for last cell to complete of ${codeCells.length} cells`);
     return codeCell!;
 }
 

--- a/src/test/datascience/helpers.ts
+++ b/src/test/datascience/helpers.ts
@@ -5,7 +5,7 @@
 import { assert } from 'chai';
 import * as vscode from 'vscode';
 import { getFilePath } from '../../platform/common/platform/fs-paths';
-import { traceInfo } from '../../platform/logging';
+import { traceInfo, traceInfoIfCI } from '../../platform/logging';
 import { IPythonApiProvider } from '../../platform/api/types';
 import { IJupyterSettings, Resource } from '../../platform/common/types';
 import { InteractiveWindow } from '../../interactive-window/interactiveWindow';
@@ -281,6 +281,7 @@ export async function waitForLastCellToComplete(
     } else {
         await waitForExecutionCompletedSuccessfully(codeCell!);
     }
+    traceInfoIfCI(`finished waiting for last cell to complete of ${numberOfCells} cells`);
     return codeCell!;
 }
 
@@ -316,6 +317,7 @@ export async function waitForCodeLenses(document: vscode.Uri, command: string) {
         `Code lens with command ${command} not found`
     );
 
+    traceInfoIfCI(`Found code lenses with command ${command}`);
     return codeLenses;
 }
 

--- a/src/test/datascience/interactiveDebugging.vscode.common.ts
+++ b/src/test/datascience/interactiveDebugging.vscode.common.ts
@@ -35,7 +35,7 @@ export function sharedIWDebuggerTests(
         suiteSetup?: (debuggerType: DebuggerType) => Promise<void>;
     }
 ) {
-    const debuggerTypes: DebuggerType[] = ['VSCodePythonDebugger'];
+    const debuggerTypes: DebuggerType[] = ['VSCodePythonDebugger', 'JupyterProtocolDebugger'];
     debuggerTypes.forEach((debuggerType) => {
         suite(`Debugging with ${debuggerType}`, async function () {
             this.timeout(120_000);

--- a/src/test/datascience/interactiveDebugging.vscode.common.ts
+++ b/src/test/datascience/interactiveDebugging.vscode.common.ts
@@ -58,6 +58,17 @@ export function sharedIWDebuggerTests(
                 if (options?.suiteSetup) {
                     await options?.suiteSetup(debuggerType);
                 }
+
+                // ensure debugger is torn down from previous suites
+                await vscode.commands.executeCommand('workbench.action.debug.stop');
+                await vscode.commands.executeCommand('workbench.action.debug.disconnect');
+                await waitForCondition(
+                    async () => {
+                        return vscode.debug.activeDebugSession === undefined;
+                    },
+                    defaultNotebookTestTimeout,
+                    `Unable to stop debug session on test teardown`
+                );
             });
             suiteTeardown(() => vscode.commands.executeCommand('workbench.debug.viewlet.action.removeAllBreakpoints'));
             setup(async function () {
@@ -96,9 +107,7 @@ export function sharedIWDebuggerTests(
                 await closeNotebooksAndCleanUpAfterTests(disposables);
             });
 
-            // Flakey test: https://github.com/microsoft/vscode-jupyter/issues/10521
-
-            test.skip('Debug a cell from a python file', async () => {
+            test('Debug a cell from a python file', async () => {
                 // Run a cell to get IW open
                 const source = 'print(42)';
                 const { activeInteractiveWindow, untitledPythonFile } = await submitFromPythonFile(

--- a/src/test/datascience/interactiveDebugging.vscode.common.ts
+++ b/src/test/datascience/interactiveDebugging.vscode.common.ts
@@ -35,7 +35,7 @@ export function sharedIWDebuggerTests(
         suiteSetup?: (debuggerType: DebuggerType) => Promise<void>;
     }
 ) {
-    const debuggerTypes: DebuggerType[] = ['VSCodePythonDebugger', 'JupyterProtocolDebugger'];
+    const debuggerTypes: DebuggerType[] = ['VSCodePythonDebugger'];
     debuggerTypes.forEach((debuggerType) => {
         suite(`Debugging with ${debuggerType}`, async function () {
             this.timeout(120_000);
@@ -292,8 +292,7 @@ export function sharedIWDebuggerTests(
 
                 // Aquire the variable view from the provider
                 const coreVariableView = await variableViewProvider.activeVariableView;
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const variableView = coreVariableView as any as ITestWebviewHost;
+                const variableView = coreVariableView as unknown as ITestWebviewHost;
 
                 // Parse the HTML for our expected variables
                 let expectedVariables = [{ name: 'x', type: 'int', length: '', value: '1' }];

--- a/src/test/datascience/notebook/nonPythonKernels.vscode.test.ts
+++ b/src/test/datascience/notebook/nonPythonKernels.vscode.test.ts
@@ -96,7 +96,8 @@ suite('DataScience - VSCode Notebook - Kernels (non-python-kernel) (slow)', () =
         verifyPromptWasNotDisplayed();
         await closeNotebooksAndCleanUpAfterTests(disposables);
     });
-    test('Automatically pick java kernel when opening a Java Notebook', async function () {
+    // https://github.com/microsoft/vscode-jupyter/issues/10900
+    test.skip('Automatically pick java kernel when opening a Java Notebook', async function () {
         if (!testJavaKernels) {
             return this.skip();
         }


### PR DESCRIPTION
More diagnostic logging for CI test runs and clean up the debug session before the IW debugging test suite - a previous suite was leaving the debugging service in a weird state that still had a debugging context with no debugger running.

skipping java kernel test - https://github.com/microsoft/vscode-jupyter/issues/10900