### PR TITLE
interpolate auth header string correctly

### DIFF
--- a/pythonFiles/aggregateTestResults.py
+++ b/pythonFiles/aggregateTestResults.py
@@ -5,6 +5,7 @@ import zipfile
 import io
 
 authtoken = sys.argv[1]
+print("Using authtoken with prefix: " + authtoken[:4])
 
 
 def getRuns(createdDate):
@@ -24,7 +25,7 @@ def getArtifactData(id):
         f"https://api.github.com/repos/microsoft/vscode-jupyter/actions/artifacts/{id}/zip",
         headers={
             "Accept": "application/vnd.github+json",
-            f"Authorization": "Bearer {authtoken}",
+            "Authorization": f"Bearer {authtoken}",
         },
     )
 


### PR DESCRIPTION
I was not adding the auth header correctly and getting a 401 when retrieving the artifacts.