### PR TITLE
Improved kernel startup and failure telemetry

### DIFF
--- a/src/kernels/execution/cellExecution.ts
+++ b/src/kernels/execution/cellExecution.ts
@@ -21,10 +21,10 @@ import { analyzeKernelErrors, createOutputWithErrorMessageForDisplay } from '../
 import { BaseError } from '../../platform/errors/types';
 import { disposeAllDisposables } from '../../platform/common/helpers';
 import { traceError, traceInfoIfCI, traceWarning } from '../../platform/logging';
-import { IDisposable } from '../../platform/common/types';
+import { IDisposable, Resource } from '../../platform/common/types';
 import { createDeferred } from '../../platform/common/utils/async';
 import { StopWatch } from '../../platform/common/utils/stopWatch';
-import { sendTelemetryEvent, Telemetry } from '../../telemetry';
+import { Telemetry } from '../../telemetry';
 import { noop } from '../../platform/common/utils/misc';
 import { getDisplayNameOrNameOfKernelConnection, isPythonKernelConnection } from '../../kernels/helpers';
 import { isCancellationError } from '../../platform/common/cancellation';
@@ -33,6 +33,7 @@ import { CellExecutionMessageHandlerService } from './cellExecutionMessageHandle
 import { IKernelConnectionSession, KernelConnectionMetadata, NotebookCellRunState } from '../../kernels/types';
 import { NotebookCellStateTracker, traceCellMessage } from './helpers';
 import { JupyterNotebookView } from '../../platform/common/constants';
