### PR TITLE
Fix for issue #11396

### DIFF
--- a/news/2 Fixes/11396.md
+++ b/news/2 Fixes/11396.md
@@ -1,0 +1,2 @@
+Fixed a bug that introduced a cross-OS interworking issue, making the notebook cell debugger skip breakpoints when VSCode is run on Windows but the kernel is run on Unix
+(thanks [Adam Zlatniczki](https://github.com/adam-zlatniczki))

--- a/src/interactive-window/debugger/jupyter/kernelDebugAdapter.ts
+++ b/src/interactive-window/debugger/jupyter/kernelDebugAdapter.ts
@@ -87,10 +87,10 @@ export class KernelDebugAdapter extends KernelDebugAdapterBase {
         }
         try {
             const code = (metadata.generatedCode?.code || cell.document.getText()).replace(/\r\n/g, '\n');
-            const response = await this.session.customRequest('dumpCell', { code });
+            const response = (await this.session.customRequest('dumpCell', { code })) as IDumpCellResponse;
 
             // We know jupyter will strip out leading white spaces, hence take that into account.
-            const norm = KernelDebugAdapterBase.extractDumpFilePathOnKernelSide(response as IDumpCellResponse);
+            const norm = KernelDebugAdapterBase.normalizeFsAware(response.sourcePath);
             this.fileToCell.set(norm, Uri.parse(metadata.interactive.uristring));
 
             // If this cell doesn't have a cell marker, then

--- a/src/interactive-window/debugger/jupyter/kernelDebugAdapter.ts
+++ b/src/interactive-window/debugger/jupyter/kernelDebugAdapter.ts
@@ -90,7 +90,7 @@ export class KernelDebugAdapter extends KernelDebugAdapterBase {
             const response = await this.session.customRequest('dumpCell', { code });
 
             // We know jupyter will strip out leading white spaces, hence take that into account.
-            const norm = path.normalize((response as IDumpCellResponse).sourcePath);
+            const norm = KernelDebugAdapterBase.extractDumpFilePathOnKernelSide(response as IDumpCellResponse);
             this.fileToCell.set(norm, Uri.parse(metadata.interactive.uristring));
 
             // If this cell doesn't have a cell marker, then
@@ -131,8 +131,10 @@ export class KernelDebugAdapter extends KernelDebugAdapterBase {
         if (!cell) {
             return;
         }
+
         source.name = path.basename(cell.interactiveWindow.path);
-        source.path = cell.interactiveWindow.toString();
+        source.path = cell.interactiveWindow.path;
+
         if (typeof lines?.endLine === 'number') {
             lines.endLine = lines.endLine + (cell.lineOffset || 0);
         }

--- a/src/notebooks/debugger/kernelDebugAdapter.ts
+++ b/src/notebooks/debugger/kernelDebugAdapter.ts
@@ -3,11 +3,10 @@
 
 'use strict';
 
-import * as path from '../../platform/vscode-path/path';
-import { IDumpCellResponse } from './debuggingTypes';
 import { traceError } from '../../platform/logging';
 import { KernelDebugAdapterBase } from './kernelDebugAdapterBase';
 import { DebugProtocol } from 'vscode-debugprotocol';
+import { IDumpCellResponse } from './debuggingTypes';
 
 /**
  * Concrete implementation of the KernelDebugAdapterBase class that will dump cells
@@ -22,7 +21,7 @@ export class KernelDebugAdapter extends KernelDebugAdapterBase {
             const response = await this.session.customRequest('dumpCell', {
                 code: cell.document.getText().replace(/\r\n/g, '\n')
             });
-            const norm = path.normalize((response as IDumpCellResponse).sourcePath);
+            const norm = KernelDebugAdapterBase.extractDumpFilePathOnKernelSide(response as IDumpCellResponse);
             this.fileToCell.set(norm, cell.document.uri);
             this.cellToFile.set(cell.document.uri.toString(), norm);
         } catch (err) {

--- a/src/notebooks/debugger/kernelDebugAdapter.ts
+++ b/src/notebooks/debugger/kernelDebugAdapter.ts
@@ -18,10 +18,10 @@ export class KernelDebugAdapter extends KernelDebugAdapterBase {
     protected override async dumpCell(index: number): Promise<void> {
         const cell = this.notebookDocument.cellAt(index);
         try {
-            const response = await this.session.customRequest('dumpCell', {
+            const response = (await this.session.customRequest('dumpCell', {
                 code: cell.document.getText().replace(/\r\n/g, '\n')
-            });
-            const norm = KernelDebugAdapterBase.extractDumpFilePathOnKernelSide(response as IDumpCellResponse);
+            })) as IDumpCellResponse;
+            const norm = KernelDebugAdapterBase.normalizeFsAware(response.sourcePath);
             this.fileToCell.set(norm, cell.document.uri);
             this.cellToFile.set(cell.document.uri.toString(), norm);
         } catch (err) {

--- a/src/notebooks/debugger/kernelDebugAdapterBase.ts
+++ b/src/notebooks/debugger/kernelDebugAdapterBase.ts
@@ -21,7 +21,6 @@ import {
     Uri,
     workspace
 } from 'vscode';
-import { IDumpCellResponse } from './debuggingTypes';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { executeSilently } from '../../kernels/helpers';
 import { IKernel, IKernelConnectionSession } from '../../kernels/types';
@@ -265,16 +264,14 @@ export abstract class KernelDebugAdapterBase implements DebugAdapter, IKernelDeb
         });
     }
 
-    static extractDumpFilePathOnKernelSide(dumpCellResponse: IDumpCellResponse) {
-        // Based on the response, check if the kernel runs on a Unix or Windows machine.
-        // If it runs on Windows, then path windows-style normalization might be necessary
+    static normalizeFsAware(sourcePath: string) {
+        // If the kernel runs on Windows, then do windows-style path normalization
         // (see https://github.com/ipython/ipykernel/issues/995).
-        const dumpFilePathOnKernelSide = dumpCellResponse.sourcePath;
         let norm = '';
-        if (dumpFilePathOnKernelSide.match(/^[A-Za-z]:/)) {
-            norm = path.win32.normalize(dumpFilePathOnKernelSide);
+        if (sourcePath.match(/^[A-Za-z]:/)) {
+            norm = path.win32.normalize(sourcePath);
         } else {
-            norm = dumpFilePathOnKernelSide;
+            norm = sourcePath;
         }
         return norm;
     }

--- a/src/notebooks/debugger/kernelDebugAdapterBase.ts
+++ b/src/notebooks/debugger/kernelDebugAdapterBase.ts
@@ -21,6 +21,7 @@ import {
     Uri,
     workspace
 } from 'vscode';
+import { IDumpCellResponse } from './debuggingTypes';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { executeSilently } from '../../kernels/helpers';
 import { IKernel, IKernelConnectionSession } from '../../kernels/types';
@@ -262,6 +263,20 @@ export abstract class KernelDebugAdapterBase implements DebugAdapter, IKernelDeb
                 }
             });
         });
+    }
+
+    static extractDumpFilePathOnKernelSide(dumpCellResponse: IDumpCellResponse) {
+        // Based on the response, check if the kernel runs on a Unix or Windows machine.
+        // If it runs on Windows, then path windows-style normalization might be necessary
+        // (see https://github.com/ipython/ipykernel/issues/995).
+        const dumpFilePathOnKernelSide = dumpCellResponse.sourcePath;
+        let norm = '';
+        if (dumpFilePathOnKernelSide.match(/^[A-Za-z]:/)) {
+            norm = path.win32.normalize(dumpFilePathOnKernelSide);
+        } else {
+            norm = dumpFilePathOnKernelSide;
+        }
+        return norm;
     }
 
     private lookupCellByLongName(sourcePath: string) {

--- a/src/test/debugger/jupyter/kernelDebugAdapter.unit.test.ts
+++ b/src/test/debugger/jupyter/kernelDebugAdapter.unit.test.ts
@@ -3,25 +3,24 @@
 
 import { expect } from 'chai';
 import { KernelDebugAdapterBase } from '../../../notebooks/debugger/kernelDebugAdapterBase';
-import { IDumpCellResponse } from '../../../notebooks/debugger/debuggingTypes';
 
 suite('Debugging - KernelDebugAdapterBase', () => {
     suite('extractDumpFilePathOnKernelSide', async () => {
         test('Kernel runs on Windows backend', () => {
-            const mockResponseFromKernel = { sourcePath: 'c:\\tmp\\1.py' } as IDumpCellResponse;
-            const path = KernelDebugAdapterBase.extractDumpFilePathOnKernelSide(mockResponseFromKernel);
+            const pathFromKernel = 'c:\\tmp\\1.py';
+            const path = KernelDebugAdapterBase.normalizeFsAware(pathFromKernel);
             expect(path).to.equal('c:\\tmp\\1.py');
         });
 
         test('Kernel runs on Windows backend with ipykernel issue', () => {
-            const mockResponseFromKernel = { sourcePath: 'c:\\tmp/1.py' } as IDumpCellResponse;
-            const path = KernelDebugAdapterBase.extractDumpFilePathOnKernelSide(mockResponseFromKernel);
+            const pathFromKernel = 'c:\\tmp/1.py';
+            const path = KernelDebugAdapterBase.normalizeFsAware(pathFromKernel);
             expect(path).to.equal('c:\\tmp\\1.py');
         });
 
         test('Kernel runs on Unix backend', () => {
-            const mockResponseFromKernel = { sourcePath: '/tmp/1.py' } as IDumpCellResponse;
-            const path = KernelDebugAdapterBase.extractDumpFilePathOnKernelSide(mockResponseFromKernel);
+            const pathFromKernel = '/tmp/1.py';
+            const path = KernelDebugAdapterBase.normalizeFsAware(pathFromKernel);
             expect(path).to.equal('/tmp/1.py');
         });
     });

--- a/src/test/debugger/jupyter/kernelDebugAdapter.unit.test.ts
+++ b/src/test/debugger/jupyter/kernelDebugAdapter.unit.test.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { expect } from 'chai';
+import { KernelDebugAdapterBase } from '../../../notebooks/debugger/kernelDebugAdapterBase';
+import { IDumpCellResponse } from '../../../notebooks/debugger/debuggingTypes';
+
+suite('Debugging - KernelDebugAdapterBase', () => {
+    suite('extractDumpFilePathOnKernelSide', async () => {
+        test('Kernel runs on Windows backend', () => {
+            const mockResponseFromKernel = { sourcePath: 'c:\\tmp\\1.py' } as IDumpCellResponse;
+            const path = KernelDebugAdapterBase.extractDumpFilePathOnKernelSide(mockResponseFromKernel);
+            expect(path).to.equal('c:\\tmp\\1.py');
+        });
+
+        test('Kernel runs on Windows backend with ipykernel issue', () => {
+            const mockResponseFromKernel = { sourcePath: 'c:\\tmp/1.py' } as IDumpCellResponse;
+            const path = KernelDebugAdapterBase.extractDumpFilePathOnKernelSide(mockResponseFromKernel);
+            expect(path).to.equal('c:\\tmp\\1.py');
+        });
+
+        test('Kernel runs on Unix backend', () => {
+            const mockResponseFromKernel = { sourcePath: '/tmp/1.py' } as IDumpCellResponse;
+            const path = KernelDebugAdapterBase.extractDumpFilePathOnKernelSide(mockResponseFromKernel);
+            expect(path).to.equal('/tmp/1.py');
+        });
+    });
+});


### PR DESCRIPTION
* During notebook cell debugging, apply path normalization on the path of the dumped tmp file only if the kernel runs on a Windows machine.

Fixes #11396

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] Has telemetry for feature-requests.
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
