### PR TITLE
enable settings telemetry

### DIFF
--- a/TELEMETRY.csv
+++ b/TELEMETRY.csv
@@ -2526,6 +2526,8 @@ selectAnotherInterpreter - Selected another interpreter.","","'notSelected'
 'selected' 
 'installationCancelled' 
 'selectAnotherInterpreter' ",true
+"DS_INTERNAL.SETTINGS","The list of settings a user has set. Sent on activation.","Telemetry.DataScienceSettings","amunger","N/A","","","settingsJson","A json representation of settings that the user has set.
+The values for string based settings are transalted to 'default' | 'non-default' unless white-listed.","string","",false
 "DS_INTERNAL.SHIFTENTER_BANNER_SHOWN","Information banner displayed to give the user the option to configure shift+enter for the Interactive Window.","Telemetry.ShiftEnterBannerShown","amunger","InteractiveWindow","","","","","","",""
 "DS_INTERNAL.SHOW_DATA_NO_PANDAS","User tried to open the data viewer and Pandas package was not installed.
 Note: Not a failure state, as we prompt for install after this.","Telemetry.PandasNotInstalled","IanMatthewHuff","DataFrameViewer","","","","","","",""

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -4643,6 +4643,18 @@ In such cases we do not notify user of any failures or the like.
             - `'selectAnotherInterpreter'`  
 
 
+* DS_INTERNAL.SETTINGS  (Telemetry.DataScienceSettings)  
+      Owner: [@amunger](https://github.com/amunger)  
+    ```
+    The list of settings a user has set. Sent on activation.  
+    ```
+
+    - Properties:  
+        - `settingsJson`: `string`  
+        A json representation of settings that the user has set.  
+        The values for string based settings are transalted to 'default' | 'non-default' unless white-listed.  
+
+
 * DS_INTERNAL.SHIFTENTER_BANNER_SHOWN  (Telemetry.ShiftEnterBannerShown)  
       Owner: [@amunger](https://github.com/amunger)  
     ```

--- a/src/gdpr.ts
+++ b/src/gdpr.ts
@@ -7281,6 +7281,50 @@
      ]
    }
  */
+//Telemetry.DataScienceSettings
+/* __GDPR__
+   "DS_INTERNAL.SETTINGS" : {
+     "settingsJson": {"classification":"SystemMetaData","purpose":"SystemMetaData","comment":"A json representation of settings that the user has set. The values for string based settings are transalted to 'default' | 'non-default' unless white-listed.","owner":"amunger"},
+     "${include}": [
+       "${F1}",
+       "${F2}",
+       "${F3}",
+       "${F4}",
+       "${F5}",
+       "${F6}",
+       "${F7}",
+       "${F8}",
+       "${F9}",
+       "${F10}",
+       "${F11}",
+       "${F12}",
+       "${F13}",
+       "${F14}",
+       "${F15}",
+       "${F16}",
+       "${F17}",
+       "${F18}",
+       "${F19}",
+       "${F20}",
+       "${F21}",
+       "${F22}",
+       "${F23}",
+       "${F24}",
+       "${F25}",
+       "${F26}",
+       "${F27}",
+       "${F28}",
+       "${F29}",
+       "${F30}",
+       "${F31}",
+       "${F32}",
+       "${F33}",
+       "${F34}",
+       "${F35}",
+       "${F36}"
+     ]
+   }
+ */
 //Telemetry.ShiftEnterBannerShown
 /* __GDPR__
    "DS_INTERNAL.SHIFTENTER_BANNER_SHOWN" : {

--- a/src/standalone/activation/globalActivation.ts
+++ b/src/standalone/activation/globalActivation.ts
@@ -6,7 +6,7 @@ import type { JSONObject } from '@lumino/coreutils';
 import { inject, injectable, multiInject, optional } from 'inversify';
 import * as vscode from 'vscode';
 import { ICommandManager, IDocumentManager, IWorkspaceService } from '../../platform/common/application/types';
-import { PYTHON_FILE_ANY_SCHEME, PYTHON_LANGUAGE } from '../../platform/common/constants';
+import { PYTHON_FILE_ANY_SCHEME, PYTHON_LANGUAGE, Telemetry } from '../../platform/common/constants';
 import { ContextKey } from '../../platform/common/contextKey';
 import '../../platform/common/extensions';
 import {
@@ -23,6 +23,7 @@ import { IExtensionSingleActivationService } from '../../platform/activation/typ
 import { IDataScienceCodeLensProvider } from '../../interactive-window/editor-integration/types';
 import { IRawNotebookSupportedService } from '../../kernels/raw/types';
 import { hasCells } from '../../interactive-window/editor-integration/cellFactory';
+import { sendTelemetryEvent } from '../../telemetry';
 
 /**
  * Singleton class that activate a bunch of random things that didn't fit anywhere else.
@@ -148,7 +149,10 @@ export class GlobalActivation implements IExtensionSingleActivationService {
                     resultSettings[k] = currentValue;
                 }
             }
-            // sendTelemetryEvent(Telemetry.DataScienceSettings, undefined, resultSettings);
+
+            sendTelemetryEvent(Telemetry.DataScienceSettings, undefined, {
+                settingsJson: JSON.stringify(resultSettings)
+            });
         }
     }
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -922,10 +922,26 @@ export class IEventNamePropertyMapping {
         source: 'N/A',
         tags: ['KernelStartup']
     };
-    // [Telemetry.DataScienceSettings]: TelemetryEventInfo<{}> = {
-    //     owner: 'unknown',
-    //     feature: 'N/A'
-    // } as any;
+    /**
+     * The list of settings a user has set. Sent on activation.
+     */
+    [Telemetry.DataScienceSettings]: TelemetryEventInfo<{
+        /**
+         * A json representation of settings that the user has set.
+         * The values for string based settings are transalted to 'default' | 'non-default' unless white-listed.
+         */
+        settingsJson: string;
+    }> = {
+        owner: 'amunger',
+        feature: 'N/A',
+        source: 'N/A',
+        properties: {
+            settingsJson: {
+                classification: 'SystemMetaData',
+                purpose: 'FeatureInsight'
+            }
+        }
+    };
     /**
      * Telemetry event sent when user hits the `continue` button while debugging IW
      */


### PR DESCRIPTION
https://github.com/microsoft/vscode-jupyter-internal/issues/340

re-enabled telemetry for user settings. For string-based settings, only `interactiveWindowMode` has been white-listed to send the actual value.