### PR TITLE
restrict shouldAllowIntellisense to only python notebook cells so tha…

### DIFF
--- a/src/standalone/intellisense/intellisenseProvider.node.ts
+++ b/src/standalone/intellisense/intellisenseProvider.node.ts
@@ -225,7 +225,8 @@ export class IntellisenseProvider implements INotebookCompletionProvider, IExten
         // Cell also have to support python
         const cell = notebook?.getCells().find((c) => c.document.uri.toString() === uri.toString());
 
-        return interpreterId == notebookId && (!cell || cell.document.languageId === 'python');
+        const shouldAllow = interpreterId == notebookId && cell?.document.languageId === 'python';
+        return shouldAllow;
     }
 
     private getNotebookHeader(uri: Uri) {


### PR DESCRIPTION
…t plain .py files dont get duplicate results in api calls to onHover etc.

Fixes # https://github.com/microsoft/pylance-release/issues/3027

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
