### PR TITLE
Validate handles on remove uri provider registration

### DIFF
--- a/src/notebooks/controllers/remoteKernelControllerWatcher.ts
+++ b/src/notebooks/controllers/remoteKernelControllerWatcher.ts
@@ -34,6 +34,9 @@ export class RemoteKernelControllerWatcher implements IExtensionSyncActivationSe
     private async addProviderHandlers() {
         const providers = await this.providerRegistry.getProviders();
         providers.forEach((provider) => {
+            // clear out any old handlers
+            this.onProviderHandlesChanged(provider).catch(noop);
+
             if (provider.onDidChangeHandles && !this.handledProviders.has(provider)) {
                 provider.onDidChangeHandles(this.onProviderHandlesChanged.bind(this, provider), this, this.disposables);
             }


### PR DESCRIPTION
Jupyter servers contributed by remote uri providers are not validated on provider registration.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
