### PR TITLE
fix failing java kernel test

### DIFF
--- a/src/kernels/helpers.ts
+++ b/src/kernels/helpers.ts
@@ -176,7 +176,7 @@ export function rankKernels(
     }
 
     traceInfoIfCI(`preferredInterpreterKernelSpecIndex = ${preferredInterpreterKernelSpec?.id}`);
-    // traceInfoIfCI(`filtering kernels: ${JSON.stringify(kernels)}`); very large log, but useful for debugging
+    traceInfoIfCI(`filtering kernels: ${JSON.stringify(kernels)}`); // very large log, but useful for debugging
 
     // Figure out our possible language from the metadata
     const actualNbMetadataLanguage: string | undefined =
@@ -195,6 +195,11 @@ export function rankKernels(
             kernel.kernelSpec.language.toLowerCase() !== possibleNbMetadataLanguage
         ) {
             return false;
+        }
+        if (kernel.kind !== 'connectToLiveRemoteKernel' && kernel.kernelSpec) {
+            traceInfoIfCI(`including kernel with language ${kernel.kernelSpec.language}`);
+        } else {
+            traceInfoIfCI(`including kernel ${kernel.id}`);
         }
         // Return everything else
         return true;
@@ -227,6 +232,7 @@ export function rankKernels(
             preferredRemoteKernelId
         )
     );
+    traceInfoIfCI(`ranked kernels: ${JSON.stringify(kernels)}`);
     return kernels;
 }
 

--- a/src/kernels/helpers.ts
+++ b/src/kernels/helpers.ts
@@ -176,6 +176,7 @@ export function rankKernels(
     }
 
     traceInfoIfCI(`preferredInterpreterKernelSpecIndex = ${preferredInterpreterKernelSpec?.id}`);
+    traceInfoIfCI(`filtering kernels: ${JSON.stringify(kernels)}`);
 
     // Figure out our possible language from the metadata
     const actualNbMetadataLanguage: string | undefined =
@@ -196,6 +197,10 @@ export function rankKernels(
             return false;
         }
         // Return everything else
+        if (kernel.kind !== 'connectToLiveRemoteKernel' && kernel.kernelSpec.language) {
+            traceInfoIfCI(`including Kernel with language ${kernel.kernelSpec.language} as a possible match`);
+        }
+
         return true;
     });
 
@@ -226,7 +231,7 @@ export function rankKernels(
             preferredRemoteKernelId
         )
     );
-
+    traceInfoIfCI(`ranked kernels: ${JSON.stringify(kernels)}`);
     return kernels;
 }
 

--- a/src/kernels/helpers.ts
+++ b/src/kernels/helpers.ts
@@ -176,7 +176,7 @@ export function rankKernels(
     }
 
     traceInfoIfCI(`preferredInterpreterKernelSpecIndex = ${preferredInterpreterKernelSpec?.id}`);
-    traceInfoIfCI(`filtering kernels: ${JSON.stringify(kernels)}`); // very large log, but useful for debugging
+    // traceInfoIfCI(`filtering kernels: ${JSON.stringify(kernels)}`); // very large log, but useful for debugging
 
     // Figure out our possible language from the metadata
     const actualNbMetadataLanguage: string | undefined =
@@ -195,11 +195,6 @@ export function rankKernels(
             kernel.kernelSpec.language.toLowerCase() !== possibleNbMetadataLanguage
         ) {
             return false;
-        }
-        if (kernel.kind !== 'connectToLiveRemoteKernel' && kernel.kernelSpec) {
-            traceInfoIfCI(`including kernel with language ${kernel.kernelSpec.language}`);
-        } else {
-            traceInfoIfCI(`including kernel ${kernel.id}`);
         }
         // Return everything else
         return true;
@@ -232,7 +227,7 @@ export function rankKernels(
             preferredRemoteKernelId
         )
     );
-    traceInfoIfCI(`ranked kernels: ${JSON.stringify(kernels)}`);
+    // traceInfoIfCI(`ranked kernels: ${JSON.stringify(kernels)}`);
     return kernels;
 }
 

--- a/src/kernels/helpers.ts
+++ b/src/kernels/helpers.ts
@@ -176,7 +176,7 @@ export function rankKernels(
     }
 
     traceInfoIfCI(`preferredInterpreterKernelSpecIndex = ${preferredInterpreterKernelSpec?.id}`);
-    traceInfoIfCI(`filtering kernels: ${JSON.stringify(kernels)}`);
+    // traceInfoIfCI(`filtering kernels: ${JSON.stringify(kernels)}`); very large log, but useful for debugging
 
     // Figure out our possible language from the metadata
     const actualNbMetadataLanguage: string | undefined =
@@ -184,12 +184,12 @@ export function rankKernels(
         (notebookMetadata?.kernelspec as undefined | IJupyterKernelSpec)?.language?.toLowerCase();
     let possibleNbMetadataLanguage = actualNbMetadataLanguage;
 
+    traceInfoIfCI(`filtering out kernels that don't match notebook's language: ${possibleNbMetadataLanguage}`);
     // If the notebook has a language set, remove anything not that language as we don't want to rank those items
     kernels = kernels.filter((kernel) => {
         if (
             possibleNbMetadataLanguage &&
             possibleNbMetadataLanguage !== PYTHON_LANGUAGE &&
-            !notebookMetadata?.kernelspec &&
             kernel.kind !== 'connectToLiveRemoteKernel' &&
             kernel.kernelSpec.language &&
             kernel.kernelSpec.language.toLowerCase() !== possibleNbMetadataLanguage
@@ -197,10 +197,6 @@ export function rankKernels(
             return false;
         }
         // Return everything else
-        if (kernel.kind !== 'connectToLiveRemoteKernel' && kernel.kernelSpec.language) {
-            traceInfoIfCI(`including Kernel with language ${kernel.kernelSpec.language} as a possible match`);
-        }
-
         return true;
     });
 
@@ -231,7 +227,6 @@ export function rankKernels(
             preferredRemoteKernelId
         )
     );
-    traceInfoIfCI(`ranked kernels: ${JSON.stringify(kernels)}`);
     return kernels;
 }
 

--- a/src/test/datascience/notebook/nonPythonKernels.vscode.test.ts
+++ b/src/test/datascience/notebook/nonPythonKernels.vscode.test.ts
@@ -32,6 +32,7 @@ import {
 import { PythonExtensionChecker } from '../../../platform/api/pythonApi';
 import { NotebookCellLanguageService } from '../../../notebooks/languages/cellLanguageService';
 import { INotebookEditorProvider } from '../../../notebooks/types';
+import { captureScreenShot } from '../../common';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, no-invalid-this */
 suite('DataScience - VSCode Notebook - Kernels (non-python-kernel) (slow)', () => {
@@ -92,8 +93,11 @@ suite('DataScience - VSCode Notebook - Kernels (non-python-kernel) (slow)', () =
         testEmptyPythonNb = await createTemporaryNotebookFromFile(emptyPythonNb, disposables);
         traceInfo(`Start Test (completed) ${this.currentTest?.title}`);
     });
-    teardown(async () => {
+    teardown(async function () {
         verifyPromptWasNotDisplayed();
+        if (this.currentTest?.isFailed()) {
+            await captureScreenShot(this);
+        }
         await closeNotebooksAndCleanUpAfterTests(disposables);
     });
     test('Automatically pick java kernel when opening a Java Notebook', async function () {


### PR DESCRIPTION
Fixes #10900

There is a case that causes us not to filter on language when ranking kernels.
