### PR TITLE
Remove unneeded perfTelemetry

### DIFF
--- a/TELEMETRY.csv
+++ b/TELEMETRY.csv
@@ -24,16 +24,11 @@ the slice control panel. `source` is one of `dropdown`,
 `textbox`, or `checkbox`.","","dropdown ()
 textbox ()
 checkbox ()",false
-"DATASCIENCE.DEBUG_CONTINUE","Telemetry event sent when user hits the `continue` button while debugging IW","Telemetry.DebugContinue","roblourens","Debugger","","","duration","Duration of a measure in milliseconds.
-Common measurement used across a number of events.","number","",false
-"DATASCIENCE.DEBUG_CURRENT_CELL","Telemetry event sent when user debugs the cell in the IW","Telemetry.DebugCurrentCell","roblourens","Debugger","","","duration","Duration of a measure in milliseconds.
-Common measurement used across a number of events.","number","",false
-"DATASCIENCE.DEBUG_FILE_INTERACTIVE","Telemetry event sent when user debugs the file in the IW","Telemetry.DebugFileInteractive","roblourens","Debugger","","","duration","Duration of a measure in milliseconds.
-Common measurement used across a number of events.","number","",false
-"DATASCIENCE.DEBUG_STEP_OVER","Telemetry event sent when user hits the `step over` button while debugging IW","Telemetry.DebugStepOver","roblourens","Debugger","","","duration","Duration of a measure in milliseconds.
-Common measurement used across a number of events.","number","",false
-"DATASCIENCE.DEBUG_STOP","Telemetry event sent when user hits the `stop` button while debugging IW","Telemetry.DebugStop","roblourens","Debugger","","","duration","Duration of a measure in milliseconds.
-Common measurement used across a number of events.","number","",false
+"DATASCIENCE.DEBUG_CONTINUE","Telemetry event sent when user hits the `continue` button while debugging IW","Telemetry.DebugContinue","roblourens","Debugger","","","","","","",""
+"DATASCIENCE.DEBUG_CURRENT_CELL","Telemetry event sent when user debugs the cell in the IW","Telemetry.DebugCurrentCell","roblourens","Debugger","","","","","","",""
+"DATASCIENCE.DEBUG_FILE_INTERACTIVE","Telemetry event sent when user debugs the file in the IW","Telemetry.DebugFileInteractive","roblourens","Debugger","","","","","","",""
+"DATASCIENCE.DEBUG_STEP_OVER","Telemetry event sent when user hits the `step over` button while debugging IW","Telemetry.DebugStepOver","roblourens","Debugger","","","","","","",""
+"DATASCIENCE.DEBUG_STOP","Telemetry event sent when user hits the `stop` button while debugging IW","Telemetry.DebugStop","roblourens","Debugger","","","","","","",""
 "DATASCIENCE.DEBUGGING.CLICKED_ON_SETUP","Sent when the user accepts the prompt to install ipykernel 6 automatically.","DebuggingTelemetry.clickedOnSetup","roblourens","Debugger","","","","","","",""
 "DATASCIENCE.DEBUGGING.CLICKED_RUN_AND_DEBUG_CELL","Sent when the user attempts to start debugging a notebook cell.","DebuggingTelemetry.clickedRunAndDebugCell","roblourens","Debugger","","","","","","",""
 "DATASCIENCE.DEBUGGING.CLICKED_RUNBYLINE","Sent when the user attempts to start run by line.","DebuggingTelemetry.clickedRunByLine","roblourens","Debugger","","","","","","",""

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -96,10 +96,6 @@ Expand each section to see more information about that event.
     Telemetry event sent when user hits the `continue` button while debugging IW  
     ```
 
-    - Measures:  
-        - `duration`: `number`  
-        Duration of a measure in milliseconds.  
-        Common measurement used across a number of events.  
 
 
 * DATASCIENCE.DEBUG_CURRENT_CELL  (Telemetry.DebugCurrentCell)  
@@ -108,10 +104,6 @@ Expand each section to see more information about that event.
     Telemetry event sent when user debugs the cell in the IW  
     ```
 
-    - Measures:  
-        - `duration`: `number`  
-        Duration of a measure in milliseconds.  
-        Common measurement used across a number of events.  
 
 
 * DATASCIENCE.DEBUG_FILE_INTERACTIVE  (Telemetry.DebugFileInteractive)  
@@ -120,10 +112,6 @@ Expand each section to see more information about that event.
     Telemetry event sent when user debugs the file in the IW  
     ```
 
-    - Measures:  
-        - `duration`: `number`  
-        Duration of a measure in milliseconds.  
-        Common measurement used across a number of events.  
 
 
 * DATASCIENCE.DEBUG_STEP_OVER  (Telemetry.DebugStepOver)  
@@ -132,10 +120,6 @@ Expand each section to see more information about that event.
     Telemetry event sent when user hits the `step over` button while debugging IW  
     ```
 
-    - Measures:  
-        - `duration`: `number`  
-        Duration of a measure in milliseconds.  
-        Common measurement used across a number of events.  
 
 
 * DATASCIENCE.DEBUG_STOP  (Telemetry.DebugStop)  
