### PR TITLE
notebookWorkspaceEdit api is stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -2104,7 +2104,6 @@
     },
     "enabledApiProposals": [
         "notebookControllerKind",
-        "notebookWorkspaceEdit",
         "notebookDebugOptions",
         "notebookDeprecated",
         "notebookMessaging",


### PR DESCRIPTION
`notebookWorkspaceEdit` is now a stable api, removing it from `enabledApiProposals`.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
