### PR TITLE
Fix Widget CI failures

### DIFF
--- a/build/conda-nonconda-test-requirements.txt
+++ b/build/conda-nonconda-test-requirements.txt
@@ -4,6 +4,7 @@ packaging
 livelossplot
 versioneer
 pythreejs
+# Pinned per ipywidget 8 support: https://github.com/microsoft/vscode-jupyter/issues/11598
 ipysheet==0.5.0
 ipyvolume
 beakerx

--- a/build/conda-nonconda-test-requirements.txt
+++ b/build/conda-nonconda-test-requirements.txt
@@ -4,7 +4,7 @@ packaging
 livelossplot
 versioneer
 pythreejs
-ipysheet
+ipysheet==0.5.0
 ipyvolume
 beakerx
 beakerx_kernel_java

--- a/build/conda-test-requirements.yml
+++ b/build/conda-test-requirements.yml
@@ -1,6 +1,6 @@
 # Functional requirements using a conda environment file
 dependencies:
-  - ipywidgets=7.7.2
+  - ipywidgets=7.7.2 # Pinned per ipywidget 8 support: https://github.com/microsoft/vscode-jupyter/issues/11598
   - pandas
   - nbformat=5.0.8 # Lock down to prevent this error: https://github.com/jupyter/nbformat/issues/206
   - jinja2=3.0.3 # https://github.com/microsoft/vscode-jupyter/issues/9468#issuecomment-1078468039

--- a/build/conda-test-requirements.yml
+++ b/build/conda-test-requirements.yml
@@ -1,8 +1,6 @@
 # Functional requirements using a conda environment file
 dependencies:
   - ipywidgets=7.7.2
-  - jupyterlab-widgets=1.1.1
-  - widgetsnbextension=3.6.1
   - pandas
   - nbformat=5.0.8 # Lock down to prevent this error: https://github.com/jupyter/nbformat/issues/206
   - jinja2=3.0.3 # https://github.com/microsoft/vscode-jupyter/issues/9468#issuecomment-1078468039

--- a/build/conda-test-requirements.yml
+++ b/build/conda-test-requirements.yml
@@ -1,5 +1,8 @@
 # Functional requirements using a conda environment file
 dependencies:
+  - ipywidgets=7.7.2
+  - jupyterlab-widgets=1.1.1
+  - widgetsnbextension=3.6.1
   - pandas
   - nbformat=5.0.8 # Lock down to prevent this error: https://github.com/jupyter/nbformat/issues/206
   - jinja2=3.0.3 # https://github.com/microsoft/vscode-jupyter/issues/9468#issuecomment-1078468039

--- a/build/venv-test-requirements.txt
+++ b/build/venv-test-requirements.txt
@@ -14,7 +14,6 @@ versioneer
 pythreejs
 ipywidgets==7.7.2
 ipysheet==0.5.0
-widgetsnbextension==3.6.1
 ipyvolume
 beakerx
 beakerx_kernel_java

--- a/build/venv-test-requirements.txt
+++ b/build/venv-test-requirements.txt
@@ -12,6 +12,7 @@ jupyter
 livelossplot
 versioneer
 pythreejs
+# Pinned per ipywidget 8 support: https://github.com/microsoft/vscode-jupyter/issues/11598
 ipywidgets==7.7.2
 ipysheet==0.5.0
 ipyvolume

--- a/build/venv-test-requirements.txt
+++ b/build/venv-test-requirements.txt
@@ -12,7 +12,9 @@ jupyter
 livelossplot
 versioneer
 pythreejs
-ipysheet
+ipywidgets==7.7.2
+ipysheet==0.5.0
+widgetsnbextension==3.6.1
 ipyvolume
 beakerx
 beakerx_kernel_java


### PR DESCRIPTION
Pin widget versions back on 7 for CI. No issue assigned for this. ipywidget 8 has known support issues.