@@ -144,10 +128,6 @@ Expand each section to see more information about that event.
     Telemetry event sent when user hits the `stop` button while debugging IW  
     ```
 
-    - Measures:  
-        - `duration`: `number`  
-        Duration of a measure in milliseconds.  
-        Common measurement used across a number of events.  
 
 
 * DATASCIENCE.DEBUGGING.CLICKED_ON_SETUP  (DebuggingTelemetry.clickedOnSetup)  

--- a/src/interactive-window/commands/commandRegistry.ts
+++ b/src/interactive-window/commands/commandRegistry.ts
@@ -418,7 +418,7 @@ export class CommandRegistry implements IDisposable, IExtensionSingleActivationS
         }
     }
 
-    @capturePerfTelemetry(Telemetry.DebugStepOver)
+    @captureUsageTelemetry(Telemetry.DebugStepOver)
     private async debugStepOver(): Promise<void> {
         // Make sure that we are in debug mode
         if (this.debugService?.activeDebugSession) {
@@ -426,7 +426,7 @@ export class CommandRegistry implements IDisposable, IExtensionSingleActivationS
         }
     }
 
-    @capturePerfTelemetry(Telemetry.DebugStop)
+    @captureUsageTelemetry(Telemetry.DebugStop)
     private async debugStop(uri: Uri): Promise<void> {
         // Make sure that we are in debug mode
         if (this.debugService?.activeDebugSession && this.interactiveWindowProvider) {
@@ -444,7 +444,7 @@ export class CommandRegistry implements IDisposable, IExtensionSingleActivationS
         }
     }
 
-    @capturePerfTelemetry(Telemetry.DebugContinue)
+    @captureUsageTelemetry(Telemetry.DebugContinue)
     private async debugContinue(): Promise<void> {
         // Make sure that we are in debug mode
         if (this.debugService?.activeDebugSession) {

--- a/src/interactive-window/editor-integration/codewatcher.ts
+++ b/src/interactive-window/editor-integration/codewatcher.ts
@@ -115,7 +115,7 @@ export class CodeWatcher implements ICodeWatcher {
         return this.codeLenses;
     }
 
-    @capturePerfTelemetry(Telemetry.DebugCurrentCell)
+    @captureUsageTelemetry(Telemetry.DebugCurrentCell)
     public async debugCurrentCell() {
         if (!this.documentManager.activeTextEditor || !this.documentManager.activeTextEditor.document) {
             return;
@@ -179,7 +179,7 @@ export class CodeWatcher implements ICodeWatcher {
         return this.runFileInteractiveInternal(false);
     }
 
-    @capturePerfTelemetry(Telemetry.DebugFileInteractive)
+    @captureUsageTelemetry(Telemetry.DebugFileInteractive)
     public async debugFileInteractive() {
         return this.runFileInteractiveInternal(true);
     }
@@ -313,7 +313,7 @@ export class CodeWatcher implements ICodeWatcher {
         return this.runMatchingCell(range, advance);
     }
 
-    @capturePerfTelemetry(Telemetry.DebugCurrentCell)
+    @captureUsageTelemetry(Telemetry.DebugCurrentCell)
     public async debugCell(range: Range): Promise<void> {
         if (!this.documentManager.activeTextEditor || !this.documentManager.activeTextEditor.document) {
             return;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -929,47 +929,42 @@ export class IEventNamePropertyMapping {
     /**
      * Telemetry event sent when user hits the `continue` button while debugging IW
      */
-    [Telemetry.DebugContinue]: TelemetryEventInfo<DurationMeasurement> = {
+    [Telemetry.DebugContinue]: TelemetryEventInfo<never | undefined> = {
         owner: 'roblourens',
         feature: ['Debugger'],
-        source: 'User Action',
-        measures: commonClassificationForDurationProperties()
+        source: 'User Action'
     };
     /**
      * Telemetry event sent when user debugs the cell in the IW
      */
-    [Telemetry.DebugCurrentCell]: TelemetryEventInfo<DurationMeasurement> = {
+    [Telemetry.DebugCurrentCell]: TelemetryEventInfo<never | undefined> = {
         owner: 'roblourens',
         feature: ['Debugger'],
-        source: 'User Action',
-        measures: commonClassificationForDurationProperties()
+        source: 'User Action'
     };
     /**
      * Telemetry event sent when user hits the `step over` button while debugging IW
      */
-    [Telemetry.DebugStepOver]: TelemetryEventInfo<DurationMeasurement> = {
+    [Telemetry.DebugStepOver]: TelemetryEventInfo<never | undefined> = {
         owner: 'roblourens',
         feature: ['Debugger'],
-        source: 'User Action',
-        measures: commonClassificationForDurationProperties()
+        source: 'User Action'
     };
     /**
      * Telemetry event sent when user hits the `stop` button while debugging IW
      */
-    [Telemetry.DebugStop]: TelemetryEventInfo<DurationMeasurement> = {
+    [Telemetry.DebugStop]: TelemetryEventInfo<never | undefined> = {
         owner: 'roblourens',
         feature: ['Debugger'],
-        source: 'User Action',
-        measures: commonClassificationForDurationProperties()
+        source: 'User Action'
     };
     /**
      * Telemetry event sent when user debugs the file in the IW
      */
-    [Telemetry.DebugFileInteractive]: TelemetryEventInfo<DurationMeasurement> = {
+    [Telemetry.DebugFileInteractive]: TelemetryEventInfo<never | undefined> = {
         owner: 'roblourens',
         feature: ['Debugger'],
-        source: 'User Action',
-        measures: commonClassificationForDurationProperties()
+        source: 'User Action'
     };
     /**
      * Sent when we fail to update the kernel spec json file.


### PR DESCRIPTION
Switching to 'usage telemetry' for things that don't need to be timed