### PR TITLE
increase timeout for perf tests

### DIFF
--- a/src/test/performance/notebookCellExecution.perf.test.ts
+++ b/src/test/performance/notebookCellExecution.perf.test.ts
@@ -12,6 +12,7 @@ import { activateExtension, initializePython } from '../initialize.node';
 import { PerformanceTracker } from './performanceTracker';
 
 suite('Initial Notebook Cell Execution Perf Test', function () {
+    this.timeout(120_000);
     let tracker: PerformanceTracker;
     setup(function () {
         sinon.restore();


### PR DESCRIPTION
bring the timeout more in line with other Integration tests, the telemetry also shows that it may actually be taking over a minute in some runs.