### PR TITLE
Set jupyter functions for pylance as well when it sets those functions for python core ext and use pylance completion api to do dedup

### DIFF
--- a/src/standalone/intellisense/intellisenseProvider.node.ts
+++ b/src/standalone/intellisense/intellisenseProvider.node.ts
@@ -92,7 +92,7 @@ export class IntellisenseProvider implements INotebookCompletionProvider, IExten
         this.workspaceService.onDidChangeConfiguration(this.onDidChangeConfiguration, this, this.disposables);
     }
 
-    private async getLanguageClient(notebook: NotebookDocument) {
+    public async getLanguageClient(notebook: NotebookDocument) {
         const controller = this.notebookControllerSelection.getSelected(notebook);
         const interpreter = controller
             ? controller.connection.interpreter


### PR DESCRIPTION
<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] ~Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).~
-   [x] ~Title summarizes what is changing.~
-   [x] ~Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).~
-   [x] ~Appropriate comments and documentation strings in the code.~
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for feature-requests.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
