### PR TITLE
remove delayed IW scroll in favor or core auto scroll

### DIFF
--- a/news/3 Code Health/7686.md
+++ b/news/3 Code Health/7686.md
@@ -1,0 +1,1 @@
+Removed delayed scrolling reveal in the interactive window now that core does auto-scrolling.

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -10,7 +10,6 @@ import {
     NotebookCellData,
     NotebookCellKind,
     NotebookDocument,
-    NotebookEditorRevealType,
     NotebookRange,
     Uri,
     Range,
@@ -721,13 +720,6 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
     private revealCell(notebookCell: NotebookCell) {
         const notebookRange = new NotebookRange(notebookCell.index, notebookCell.index + 1);
         this.pendingNotebookScrolls.push(notebookRange);
-        // This will always try to reveal the whole cell--input + output combined
-        setTimeout(() => {
-            this.notebookEditor.revealRange(notebookRange, NotebookEditorRevealType.Default);
-
-            // No longer pending
-            this.pendingNotebookScrolls.shift();
-        }, 200); // Rendering output is async so the output is not guaranteed to immediately exist
     }
 
     public async hasCell(id: string): Promise<boolean> {


### PR DESCRIPTION
Fixes #7686

core's auto-scrolling takes care of revealing new cells/outputs in the Interactive window, so we don't need to rely on this delay


