### PR TITLE
move feature requests back to issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/3_feature_request.md
@@ -1,0 +1,9 @@
+---
+name: General feature request
+about: Suggest an idea for this project
+labels: feature-request
+---
+
+<!-- Please search existing issues to avoid creating duplicates. -->
+
+<!-- Describe the feature you'd like. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,9 +3,6 @@ contact_links:
   - name: "Help and Support"
     url: https://github.com/microsoft/vscode-jupyter/discussions/categories/questions-and-answers
     about: "Need help getting something to work, but you're not sure it's worth of submitting an issue? Ask here."
-  - name: "New Feature Ideas"
-    url: https://github.com/microsoft/vscode-jupyter/discussions/categories/new-ideas
-    about: "Have a great idea for a new feature or behavior? Tell us and the community about it."
   - name: "Chat on Discord"
     url: https://aka.ms/python-discord
     about: 'You can ask for help or chat in the `#jupyter` channel of our microsoft-python Discord server'


### PR DESCRIPTION
- creating a feature request takes two steps right now - for tracking and ownership, these need to be issues, so each one just gets converted anyway
- Follow how VS Code core creates feature requests now that they also have discussions
- I'm setting the label to be `feature-request` since that one seems more used that `enhancement`