### PR TITLE
check for correct github artifact name for test results

### DIFF
--- a/.github/workflows/aggregate-test-results.yml
+++ b/.github/workflows/aggregate-test-results.yml
@@ -31,6 +31,6 @@ jobs:
       - name: Upload test result files
         uses: actions/upload-artifact@v3
         with:
-          name: testResults
+          name: testResults-${{ inputs.collection_date }}
           path: AggTestResults-*.json
           retention-days: 60

--- a/.vscode/notebooks/CITestResults.ipynb
+++ b/.vscode/notebooks/CITestResults.ipynb
@@ -231,11 +231,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "testData.where(testData['status'] == 'failed').dropna()\n",
-    "recentfailures = testData[['date', 'runUrl']].sort_values(by=['date'], ascending=False).head(10)\n",
+    "failures = testData.where(testData['status'] == 'failed').dropna()\n",
+    "failures = failures[['date', 'status', 'scenario', 'runUrl']].sort_values(by=['date'], ascending=False).head(10)\n",
     "\n",
-    "for index, row in recentfailures.iterrows():\n",
-    "    print(f\"{row['date']} - {row['runUrl']}\")"
+    "for index, row in failures.iterrows():\n",
+    "    print(f\"{row['date']} - {row['scenario']}\\n{row['runUrl']}\")"
    ]
   }
  ],

