### PR TITLE
Add Display name (if !== URL) for a server in the kernel picker

### DIFF
--- a/news/1 Enhancements/11381.md
+++ b/news/1 Enhancements/11381.md
@@ -1,0 +1,1 @@
+If a display name is specified for a remote jupyte server display that name instead of (Remote) in the kernel picker.

--- a/package.nls.json
+++ b/package.nls.json
@@ -102,14 +102,17 @@
         "message": "Choose the kernels that are available in the kernel picker.",
         "comment": ["{Locked='kernel'}"]
     },
-    "jupyter.kernel.category.jupyterSession": "(Remote) Jupyter Session",
+    "jupyter.kernel.category.jupyterSession": "({0}) Jupyter Session",
     "jupyter.kernel.category.jupyterKernel": {
         "message": "Jupyter Kernel",
         "comment": ["{Locked='Kernel'}"]
     },
     "jupyter.kernel.category.jupyterRemoteKernel": {
-        "message": "(Remote) Jupyter Kernel",
+        "message": "({0}) Jupyter Kernel",
         "comment": ["{Locked='Kernel'}"]
+    },
+    "DataScience.kernelDefaultRemoteDisplayName": {
+        "message": "Remote"
     },
     "jupyter.kernel.category.conda": "Conda Env",
     "jupyter.kernel.category.poetry": {

--- a/src/kernels/jupyter/launcher/serverUriStorage.ts
+++ b/src/kernels/jupyter/launcher/serverUriStorage.ts
@@ -29,9 +29,7 @@ export const currentServerHashKey = 'currentServerHash';
  */
 @injectable()
 export class JupyterServerUriStorage implements IJupyterServerUriStorage, IServerConnectionType {
-    private lastSavedList?: Promise<
-        { uri: string; serverId: string; time: number; displayName?: string | undefined }[]
-    >;
+    private lastSavedList?: Promise<IJupyterServerUriEntry[]>;
     private currentUriPromise: Promise<string | undefined> | undefined;
     private _currentServerId: string | undefined;
     private _localOnly: boolean = false;

--- a/src/notebooks/controllers/controllerRegistration.ts
+++ b/src/notebooks/controllers/controllerRegistration.ts
@@ -136,7 +136,8 @@ export class ControllerRegistration implements IControllerRegistration {
                         this.appShell,
                         this.browser,
                         this.extensionChecker,
-                        this.serviceContainer
+                        this.serviceContainer,
+                        this.serverUriStorage
                     );
                     controller.onDidDispose(
                         () => {

--- a/src/notebooks/controllers/vscodeNotebookController.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.ts
@@ -190,7 +190,6 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
             kernelConnection.kind === 'connectToLiveRemoteKernel'
                 ? getRemoteKernelSessionInformation(kernelConnection)
                 : '';
-        // this.controller.kind = getKernelConnectionCategory(kernelConnection, this.serverUriStorage);
         getKernelConnectionCategory(kernelConnection, this.serverUriStorage)
             .then((kind) => {
                 this.controller.kind = kind;

--- a/src/platform/common/utils/localize.ts
+++ b/src/platform/common/utils/localize.ts
@@ -1239,14 +1239,16 @@ export namespace DataScience {
     export const importingIpynb = () => localize('DataScience.importingIpynb', 'Importing notebook file');
     export const exportingToFormat = () => localize('DataScience.exportingToFormat', 'Exporting to {0}');
     export const kernelCategoryForJupyterSession = () =>
-        localize('jupyter.kernel.category.jupyterSession', '(Remote) Jupyter Session');
+        localize('jupyter.kernel.category.jupyterSession', '({0}) Jupyter Session');
     export const kernelPrefixForRemote = () => localize('DataScience.kernelPrefixForRemote', '(Remote)');
+    export const kernelDefaultRemoteDisplayName = () =>
+        localize('DataScience.kernelDefaultRemoteDisplayName', 'Remote');
     export const kernelCategoryForJupyterKernel = () =>
         localize({ key: 'jupyter.kernel.category.jupyterKernel', comment: ['{Locked="Kernel"}'] }, 'Jupyter Kernel');
     export const kernelCategoryForRemoteJupyterKernel = () =>
         localize(
             { key: 'jupyter.kernel.category.jupyterRemoteKernel', comment: ['{Locked="kernel"}'] },
-            '(Remote) Jupyter Kernel'
+            '({0}) Jupyter Kernel'
         );
     export const kernelCategoryForConda = () => localize('jupyter.kernel.category.conda', 'Conda Env');
     export const kernelCategoryForPoetry = () =>


### PR DESCRIPTION
Fixes #11381

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
