### PR TITLE
account for cell based stack frames, re-enable IW error output tests

### DIFF
--- a/src/notebooks/outputs/tracebackFormatter.ts
+++ b/src/notebooks/outputs/tracebackFormatter.ts
@@ -23,7 +23,7 @@ export class NotebookTracebackFormatter implements ITracebackFormatter {
         return traceback.map((traceFrame) => this.modifyTracebackFrameIPython(cell, traceFrame));
     }
     private modifyTracebackFrameIPython(cell: NotebookCell, traceFrame: string): string {
-        if (/^[Input|File].*?\n.*/.test(traceFrame)) {
+        if (/^[Cell|Input|File].*?\n.*/.test(traceFrame)) {
             return this.modifyTracebackFrameIPython8(cell, traceFrame);
         } else {
             return traceFrame;
@@ -58,12 +58,13 @@ export class NotebookTracebackFormatter implements ITracebackFormatter {
             });
 
             // Then replace the input line with our uri for this cell
+            const cellAt = DataScience.cellAtFormat().format(
+                getFilePath(cell.document.uri),
+                (cell.index + 1).toString()
+            );
             return afterLineReplace.replace(
                 /.*?\n/,
-                `\u001b[1;32m${DataScience.cellAtFormat().format(
-                    getFilePath(cell.document.uri),
-                    (cell.index + 1).toString()
-                )}\u001b[0m in \u001b[0;36m${inputMatch[2]}\n`
+                `\u001b[1;32m${cellAt}\u001b[0m in \u001b[0;36m${inputMatch[2]}\n`
             );
         }
         return traceFrame;

--- a/src/test/datascience/interactiveWindow.vscode.common.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.common.test.ts
@@ -457,7 +457,6 @@ ${actualCode}
     });
 
     test('Error stack traces have correct line hrefs with mix of cell sources', async function () {
-        this.skip();
         const settings = vscode.workspace.getConfiguration('jupyter', null);
         await settings.update('interactiveWindowMode', 'single');
 
@@ -490,7 +489,6 @@ ${actualCode}
     });
 
     test('Raising an exception from within a function has a stack trace', async function () {
-        this.skip();
         const { activeInteractiveWindow } = await runNewPythonFile(
             interactiveWindowProvider,
             '# %%\ndef raiser():\n  raise Exception("error")\n# %%\nraiser()',


### PR DESCRIPTION
Fixes #11306

old
"**Input** \u001b[1;32m**In [1]**\u001b[0m, in \u001b[0;36m**<cell line: 1>**\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124merror\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",

new
"**Cell** \u001b[1;32m**In [5], line 1**\u001b[0m\n\u001b[1;32m----> 1\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124merror\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",

Creating the links correctly for notebooks is more difficult but has quite a few issues with it already (e.g. it always points to the current cell if it came from any cell)