### PR TITLE
clean up interactive window creation

### DIFF
--- a/src/interactive-window/editor-integration/codewatcher.ts
+++ b/src/interactive-window/editor-integration/codewatcher.ts
@@ -20,7 +20,6 @@ import {
 
 import { IDocumentManager } from '../../platform/common/application/types';
 import { ICellRange, IConfigurationService, IDisposable, Resource } from '../../platform/common/types';
-import { chainable } from '../../platform/common/utils/decorators';
 import { isUri, noop } from '../../platform/common/utils/misc';
 import { capturePerfTelemetry, captureUsageTelemetry } from '../../telemetry';
 import { ICodeExecutionHelper } from '../../platform/terminals/types';
@@ -984,9 +983,7 @@ export class CodeWatcher implements ICodeWatcher {
         }
     }
 
-    @chainable()
     private getActiveInteractiveWindow() {
-        // This should be chained so that a queue forms when getting the interactive window
         return this.interactiveWindowProvider.getOrCreate(this.document?.uri);
     }
     private async addCode(

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -100,6 +100,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
     public get kernelConnectionMetadata(): KernelConnectionMetadata | undefined {
         return this.currentKernelInfo.metadata;
     }
+    private initialized = false;
     private _onDidChangeViewState = new EventEmitter<void>();
     private closedEvent = new EventEmitter<void>();
     private _submitters: Uri[] = [];
@@ -180,7 +181,11 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         }
     }
 
-    public start() {
+    public initialize() {
+        if (this.initialized) {
+            return;
+        }
+        this.initialized = true;
         window.onDidChangeActiveNotebookEditor((e) => {
             if (e === this.notebookEditor) {
                 this._onDidChangeViewState.fire();
@@ -228,7 +233,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
             }
         }
 
-        this.start();
+        this.initialize();
     }
 
     /**

--- a/src/interactive-window/types.ts
+++ b/src/interactive-window/types.ts
@@ -67,7 +67,7 @@ export interface IInteractiveWindow extends IInteractiveBase {
     readonly inputUri?: Uri;
     readonly notebookDocument?: NotebookDocument;
     closed: Event<void>;
-    start(): void;
+    initialize(): void;
     restore(preferredController: IVSCodeNotebookController | undefined): Promise<void>;
     addCode(code: string, file: Uri, line: number): Promise<boolean>;
     addErrorMessage(message: string, cell: NotebookCell): Promise<void>;


### PR DESCRIPTION
Part of #10808

- Remove the excessive thread safety, the deferred creation promise should be enough to ensure duplicate IWs are not created
- Stop subscribing to events each time a cell is added by making the restore method more idempotent