### PR TITLE
Remove triage-needed from bug report form.

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_bug_form.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_form.yml
@@ -1,6 +1,6 @@
 name: Bug Report Form
 description: Same as above, but friendlier. :)
-labels: [bug, triage-needed]
+labels: [bug]
 assignees:
   - octocat
 body:


### PR DESCRIPTION
We don't use this label anymore.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
