### PR TITLE
Fix /lab path for jupyter lab server

### DIFF
--- a/src/kernels/jupyter/jupyterUtils.ts
+++ b/src/kernels/jupyter/jupyterUtils.ts
@@ -101,20 +101,18 @@ export function createRemoteConnectionInfo(
     let url: URL;
     try {
         url = new URL(uri);
-
-        // Special case for URI's ending with 'lab'. Remove this from the URI. This is not
-        // the location for connecting to jupyterlab
-        if (url.pathname === '/lab') {
-            uri = uri.replace('lab', '');
-        }
-        url = new URL(uri);
     } catch (err) {
         // This should already have been parsed when set, so just throw if it's not right here
         throw err;
     }
 
     const serverUri = getJupyterServerUri(uri);
-    const baseUrl = serverUri ? serverUri.baseUrl : `${url.protocol}//${url.host}${url.pathname}`;
+
+    const baseUrl = serverUri
+        ? serverUri.baseUrl
+        : // Special case for URI's ending with 'lab'. Remove this from the URI. This is not
+          // the location for connecting to jupyterlab
+          `${url.protocol}//${url.host}${url.pathname === '/lab' ? '' : url.pathname}`;
     const token = serverUri ? serverUri.token : `${url.searchParams.get('token')}`;
     const hostName = serverUri ? new URL(serverUri.baseUrl).hostname : url.hostname;
 


### PR DESCRIPTION
Fixes #10962

The `Uri.path` only needs to be updated for generating `baseUrl`, which is used to create requests to the server. Thus this PR leaves the `url` untouched, which will be used as the source for generating unique server ID.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
