### PR TITLE
Don't prepopulate server display name field with the URI

### DIFF
--- a/news/2 Fixes/11643.md
+++ b/news/2 Fixes/11643.md
@@ -1,0 +1,1 @@
+In the insiders kernel picker, don't prepopulate the server display name field with the URI.

--- a/package.nls.json
+++ b/package.nls.json
@@ -598,7 +598,7 @@
     "DataScience.jupyterSelectUserAndPasswordTitle": "Enter your user name and password to connect to Jupyter Hub",
     "DataScience.jupyterSelectUserPrompt": "Enter your user name",
     "DataScience.jupyterSelectPasswordPrompt": "Enter your password",
-    "DataScience.jupyterRenameServer": "Change Server Display Name",
+    "DataScience.jupyterRenameServer": "Change Server Display Name (Leave Blank To Use URI)",
     "DataScience.removeRemoteJupyterServerEntryInQuickPick": "Remove",
     "DataScience.jupyterNotebookFailure": "Jupyter notebook failed to launch. \r\n{0}",
     "DataScience.remoteJupyterServerProvidedBy3rdPartyExtensionNoLongerValid": "The remote Jupyter Server contributed by the extension '{0}' is no longer available.",

--- a/src/kernels/jupyter/serverSelector.ts
+++ b/src/kernels/jupyter/serverSelector.ts
@@ -848,14 +848,13 @@ class JupyterServerSelector_Insiders implements IJupyterServerSelector {
         });
 
         // Offer the user a change to pick a display name for the server
-        // Prepopulate the value with the uri as the default suggestiong
+        // Leaving it blank will use the URI as the display name
         const newDisplayName = await this.applicationShell.showInputBox({
-            title: DataScience.jupyterRenameServer(),
-            value: uri
+            title: DataScience.jupyterRenameServer()
         });
 
         if (uri) {
-            await this.setJupyterURIToRemote(uri, true, newDisplayName);
+            await this.setJupyterURIToRemote(uri, true, newDisplayName || uri);
         }
     }
 

--- a/src/platform/common/utils/localize.ts
+++ b/src/platform/common/utils/localize.ts
@@ -643,7 +643,8 @@ export namespace DataScience {
             'DataScience.jupyterSelectUserAndPasswordTitle',
             'Enter your user name and password to connect to Jupyter Hub'
         );
-    export const jupyterRenameServer = () => localize('DataScience.jupyterRenameServer', 'Change Server Display Name');
+    export const jupyterRenameServer = () =>
+        localize('DataScience.jupyterRenameServer', 'Change Server Display Name (Leave Blank To Use URI)');
     export const jupyterSelectUserPrompt = () =>
         localize('DataScience.jupyterSelectUserPrompt', 'Enter your user name');
     export const jupyterSelectPasswordPrompt = () =>


### PR DESCRIPTION
Fixes #11643

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
