### PR TITLE
Revert "Do not append/prepend path values unnecessarily (#10907)"

### DIFF
--- a/news/2 Fixes/10906.md
+++ b/news/2 Fixes/10906.md
@@ -1,2 +1,0 @@
-Do not append/prepend path values unnecessarily
-.

--- a/src/platform/common/variables/environment.node.ts
+++ b/src/platform/common/variables/environment.node.ts
@@ -91,13 +91,13 @@ export class EnvironmentVariablesService implements IEnvironmentVariablesService
         // depending upon where the environment variable comes from (kernelspec might have 'PATH' whereas windows might use 'Path')
         const variableNameLower = variableName.toLowerCase();
         const matchingKey = vars ? Object.keys(vars).find((k) => k.toLowerCase() == variableNameLower) : undefined;
-        const existingValue = vars && matchingKey ? vars[matchingKey] : undefined;
+        const variable = vars && matchingKey ? vars[matchingKey] : undefined;
         const setKey = matchingKey || variableName;
-        if (existingValue && typeof existingValue === 'string' && existingValue.length > 0) {
-            if (append && !(vars[setKey] || '').endsWith(path.delimiter + valueToAppendOrPrepend)) {
-                vars[setKey] = existingValue + path.delimiter + valueToAppendOrPrepend;
-            } else if (!append && !(vars[setKey] || '').startsWith(valueToAppendOrPrepend + path.delimiter)) {
-                vars[setKey] = valueToAppendOrPrepend + path.delimiter + existingValue;
+        if (variable && typeof variable === 'string' && variable.length > 0) {
+            if (append) {
+                vars[setKey] = variable + path.delimiter + valueToAppendOrPrepend;
+            } else {
+                vars[setKey] = valueToAppendOrPrepend + path.delimiter + variable;
             }
         } else {
             vars[setKey] = valueToAppendOrPrepend;

--- a/src/test/common/variables/envVarsService.unit.test.ts
+++ b/src/test/common/variables/envVarsService.unit.test.ts
@@ -223,7 +223,7 @@ PYTHON=${BINDIR}/python3\n\
             expect(vars).to.have.property(pathVariable, 'PATH', 'Incorrect value');
         });
 
-        test(`Ensure PATH is appended irregardless of case`, async () => {
+        test(`Ensure PATH is appeneded irregardless of case`, async () => {
             const vars = { ONE: '1' };
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (vars as any)['paTh'] = 'PATH';
@@ -234,54 +234,6 @@ PYTHON=${BINDIR}/python3\n\
             expect(Object.keys(vars)).lengthOf(2, `Incorrect number of variables ${Object.keys(vars).join(' ')}`);
             expect(vars).to.have.property('ONE', '1', 'Incorrect value');
             expect(vars).to.have.property(`paTh`, `PATH${path.delimiter}${pathToAppend}`, 'Incorrect value');
-        });
-        test(`Ensure PATH is not appended if already at the end`, async () => {
-            const defaultPath = `/usr/one${path.delimiter}/usr/three${path.delimiter}/usr/four${path.delimiter}/usr/five`;
-            const vars = {
-                ONE: '1',
-                paTh: defaultPath
-            };
-            const pathToAppend = `/usr/four${path.delimiter}/usr/five`;
-
-            variablesService.appendPath(vars, pathToAppend);
-
-            expect(vars).to.have.property(`paTh`, defaultPath, 'Incorrect value');
-        });
-        test(`Ensure PATH is appended even if path exists elsewhere in the PATH value`, async () => {
-            const defaultPath = `/usr/one${path.delimiter}/usr/three${path.delimiter}/usr/four${path.delimiter}/usr/five`;
-            const vars = {
-                ONE: '1',
-                paTh: defaultPath
-            };
-            const pathToAppend = `/usr/one${path.delimiter}/usr/three`;
-
-            variablesService.appendPath(vars, pathToAppend);
-
-            expect(vars).to.have.property(`paTh`, `${defaultPath}${path.delimiter}${pathToAppend}`, 'Incorrect value');
-        });
-        test(`Ensure PATH is not prepended if already at the start`, async () => {
-            const defaultPath = `/usr/one${path.delimiter}/usr/three${path.delimiter}/usr/four${path.delimiter}/usr/five`;
-            const vars = {
-                ONE: '1',
-                paTh: defaultPath
-            };
-            const pathToPrepend = `/usr/one${path.delimiter}/usr/three`;
-
-            variablesService.prependPath(vars, pathToPrepend);
-
-            expect(vars).to.have.property(`paTh`, defaultPath, 'Incorrect value');
-        });
-        test(`Ensure PATH is prepended even if path exists elsewhere in the PATH value`, async () => {
-            const defaultPath = `/usr/one${path.delimiter}/usr/three${path.delimiter}/usr/four${path.delimiter}/usr/five`;
-            const vars = {
-                ONE: '1',
-                paTh: defaultPath
-            };
-            const pathToPrepend = `/usr/four${path.delimiter}/usr/five`;
-
-            variablesService.prependPath(vars, pathToPrepend);
-
-            expect(vars).to.have.property(`paTh`, `${pathToPrepend}${path.delimiter}${defaultPath}`, 'Incorrect value');
         });
     });
 


### PR DESCRIPTION
This reverts commit 89b448a92165b584ea7ba94f3ee39f32ce51f209.

This was breaking some tests