### PR TITLE
Telemetry tweak to web view loading

### DIFF
--- a/TELEMETRY.csv
+++ b/TELEMETRY.csv
@@ -1061,6 +1061,8 @@ Note: This could be just ignoring the UI so not a user action.","Telemetry.UserD
 "DATASCIENCE.USER_INSTALLED_PANDAS","Installed the python Pandas package.","Telemetry.UserInstalledPandas","IanMatthewHuff","DataFrameViewer","","","","","","",""
 "DATAVIEWER.USING_INTERPRETER","When the Data Viewer installer is using a Python interpreter to do the install.","Telemetry.DataViewerUsingInterpreter","IanMatthewHuff","DataFrameViewer","","","","","","",""
 "DATAVIEWER.USING_KERNEL","When the Data Viewer installer is using the Kernel to do the install.","Telemetry.DataViewerUsingKernel","IanMatthewHuff","DataFrameViewer","","","","","","",""
+"DATAVIEWER.WEBVIEW_LOADED","The Data Viewer webview was loaded.","Telemetry.DataViewerWebviewLoaded","IanMatthewHuff","DataFrameViewer","","","duration","Duration of a measure in milliseconds.
+Common measurement used across a number of events.","number","",false
 "DS_INTERNAL.ACTIVE_INTERPRETER_LISTING_PERF","Total time taken by Python extension to return the active Python environment.","Telemetry.ActiveInterpreterListingPerf","donjayamanne","N/A","","","duration","Total time taken to list interpreters.","number","",false
 "DS_INTERNAL.ACTIVE_INTERPRETER_LISTING_PERF","Total time taken by Python extension to return the active Python environment.","Telemetry.ActiveInterpreterListingPerf","donjayamanne","N/A","","","firstTime","Whether this is the first time in the session.
 (fetching kernels first time in the session is slower, later its cached).
@@ -2730,7 +2732,6 @@ This is required to identify output types that we're not mapping correctly.","st
 Common measurement used across a number of events.","number","",false
 "DS_INTERNAL.WEBVIEW_STARTUP","We started up a webview.","Telemetry.WebviewStartup","IanMatthewHuff","N/A","","","duration","Duration of a measure in milliseconds.
 Common measurement used across a number of events.","number","",false
-"DS_INTERNAL.WEBVIEW_STARTUP","We started up a webview.","Telemetry.WebviewStartup","IanMatthewHuff","N/A","","","type","The type of webview started up.","string","",false
 "DS_INTERNAL.ZMQ_NATIVE_BINARIES_LOADING","Telemetry event sent when the ZMQ native binaries do work.","Telemetry.ZMQSupported","donjayamanne","N/A","KernelStartup","","","","","",""
 "DS_INTERNAL.ZMQ_NATIVE_BINARIES_NOT_LOADING","Telemetry event sent when the ZMQ native binaries do not work.","Telemetry.ZMQNotSupported","donjayamanne","N/A","KernelStartup","","","","","",""
 "ENVFILE_VARIABLE_SUBSTITUTION","Telemetry event sent when substituting Environment variables to calculate value of variables.
@@ -2769,3 +2770,5 @@ I.e. jupyter can be found in the path as defined by the env variable process.env
 "OPEN_DATAVIEWER_FROM_VARIABLE_WINDOW_ERROR_EX","Telemetry event sent when user opens the data viewer via the variable view and there is an error in doing so.","EventName.OPEN_DATAVIEWER_FROM_VARIABLE_WINDOW_ERROR","IanMatthewHuff","DataFrameViewer, VariableViewer","","","","","","",""
 "OPEN_DATAVIEWER_FROM_VARIABLE_WINDOW_REQUEST_EX","Telemetry event sent when user opens the data viewer via the variable view.","EventName.OPEN_DATAVIEWER_FROM_VARIABLE_WINDOW_REQUEST","IanMatthewHuff","DataFrameViewer, VariableViewer","","","","","","",""
 "OPEN_DATAVIEWER_FROM_VARIABLE_WINDOW_SUCCESS_EX","Telemetry event sent when user opens the data viewer via the variable view and we successfully open the view.","EventName.OPEN_DATAVIEWER_FROM_VARIABLE_WINDOW_SUCCESS","IanMatthewHuff","DataFrameViewer, VariableViewer","","","","","","",""
