### PR TITLE
Ignore python files when looking for packages

### DIFF
--- a/src/test/datascience/editor-integration/helpers.ts
+++ b/src/test/datascience/editor-integration/helpers.ts
@@ -15,7 +15,7 @@ import {
     NotebookRange,
     NotebookCellData
 } from 'vscode';
-import { JupyterNotebookView, NotebookCellScheme } from '../../../platform/common/constants';
+import { InteractiveWindowView, JupyterNotebookView, NotebookCellScheme } from '../../../platform/common/constants';
 
 /* eslint-disable , no-trailing-spaces, no-multi-str */
 // Disable whitespace / multiline as we use that to pass in our fake file strings
@@ -158,7 +158,8 @@ const defaultMetadata = {
 export function createMockedNotebookDocument(
     cells: NotebookCellData[],
     metadata: Partial<nbformat.INotebookMetadata> = defaultMetadata,
-    uri: Uri = Uri.file('foo.ipynb')
+    uri: Uri = Uri.file('foo.ipynb'),
+    notebookType: typeof JupyterNotebookView | typeof InteractiveWindowView = JupyterNotebookView
 ): NotebookDocument {
     const notebook = mock<NotebookDocument>();
     const nbMetadata = JSON.parse(JSON.stringify(defaultMetadata));
@@ -174,7 +175,7 @@ export function createMockedNotebookDocument(
     const notebookContent: Partial<nbformat.INotebookContent> = {
         metadata: nbMetadata
     };
-    when(notebook.notebookType).thenReturn(JupyterNotebookView);
+    when(notebook.notebookType).thenReturn(notebookType);
     when(notebook.metadata).thenReturn({ custom: notebookContent } as never);
 
     const nbCells = cells.map((data, index) => {
@@ -194,6 +195,7 @@ export function createMockedNotebookDocument(
     });
     when(notebook.cellCount).thenReturn(nbCells.length);
     when(notebook.cellAt(anything())).thenCall((index) => nbCells[index]);
+    when(notebook.getCells()).thenCall(() => nbCells);
     when(notebook.getCells(anything())).thenCall((range: NotebookRange) => nbCells.slice(range.start, range.end));
     return instance(notebook);
 }

--- a/src/test/telemetry/importTracker.unit.test.ts
+++ b/src/test/telemetry/importTracker.unit.test.ts
@@ -11,15 +11,15 @@ import {
     NotebookCellExecutionState,
     NotebookCellExecutionStateChangeEvent,
     NotebookCellKind,
-    NotebookDocument,
-    TextDocument,
-    Uri
+    NotebookDocument
 } from 'vscode';
 
-import { IDocumentManager, IVSCodeNotebook, IWorkspaceService } from '../../platform/common/application/types';
+import { IVSCodeNotebook, IWorkspaceService } from '../../platform/common/application/types';
 import {
+    InteractiveWindowView,
     isTestExecution,
     isUnitTestExecution,
+    JupyterNotebookView,
     setTestExecution,
     setUnitTestExecution
 } from '../../platform/common/constants';
@@ -30,16 +30,17 @@ import { getTelemetrySafeHashedString } from '../../platform/telemetry/helpers';
 import { ImportTracker } from '../../standalone/import-export/importTracker';
 import { ResourceTypeTelemetryProperty } from '../../telemetry';
 import { waitForCondition } from '../common';
-import { createMockedDocument, createMockedNotebookDocument } from '../datascience/editor-integration/helpers';
+import { createMockedNotebookDocument } from '../datascience/editor-integration/helpers';
 
 suite('Import Tracker', async () => {
     const oldValueOfVSC_JUPYTER_UNIT_TEST = isUnitTestExecution();
     const oldValueOfVSC_JUPYTER_CI_TEST = isTestExecution();
     let importTracker: ImportTracker;
-    let documentManager: IDocumentManager;
-    let openedEventEmitter: EventEmitter<TextDocument>;
-    let savedEventEmitter: EventEmitter<TextDocument>;
     let onDidChangeNotebookCellExecutionState: EventEmitter<NotebookCellExecutionStateChangeEvent>;
+    let onDidOpenNbEvent: EventEmitter<NotebookDocument>;
+    let onDidCloseNbEvent: EventEmitter<NotebookDocument>;
+    let onDidSaveNbEvent: EventEmitter<NotebookDocument>;
+    let vscNb: IVSCodeNotebook;
     let pandasHash: string;
     let elephasHash: string;
     let kerasHash: string;
@@ -109,22 +110,20 @@ suite('Import Tracker', async () => {
         setTestExecution(false);
         setUnitTestExecution(false);
 
-        openedEventEmitter = new EventEmitter<TextDocument>();
-        savedEventEmitter = new EventEmitter<TextDocument>();
-
-        documentManager = mock<IDocumentManager>();
-        when(documentManager.onDidOpenTextDocument).thenReturn(openedEventEmitter.event);
-        when(documentManager.onDidSaveTextDocument).thenReturn(savedEventEmitter.event);
-
         rewiremock.enable();
         rewiremock('@vscode/extension-telemetry').with({ default: Reporter });
 
-        const vscNb = mock<IVSCodeNotebook>();
-        const onDidOpenCloseNbEvent = new EventEmitter<NotebookDocument>();
-        disposables.push(onDidOpenCloseNbEvent);
-        when(vscNb.onDidOpenNotebookDocument).thenReturn(onDidOpenCloseNbEvent.event);
-        when(vscNb.onDidCloseNotebookDocument).thenReturn(onDidOpenCloseNbEvent.event);
+        vscNb = mock<IVSCodeNotebook>();
+        onDidOpenNbEvent = new EventEmitter<NotebookDocument>();
+        onDidCloseNbEvent = new EventEmitter<NotebookDocument>();
+        onDidSaveNbEvent = new EventEmitter<NotebookDocument>();
         onDidChangeNotebookCellExecutionState = new EventEmitter<NotebookCellExecutionStateChangeEvent>();
+        disposables.push(onDidOpenNbEvent);
+        disposables.push(onDidCloseNbEvent);
+        disposables.push(onDidSaveNbEvent);
+        when(vscNb.onDidOpenNotebookDocument).thenReturn(onDidOpenNbEvent.event);
+        when(vscNb.onDidCloseNotebookDocument).thenReturn(onDidCloseNbEvent.event);
+        when(vscNb.onDidSaveNotebookDocument).thenReturn(onDidSaveNbEvent.event);
         when(vscNb.onDidChangeNotebookCellExecutionState).thenReturn(onDidChangeNotebookCellExecutionState.event);
         when(vscNb.notebookDocuments).thenReturn([]);
         const workspace = mock<IWorkspaceService>();
@@ -136,7 +135,7 @@ suite('Import Tracker', async () => {
                 };
             }
         } as any);
-        importTracker = new ImportTracker(instance(documentManager), instance(vscNb), disposables, instance(workspace));
+        importTracker = new ImportTracker(instance(vscNb), disposables, instance(workspace));
     });
     teardown(() => {
         setUnitTestExecution(oldValueOfVSC_JUPYTER_UNIT_TEST);
@@ -148,182 +147,174 @@ suite('Import Tracker', async () => {
         disposeAllDisposables(disposables);
     });
 
-    function emitDocEvent(code: string, ev: EventEmitter<TextDocument>) {
-        const textDoc = createMockedDocument(code, Uri.file('foo.py'), 1, true);
-        ev.fire(textDoc);
-    }
-
     test('Open document', async () => {
-        emitDocEvent('import pandas\r\n', openedEventEmitter);
-        await Reporter.expectHashes('onOpenCloseOrSave', undefined, pandasHash);
+        const code = `import pandas\r\n`;
+        const nb = createMockedNotebookDocument([{ kind: NotebookCellKind.Code, languageId: 'python', value: code }]);
+        onDidOpenNbEvent.fire(nb);
+
+        await Reporter.expectHashes('onOpenCloseOrSave', 'notebook', pandasHash);
+    });
+    test('Close document', async () => {
+        const code = `import pandas\r\n`;
+        const nb = createMockedNotebookDocument([{ kind: NotebookCellKind.Code, languageId: 'python', value: code }]);
+        onDidCloseNbEvent.fire(nb);
+
+        await Reporter.expectHashes('onOpenCloseOrSave', 'notebook', pandasHash);
+    });
+    test('Save document', async () => {
+        const code = `import pandas\r\n`;
+        const nb = createMockedNotebookDocument([{ kind: NotebookCellKind.Code, languageId: 'python', value: code }]);
+        onDidSaveNbEvent.fire(nb);
+
+        await Reporter.expectHashes('onOpenCloseOrSave', 'notebook', pandasHash);
     });
 
     test('Already opened documents', async () => {
-        const doc = createMockedDocument('import pandas\r\n', Uri.file('foo.py'), 1, true);
-        when(documentManager.textDocuments).thenReturn([doc]);
+        const code = `import pandas\r\n`;
+        const nb = createMockedNotebookDocument([{ kind: NotebookCellKind.Code, languageId: 'python', value: code }]);
+        when(vscNb.notebookDocuments).thenReturn([nb]);
+
         await importTracker.activate();
 
-        await Reporter.expectHashes('onOpenCloseOrSave', undefined, pandasHash);
+        await Reporter.expectHashes('onOpenCloseOrSave', 'notebook', pandasHash);
     });
+    async function testImports(
+        code: string,
+        notebookType: typeof JupyterNotebookView | typeof InteractiveWindowView,
+        ...expectedPackageHashes: string[]
+    ) {
+        const nb = createMockedNotebookDocument(
+            [{ kind: NotebookCellKind.Code, languageId: 'python', value: code }],
+            undefined,
+            undefined,
+            notebookType
+        );
+        when(vscNb.notebookDocuments).thenReturn([nb]);
 
-    test('Save document', async () => {
-        emitDocEvent('import pandas\r\n', savedEventEmitter);
+        await importTracker.activate();
 
-        await Reporter.expectHashes('onOpenCloseOrSave', undefined, pandasHash);
-    });
-
+        await Reporter.expectHashes(
+            'onOpenCloseOrSave',
+            notebookType === 'jupyter-notebook' ? 'notebook' : 'interactive',
+            ...expectedPackageHashes
+        );
+    }
     test('from <pkg>._ import _, _', async () => {
-        const elephas = `
-        from elephas.java import java_classes, adapter
-        from keras.models import Sequential
-        from keras.layers import Dense
+        const code = `
+            from elephas.java import java_classes, adapter
+            from keras.models import Sequential
+            from keras.layers import Dense
 
+            model = Sequential()
+            model.add(Dense(units=64, activation='relu', input_dim=100))
+            model.add(Dense(units=10, activation='softmax'))
+            model.compile(loss='categorical_crossentropy', optimizer='sgd', metrics=['accuracy'])
 
-        model = Sequential()
-        model.add(Dense(units=64, activation='relu', input_dim=100))
-        model.add(Dense(units=10, activation='softmax'))
-        model.compile(loss='categorical_crossentropy', optimizer='sgd', metrics=['accuracy'])
+            model.save('test.h5')
 
-        model.save('test.h5')
+            kmi = java_classes.KerasModelImport
+            file = java_classes.File("test.h5")
 
+            java_model = kmi.importKerasSequentialModelAndWeights(file.absolutePath)
 
-        kmi = java_classes.KerasModelImport
-        file = java_classes.File("test.h5")
-
-        java_model = kmi.importKerasSequentialModelAndWeights(file.absolutePath)
-
-        weights = adapter.retrieve_keras_weights(java_model)
-        model.set_weights(weights)`;
-
-        emitDocEvent(elephas, savedEventEmitter);
-
-        await Reporter.expectHashes('onOpenCloseOrSave', undefined, elephasHash, kerasHash);
+            weights = adapter.retrieve_keras_weights(java_model)
+            model.set_weights(weights)`;
+        await testImports(code, 'jupyter-notebook', elephasHash, kerasHash);
     });
 
     test('from <pkg>._ import _', async () => {
-        const pyspark = `from pyspark.ml.classification import LogisticRegression
-        from pyspark.ml.evaluation import MulticlassClassificationEvaluator
-        from pyspark.ml import Pipeline
-        from sparkdl import DeepImageFeaturizer
+        const code = `from pyspark.ml.classification import LogisticRegression
+            from pyspark.ml.evaluation import MulticlassClassificationEvaluator
+            from pyspark.ml import Pipeline
+            from sparkdl import DeepImageFeaturizer
 
-        featurizer = DeepImageFeaturizer(inputCol="image", outputCol="features", modelName="InceptionV3")
-        lr = LogisticRegression(maxIter=20, regParam=0.05, elasticNetParam=0.3, labelCol="label")
-        p = Pipeline(stages=[featurizer, lr])
+            featurizer = DeepImageFeaturizer(inputCol="image", outputCol="features", modelName="InceptionV3")
+            lr = LogisticRegression(maxIter=20, regParam=0.05, elasticNetParam=0.3, labelCol="label")
+            p = Pipeline(stages=[featurizer, lr])
 
-        model = p.fit(train_images_df)    # train_images_df is a dataset of images and labels
+            model = p.fit(train_images_df)    # train_images_df is a dataset of images and labels
 
-        # Inspect training error
-        df = model.transform(train_images_df.limit(10)).select("image", "probability",  "uri", "label")
-        predictionAndLabels = df.select("prediction", "label")
-        evaluator = MulticlassClassificationEvaluator(metricName="accuracy")
-        print("Training set accuracy = " + str(evaluator.evaluate(predictionAndLabels)))`;
+            # Inspect training error
+            df = model.transform(train_images_df.limit(10)).select("image", "probability",  "uri", "label")
+            predictionAndLabels = df.select("prediction", "label")
+            evaluator = MulticlassClassificationEvaluator(metricName="accuracy")
+            print("Training set accuracy = " + str(evaluator.evaluate(predictionAndLabels)))`;
 
-        emitDocEvent(pyspark, savedEventEmitter);
-
-        await Reporter.expectHashes('onOpenCloseOrSave', undefined, pysparkHash, sparkdlHash);
+        await testImports(code, 'interactive', pysparkHash, sparkdlHash);
     });
 
     test('import <pkg> as _', async () => {
         const code = `import pandas as pd
-import numpy as np
-import random as rnd
+    import numpy as np
+    import random as rnd
 
-def simplify_ages(df):
-    df.Age = df.Age.fillna(-0.5)
-    bins = (-1, 0, 5, 12, 18, 25, 35, 60, 120)
-    group_names = ['Unknown', 'Baby', 'Child', 'Teenager', 'Student', 'Young Adult', 'Adult', 'Senior']
-    categories = pd.cut(df.Age, bins, labels=group_names)
-    df.Age = categories
-    return df`;
-        emitDocEvent(code, savedEventEmitter);
+    def simplify_ages(df):
+        df.Age = df.Age.fillna(-0.5)
+        bins = (-1, 0, 5, 12, 18, 25, 35, 60, 120)
+        group_names = ['Unknown', 'Baby', 'Child', 'Teenager', 'Student', 'Young Adult', 'Adult', 'Senior']
+        categories = pd.cut(df.Age, bins, labels=group_names)
+        df.Age = categories
+        return df`;
 
-        await Reporter.expectHashes('onOpenCloseOrSave', undefined, pandasHash, numpyHash, randomHash);
+        await testImports(code, 'interactive', pandasHash, numpyHash, randomHash);
     });
 
     test('from <pkg> import _', async () => {
         const code = `from scipy import special
-def drumhead_height(n, k, distance, angle, t):
-   kth_zero = special.jn_zeros(n, k)[-1]
-   return np.cos(t) * np.cos(n*angle) * special.jn(n, distance*kth_zero)
-theta = np.r_[0:2*np.pi:50j]
-radius = np.r_[0:1:50j]
-x = np.array([r * np.cos(theta) for r in radius])
-y = np.array([r * np.sin(theta) for r in radius])
-z = np.array([drumhead_height(1, 1, r, theta, 0.5) for r in radius])`;
-        emitDocEvent(code, savedEventEmitter);
+    def drumhead_height(n, k, distance, angle, t):
+       kth_zero = special.jn_zeros(n, k)[-1]
+       return np.cos(t) * np.cos(n*angle) * special.jn(n, distance*kth_zero)
+    theta = np.r_[0:2*np.pi:50j]
+    radius = np.r_[0:1:50j]
+    x = np.array([r * np.cos(theta) for r in radius])
+    y = np.array([r * np.sin(theta) for r in radius])
+    z = np.array([drumhead_height(1, 1, r, theta, 0.5) for r in radius])`;
 
-        await Reporter.expectHashes('onOpenCloseOrSave', undefined, scipyHash);
+        await testImports(code, 'interactive', scipyHash);
     });
 
     test('from <pkg> import _ as _', async () => {
         const code = `from pandas import DataFrame as df`;
-        emitDocEvent(code, savedEventEmitter);
-
-        await Reporter.expectHashes('onOpenCloseOrSave', undefined, pandasHash);
+        await testImports(code, 'jupyter-notebook', pandasHash);
     });
 
     test('import <pkg1>, <pkg2>', async () => {
         const code = `
-def drumhead_height(n, k, distance, angle, t):
-   import sklearn, pandas
-   return np.cos(t) * np.cos(n*angle) * special.jn(n, distance*kth_zero)
-theta = np.r_[0:2*np.pi:50j]
-radius = np.r_[0:1:50j]
-x = np.array([r * np.cos(theta) for r in radius])
-y = np.array([r * np.sin(theta) for r in radius])
-z = np.array([drumhead_height(1, 1, r, theta, 0.5) for r in radius])`;
-        emitDocEvent(code, savedEventEmitter);
-
-        await Reporter.expectHashes('onOpenCloseOrSave', undefined, sklearnHash, pandasHash);
+    def drumhead_height(n, k, distance, angle, t):
+       import sklearn, pandas
+       return np.cos(t) * np.cos(n*angle) * special.jn(n, distance*kth_zero)
+    theta = np.r_[0:2*np.pi:50j]
+    radius = np.r_[0:1:50j]
+    x = np.array([r * np.cos(theta) for r in radius])
+    y = np.array([r * np.sin(theta) for r in radius])
+    z = np.array([drumhead_height(1, 1, r, theta, 0.5) for r in radius])`;
+        await testImports(code, 'interactive', sklearnHash, pandasHash);
     });
 
     test('Import from within a function', async () => {
         const code = `
-def drumhead_height(n, k, distance, angle, t):
-   import sklearn as sk
-   return np.cos(t) * np.cos(n*angle) * special.jn(n, distance*kth_zero)
-theta = np.r_[0:2*np.pi:50j]
-radius = np.r_[0:1:50j]
-x = np.array([r * np.cos(theta) for r in radius])
-y = np.array([r * np.sin(theta) for r in radius])
-z = np.array([drumhead_height(1, 1, r, theta, 0.5) for r in radius])`;
-        emitDocEvent(code, savedEventEmitter);
+    def drumhead_height(n, k, distance, angle, t):
+       import sklearn as sk
+       return np.cos(t) * np.cos(n*angle) * special.jn(n, distance*kth_zero)
+    theta = np.r_[0:2*np.pi:50j]
+    radius = np.r_[0:1:50j]
+    x = np.array([r * np.cos(theta) for r in radius])
+    y = np.array([r * np.sin(theta) for r in radius])
+    z = np.array([drumhead_height(1, 1, r, theta, 0.5) for r in radius])`;
 
-        await Reporter.expectHashes('onOpenCloseOrSave', undefined, sklearnHash);
+        await testImports(code, 'interactive', sklearnHash);
     });
 
     test('Do not send the same package twice', async () => {
         const code = `
-import pandas
-import pandas`;
-        emitDocEvent(code, savedEventEmitter);
-
-        await Reporter.expectHashes('onOpenCloseOrSave', undefined, pandasHash);
+    import pandas
+    import pandas`;
+        await testImports(code, 'interactive', pandasHash);
     });
 
     test('Ignore relative imports', async () => {
         const code = 'from .pandas import not_real';
-        emitDocEvent(code, savedEventEmitter);
-
-        await Reporter.expectHashes('onOpenCloseOrSave');
-    });
-
-    test('Ignore docstring for `from` imports', async () => {
-        const code = `"""
-from numpy import the random function
-"""`;
-        emitDocEvent(code, savedEventEmitter);
-
-        await Reporter.expectHashes('onOpenCloseOrSave');
-    });
-
-    test('Ignore docstring for `import` imports', async () => {
-        const code = `"""
-import numpy for all the things
-"""`;
-        emitDocEvent(code, savedEventEmitter);
-
-        await Reporter.expectHashes('onOpenCloseOrSave');
+        await testImports(code, 'interactive');
     });
     test('Track packages when a cell is executed', async () => {
         const code = `import numpy`;


### PR DESCRIPTION
Python extension already has code to look for packages in `.py` files for telemetry, hence we don't need to do the same thing.
We only need to check the notebook files (IW or ipynb).