### PR TITLE
diagnostics for why result file isn't uploaded

### DIFF
--- a/.github/workflows/aggregate-test-results.yml
+++ b/.github/workflows/aggregate-test-results.yml
@@ -25,8 +25,14 @@ jobs:
 
       - name: Upload test result files
         uses: actions/upload-artifact@v3
-        if: always()
         with:
-          name: testResults.json
-          path: ./AggTestresults.json
+          name: testResults
+          path: pythonFiles/AggTestResults-*.json
+          retention-days: 60
+
+      - name: Upload test result files
+        uses: actions/upload-artifact@v3
+        with:
+          name: testResults
+          path: AggTestResults-*.json
           retention-days: 60

--- a/pythonFiles/aggregateTestResults.py
+++ b/pythonFiles/aggregateTestResults.py
@@ -8,6 +8,7 @@ import io
 authtoken = sys.argv[1]
 print("Using authtoken with prefix: " + authtoken[:4])
 
+
 def getRuns(createdDate):
     runsResponse = requests.get(
         "https://api.github.com/repos/microsoft/vscode-jupyter/actions/runs",

--- a/pythonFiles/aggregateTestResults.py
+++ b/pythonFiles/aggregateTestResults.py
@@ -1,3 +1,4 @@
+# %%
 import sys
 import requests
 import json
@@ -6,7 +7,6 @@ import io
 
 authtoken = sys.argv[1]
 print("Using authtoken with prefix: " + authtoken[:4])
-
 
 def getRuns(createdDate):
     runsResponse = requests.get(
@@ -69,9 +69,9 @@ def getResultsForRun(run):
     return results
 
 
-def flattenTestResultsToFile(runResults):
+def flattenTestResultsToFile(runResults, filename):
     resultCount = 1
-    with open("AggTestResults.json", "w") as outfile:
+    with open(filename, "w") as outfile:
         outfile.write("[\n")
         for runResult in runResults:
             print(f"writing results {resultCount} of {len(runResults)}")
@@ -118,4 +118,11 @@ for run in runs:
         runResults.append(getResultsForRun(run))
 
 # %%
-allTests = flattenTestResultsToFile(runResults)
+resultFile = f'AggTestResults-{yesterday.strftime("%Y-%m-%d")}.json'
+allTests = flattenTestResultsToFile(runResults, resultFile)
+
+# %%
+import os
+
+file_size = os.path.getsize(resultFile)
+print(f"Wrote {file_size} bytes to {resultFile}")


### PR DESCRIPTION
no results file is found to upload, trying two places and without the `./`.
log number of bytes written to ensure that the file was created.
Added the date to the filename.