+import { sendKernelTelemetryEvent } from '../telemetry/sendKernelTelemetryEvent';
 
 /**
  * Factory for CellExecution objects.
@@ -43,9 +44,14 @@ export class CellExecutionFactory {
         private readonly requestListener: CellExecutionMessageHandlerService
     ) {}
 
-    public create(cell: NotebookCell, code: string | undefined, metadata: Readonly<KernelConnectionMetadata>) {
+    public create(
+        cell: NotebookCell,
+        code: string | undefined,
+        metadata: Readonly<KernelConnectionMetadata>,
+        resourceUri: Resource
+    ) {
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        return CellExecution.fromCell(cell, code, metadata, this.controller, this.requestListener);
+        return CellExecution.fromCell(cell, code, metadata, this.controller, this.requestListener, resourceUri);
     }
 }
 
@@ -88,6 +94,7 @@ export class CellExecution implements IDisposable {
         private readonly codeOverride: string | undefined,
         private readonly kernelConnection: Readonly<KernelConnectionMetadata>,
         private readonly controller: NotebookController,
+        private readonly resourceUri: Resource,
         private readonly requestListener: CellExecutionMessageHandlerService
     ) {
         workspace.onDidCloseTextDocument(
@@ -133,9 +140,10 @@ export class CellExecution implements IDisposable {
         code: string | undefined,
         metadata: Readonly<KernelConnectionMetadata>,
         controller: NotebookController,
-        requestListener: CellExecutionMessageHandlerService
+        requestListener: CellExecutionMessageHandlerService,
+        resourceUri: Resource
     ) {
-        return new CellExecution(cell, code, metadata, controller, requestListener);
+        return new CellExecution(cell, code, metadata, controller, resourceUri, requestListener);
     }
     public async start(session: IKernelConnectionSession) {
         if (this.cancelHandled) {
@@ -301,9 +309,19 @@ export class CellExecution implements IDisposable {
         const props = { notebook: this.controller.notebookType === JupyterNotebookView };
         if (!CellExecution.sentExecuteCellTelemetry) {
             CellExecution.sentExecuteCellTelemetry = true;
-            sendTelemetryEvent(Telemetry.ExecuteCellPerceivedCold, this.stopWatchForTelemetry.elapsedTime, props);
+            sendKernelTelemetryEvent(
+                this.resourceUri,
+                Telemetry.ExecuteCellPerceivedCold,
+                this.stopWatchForTelemetry.elapsedTime,
+                props
+            );
         } else {
-            sendTelemetryEvent(Telemetry.ExecuteCellPerceivedWarm, this.stopWatchForTelemetry.elapsedTime, props);
+            sendKernelTelemetryEvent(
+                this.resourceUri,
+                Telemetry.ExecuteCellPerceivedWarm,
+                this.stopWatchForTelemetry.elapsedTime,
+                props
+            );
         }
     }
     private canExecuteCell() {

--- a/src/kernels/execution/cellExecutionQueue.ts
+++ b/src/kernels/execution/cellExecutionQueue.ts
@@ -7,6 +7,7 @@ import { noop } from '../../platform/common/utils/misc';
 import { traceCellMessage } from './helpers';
 import { CellExecution, CellExecutionFactory } from './cellExecution';
 import { IKernelConnectionSession, KernelConnectionMetadata, NotebookCellRunState } from '../../kernels/types';
+import { Resource } from '../../platform/common/types';
 
 /**
  * A queue responsible for execution of cells.
@@ -39,7 +40,8 @@ export class CellExecutionQueue implements Disposable {
     constructor(
         private readonly session: Promise<IKernelConnectionSession>,
         private readonly executionFactory: CellExecutionFactory,
-        readonly metadata: Readonly<KernelConnectionMetadata>
+        readonly metadata: Readonly<KernelConnectionMetadata>,
+        readonly resourceUri: Resource
     ) {}
 
     public dispose() {
@@ -59,7 +61,7 @@ export class CellExecutionQueue implements Disposable {
             traceCellMessage(cell, 'Use existing cell execution');
             return;
         }
-        const cellExecution = this.executionFactory.create(cell, codeOverride, this.metadata);
+        const cellExecution = this.executionFactory.create(cell, codeOverride, this.metadata, this.resourceUri);
         this.disposables.push(cellExecution);
         cellExecution.preExecute((c) => this._onPreExecute.fire(c), this, this.disposables);
         this.queueOfCellsToExecute.push(cellExecution);

--- a/src/kernels/execution/kernelExecution.ts
+++ b/src/kernels/execution/kernelExecution.ts
@@ -316,7 +316,8 @@ export class KernelExecution extends BaseKernelExecution<IKernel> {
         const newCellExecutionQueue = new CellExecutionQueue(
             sessionPromise,
             this.executionFactory,
-            this.kernel.kernelConnectionMetadata
+            this.kernel.kernelConnectionMetadata,
+            this.kernel.resourceUri
         );
         this.disposables.push(newCellExecutionQueue);
 

--- a/src/kernels/kernel.ts
+++ b/src/kernels/kernel.ts
@@ -153,6 +153,18 @@ abstract class BaseKernel<TKernelExecution extends BaseKernelExecution> implemen
         this.disposables.push(this._onStarted);
         this.disposables.push(this._onDisposed);
         this.disposables.push({ dispose: () => this._kernelSocket.unsubscribe() });
+        trackKernelResourceInformation(this.resourceUri, {
+            kernelConnection: this.kernelConnectionMetadata,
+            actionSource: this.creator,
+            disableUI: this.startupUI.disableUI
+        });
+        this.startupUI.onDidChangeDisableUI(() => {
+            if (!this.startupUI.disableUI) {
+                trackKernelResourceInformation(this.resourceUri, {
+                    disableUI: false
+                });
+            }
+        }, this.disposables);
     }
 
     public addEventHook(hook: (event: 'willRestart' | 'willInterrupt') => Promise<void>): void {
@@ -305,20 +317,35 @@ abstract class BaseKernel<TKernelExecution extends BaseKernelExecution> implemen
             if (this.startCancellation.token.isCancellationRequested) {
                 this.startCancellation = new CancellationTokenSource();
             }
-            this._jupyterSessionPromise = this.createJupyterSession(new StopWatch()).catch((ex) => {
-                traceInfoIfCI(
-                    `Failed to create Jupyter Session in Kernel.startNotebook for ${getDisplayPath(this.uri)}`
-                );
-                // If we fail also clear the promise.
-                this.startCancellation.cancel();
-                this._jupyterSessionPromise = undefined;
-                throw ex;
+            const stopWatch = new StopWatch();
+            trackKernelResourceInformation(this.resourceUri, {
+                kernelConnection: this.kernelConnectionMetadata,
+                actionSource: this.creator
             });
+
+            this._jupyterSessionPromise = this.createJupyterSession()
+                .then((session) => {
+                    sendKernelTelemetryEvent(
+                        this.resourceUri,
+                        Telemetry.PerceivedJupyterStartupNotebook,
+                        stopWatch.elapsedTime
+                    );
+                    return session;
+                })
+                .catch((ex) => {
+                    traceInfoIfCI(
+                        `Failed to create Jupyter Session in Kernel.startNotebook for ${getDisplayPath(this.uri)}`
+                    );
+                    // If we fail also clear the promise.
+                    this.startCancellation.cancel();
+                    this._jupyterSessionPromise = undefined;
+                    throw ex;
+                });
         }
         return this._jupyterSessionPromise;
     }
 
-    protected async createJupyterSession(stopWatch: StopWatch): Promise<IKernelConnectionSession> {
+    private async createJupyterSession(): Promise<IKernelConnectionSession> {
         let disposables: Disposable[] = [];
         try {
             // No need to block kernel startup on UI updates.
@@ -349,11 +376,7 @@ abstract class BaseKernel<TKernelExecution extends BaseKernelExecution> implemen
             Cancellation.throwIfCanceled(this.startCancellation.token);
             await this.initializeAfterStart(session);
 
-            sendKernelTelemetryEvent(
-                this.resourceUri,
-                Telemetry.PerceivedJupyterStartupNotebook,
-                stopWatch.elapsedTime
-            );
+            this.sendKernelStartedTelemetry();
             this._session = session;
             this._onStarted.fire();
             return session;
@@ -383,6 +406,28 @@ abstract class BaseKernel<TKernelExecution extends BaseKernelExecution> implemen
         } finally {
             disposeAllDisposables(disposables);
         }
+    }
+    private uiWasDisabledWhenKernelStartupTelemetryWasLastSent?: boolean;
+    protected sendKernelStartedTelemetry(): void {
+        if (
+            this.uiWasDisabledWhenKernelStartupTelemetryWasLastSent &&
+            this.uiWasDisabledWhenKernelStartupTelemetryWasLastSent === this.startupUI.disableUI
+        ) {
+            return;
+        } else {
+            // This means the UI is enabled, which happens when starting kernels or the like.
+            // i.e. we can display error messages and the like to the user now.
+            // Note: UI is disabled during auto start.
+            // Last time we sent kernel telemetry event, it was sent indicating the fact that the ui was disabled,
+            // Now we need to send the event `Telemetry.NotebookStart` again indicating the fact that the ui is enabled & that the kernel was started successfully based on a user action.
+        }
+
+        this.uiWasDisabledWhenKernelStartupTelemetryWasLastSent = this.startupUI.disableUI === true;
+        // The corresponding failure telemetry property for the `Telemetry.NotebookStart` event will be sent in the Error Handler,
+        // after we analyze the error.
+        sendKernelTelemetryEvent(this.resourceUri, Telemetry.NotebookStart, undefined, {
+            disableUI: this.startupUI.disableUI
+        });
     }
 
     protected createProgressIndicator(disposables: IDisposable[]) {
@@ -722,6 +767,7 @@ export class Kernel extends BaseKernel<KernelExecution> implements IKernel {
     }
     public async executeCell(cell: NotebookCell, codeOverride?: string): Promise<NotebookCellRunState> {
         traceCellMessage(cell, `kernel.executeCell, ${getDisplayPath(cell.notebook.uri)}`);
+        initializeInteractiveOrNotebookTelemetryBasedOnUserAction(this.resourceUri, this.kernelConnectionMetadata);
         sendKernelTelemetryEvent(this.resourceUri, Telemetry.ExecuteCell);
         const stopWatch = new StopWatch();
         const sessionPromise = this.startJupyterSession();

--- a/src/kernels/kernel.ts
+++ b/src/kernels/kernel.ts
@@ -769,6 +769,7 @@ export class Kernel extends BaseKernel<KernelExecution> implements IKernel {
         traceCellMessage(cell, `kernel.executeCell, ${getDisplayPath(cell.notebook.uri)}`);
         initializeInteractiveOrNotebookTelemetryBasedOnUserAction(this.resourceUri, this.kernelConnectionMetadata);
         sendKernelTelemetryEvent(this.resourceUri, Telemetry.ExecuteCell);
+        this.sendKernelStartedTelemetry();
         const stopWatch = new StopWatch();
         const sessionPromise = this.startJupyterSession();
         const promise = this.kernelExecution.executeCell(sessionPromise, cell, codeOverride);

--- a/src/kernels/kernel.ts
+++ b/src/kernels/kernel.ts
@@ -41,7 +41,7 @@ import {
     initializeInteractiveOrNotebookTelemetryBasedOnUserAction,
     trackKernelResourceInformation
 } from './telemetry/helper';
-import { sendTelemetryEvent, Telemetry } from '../telemetry';
+import { Telemetry } from '../telemetry';
 import { executeSilently, getDisplayNameOrNameOfKernelConnection, isPythonKernelConnection } from './helpers';
 import {
     IKernel,
@@ -799,10 +799,18 @@ export class Kernel extends BaseKernel<KernelExecution> implements IKernel {
         // Setup telemetry
         if (!this.perceivedJupyterStartupTelemetryCaptured) {
             this.perceivedJupyterStartupTelemetryCaptured = true;
-            sendTelemetryEvent(Telemetry.PerceivedJupyterStartupNotebook, stopWatch.elapsedTime);
+            sendKernelTelemetryEvent(
+                this.resourceUri,
+                Telemetry.PerceivedJupyterStartupNotebook,
+                stopWatch.elapsedTime
+            );
             executionPromise
                 .finally(() =>
-                    sendTelemetryEvent(Telemetry.StartExecuteNotebookCellPerceivedCold, stopWatch.elapsedTime)
+                    sendKernelTelemetryEvent(
+                        this.resourceUri,
+                        Telemetry.StartExecuteNotebookCellPerceivedCold,
+                        stopWatch.elapsedTime
+                    )
                 )
                 .catch(noop);
         }

--- a/src/kernels/raw/launcher/kernelLauncher.node.ts
+++ b/src/kernels/raw/launcher/kernelLauncher.node.ts
@@ -21,7 +21,7 @@ import { IProcessServiceFactory, IPythonExecutionFactory } from '../../../platfo
 import { IDisposableRegistry, IConfigurationService, Resource } from '../../../platform/common/types';
 import { swallowExceptions } from '../../../platform/common/utils/decorators';
 import { DataScience } from '../../../platform/common/utils/localize';
-import { sendTelemetryEvent, Telemetry } from '../../../telemetry';
+import { Telemetry } from '../../../telemetry';
 import {
     isLocalConnection,
     LocalKernelSpecConnectionMetadata,
@@ -34,7 +34,7 @@ import { JupyterPaths } from '../finder/jupyterPaths.node';
 import { isTestExecution } from '../../../platform/common/constants';
 import { getDisplayPathFromLocalFile } from '../../../platform/common/platform/fs-paths.node';
 import { noop } from '../../../platform/common/utils/misc';
-import { sendKernelTelemetryWhenDone } from '../../telemetry/sendKernelTelemetryEvent';
+import { sendKernelTelemetryEvent, sendKernelTelemetryWhenDone } from '../../telemetry/sendKernelTelemetryEvent';
 import { PythonKernelInterruptDaemon } from '../finder/pythonKernelInterruptDaemon.node';
 import { IPlatformService } from '../../../platform/common/platform/types';
 
@@ -232,7 +232,7 @@ export class KernelLauncher implements IKernelLauncher {
 
         const disposable = kernelProcess.exited(
             ({ exitCode, reason }) => {
-                sendTelemetryEvent(Telemetry.RawKernelSessionKernelProcessExited, undefined, {
+                sendKernelTelemetryEvent(resource, Telemetry.RawKernelSessionKernelProcessExited, undefined, {
                     exitCode,
                     exitReason: getTelemetrySafeErrorMessageFromPythonTraceback(reason)
                 });

--- a/src/kernels/raw/session/hostRawNotebookProvider.node.ts
+++ b/src/kernels/raw/session/hostRawNotebookProvider.node.ts
@@ -21,13 +21,14 @@ import {
 import { createDeferred } from '../../../platform/common/utils/async';
 import { DataScience } from '../../../platform/common/utils/localize';
 import { trackKernelResourceInformation } from '../../telemetry/helper';
-import { captureTelemetry, sendTelemetryEvent, Telemetry } from '../../../telemetry';
+import { captureTelemetry, Telemetry } from '../../../telemetry';
 import { isPythonKernelConnection } from '../../helpers';
 import { IRawKernelConnectionSession, KernelConnectionMetadata } from '../../types';
 import { IKernelLauncher, IRawNotebookProvider, IRawNotebookSupportedService } from '../types';
 import { RawJupyterSession } from './rawJupyterSession.node';
 import { Cancellation } from '../../../platform/common/cancellation';
 import { noop } from '../../../platform/common/utils/misc';
+import { sendKernelTelemetryEvent } from '../../telemetry/sendKernelTelemetryEvent';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -91,9 +92,14 @@ export class HostRawNotebookProvider implements IRawNotebookProvider {
                 kernelConnection.kind === 'startUsingLocalKernelSpec'
             ) {
                 if (!kernelConnection.interpreter) {
-                    sendTelemetryEvent(Telemetry.AttemptedToLaunchRawKernelWithoutInterpreter, undefined, {
-                        pythonExtensionInstalled: this.extensionChecker.isPythonExtensionInstalled
-                    });
+                    sendKernelTelemetryEvent(
+                        resource,
+                        Telemetry.AttemptedToLaunchRawKernelWithoutInterpreter,
+                        undefined,
+                        {
+                            pythonExtensionInstalled: this.extensionChecker.isPythonExtensionInstalled
+                        }
+                    );
                 }
             }
             traceInfo(`Computing working directory for resource '${getDisplayPath(resource)}'`);

--- a/src/kernels/raw/session/rawJupyterSession.node.ts
+++ b/src/kernels/raw/session/rawJupyterSession.node.ts
@@ -20,7 +20,7 @@ import { DataScience } from '../../../platform/common/utils/localize';
 import { StopWatch } from '../../../platform/common/utils/stopWatch';
 import { sendKernelTelemetryEvent, sendKernelTelemetryWhenDone } from '../../telemetry/sendKernelTelemetryEvent';
 import { trackKernelResourceInformation } from '../../telemetry/helper';
-import { sendTelemetryEvent, captureTelemetry, Telemetry } from '../../../telemetry';
+import { captureTelemetry, Telemetry } from '../../../telemetry';
 import { getDisplayNameOrNameOfKernelConnection } from '../../../kernels/helpers';
 import { IRawKernelConnectionSession, ISessionWithSocket, KernelConnectionMetadata } from '../../../kernels/types';
 import { BaseJupyterSession } from '../../common/baseJupyterSession';
@@ -148,7 +148,7 @@ export class RawJupyterSession extends BaseJupyterSession implements IRawKernelC
         // We want to know why we got shut down
         const stacktrace = new Error().stack;
         return super.shutdownSession(session, statusHandler, isRequestToShutdownRestartSession).then(() => {
-            sendTelemetryEvent(Telemetry.RawKernelSessionShutdown, undefined, {
+            sendKernelTelemetryEvent(this.resource, Telemetry.RawKernelSessionShutdown, undefined, {
                 isRequestToShutdownRestartSession,
                 stacktrace
             });
@@ -174,7 +174,7 @@ export class RawJupyterSession extends BaseJupyterSession implements IRawKernelC
             if (session !== this.session) {
                 return;
             }
-            sendTelemetryEvent(Telemetry.RawKernelSessionKernelProcessExited, undefined, {
+            sendKernelTelemetryEvent(this.resource, Telemetry.RawKernelSessionKernelProcessExited, undefined, {
                 exitCode,
                 exitReason: getTelemetrySafeErrorMessageFromPythonTraceback(reason)
             });
@@ -349,7 +349,7 @@ export class RawJupyterSession extends BaseJupyterSession implements IRawKernelC
         } else {
             traceWarning(`Didn't get response for requestKernelInfo after ${stopWatch.elapsedTime}ms.`);
         }
-        sendTelemetryEvent(Telemetry.RawKernelInfoResonse, stopWatch.elapsedTime, {
+        sendKernelTelemetryEvent(this.resource, Telemetry.RawKernelInfoResonse, stopWatch.elapsedTime, {
             attempts,
             timedout: !gotIoPubMessage.completed
         });

--- a/src/kernels/raw/session/rawSession.node.ts
+++ b/src/kernels/raw/session/rawSession.node.ts
@@ -10,10 +10,11 @@ import { traceVerbose, traceInfoIfCI, traceError, traceWarning } from '../../../
 import { IDisposable, Resource } from '../../../platform/common/types';
 import { createDeferred, sleep } from '../../../platform/common/utils/async';
 import { KernelConnectionTimeoutError } from '../../errors/kernelConnectionTimeoutError';
-import { sendTelemetryEvent, Telemetry } from '../../../telemetry';
+import { Telemetry } from '../../../telemetry';
 import { ISessionWithSocket, KernelConnectionMetadata, KernelSocketInformation } from '../../types';
 import { IKernelProcess } from '../types';
 import { createRawKernel, RawKernel } from './rawKernel.node';
+import { sendKernelTelemetryEvent } from '../../telemetry/sendKernelTelemetryEvent';
 
 /*
 RawSession class implements a jupyterlab ISession object
@@ -98,7 +99,7 @@ export class RawSession implements ISessionWithSocket {
     public async dispose() {
         // We want to know who called dispose on us
         const stacktrace = new Error().stack;
-        sendTelemetryEvent(Telemetry.RawKernelSessionDisposed, undefined, { stacktrace });
+        sendKernelTelemetryEvent(this.resource, Telemetry.RawKernelSessionDisposed, undefined, { stacktrace });
 
         // Now actually dispose ourselves
         this.isDisposing = true;
@@ -279,7 +280,7 @@ export class RawSession implements ISessionWithSocket {
         traceError(`Disposing session as kernel process died ExitCode: ${e.exitCode}, Reason: ${e.reason}`);
         // Send telemetry so we know why the kernel process exited,
         // as this affects our kernel startup success
-        sendTelemetryEvent(Telemetry.RawKernelSessionKernelProcessExited, undefined, {
+        sendKernelTelemetryEvent(this.resource, Telemetry.RawKernelSessionKernelProcessExited, undefined, {
             exitCode: e.exitCode,
             exitReason: getTelemetrySafeErrorMessageFromPythonTraceback(e.reason)
         });

--- a/src/kernels/telemetry/helper.ts
+++ b/src/kernels/telemetry/helper.ts
@@ -90,6 +90,8 @@ export function trackKernelResourceInformation(resource: Resource, information: 
         if (context.previouslySelectedKernelConnectionId !== newKernelConnectionId) {
             clearInterruptCounter(resource);
             clearRestartCounter(resource);
+            currentData.userExecutedCell = information.userExecutedCell;
+            currentData.disableUI = information.disableUI;
         }
         if (
             context.previouslySelectedKernelConnectionId &&

--- a/src/kernels/telemetry/helper.ts
+++ b/src/kernels/telemetry/helper.ts
@@ -12,7 +12,6 @@ import { getComparisonKey } from '../../platform/vscode-path/resources';
 import { getFilePath } from '../../platform/common/platform/fs-paths';
 import { trackedInfo, pythonEnvironmentsByHash, updatePythonPackages } from '../../platform/telemetry/telemetry';
 import { KernelActionSource, KernelConnectionMetadata } from '../types';
-import { setSharedProperty } from '../../telemetry';
 
 /**
  * This information is sent with each telemetry event.
@@ -37,6 +36,15 @@ export type ContextualTelemetryProps = {
      */
     interpreterMatchesKernel: boolean;
     actionSource: KernelActionSource;
