### PR TITLE
Ensure verbose log messages are logged on CI

### DIFF
--- a/src/test/.vscode/settings.json
+++ b/src/test/.vscode/settings.json
@@ -19,5 +19,6 @@
     // Do not set this to "Microsoft", else it will result in LS being downloaded on CI
     // and that slows down tests significantly. We have other tests on CI for testing
     // downloading of LS with this setting enabled.
-    "python.languageServer": "Pylance"
+    "python.languageServer": "Pylance",
+    "jupyter.logging.level": "verbose"
 }


### PR DESCRIPTION
I needed this to diagnose issue with Java kernels (coulnd't find the discovered kernels being logged anywhere, I'm know we had this, and thats what led me down the path of verbose logs not working)  and found that the verbose logs weren't logged at all.