### PR TITLE
fix interactive window restore

### DIFF
--- a/news/2 Fixes/11574.md
+++ b/news/2 Fixes/11574.md
@@ -1,0 +1,1 @@
+A restored Interactive Window will be re-used for code cells from the same python file.

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -437,6 +437,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
                         controller: e.controller.controller,
                         metadata: e.controller.connection
                     };
+                    // don't start the kernel if the IW has only been restored from a previous session
                     if (this.initialized) {
                         this.startKernel().ignoreErrors();
                     }

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -196,7 +196,6 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
 
     public ensureInitialized() {
         if (this.currentKernelInfo) {
-            // Also start connecting to our kernel but don't wait for it to finish
             this.startKernel().ignoreErrors();
         } else {
             traceWarning('No controller selected for Interactive Window');

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -209,8 +209,20 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
             (editor) => editor.notebook.uri.toString() === this.notebookUri.toString()
         );
         if (!this._notebookEditor || !visibleEditor) {
+            let currentTab: InteractiveTab | undefined;
+            window.tabGroups.all.find((group) => {
+                group.tabs.find((tab) => {
+                    if (isInteractiveInputTab(tab) && tab.input.uri.toString() == this.notebookUri.toString()) {
+                        currentTab = tab;
+                    }
+                });
+            });
+
             const document = await workspace.openNotebookDocument(this.notebookUri);
-            this._notebookEditor = await window.showNotebookDocument(document);
+            this._notebookEditor = await window.showNotebookDocument(document, {
+                preserveFocus: true,
+                viewColumn: currentTab?.group.viewColumn
+            });
 
             this.codeGeneratorFactory.getOrCreate(this.notebookDocument);
         }

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -95,7 +95,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         return this._submitters;
     }
     public get notebookDocument(): NotebookDocument {
-        return this.notebookEditor.notebook;
+        return this.notebookEditor?.notebook;
     }
     public get kernelConnectionMetadata(): KernelConnectionMetadata | undefined {
         return this.currentKernelInfo.metadata;
@@ -202,6 +202,9 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
         this.listenForControllerSelection();
 
         this.cellMatcher = new CellMatcher(this.configuration.getSettings(this.owningResource));
+        if (this.notebookDocument) {
+            this.codeGeneratorFactory.getOrCreate(this.notebookDocument);
+        }
     }
 
     public async ensureInitialized() {

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -190,7 +190,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
             }
         }, this.internalDisposables);
         workspace.onDidCloseNotebookDocument((notebookDocument) => {
-            if (notebookDocument === this.notebookDocument) {
+            if (notebookDocument.uri.toString() === this.notebookUri.toString()) {
                 this.closedEvent.fire();
             }
         }, this.internalDisposables);
@@ -205,10 +205,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
     }
 
     public async ensureInitialized() {
-        const visibleEditor = window.visibleNotebookEditors.find(
-            (editor) => editor.notebook.uri.toString() === this.notebookUri.toString()
-        );
-        if (!this._notebookEditor || !visibleEditor) {
+        if (!this._notebookEditor) {
             let currentTab: InteractiveTab | undefined;
             window.tabGroups.all.find((group) => {
                 group.tabs.find((tab) => {

--- a/src/interactive-window/interactiveWindowProvider.ts
+++ b/src/interactive-window/interactiveWindowProvider.ts
@@ -124,12 +124,20 @@ export class InteractiveWindowProvider
                 return;
             }
 
+            const tab = interactiveWindowMapping.get(iw.uriString);
+            const notebookEditor = window.visibleNotebookEditors.find(
+                (e) => e.notebook.uri.toString() === tab?.input.uri.toString()
+            );
+            if (!notebookEditor) {
+                return;
+            }
+
             const result = new InteractiveWindow(
                 this.serviceContainer,
                 iw.owner !== undefined ? Uri.from(iw.owner) : undefined,
                 iw.mode,
                 undefined,
-                interactiveWindowMapping.get(iw.uriString)!,
+                notebookEditor,
                 Uri.parse(iw.inputBoxUriString)
             );
             this._windows.push(result);

--- a/src/interactive-window/interactiveWindowProvider.ts
+++ b/src/interactive-window/interactiveWindowProvider.ts
@@ -126,11 +126,6 @@ export class InteractiveWindowProvider
 
             const tab = interactiveWindowMapping.get(iw.uriString);
 
-            // const notebookEditor = window.visibleNotebookEditors.find(
-            //     (editor) => editor.notebook.uri.toString() === tab?.input.uri.toString()
-            // );
-            // var editorOrTab = notebookEditor ? notebookEditor : tab;
-
             if (!tab) {
                 return;
             }

--- a/src/interactive-window/interactiveWindowProvider.ts
+++ b/src/interactive-window/interactiveWindowProvider.ts
@@ -125,10 +125,13 @@ export class InteractiveWindowProvider
             }
 
             const tab = interactiveWindowMapping.get(iw.uriString);
-            const notebookEditor = window.visibleNotebookEditors.find(
-                (e) => e.notebook.uri.toString() === tab?.input.uri.toString()
-            );
-            if (!notebookEditor) {
+
+            // const notebookEditor = window.visibleNotebookEditors.find(
+            //     (editor) => editor.notebook.uri.toString() === tab?.input.uri.toString()
+            // );
+            // var editorOrTab = notebookEditor ? notebookEditor : tab;
+
+            if (!tab) {
                 return;
             }
 
@@ -137,7 +140,7 @@ export class InteractiveWindowProvider
                 iw.owner !== undefined ? Uri.from(iw.owner) : undefined,
                 iw.mode,
                 undefined,
-                notebookEditor,
+                tab,
                 Uri.parse(iw.inputBoxUriString)
             );
             this._windows.push(result);
@@ -172,7 +175,7 @@ export class InteractiveWindowProvider
             result = await this.create(resource, mode, connection);
         }
 
-        result.ensureInitialized();
+        await result.ensureInitialized();
 
         return result;
     }

--- a/src/interactive-window/types.ts
+++ b/src/interactive-window/types.ts
@@ -4,7 +4,6 @@
 import { Disposable, Event, NotebookCell, NotebookDocument, NotebookEditor, Tab, Uri } from 'vscode';
 import { IDebuggingManager } from '../notebooks/debugger/debuggingTypes';
 import { IKernel, KernelConnectionMetadata } from '../kernels/types';
-import { IVSCodeNotebookController } from '../notebooks/controllers/types';
 import { Resource, InteractiveWindowMode, ICell } from '../platform/common/types';
 import { IFileGeneratedCodes } from './editor-integration/types';
 
@@ -67,8 +66,7 @@ export interface IInteractiveWindow extends IInteractiveBase {
     readonly inputUri?: Uri;
     readonly notebookDocument?: NotebookDocument;
     closed: Event<void>;
-    initialize(): void;
-    restore(preferredController: IVSCodeNotebookController | undefined): Promise<void>;
+    ensureInitialized(): void;
     addCode(code: string, file: Uri, line: number): Promise<boolean>;
     addErrorMessage(message: string, cell: NotebookCell): Promise<void>;
     debugCode(code: string, file: Uri, line: number): Promise<boolean>;

--- a/src/interactive-window/types.ts
+++ b/src/interactive-window/types.ts
@@ -66,7 +66,7 @@ export interface IInteractiveWindow extends IInteractiveBase {
     readonly inputUri?: Uri;
     readonly notebookDocument?: NotebookDocument;
     closed: Event<void>;
-    ensureInitialized(): void;
+    ensureInitialized(): Promise<void>;
     addCode(code: string, file: Uri, line: number): Promise<boolean>;
     addErrorMessage(message: string, cell: NotebookCell): Promise<void>;
     debugCode(code: string, file: Uri, line: number): Promise<boolean>;


### PR DESCRIPTION
Fixes #11574
part of #10808

- Most of the restoration is done just by recovering the editor, the controller is automatically selected.
- We need to make sure the events are all hooked up correctly even if no cells are run in the IW. (closing the IW should remove it from the list of windows)
- Get the editor information from the `windows` API instead of calling an API that might end up creating a new one. 
    - If the editor is closed before the extension does it's restore logic, we don't want to restore that editor