+    /**
+     * Whether the user executed a cell.
+     */
+    userExecutedCell?: boolean;
+    /**
+     * Whether the notebook startup UI (progress indicator & the like) was displayed to the user or not.
+     * If its not displayed, then its considered an auto start (start in the background, like pre-warming kernel)
+     */
+    disableUI?: boolean;
 };
 
 export function trackKernelResourceInformation(resource: Resource, information: Partial<ContextualTelemetryProps>) {
@@ -68,7 +76,12 @@ export function trackKernelResourceInformation(resource: Resource, information: 
     currentData.kernelLiveCount = information.kernelLiveCount || currentData.kernelLiveCount || 0;
     currentData.kernelInterpreterCount = information.kernelInterpreterCount || currentData.kernelInterpreterCount || 0;
     currentData.pythonEnvironmentCount = InterpreterCountTracker.totalNumberOfInterpreters;
-
+    if (information.userExecutedCell) {
+        currentData.userExecutedCell = true;
+    }
+    if (typeof information.disableUI === 'boolean') {
+        currentData.disableUI = information.disableUI;
+    }
     const kernelConnection = information.kernelConnection;
     if (kernelConnection) {
         const newKernelConnectionId = kernelConnection.id;
@@ -141,8 +154,7 @@ export function initializeInteractiveOrNotebookTelemetryBasedOnUserAction(
     resourceUri: Resource,
     kernelConnection: KernelConnectionMetadata
 ) {
-    setSharedProperty('userExecutedCell', 'true');
-    trackKernelResourceInformation(resourceUri, { kernelConnection });
+    trackKernelResourceInformation(resourceUri, { kernelConnection, userExecutedCell: true });
 }
 
 export function clearInterruptCounter(resource: Resource) {

--- a/src/kernels/telemetry/sendKernelTelemetryEvent.ts
+++ b/src/kernels/telemetry/sendKernelTelemetryEvent.ts
@@ -3,7 +3,7 @@
 
 import { Resource } from '../../platform/common/types';
 import { Telemetry } from '../../platform/common/constants';
-import { setSharedProperty, sendTelemetryEvent, waitBeforeSending, IEventNamePropertyMapping } from '../../telemetry';
+import { sendTelemetryEvent, waitBeforeSending, IEventNamePropertyMapping } from '../../telemetry';
 import { getContextualPropsForTelemetry } from '../../platform/telemetry/telemetry';
 import { clearInterruptCounter, trackKernelResourceInformation } from './helper';
 import { StopWatch } from '../../platform/common/utils/stopWatch';
@@ -35,10 +35,6 @@ export function sendKernelTelemetryEvent<P extends IEventNamePropertyMapping, E 
     properties?: P[E] & { waitBeforeSending?: Promise<void> },
     ex?: Error
 ) {
-    if (eventName === Telemetry.ExecuteCell) {
-        setSharedProperty('userExecutedCell', 'true');
-    }
-
     const props = getContextualPropsForTelemetry(resource);
     Object.assign(props, properties || {});
     sendTelemetryEvent(
@@ -72,9 +68,6 @@ export function sendKernelTelemetryWhenDone<P extends IEventNamePropertyMapping,
     handleError: boolean,
     properties?: P[E] & { [waitBeforeSending]?: Promise<void> }
 ) {
-    if (eventName === Telemetry.ExecuteCell) {
-        setSharedProperty('userExecutedCell', 'true');
-    }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const props: any = properties || {};
     const stopWatch = new StopWatch();

--- a/src/notebooks/notebookCommandListener.ts
+++ b/src/notebooks/notebookCommandListener.ts
@@ -25,7 +25,7 @@ import { IKernel, IKernelProvider } from '../kernels/types';
 import { getDisplayPath } from '../platform/common/platform/fs-paths';
 import { DataScience } from '../platform/common/utils/localize';
 import { traceInfoIfCI, traceInfo } from '../platform/logging';
-import { sendTelemetryEvent, Telemetry } from '../telemetry';
+import { Telemetry } from '../telemetry';
 import { trackKernelResourceInformation } from '../kernels/telemetry/helper';
 import { INotebookEditorProvider } from './types';
 import { IServiceContainer } from '../platform/ioc/types';
@@ -35,6 +35,7 @@ import { IDataScienceErrorHandler } from '../kernels/errors/types';
 import { getNotebookMetadata } from '../platform/common/utils';
 import { KernelConnector } from './controllers/kernelConnector';
 import { IControllerSelection } from './controllers/types';
+import { sendKernelTelemetryEvent } from '../kernels/telemetry/sendKernelTelemetryEvent';
 
 /**
  * Registers commands specific to the notebook UI
@@ -208,10 +209,10 @@ export class NotebookCommandListener implements IDataScienceCommandListener {
             return;
         }
 
-        sendTelemetryEvent(Telemetry.RestartKernelCommand);
         const kernel = this.kernelProvider.get(document);
 
         if (kernel) {
+            sendKernelTelemetryEvent(kernel.resourceUri, Telemetry.RestartKernelCommand);
             trackKernelResourceInformation(kernel.resourceUri, { restartKernel: true });
             if (await this.shouldAskForRestart(document.uri)) {
                 // Ask the user if they want us to restart or not.

--- a/src/platform/telemetry/index.ts
+++ b/src/platform/telemetry/index.ts
@@ -156,10 +156,7 @@ export function sendTelemetryEvent<P extends IEventNamePropertyMapping, E extend
     }
     // If stuff is already queued, then queue the rest.
     // Queue telemetry for now only in insiders.
-    if (
-        sharedProperties['isInsiderExtension'] === 'true' &&
-        (isPromise(properties?.waitBeforeSending) || queuedTelemetry.length)
-    ) {
+    if (isPromise(properties?.waitBeforeSending) || queuedTelemetry.length) {
         queuedTelemetry.push({
             eventName: eventName as string,
             durationMs,

--- a/src/platform/telemetry/index.ts
+++ b/src/platform/telemetry/index.ts
@@ -392,14 +392,6 @@ export function sendTelemetryWhenDone<P extends IEventNamePropertyMapping, E ext
  */
 export interface ISharedPropertyMapping {
     /**
-     * Whether user ran a cell or not.
-     * Its possible we have auto start enabled, in which case things could fall over
-     * (jupyter not start, kernel not start), and these are all not user initiated events.
-     * Hence sending telemetry indicating failure in starting a kernel could be misleading.
-     * This tells us that user started the action.
-     */
-    userExecutedCell: 'true';
-    /**
      * For every DS telemetry we would like to know the type of Notebook Editor used when doing something.
      */
     ['ds_notebookeditor']: undefined | 'old' | 'custom' | 'native';

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -432,7 +432,7 @@ export interface IEventNamePropertyMapping {
     /**
      * Time take for jupyter server to be busy from the time user first hit `run` cell until jupyter reports it is busy running a cell.
      */
-    [Telemetry.StartExecuteNotebookCellPerceivedCold]: never | undefined;
+    [Telemetry.StartExecuteNotebookCellPerceivedCold]: ResourceSpecificTelemetryProperties;
     [Telemetry.ExpandAll]: never | undefined;
     [Telemetry.ExportNotebookInteractive]: never | undefined;
     /**

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -34,6 +34,10 @@ export * from './platform/telemetry/index';
 export type ResourceSpecificTelemetryProperties = Partial<{
     resourceType: 'notebook' | 'interactive';
     /**
+     * Whether the user executed a cell.
+     */
+    userExecutedCell?: boolean;
+    /**
      * Hash of the Kernel Connection id.
      */
     kernelId: string;
@@ -424,7 +428,7 @@ export interface IEventNamePropertyMapping {
      * Time take for jupyter server to start and be ready to run first user cell.
      * (Note: The property `notebook` only gets sent correctly in Jupyter version 2022.8.0 or later)
      */
-    [Telemetry.PerceivedJupyterStartupNotebook]: never | undefined;
+    [Telemetry.PerceivedJupyterStartupNotebook]: ResourceSpecificTelemetryProperties;
     /**
      * Time take for jupyter server to be busy from the time user first hit `run` cell until jupyter reports it is busy running a cell.
      */

--- a/src/test/kernels/kernelProvider.node.unit.test.ts
+++ b/src/test/kernels/kernelProvider.node.unit.test.ts
@@ -202,12 +202,12 @@ suite('KernelProvider Node', () => {
         };
 
         // Dispose the first kernel
-        const kernel = kernelProvider.getOrCreate(sampleNotebook1, options);
+        const kernel = kernelProvider.getOrCreate(instance(sampleNotebook1), options);
         await kernel.dispose();
 
         assert.isTrue(kernel.disposed, 'Kernel should be disposed');
         assert.isUndefined(kernelProvider.get(sampleUri1), 'Should not return an instance as kernel was disposed');
-        const newKernel = kernelProvider.getOrCreate(sampleNotebook1, options);
+        const newKernel = kernelProvider.getOrCreate(instance(sampleNotebook1), options);
         asyncDisposables.push(newKernel);
         assert.notEqual(kernel, newKernel, 'Should return a different instance');
     });


### PR DESCRIPTION
This ensures we can better track failures per environment instead of checking if things fail in generate for a machine id.

* When sending the telemetry we check if the user actually executed a cell for a particular kernel (notebook)
* When user starts a cell, we re-send the telemetry that indicates whether the notebook was successfully started or not.