### PR TITLE
Remove the gh team as a codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @microsoft/datascience-vsc-team-reviewers


### PR DESCRIPTION
so it isn't auto assigned as a reviewer to every PR