### PR TITLE
Bump @actions/core from 1.6.0 to 1.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
                 "zeromq": "^6.0.0-beta.6"
             },
             "devDependencies": {
-                "@actions/core": "^1.2.6",
+                "@actions/core": "^1.9.1",
                 "@actions/github": "^4.0.0",
                 "@actions/glob": "^0.3.0",
                 "@babel/cli": "^7.15.4",
@@ -300,12 +300,31 @@
             "dev": true
         },
         "node_modules/@actions/core": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
-            "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
+            "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
             "dev": true,
             "dependencies": {
-                "@actions/http-client": "^1.0.11"
+                "@actions/http-client": "^2.0.1",
+                "uuid": "^8.3.2"
+            }
+        },
+        "node_modules/@actions/core/node_modules/@actions/http-client": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+            "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+            "dev": true,
+            "dependencies": {
+                "tunnel": "^0.0.6"
+            }
+        },
+        "node_modules/@actions/core/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@actions/github": {
@@ -24709,12 +24728,30 @@
     },
     "dependencies": {
         "@actions/core": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
-            "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
+            "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
             "dev": true,
             "requires": {
-                "@actions/http-client": "^1.0.11"
+                "@actions/http-client": "^2.0.1",
+                "uuid": "^8.3.2"
+            },
+            "dependencies": {
+                "@actions/http-client": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+                    "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+                    "dev": true,
+                    "requires": {
+                        "tunnel": "^0.0.6"
+                    }
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+                    "dev": true
+                }
             }
         },
         "@actions/github": {

--- a/package.json
+++ b/package.json
@@ -2261,7 +2261,7 @@
         "zeromq": "^6.0.0-beta.6"
     },
     "devDependencies": {
-        "@actions/core": "^1.2.6",
+        "@actions/core": "^1.9.1",
         "@actions/github": "^4.0.0",
         "@actions/glob": "^0.3.0",
         "@babel/cli": "^7.15.4",


### PR DESCRIPTION
dependabot update but including the required `npm install` step.
fixes a warning that comes when pushing