--- a/.vscode/notebooks/CITestResults.ipynb
+++ b/.vscode/notebooks/CITestResults.ipynb
@@ -227,9 +227,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "1969.59s - Error inserting pydevd breaks.\n",
+      "Traceback (most recent call last):\n",
+      "  File \"c:\\venvs\\venv2\\lib\\site-packages\\debugpy\\_vendored\\pydevd\\_pydevd_frame_eval\\pydevd_modify_bytecode.py\", line 328, in insert_pydevd_breaks\n",
+      "    for new_instruction in get_instructions_to_add(\n",
+      "  File \"c:\\venvs\\venv2\\lib\\site-packages\\debugpy\\_vendored\\pydevd\\_pydevd_frame_eval\\pydevd_modify_bytecode.py\", line 102, in get_instructions_to_add\n",
+      "    Instr(\"LOAD_CONST\", _pydev_stop_at_break, lineno=stop_at_line - 1),\n",
+      "  File \"c:\\venvs\\venv2\\lib\\site-packages\\debugpy\\_vendored\\pydevd\\_pydevd_frame_eval\\vendored\\bytecode\\instr.py\", line 171, in __init__\n",
+      "    self._set(name, arg, lineno)\n",
+      "  File \"c:\\venvs\\venv2\\lib\\site-packages\\debugpy\\_vendored\\pydevd\\_pydevd_frame_eval\\vendored\\bytecode\\instr.py\", line 239, in _set\n",
+      "    _check_lineno(lineno)\n",
+      "  File \"c:\\venvs\\venv2\\lib\\site-packages\\debugpy\\_vendored\\pydevd\\_pydevd_frame_eval\\vendored\\bytecode\\instr.py\", line 74, in _check_lineno\n",
+      "    raise ValueError(\"invalid lineno\")\n",
+      "ValueError: invalid lineno\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-09-12 - TestResult-remote-nonConda-3.9--web-ubuntu-latest\n",
+      "https://github.com/microsoft/vscode-jupyter/actions/runs/3039654787\n",
+      "2022-09-12 - TestResult-remote-nonConda-3.9--web-ubuntu-latest\n",
+      "https://github.com/microsoft/vscode-jupyter/actions/runs/3039141606\n",
+      "2022-09-12 - TestResult-remote-nonConda-3.9--web-ubuntu-latest\n",
+      "https://github.com/microsoft/vscode-jupyter/actions/runs/3038467661\n",
+      "2022-09-07 - TestResult-remote-nonConda-3.9--web-ubuntu-latest\n",
+      "https://github.com/microsoft/vscode-jupyter/actions/runs/3010735863\n",
+      "2022-09-06 - TestResult-remote-nonConda-3.9--web-ubuntu-latest\n",
+      "https://github.com/microsoft/vscode-jupyter/actions/runs/3003869034\n",
+      "2022-09-02 - TestResult-remote-nonConda-3.9--web-ubuntu-latest\n",
+      "https://github.com/microsoft/vscode-jupyter/actions/runs/2981854984\n",
+      "2022-09-01 - TestResult-remote-nonConda-3.9--web-ubuntu-latest\n",
+      "https://github.com/microsoft/vscode-jupyter/actions/runs/2975744539\n",
+      "2022-08-31 - TestResult-remote-nonConda-3.9--web-ubuntu-latest\n",
+      "https://github.com/microsoft/vscode-jupyter/actions/runs/2966641244\n"
+     ]
+    }
+   ],
    "source": [
     "failures = testData.where(testData['status'] == 'failed').dropna()\n",
     "failures = failures[['date', 'status', 'scenario', 'runUrl']].sort_values(by=['date'], ascending=False).head(10)\n",

--- a/.vscode/notebooks/CITestResults.ipynb
+++ b/.vscode/notebooks/CITestResults.ipynb
@@ -227,51 +227,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "1969.59s - Error inserting pydevd breaks.\n",
-      "Traceback (most recent call last):\n",
-      "  File \"c:\\venvs\\venv2\\lib\\site-packages\\debugpy\\_vendored\\pydevd\\_pydevd_frame_eval\\pydevd_modify_bytecode.py\", line 328, in insert_pydevd_breaks\n",
-      "    for new_instruction in get_instructions_to_add(\n",
-      "  File \"c:\\venvs\\venv2\\lib\\site-packages\\debugpy\\_vendored\\pydevd\\_pydevd_frame_eval\\pydevd_modify_bytecode.py\", line 102, in get_instructions_to_add\n",
-      "    Instr(\"LOAD_CONST\", _pydev_stop_at_break, lineno=stop_at_line - 1),\n",
-      "  File \"c:\\venvs\\venv2\\lib\\site-packages\\debugpy\\_vendored\\pydevd\\_pydevd_frame_eval\\vendored\\bytecode\\instr.py\", line 171, in __init__\n",
-      "    self._set(name, arg, lineno)\n",
-      "  File \"c:\\venvs\\venv2\\lib\\site-packages\\debugpy\\_vendored\\pydevd\\_pydevd_frame_eval\\vendored\\bytecode\\instr.py\", line 239, in _set\n",
-      "    _check_lineno(lineno)\n",
-      "  File \"c:\\venvs\\venv2\\lib\\site-packages\\debugpy\\_vendored\\pydevd\\_pydevd_frame_eval\\vendored\\bytecode\\instr.py\", line 74, in _check_lineno\n",
-      "    raise ValueError(\"invalid lineno\")\n",
-      "ValueError: invalid lineno\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2022-09-12 - TestResult-remote-nonConda-3.9--web-ubuntu-latest\n",
-      "https://github.com/microsoft/vscode-jupyter/actions/runs/3039654787\n",
-      "2022-09-12 - TestResult-remote-nonConda-3.9--web-ubuntu-latest\n",
-      "https://github.com/microsoft/vscode-jupyter/actions/runs/3039141606\n",
-      "2022-09-12 - TestResult-remote-nonConda-3.9--web-ubuntu-latest\n",
-      "https://github.com/microsoft/vscode-jupyter/actions/runs/3038467661\n",
-      "2022-09-07 - TestResult-remote-nonConda-3.9--web-ubuntu-latest\n",
-      "https://github.com/microsoft/vscode-jupyter/actions/runs/3010735863\n",
-      "2022-09-06 - TestResult-remote-nonConda-3.9--web-ubuntu-latest\n",
-      "https://github.com/microsoft/vscode-jupyter/actions/runs/3003869034\n",
-      "2022-09-02 - TestResult-remote-nonConda-3.9--web-ubuntu-latest\n",
-      "https://github.com/microsoft/vscode-jupyter/actions/runs/2981854984\n",
-      "2022-09-01 - TestResult-remote-nonConda-3.9--web-ubuntu-latest\n",
-      "https://github.com/microsoft/vscode-jupyter/actions/runs/2975744539\n",
-      "2022-08-31 - TestResult-remote-nonConda-3.9--web-ubuntu-latest\n",
-      "https://github.com/microsoft/vscode-jupyter/actions/runs/2966641244\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "failures = testData.where(testData['status'] == 'failed').dropna()\n",
     "failures = failures[['date', 'status', 'scenario', 'runUrl']].sort_values(by=['date'], ascending=False).head(10)\n",

--- a/pythonFiles/aggregateTestResults.py
+++ b/pythonFiles/aggregateTestResults.py
@@ -65,7 +65,9 @@ def getResultsForRun(run):
 
     results = []
     for artifact in artifacts:
-        if artifact["name"].startswith("TestResult-"):
+        if artifact["name"].startswith("TestResult-") or artifact["name"].startswith(
+            "TestResults-"
+        ):
             print(f"    retrieving {artifact['name']}")
             rawData = getArtifactData(artifact["id"])
             testRunResults = getResultsJson(rawData)


### PR DESCRIPTION
- the test results artifact is now named testResult**s**-, so look for that one as well.
- name the aggregated results with the date of collection if it was a manual run so we know what's in there before downloading it
- fix a report cell 