### PR TITLE
Ensure display name is updated correctly when existed

### DIFF
--- a/src/kernels/jupyter/launcher/serverUriStorage.ts
+++ b/src/kernels/jupyter/launcher/serverUriStorage.ts
@@ -241,7 +241,7 @@ export class JupyterServerUriStorage implements IJupyterServerUriStorage, IServe
         return this.setUri(undefined, undefined);
     }
 
-    public async setUri(uri: string | undefined, disaplayName: string | undefined) {
+    public async setUri(uri: string | undefined, displayName: string | undefined) {
         // Set the URI as our current state
         this.currentUriPromise = Promise.resolve(uri);
         this._currentServerId = uri ? await computeServerId(uri) : undefined;
@@ -255,7 +255,7 @@ export class JupyterServerUriStorage implements IJupyterServerUriStorage, IServe
 
         if (!this._localOnly && uri) {
             // disaplay name is wrong here
-            await this.addToUriList(uri, Date.now(), disaplayName ?? uri);
+            await this.addToUriList(uri, Date.now(), displayName ?? uri);
 
             // Save in the storage (unique account per workspace)
             const key = await this.getUriAccountKey();

--- a/src/kernels/jupyter/launcher/serverUriStorage.ts
+++ b/src/kernels/jupyter/launcher/serverUriStorage.ts
@@ -226,22 +226,22 @@ export class JupyterServerUriStorage implements IJupyterServerUriStorage, IServe
     }
     public async setUriToLocal(): Promise<void> {
         traceInfoIfCI(`setUriToLocal`);
-        await this.setUri(Settings.JupyterServerLocalLaunch);
+        await this.setUri(Settings.JupyterServerLocalLaunch, undefined);
     }
     public async setUriToRemote(uri: string, displayName: string): Promise<void> {
         // Make sure to add to the saved list before we set the uri. Otherwise
         // handlers for the URI changing will use the saved list to make sure the
         // server id matches
         await this.addToUriList(uri, Date.now(), displayName);
-        await this.setUri(uri);
+        await this.setUri(uri, displayName);
     }
 
     public async setUriToNone(): Promise<void> {
         traceInfoIfCI(`setUriToNone`);
-        return this.setUri(undefined);
+        return this.setUri(undefined, undefined);
     }
 
-    public async setUri(uri: string | undefined) {
+    public async setUri(uri: string | undefined, disaplayName: string | undefined) {
         // Set the URI as our current state
         this.currentUriPromise = Promise.resolve(uri);
         this._currentServerId = uri ? await computeServerId(uri) : undefined;
@@ -254,7 +254,8 @@ export class JupyterServerUriStorage implements IJupyterServerUriStorage, IServe
         await this.globalMemento.update(currentServerHashKey, this._currentServerId);
 
         if (!this._localOnly && uri) {
-            await this.addToUriList(uri, Date.now(), uri);
+            // disaplay name is wrong here
+            await this.addToUriList(uri, Date.now(), disaplayName ?? uri);
 
             // Save in the storage (unique account per workspace)
             const key = await this.getUriAccountKey();

--- a/src/test/datascience/jupyter/serverSelector.unit.test.ts
+++ b/src/test/datascience/jupyter/serverSelector.unit.test.ts
@@ -235,7 +235,7 @@ suite('DataScience - Jupyter Server URI Selector', () => {
 
         test('Remote server uri (do not reload VSCode if there is no change in settings)', async () => {
             const { selector, storage } = createDataScienceObject('http://localhost:1111', '', true);
-            await storage.setUri('http://localhost:1111');
+            await storage.setUri('http://localhost:1111', undefined);
 
             await selector.selectJupyterURI();
             const value = await storage.getUri();
@@ -445,7 +445,7 @@ suite('DataScience - Jupyter Server URI Selector', () => {
 
         test('Remote server uri (do not reload VSCode if there is no change in settings)', async () => {
             const { selector, storage } = createDataScienceObject('$(server) Existing', 'http://localhost:1111', true);
-            await storage.setUri('http://localhost:1111');
+            await storage.setUri('http://localhost:1111', undefined);
 
             await selector.selectJupyterURI('commandPalette');
             const value = await storage.getUri();


### PR DESCRIPTION
Fixes #11380. This is the code path where we didn't update the display name correctly when it exists.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