+"PLOTVIEWER.WEBVIEW_LOADED","The Plot Viewer webview was loaded.","Telemetry.PlotViewerWebviewLoaded","IanMatthewHuff","PlotViewer","","","duration","Duration of a measure in milliseconds.
+Common measurement used across a number of events.","number","",false

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -2152,6 +2152,18 @@ Expand each section to see more information about that event.
 
 
 
+* DATAVIEWER.WEBVIEW_LOADED  (Telemetry.DataViewerWebviewLoaded)  
+      Owner: [@IanMatthewHuff](https://github.com/IanMatthewHuff)  
+    ```
+    The Data Viewer webview was loaded.  
+    ```
+
+    - Measures:  
+        - `duration`: `number`  
+        Duration of a measure in milliseconds.  
+        Common measurement used across a number of events.  
+
+
 * DS_INTERNAL.ACTIVE_INTERPRETER_LISTING_PERF  (Telemetry.ActiveInterpreterListingPerf)  
       Owner: [@donjayamanne](https://github.com/donjayamanne)  
     ```
@@ -4996,9 +5008,6 @@ In such cases we do not notify user of any failures or the like.
     We started up a webview.  
     ```
 
-    - Properties:  
-        - `type`: `string`  
-        The type of webview started up.  
     - Measures:  
         - `duration`: `number`  
         Duration of a measure in milliseconds.  
@@ -5149,5 +5158,17 @@ In such cases we do not notify user of any failures or the like.
     Telemetry event sent when user opens the data viewer via the variable view and we successfully open the view.  
     ```
 
+
+
+* PLOTVIEWER.WEBVIEW_LOADED  (Telemetry.PlotViewerWebviewLoaded)  
+      Owner: [@IanMatthewHuff](https://github.com/IanMatthewHuff)  
+    ```
+    The Plot Viewer webview was loaded.  
+    ```
+
+    - Measures:  
+        - `duration`: `number`  
+        Duration of a measure in milliseconds.  
+        Common measurement used across a number of events.  
 
 

--- a/src/gdpr.ts
+++ b/src/gdpr.ts
@@ -1098,6 +1098,15 @@
      ]
    }
  */
+//Telemetry.DataViewerWebviewLoaded
+/* __GDPR__
+   "DATAVIEWER.WEBVIEW_LOADED" : {
+     "${include}": [
+       "${F1}"
+
+     ]
+   }
+ */
 //Telemetry.ActiveInterpreterListingPerf
 /* __GDPR__
    "DS_INTERNAL.ACTIVE_INTERPRETER_LISTING_PERF" : {
@@ -2241,7 +2250,6 @@
 //Telemetry.WebviewStartup
 /* __GDPR__
    "DS_INTERNAL.WEBVIEW_STARTUP" : {
-     "type": {"classification":"SystemMetaData","purpose":"FeatureInsight","comment":"The type of webview started up.","owner":"IanMatthewHuff"},
      "${include}": [
        "${F1}"
 
@@ -2353,6 +2361,15 @@
 //EventName.OPEN_DATAVIEWER_FROM_VARIABLE_WINDOW_SUCCESS
 /* __GDPR__
    "OPEN_DATAVIEWER_FROM_VARIABLE_WINDOW_SUCCESS_EX" : {
+     "${include}": [
+       "${F1}"
+
+     ]
+   }
+ */
+//Telemetry.PlotViewerWebviewLoaded
+/* __GDPR__
+   "PLOTVIEWER.WEBVIEW_LOADED" : {
      "${include}": [
        "${F1}"
 

--- a/src/platform/common/constants.ts
+++ b/src/platform/common/constants.ts
@@ -569,7 +569,9 @@ export enum Telemetry {
     JupyterInstalled = 'JUPYTER_IS_INSTALLED',
     NoActiveKernelSession = 'DATASCIENCE.NO_ACTIVE_KERNEL_SESSION',
     DataViewerUsingInterpreter = 'DATAVIEWER.USING_INTERPRETER',
-    DataViewerUsingKernel = 'DATAVIEWER.USING_KERNEL'
+    DataViewerUsingKernel = 'DATAVIEWER.USING_KERNEL',
+    DataViewerWebviewLoaded = 'DATAVIEWER.WEBVIEW_LOADED',
+    PlotViewerWebviewLoaded = 'PLOTVIEWER.WEBVIEW_LOADED'
 }
 
 export enum JupyterCommands {

--- a/src/platform/webviews/webviewHost.ts
+++ b/src/platform/webviews/webviewHost.ts
@@ -255,11 +255,7 @@ export abstract class WebviewHost<IMapping> implements IDisposable {
     protected webViewRendered() {
         if (this.webviewInit && !this.webviewInit.resolved) {
             // Send telemetry for startup
-            sendTelemetryEvent(
-                Telemetry.WebviewStartup,
-                { duration: this.startupStopwatch.elapsedTime },
-                { type: this.title }
-            );
+            sendTelemetryEvent(Telemetry.WebviewStartup, { duration: this.startupStopwatch.elapsedTime });
 
             // Resolve our started promise. This means the webpanel is ready to go.
             this.webviewInit.resolve();

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -2083,24 +2083,11 @@ export class IEventNamePropertyMapping {
     /**
      * We started up a webview.
      */
-    [Telemetry.WebviewStartup]: TelemetryEventInfo<
-        {
-            /**
-             * The type of webview started up.
-             */
-            type: string;
-        } & DurationMeasurement
-    > = {
+    [Telemetry.WebviewStartup]: TelemetryEventInfo<DurationMeasurement> = {
         owner: 'IanMatthewHuff',
         feature: 'N/A',
         source: 'N/A',
-        measures: commonClassificationForDurationProperties(),
-        properties: {
-            type: {
-                classification: 'SystemMetaData',
-                purpose: 'FeatureInsight'
-            }
-        }
+        measures: commonClassificationForDurationProperties()
     };
     /**
      * Sent to measure the time taken to register an interpreter as a Jupyter kernel.
@@ -3144,6 +3131,24 @@ export class IEventNamePropertyMapping {
         owner: 'IanMatthewHuff',
         feature: ['VariableViewer'],
         source: 'N/A'
+    };
+    /**
+     * The Data Viewer webview was loaded.
+     */
+    [Telemetry.DataViewerWebviewLoaded]: TelemetryEventInfo<DurationMeasurement> = {
+        owner: 'IanMatthewHuff',
+        feature: ['DataFrameViewer'],
+        source: 'N/A',
+        measures: commonClassificationForDurationProperties()
+    };
+    /**
+     * The Plot Viewer webview was loaded.
+     */
+    [Telemetry.PlotViewerWebviewLoaded]: TelemetryEventInfo<DurationMeasurement> = {
+        owner: 'IanMatthewHuff',
+        feature: ['PlotViewer'],
+        source: 'N/A',
+        measures: commonClassificationForDurationProperties()
     };
     /**
      * A command that the extension contributes is executed.

--- a/src/webviews/extension-side/dataviewer/dataViewer.ts
+++ b/src/webviews/extension-side/dataviewer/dataViewer.ts
@@ -7,7 +7,7 @@ import '../../../platform/common/extensions';
 import { inject, injectable, named } from 'inversify';
 import { EventEmitter, Memento, Uri, ViewColumn } from 'vscode';
 
-import { sendTelemetryEvent } from '../../../telemetry';
+import { capturePerfTelemetry, sendTelemetryEvent } from '../../../telemetry';
 import { JupyterDataRateLimitError } from '../../../platform/errors/jupyterDataRateLimitError';
 import { DataViewerMessageListener } from './dataViewerMessageListener';
 import {
@@ -98,6 +98,7 @@ export class DataViewer extends WebviewPanelHost<IDataViewerMapping> implements 
         this.onDidDispose(this.dataViewerDisposed, this);
     }
 
+    @capturePerfTelemetry(Telemetry.DataViewerWebviewLoaded)
     public async showData(
         dataProvider: IDataViewerDataProvider | IJupyterVariableDataProvider,
         title: string


### PR DESCRIPTION
Changing the base webviewHost class to just be concerned with the loading time for a webview, not the type. For each class that uses the webviewHost make sure their initial loading function (whatever prep work is required and the webview load itself) is covered by a duration telemetry as well.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [x] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
