### PR TITLE
new setting for where to open a standalone Interactive Window

### DIFF
--- a/package.json
+++ b/package.json
@@ -1946,6 +1946,17 @@
                     "description": "%jupyter.configuration.jupyter.interactiveWindowMode.description%",
                     "default": "multiple"
                 },
+                "jupyter.interactiveWindowViewColumn": {
+                    "type": "string",
+                    "enum": [
+                        "beside",
+                        "active",
+                        "secondGroup"
+                    ],
+                    "scope": "resource",
+                    "description": "%jupyter.configuration.jupyter.interactiveWindowViewColumn.description%",
+                    "default": "secondGroup"
+                },
                 "jupyter.magicCommandsAsComments": {
                     "type": "boolean",
                     "default": false,

--- a/package.nls.json
+++ b/package.nls.json
@@ -342,6 +342,10 @@
         "message": "Behavior of the Interactive Window. 'perFile' will create a new interactive window for every file that runs a cell. 'single' allows a single window. 'multiple' allows the creation of multiple.",
         "comment": ["{Locked='perFile'}", "{Locked=\"'single'\"}", "{Locked=\"'multiple'\"}"]
     },
+    "jupyter.configuration.jupyter.interactiveWindowViewColumn.description":{
+        "message": "Where to open an Interactive Window that is not associated with a python file. 'beside' will open the interactive window to the right of the active editor. 'active' will open the interactive window in place of the active editor. 'secondGroup' will open the interactive window in the second editor group.",
+        "comment": ["{Locked='beside'}", "{Locked=\"'active'\"}", "{Locked=\"'secondGroup'\"}"]
+    },
     "jupyter.configuration.jupyter.magicCommandsAsComments.description": "Uncomment shell assignments (#!), line magic (#!%) and cell magic (#!%%) when parsing code cells.",
     "jupyter.configuration.jupyter.pythonExportMethod.description": {
         "message": "The method to use when exporting a notebook to a Python file. 'direct' will copy over the code directly as is. 'commentMagics' will comment out lines starting with line magics (%), cell magics (%%), and shell commands(!). 'nbconvert' will install nbconvert and use that for the conversion which can translate iPython syntax into Python syntax.",

--- a/src/platform/common/configSettings.ts
+++ b/src/platform/common/configSettings.ts
@@ -20,6 +20,7 @@ import {
     IExperiments,
     ILoggingSettings,
     InteractiveWindowMode,
+    InteractiveWindowViewColumn,
     IVariableQuery,
     IVariableTooltipFields,
     IWatchableJupyterSettings,
@@ -91,6 +92,7 @@ export class JupyterSettings implements IWatchableJupyterSettings {
     public jupyterCommandLineArguments: string[] = [];
     public widgetScriptSources: WidgetCDNs[] = [];
     public interactiveWindowMode: InteractiveWindowMode = 'multiple';
+    public interactiveWindowViewColumn: InteractiveWindowViewColumn = 'secondGroup';
     // Hidden settings not surfaced in package.json
     public disableZMQSupport: boolean = false;
     // Hidden settings not surfaced in package.json

--- a/src/platform/common/types.ts
+++ b/src/platform/common/types.ts
@@ -102,6 +102,7 @@ export interface IJupyterSettings {
     readonly jupyterCommandLineArguments: string[];
     readonly widgetScriptSources: WidgetCDNs[];
     readonly interactiveWindowMode: InteractiveWindowMode;
+    readonly interactiveWindowViewColumn: InteractiveWindowViewColumn;
     readonly disableZMQSupport: boolean;
     readonly forceIPyKernelDebugger?: boolean;
     readonly disablePythonDaemon: boolean;
@@ -157,6 +158,8 @@ export interface IVariableQuery {
 }
 
 export type InteractiveWindowMode = 'perFile' | 'single' | 'multiple';
+
+export type InteractiveWindowViewColumn = 'beside' | 'active' | 'secondGroup';
 
 export type WidgetCDNs = 'unpkg.com' | 'jsdelivr.com';
 


### PR DESCRIPTION
Fixes #7095

- add `interactiveWindowViewColumn` setting to configure how a new IW will open
  - default to the right-hand column which is the typical behavior unless you were focused in an editor in that column already
- I'm very open to a better name than `secondGroup` for the default value