### PR TITLE
more fixes to test results aggregator action

### DIFF
--- a/.github/workflows/aggregate-test-results.yml
+++ b/.github/workflows/aggregate-test-results.yml
@@ -27,6 +27,6 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: AggTestResults.json
-          path: testresults.json
+          name: testResults.json
+          path: ./AggTestresults.json
           retention-days: 60


### PR DESCRIPTION
There was an extra loop, creating duplicate result rows.
Write the flattened results to the out file directly
Fix the upload step to look for the correct filename