### PR TITLE
Send un-hashed moduleName if module found on CDN

### DIFF
--- a/TELEMETRY.csv
+++ b/TELEMETRY.csv
@@ -1222,9 +1222,20 @@ This is always sent when we display a prompt.","Telemetry.IPyWidgetPromptToUseCD
 "DS_INTERNAL.IPYWIDGET_TIME_TO_COPY_NBEXTENSIONS_DIR","Total time take to copy the nb extensions folder.","Telemetry.IPyWidgetNbExtensionCopyTime","donjayamanne","Notebook, Notebook","Widgets","","duration","Duration of a measure in milliseconds.
 Common measurement used across a number of events.","number","",false
 "DS_INTERNAL.IPYWIDGET_UNHANDLED_MESSAGE","Telemetry event sent when the widget tries to send a kernel message but nothing was listening","Telemetry.IPyWidgetUnhandledMessage","donjayamanne","Notebook, InteractiveWindow","Widgets","","msg_type","Type of the protocol message sent by Jupyter kernel.","string","",false
-"DS_INTERNAL.IPYWIDGET_USED_BY_USER","Telemetry event sent with name of a Widget that is used.","Telemetry.HashedIPyWidgetNameUsed","donjayamanne","Notebook, InteractiveWindow","Widgets","","cdnSearched","Whether we searched CDN or not.","boolean","",false
-"DS_INTERNAL.IPYWIDGET_USED_BY_USER","Telemetry event sent with name of a Widget that is used.","Telemetry.HashedIPyWidgetNameUsed","donjayamanne","Notebook, InteractiveWindow","Widgets","","hashedName","Hash of the widget","string","",false
-"DS_INTERNAL.IPYWIDGET_USED_BY_USER","Telemetry event sent with name of a Widget that is used.","Telemetry.HashedIPyWidgetNameUsed","donjayamanne","Notebook, InteractiveWindow","Widgets","","source","Where did we find the hashed name (CDN or user environment or remote jupyter).","","'cdn' 
+"DS_INTERNAL.IPYWIDGET_USED_BY_USER","Telemetry event sent with name of a Widget that is used.
+Helps determine which widgets are used the most, and which are not.
+Useful in prioritizing which widgets to work on if things fail to work.","Telemetry.HashedIPyWidgetNameUsed","donjayamanne","Notebook, InteractiveWindow","Widgets","","cdnSearched","Whether we searched CDN or not.","boolean","",false
+"DS_INTERNAL.IPYWIDGET_USED_BY_USER","Telemetry event sent with name of a Widget that is used.
+Helps determine which widgets are used the most, and which are not.
+Useful in prioritizing which widgets to work on if things fail to work.","Telemetry.HashedIPyWidgetNameUsed","donjayamanne","Notebook, InteractiveWindow","Widgets","","hashedName","Hash of the widget module.
+If the widget is found on a CDN, then the unhashed name is sent in `moduleName`.","string","",false
+"DS_INTERNAL.IPYWIDGET_USED_BY_USER","Telemetry event sent with name of a Widget that is used.
+Helps determine which widgets are used the most, and which are not.
+Useful in prioritizing which widgets to work on if things fail to work.","Telemetry.HashedIPyWidgetNameUsed","donjayamanne","Notebook, InteractiveWindow","Widgets","","moduleName","Name of the widget module, sent only for cases where `source` is `cdn`.
+As that is the onl time we can safely send the name (if its on public CDN then its public information).","string","",true
+"DS_INTERNAL.IPYWIDGET_USED_BY_USER","Telemetry event sent with name of a Widget that is used.
+Helps determine which widgets are used the most, and which are not.
+Useful in prioritizing which widgets to work on if things fail to work.","Telemetry.HashedIPyWidgetNameUsed","donjayamanne","Notebook, InteractiveWindow","Widgets","","source","Where did we find the hashed name (CDN or user environment or remote jupyter).","","'cdn' 
 'local' 
 'remote' ",true
 "DS_INTERNAL.IPYWIDGET_WIDGET_VERSION_NOT_SUPPORTED_LOAD_FAILURE","Telemetry event sent when an ipywidget version that is not supported is used & we have trapped this and warned the user abou it.","Telemetry.IPyWidgetWidgetVersionNotSupportedLoadFailure","donjayamanne","Notebook, InteractiveWindow","Widgets","","moduleHash","Hash of the widget module.","string","",false

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -2636,13 +2636,19 @@ Expand each section to see more information about that event.
       Owner: [@donjayamanne](https://github.com/donjayamanne)  
     ```
     Telemetry event sent with name of a Widget that is used.  
+    Helps determine which widgets are used the most, and which are not.  
+    Useful in prioritizing which widgets to work on if things fail to work.  
     ```
 
     - Properties:  
         - `cdnSearched`: `boolean`  
         Whether we searched CDN or not.  
         - `hashedName`: `string`  
-        Hash of the widget  
+        Hash of the widget module.  
+        If the widget is found on a CDN, then the unhashed name is sent in `moduleName`.  
+        - `moduleName`?: `string`  
+        Name of the widget module, sent only for cases where `source` is `cdn`.  
+        As that is the onl time we can safely send the name (if its on public CDN then its public information).  
         - `source`?: `<see below>`  
         Where did we find the hashed name (CDN or user environment or remote jupyter).  
         Possible values include:  

--- a/src/gdpr.ts
+++ b/src/gdpr.ts
@@ -1399,8 +1399,9 @@
 /* __GDPR__
    "DS_INTERNAL.IPYWIDGET_USED_BY_USER" : {
      "cdnSearched": {"classification":"SystemMetaData","purpose":"FeatureInsight","comment":"Whether we searched CDN or not.","owner":"donjayamanne"},
-     "hashedName": {"classification":"PublicNonPersonalData","purpose":"FeatureInsight","comment":"Hash of the widget","owner":"donjayamanne"},
+     "hashedName": {"classification":"PublicNonPersonalData","purpose":"FeatureInsight","comment":"Hash of the widget module. If the widget is found on a CDN, then the unhashed name is sent in `moduleName`.","owner":"donjayamanne"},
      "source": {"classification":"SystemMetaData","purpose":"FeatureInsight","comment":"Where did we find the hashed name (CDN or user environment or remote jupyter).","owner":"donjayamanne"},
+     "moduleName": {"classification":"PublicNonPersonalData","purpose":"FeatureInsight","comment":"Name of the widget module, sent only for cases where `source` is `cdn`. As that is the onl time we can safely send the name (if its on public CDN then its public information).","owner":"donjayamanne"},
      "${include}": [
        "${F1}"
 

--- a/src/notebooks/controllers/ipywidgets/scriptSourceProvider/ipyWidgetScriptSourceProvider.ts
+++ b/src/notebooks/controllers/ipywidgets/scriptSourceProvider/ipyWidgetScriptSourceProvider.ts
@@ -89,8 +89,14 @@ export class IPyWidgetScriptSourceProvider implements IWidgetScriptSourceProvide
             }
         }
 
+        // The telemetry reporter assumes the presence of a `/` or `\` indicates these are file paths
+        // and obscures them. We don't want that, so we replace them with `_`.
+        const telemetrySafeModuleName =
+            found.source === 'cdn' ? found.moduleName.replace(/\//g, '_').replace(/\\/g, '_') : undefined;
+
         sendTelemetryEvent(Telemetry.HashedIPyWidgetNameUsed, undefined, {
             hashedName: await getTelemetrySafeHashedString(found.moduleName),
+            moduleName: telemetrySafeModuleName,
             source: found.source,
             cdnSearched: this.configuredScriptSources.length > 0
         });

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -2288,7 +2288,7 @@ export class IEventNamePropertyMapping {
      */
     [Telemetry.HashedIPyWidgetNameUsed]: TelemetryEventInfo<{
         /**
-         * Hash of the widget.
+         * Hash of the widget module.
          * If the widget is found on a CDN, then the unhashed name is sent in `moduleName`.
          */
         hashedName: string;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -2283,12 +2283,20 @@ export class IEventNamePropertyMapping {
     };
     /**
      * Telemetry event sent with name of a Widget that is used.
+     * Helps determine which widgets are used the most, and which are not.
+     * Useful in prioritizing which widgets to work on if things fail to work.
      */
     [Telemetry.HashedIPyWidgetNameUsed]: TelemetryEventInfo<{
         /**
-         * Hash of the widget
+         * Hash of the widget.
+         * If the widget is found on a CDN, then the unhashed name is sent in `moduleName`.
          */
         hashedName: string;
+        /**
+         * Name of the widget module, sent only for cases where `source` is `cdn`.
+         * As that is the onl time we can safely send the name (if its on public CDN then its public information).
+         */
+        moduleName?: string;
         /**
          * Where did we find the hashed name (CDN or user environment or remote jupyter).
          */
@@ -2313,6 +2321,10 @@ export class IEventNamePropertyMapping {
             },
             source: {
                 classification: 'SystemMetaData',
+                purpose: 'FeatureInsight'
+            },
+            moduleName: {
+                classification: 'PublicNonPersonalData',
                 purpose: 'FeatureInsight'
             }
         }


### PR DESCRIPTION
Helpful in determining what widgets are used most often, helps prioritize issues like supporting broken widgets like vega and the like.