### PR TITLE
Fix/Reenable some RBL tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -157,7 +157,7 @@
                 "@types/strip-comments": "^2.0.1",
                 "@types/tcp-port-used": "^1.0.0",
                 "@types/temp": "^0.8.32",
-                "@types/tmp": "0.0.33",
+                "@types/tmp": "^0.2.3",
                 "@types/untildify": "^3.0.0",
                 "@types/url-parse": "^1.4.8",
                 "@types/uuid": "^3.4.3",
@@ -4055,9 +4055,9 @@
             }
         },
         "node_modules/@types/tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
+            "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
             "dev": true
         },
         "node_modules/@types/tough-cookie": {
@@ -27901,9 +27901,9 @@
             }
         },
         "@types/tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
+            "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
             "dev": true
         },
         "@types/tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -2337,7 +2337,7 @@
         "@types/strip-comments": "^2.0.1",
         "@types/tcp-port-used": "^1.0.0",
         "@types/temp": "^0.8.32",
-        "@types/tmp": "0.0.33",
+        "@types/tmp": "^0.2.3",
         "@types/untildify": "^3.0.0",
         "@types/url-parse": "^1.4.8",
         "@types/uuid": "^3.4.3",

--- a/src/platform/common/platform/fileSystem.node.ts
+++ b/src/platform/common/platform/fileSystem.node.ts
@@ -35,7 +35,7 @@ export class FileSystem extends FileSystemBase implements IFileSystemNode {
     ): Promise<TemporaryFile> {
         const suffix = typeof options === 'string' ? options : options.fileExtension;
         const prefix = options && typeof options === 'object' ? options.prefix : undefined;
-        const opts: tmp.Options = {
+        const opts: tmp.FileOptions = {
             postfix: suffix,
             prefix
         };

--- a/src/test/datascience/debugger.vscode.test.ts
+++ b/src/test/datascience/debugger.vscode.test.ts
@@ -193,7 +193,7 @@ suite('VSCode Notebook - Run By Line', function () {
         );
     });
 
-    test.skip('Stops in same-cell function called from last line', async function () {
+    test('Stops in same-cell function called from last line', async function () {
         const cell = await insertCodeCell('def foo():\n    print(1)\n\nfoo()', { index: 0 });
         const doc = vscodeNotebook.activeNotebookEditor?.notebook!;
 
@@ -204,9 +204,7 @@ suite('VSCode Notebook - Run By Line', function () {
         await commandManager.executeCommand(Commands.RunByLineNext, cell);
         await waitForStoppedEvent(debugAdapter!); // foo()
         await commandManager.executeCommand(Commands.RunByLineNext, cell);
-        await waitForStoppedEvent(debugAdapter!); // def foo
-        await commandManager.executeCommand(Commands.RunByLineNext, cell);
-        const stoppedEvent = await waitForStoppedEvent(debugAdapter!); // print(1)
+        const stoppedEvent = await waitForStoppedEvent(debugAdapter!); // print(1) inside def foo
         const stack: DebugProtocol.StackTraceResponse['body'] = await session!.customRequest('stackTrace', {
             threadId: stoppedEvent.body.threadId
         });
@@ -224,7 +222,7 @@ suite('VSCode Notebook - Run By Line', function () {
         assert.equal(stack2.stackFrames[0].line, 4, 'Stopped at the wrong line');
     });
 
-    test.skip('Does not stop in other cell', async function () {
+    test('Does not stop in other cell', async function () {
         // https://github.com/microsoft/vscode-jupyter/issues/8757
         const cell0 = await insertCodeCell('def foo():\n    print(1)');
         const cell1 = await insertCodeCell('foo()');
@@ -247,10 +245,10 @@ suite('VSCode Notebook - Run By Line', function () {
         );
     });
 
-    test.skip('Run a second time after interrupt', async function () {
+    test('Run a second time after interrupt', async function () {
         // https://github.com/microsoft/vscode-jupyter/issues/8753
         await insertCodeCell(
-            'import time\nfor i in range(0,50):\n  time.sleep(.1)\n  print("sleepy")\nprint("final output")',
+            'import time\nfor i in range(0,50):\n  time.sleep(.1)\n  print("sleepy")\nprint("final " + "output")',
             {
                 index: 0
             }
@@ -283,7 +281,8 @@ suite('VSCode Notebook - Run By Line', function () {
                 return getCellOutputs(cell).includes('sleepy');
             },
             defaultNotebookTestTimeout,
-            'Print during time loop is not working'
+            'Print during time loop is not working',
+            1000
         );
         await commandManager.executeCommand(Commands.RunByLineStop);
         await waitForCondition(


### PR DESCRIPTION
Fixes #11137

The same-cell test just needs to be adjusted for new behavior in debugpy 1.6.3, which is actually better.

The second test seems fine and I'll investigate if it's flaky

The third wasn't checking outputs correctly, and needs a slower timeout when stepping, that is fixed

And i also launch tests with a fixed extensions-dir, which is helpful when debugging, otherwise it uses my real code-insiders extensions dir