### PR TITLE
Replace @ char, widgets modules are not emails

### DIFF
--- a/src/notebooks/controllers/ipywidgets/scriptSourceProvider/ipyWidgetScriptSourceProvider.ts
+++ b/src/notebooks/controllers/ipywidgets/scriptSourceProvider/ipyWidgetScriptSourceProvider.ts
@@ -97,8 +97,9 @@ export class IPyWidgetScriptSourceProvider implements IWidgetScriptSourceProvide
                 // If the module name is found on CDN, then its not PII, its public information.
                 // The telemetry reporter assumes the presence of a `/` or `\` indicates these are file paths
                 // and obscures them. We don't want that, so we replace them with `_`.
+                // Replace @ as these could cause telemetry module to treat them as emails.
                 const telemetrySafeModuleName = isOnCDN
-                    ? found.moduleName.replace(/\//g, '_').replace(/\\/g, '_')
+                    ? found.moduleName.replace(/\//g, '_').replace(/\\/g, '_').replace(/@/g, '_at_')
                     : undefined;
 
                 sendTelemetryEvent(Telemetry.HashedIPyWidgetNameUsed, undefined, {


### PR DESCRIPTION
Found that some widget modules are obfuscated even when the widget module is found on a CDN.
If the module is on a CDN, then the data is not considered PII, hence we can safely strip the `@`