### PR TITLE
Fix problems with launching non zmq on windows

### DIFF
--- a/news/2 Fixes/10940.md
+++ b/news/2 Fixes/10940.md
@@ -1,0 +1,1 @@
+Fixes problem with starting a kernel when ZMQ wasn't supported on Windows.

--- a/src/kernels/raw/launcher/kernelEnvVarsService.node.ts
+++ b/src/kernels/raw/launcher/kernelEnvVarsService.node.ts
@@ -79,7 +79,16 @@ export class KernelEnvironmentVariablesService {
         }
         // Merge the env variables with that of the kernel env.
         interpreterEnv = interpreterEnv || {};
-        const mergedVars = { ...process.env };
+        let mergedVars = { ...process.env };
+
+        // On windows (see https://github.com/microsoft/vscode-jupyter/issues/10940)
+        // upper case all of the keys
+        if (process.platform === 'win32') {
+            mergedVars = {};
+            Object.keys(process.env).forEach((k) => {
+                mergedVars[k.toUpperCase()] = process.env[k];
+            });
+        }
         kernelEnv = kernelEnv || {};
         customEnvVars = customEnvVars || {};
         this.envVarsService.mergeVariables(interpreterEnv, mergedVars); // interpreter vars win over proc.

--- a/src/test/datascience/jupyter/kernels/jupyterKernelService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/jupyterKernelService.unit.test.ts
@@ -35,8 +35,10 @@ suite('DataScience - JupyterKernelService', () => {
     let settings: IWatchableJupyterSettings;
     let fs: IFileSystemNode;
     let testWorkspaceFolder: Uri;
-    // eslint-disable-next-line local-rules/dont-use-process
-    const pathVariable = Object.keys(process.env).find((k) => k.toLowerCase() == 'path')!;
+    // PATH variable is forced upper case on Windows
+    const pathVariable =
+        // eslint-disable-next-line local-rules/dont-use-process
+        process.platform === 'win32' ? 'PATH' : Object.keys(process.env).find((k) => k.toLowerCase() == 'path')!;
 
     // Set of kernels. Generated this by running the localKernelFinder unit test and stringifying
     // the results returned.


### PR DESCRIPTION
Fixes #10940

Root cause seems to be the case of the environment variable keys. Jupyter must have code that uses os.environ["PATH"] somewhere.

Before change https://github.com/microsoft/vscode-jupyter/commit/7308db89073d2f3a67c03d778a0b8a19e091328b my kernelspec.json had PATH in upper case. After that change, it switched to lower case.

