### PR TITLE
Respond to Jupyter server uri provider handles change event.

### DIFF
--- a/src/kernels/jupyter/jupyterUriProviderRegistration.ts
+++ b/src/kernels/jupyter/jupyterUriProviderRegistration.ts
@@ -33,7 +33,7 @@ export class JupyterUriProviderRegistration implements IJupyterUriProviderRegist
 
     constructor(
         @inject(IExtensions) private readonly extensions: IExtensions,
-        @inject(IDisposableRegistry) disposables: IDisposableRegistry,
+        @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
         @inject(IMemento) @named(GLOBAL_MEMENTO) private readonly globalMemento: Memento
     ) {
         disposables.push(this._onProvidersChanged);
@@ -96,7 +96,7 @@ export class JupyterUriProviderRegistration implements IJupyterUriProviderRegist
     private async createProvider(provider: IJupyterUriProvider): Promise<IJupyterUriProvider> {
         const info = await this.extensions.determineExtensionFromCallStack();
         this.updateRegistrationInfo(provider.id, info.extensionId).catch(noop);
-        return new JupyterUriProviderWrapper(provider, info.extensionId);
+        return new JupyterUriProviderWrapper(provider, info.extensionId, this.disposables);
     }
     @swallowExceptions()
     private async updateRegistrationInfo(providerId: string, extensionId: string): Promise<void> {


### PR DESCRIPTION
Currently when a Jupyter server uri provider updates its handles, we are not listening to the event and refresh the notebook controllers.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
