### PR TITLE
Fix two package.json commands that were using an outdated way to see if a document was jupyter

### DIFF
--- a/news/2 Fixes/9252.md
+++ b/news/2 Fixes/9252.md
@@ -1,0 +1,1 @@
+Restore the command to import a notebook from the explorer context menu.

--- a/package.json
+++ b/package.json
@@ -875,7 +875,7 @@
                     "when": "editorFocus && editorLangId == python && !notebookEditorFocused && isWorkspaceTrusted"
                 },
                 {
-                    "when": "editorFocus && editorLangId == python && resourceLangId == jupyter && !notebookEditorFocused && isWorkspaceTrusted",
+                    "when": "editorFocus && editorLangId == python && resourceExtname == .ipynb && !notebookEditorFocused && isWorkspaceTrusted",
                     "command": "jupyter.importnotebook",
                     "group": "Jupyter3@1"
                 },
@@ -1060,7 +1060,7 @@
                     "group": "Jupyter2"
                 },
                 {
-                    "when": "resourceLangId == jupyter && isWorkspaceTrusted",
+                    "when": "resourceExtname == .ipynb && isWorkspaceTrusted",
                     "command": "jupyter.importnotebookfile",
                     "group": "Jupyter"
                 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -189,7 +189,7 @@
         "message": "Import Jupyter Notebook",
         "comment": ["{Locked='Notebook'}"]
     },
-    "jupyter.command.jupyter.importnotebookfile.title": "Convert to Python Script",
+    "jupyter.command.jupyter.importnotebookfile.title": "Import Notebook to Script",
     "jupyter.command.jupyter.exportoutputasnotebook.title": {
         "message": "Export Interactive Window as Jupyter Notebook",
         "comment": ["{Locked='Notebook'}"]


### PR DESCRIPTION
Fixes #9252

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
