### PR TITLE
Correct conda install options in cell error

### DIFF
--- a/src/kernels/errors/kernelErrorHandler.ts
+++ b/src/kernels/errors/kernelErrorHandler.ts
@@ -474,7 +474,7 @@ function getJupyterMissingErrorMessageForCell(err: JupyterInstallError) {
     const productNames = `${ProductNames.get(Product.jupyter)} ${Common.and()} ${ProductNames.get(Product.notebook)}`;
     const moduleNames = [Product.jupyter, Product.notebook].map(translateProductToModule).join(' ');
 
-    const installerCommand = `python -m pip install ${moduleNames} -U\nor\nconda install ${moduleNames} -U`;
+    const installerCommand = `python -m pip install ${moduleNames} -U\nor\nconda install ${moduleNames} --update-deps --force-reinstall`;
     const installationInstructions = DataScience.installPackageInstructions().format(productNames, installerCommand);
 
     return (


### PR DESCRIPTION
`conda install` does not have a `-U` option. Make installation instructions consistent with other conda install commands in the file.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] ~Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).~
-   [x] ~Appropriate comments and documentation strings in the code.~
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for feature-requests.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
