### PR TITLE
removed 2 old notebook experiments that are no longer used.

### DIFF
--- a/.devcontainer+remote+nonconda/.devcontainer/devcontainer.json
+++ b/.devcontainer+remote+nonconda/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	"build": {
 		"dockerfile": "../Dockerfile",
 		"context": "../../",
-		"args": { 
+		"args": {
 			// Update 'VARIANT' to pick a Python version: 3, 3.9, 3.8, 3.7, 3.6.
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local on arm64/Apple Silicon.
@@ -19,7 +19,6 @@
 		"terminal.integrated.shell.linux": "/bin/bash",
         "python.defaultInterpreterPath": "/usr/local/bin/python",
         "python.languageServer": "Pylance",
-		"python.pylanceLspNotebooksEnabled": true
 	},
 
 	"extensions": ["ms-python.vscode-pylance", "ms-python.python", "ms-vscode.vscode-typescript-tslint-plugin"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "@nteract/messaging": "^7.0.0",
                 "@vscode/extension-telemetry": "^0.6.2",
                 "@vscode/jupyter-ipywidgets": "^1.0.9",
-                "@vscode/jupyter-lsp-middleware": "^0.2.49",
+                "@vscode/jupyter-lsp-middleware": "^0.2.50",
                 "ajv-keywords": "^3.5.2",
                 "ansi-to-html": "^0.6.7",
                 "arch": "^2.1.0",
@@ -4677,9 +4677,9 @@
             "hasInstallScript": true
         },
         "node_modules/@vscode/jupyter-lsp-middleware": {
-            "version": "0.2.49",
-            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.49.tgz",
-            "integrity": "sha512-JpzXThToxqEPGQFi8XhHeq/r7TQBg1bkTlqci7FQhC0cEI/WIk7iI/b4PrFuL2qfCQhfMRWvyHkXhMyDpgFk9g==",
+            "version": "0.2.50",
+            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.50.tgz",
+            "integrity": "sha512-oOEpRZOJdKjByRMkUDVdGlQDiEO4/Mjr88u5zqktaS/4h0NtX8Hk6+HNQwENp4ur3Dpu47gD8wOTCrkOWzbHlA==",
             "dependencies": {
                 "@vscode/lsp-notebook-concat": "^0.1.16",
                 "fast-myers-diff": "^3.0.1",
@@ -28176,9 +28176,9 @@
             "integrity": "sha512-xx2aAtvoXz+yFGm3zSvAJLIDBiMehcj8Xw31n2gwv8lYGKllyqeEXIqZtN8kZfi4xR5GHUmKsH6EsvpCNAwXQw=="
         },
         "@vscode/jupyter-lsp-middleware": {
-            "version": "0.2.49",
-            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.49.tgz",
-            "integrity": "sha512-JpzXThToxqEPGQFi8XhHeq/r7TQBg1bkTlqci7FQhC0cEI/WIk7iI/b4PrFuL2qfCQhfMRWvyHkXhMyDpgFk9g==",
+            "version": "0.2.50",
+            "resolved": "https://registry.npmjs.org/@vscode/jupyter-lsp-middleware/-/jupyter-lsp-middleware-0.2.50.tgz",
+            "integrity": "sha512-oOEpRZOJdKjByRMkUDVdGlQDiEO4/Mjr88u5zqktaS/4h0NtX8Hk6+HNQwENp4ur3Dpu47gD8wOTCrkOWzbHlA==",
             "requires": {
                 "@vscode/lsp-notebook-concat": "^0.1.16",
                 "fast-myers-diff": "^3.0.1",
@@ -33853,7 +33853,7 @@
             "requires": {
                 "extend": "^3.0.0",
                 "glob": "^7.1.1",
-                "glob-parent": "5.1.2",
+                "glob-parent": "^3.1.0",
                 "is-negated-glob": "^1.0.0",
                 "ordered-read-streams": "^1.0.0",
                 "pumpify": "^1.3.5",
@@ -33864,8 +33864,7 @@
             },
             "dependencies": {
                 "glob-parent": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                    "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
                     "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
                     "dev": true,
                     "requires": {
@@ -33977,7 +33976,7 @@
                         "async-each": "^1.0.1",
                         "braces": "^2.3.2",
                         "fsevents": "^1.2.7",
-                        "glob-parent": "5.1.2",
+                        "glob-parent": "^3.1.0",
                         "inherits": "^2.0.3",
                         "is-binary-path": "^1.0.0",
                         "is-glob": "^4.0.0",
@@ -34020,8 +34019,7 @@
                     }
                 },
                 "glob-parent": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                    "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
                     "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
                     "dev": true,
                     "requires": {
@@ -34716,7 +34714,7 @@
                 "he": "^1.2.0",
                 "param-case": "^3.0.4",
                 "relateurl": "^0.2.7",
-                "terser": "5.14.2"
+                "terser": "^5.10.0"
             },
             "dependencies": {
                 "commander": {
@@ -40656,7 +40654,7 @@
             "integrity": "sha512-DF7ePE5bwitJrRdJSNrV+qAnQsfds0GbRA02ywy6TQrQewkm9DSHGDUxJaoJk2WUMlyQ7Odrf2o1PCZM50BcSg==",
             "requires": {
                 "jquery": ">=1.8.0",
-                "jquery-ui": ">=1.8.0"
+                "jquery-ui": "1.13.2"
             }
         },
         "snapdragon": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33853,7 +33853,7 @@
             "requires": {
                 "extend": "^3.0.0",
                 "glob": "^7.1.1",
-                "glob-parent": "^3.1.0",
+                "glob-parent": "5.1.2",
                 "is-negated-glob": "^1.0.0",
                 "ordered-read-streams": "^1.0.0",
                 "pumpify": "^1.3.5",
@@ -33864,7 +33864,8 @@
             },
             "dependencies": {
                 "glob-parent": {
-                    "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
                     "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
                     "dev": true,
                     "requires": {
@@ -33976,7 +33977,7 @@
                         "async-each": "^1.0.1",
                         "braces": "^2.3.2",
                         "fsevents": "^1.2.7",
-                        "glob-parent": "^3.1.0",
+                        "glob-parent": "5.1.2",
                         "inherits": "^2.0.3",
                         "is-binary-path": "^1.0.0",
                         "is-glob": "^4.0.0",
@@ -34019,7 +34020,8 @@
                     }
                 },
                 "glob-parent": {
-                    "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
                     "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
                     "dev": true,
                     "requires": {
@@ -34714,7 +34716,7 @@
                 "he": "^1.2.0",
                 "param-case": "^3.0.4",
                 "relateurl": "^0.2.7",
-                "terser": "^5.10.0"
+                "terser": "5.14.2"
             },
             "dependencies": {
                 "commander": {
@@ -40654,7 +40656,7 @@
             "integrity": "sha512-DF7ePE5bwitJrRdJSNrV+qAnQsfds0GbRA02ywy6TQrQewkm9DSHGDUxJaoJk2WUMlyQ7Odrf2o1PCZM50BcSg==",
             "requires": {
                 "jquery": ">=1.8.0",
-                "jquery-ui": "1.13.2"
+                "jquery-ui": ">=1.8.0"
             }
         },
         "snapdragon": {

--- a/package.json
+++ b/package.json
@@ -2159,7 +2159,7 @@
         "@nteract/messaging": "^7.0.0",
         "@vscode/extension-telemetry": "^0.6.2",
         "@vscode/jupyter-ipywidgets": "^1.0.9",
-        "@vscode/jupyter-lsp-middleware": "^0.2.49",
+        "@vscode/jupyter-lsp-middleware": "^0.2.50",
         "ajv-keywords": "^3.5.2",
         "ansi-to-html": "^0.6.7",
         "arch": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1951,12 +1951,6 @@
                     "description": "%jupyter.configuration.jupyter.newCellOnRunLast.description%",
                     "scope": "resource"
                 },
-                "jupyter.pylanceHandlesNotebooks": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "%jupyter.configuration.jupyter.pylanceHandlesNotebooks.description%",
-                    "scope": "machine"
-                },
                 "jupyter.pythonCompletionTriggerCharacters": {
                     "type": "string",
                     "default": ".%'\"",

--- a/package.nls.json
+++ b/package.nls.json
@@ -361,7 +361,6 @@
     "jupyter.configuration.jupyter.debugJustMyCode.description": "When debugging, debug just my code.",
     "jupyter.configuration.jupyter.showOutlineButtonInNotebookToolbar.description": "Show the Outline button in the Jupyter notebook toolbar.",
     "jupyter.configuration.jupyter.newCellOnRunLast.description": "Append a new empty cell to an interactive window file on running the currently last cell.",
-    "jupyter.configuration.jupyter.pylanceHandlesNotebooks.description": "Determines if Pylance manages notebook concat doc creation.",
     "jupyter.configuration.jupyter.pythonCompletionTriggerCharacters.description": "Characters which trigger auto completion on a python jupyter kernel.",
     "jupyter.configuration.jupyter.logKernelOutputSeparately.description": "Creates separate output panels for kernels/jupyter server console output",
     "jupyter.configuration.jupyter.excludeUserSitePackages.description": {

--- a/src/platform/common/configSettings.ts
+++ b/src/platform/common/configSettings.ts
@@ -103,8 +103,6 @@ export class JupyterSettings implements IWatchableJupyterSettings {
     public verboseLogging: boolean = false;
     public showVariableViewWhenDebugging: boolean = true;
     public newCellOnRunLast: boolean = true;
-    public pylanceHandlesNotebooks: boolean = true;
-    public pylanceLspNotebooksEnabled: boolean = false;
     public pythonCompletionTriggerCharacters: string = '';
     public logKernelOutputSeparately: boolean = false;
     public poetryPath: string = '';
@@ -259,7 +257,6 @@ export class JupyterSettings implements IWatchableJupyterSettings {
         // Special case poetryPath. It actually comes from the python settings
         if (pythonConfig) {
             replacer('poetryPath', pythonConfig);
-            replacer('pylanceLspNotebooksEnabled', pythonConfig);
         }
     }
 

--- a/src/platform/common/types.ts
+++ b/src/platform/common/types.ts
@@ -109,8 +109,6 @@ export interface IJupyterSettings {
     readonly variableTooltipFields: IVariableTooltipFields;
     readonly showVariableViewWhenDebugging: boolean;
     readonly newCellOnRunLast: boolean;
-    readonly pylanceHandlesNotebooks?: boolean;
-    readonly pylanceLspNotebooksEnabled?: boolean;
     readonly pythonCompletionTriggerCharacters?: string;
     readonly logKernelOutputSeparately: boolean;
     readonly poetryPath: string;

--- a/src/standalone/intellisense/notebookPythonPathService.node.ts
+++ b/src/standalone/intellisense/notebookPythonPathService.node.ts
@@ -10,7 +10,6 @@ import { IExtensionSingleActivationService } from '../../platform/activation/typ
 import { IPythonApiProvider } from '../../platform/api/types';
 import { PylanceExtension, PythonExtension } from '../../platform/common/constants';
 import { getFilePath } from '../../platform/common/platform/fs-paths';
-import { IConfigurationService } from '../../platform/common/types';
 import { IInterpreterService } from '../../platform/interpreter/contracts';
 import * as semver from 'semver';
 import { traceInfo, traceVerbose } from '../../platform/logging';
@@ -31,8 +30,7 @@ export class NotebookPythonPathService implements IExtensionSingleActivationServ
         @inject(IPythonApiProvider) private readonly apiProvider: IPythonApiProvider,
         @inject(INotebookEditorProvider) private readonly notebookEditorProvider: INotebookEditorProvider,
         @inject(IControllerSelection) private readonly notebookControllerSelection: IControllerSelection,
-        @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
-        @inject(IConfigurationService) private readonly configService: IConfigurationService
+        @inject(IInterpreterService) private readonly interpreterService: IInterpreterService
     ) {
         if (!this._isPylanceExtensionInstalled()) {
             this.extensionChangeHandler = extensions.onDidChange(this.extensionsChangeHandler.bind(this));
@@ -80,7 +78,7 @@ export class NotebookPythonPathService implements IExtensionSingleActivationServ
      */
     public isPylanceUsingLspNotebooks() {
         if (this._isEnabled === undefined) {
-            const isInTreatmentGroup = this.configService.getSettings().pylanceLspNotebooksEnabled;
+            const isInTreatmentGroup = true;
             const pythonVersion = extensions.getExtension(PythonExtension)?.packageJSON.version;
             const pylanceVersion = extensions.getExtension(PylanceExtension)?.packageJSON.version;
 


### PR DESCRIPTION
<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] ~Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).~
-   [x] ~Title summarizes what is changing.~
-   [x] ~Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).~
-   [x] ~Appropriate comments and documentation strings in the code.~
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for feature-requests.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).

this PR is a part of bigger effort of removing old notebook experiments.

https://github.com/microsoft/vscode-jupyter-lsp-middleware/pull/60