### PR TITLE
Use workspace folder as source in dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
     // Add the IDs of extensions you want installed when the container is created.
     "extensions": ["ms-python.python", "ms-python.vscode-pylance", "ms-vscode.vscode-typescript-tslint-plugin"],
     "mounts": [
-        "source=${localEnv:HOME}${localEnv:USERPROFILE}/Desktop/Development,target=/workspaces/local,type=bind,consistency=cached"
+        "source=${localWorkspaceFolder},target=/workspaces/local,type=bind,consistency=cached"
     ],
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],


### PR DESCRIPTION
Instead of using fixed folder path `${usr}/Desktop/Development`, we can use the builtin variable localWorkspaceFolder as the mounting source, to allow the dev container to run in all our machines.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
