### PR TITLE
Fix #11675. Show 3rd party connection display name when available.

### DIFF
--- a/src/kernels/errors/kernelErrorHandler.node.ts
+++ b/src/kernels/errors/kernelErrorHandler.node.ts
@@ -19,6 +19,7 @@ import { IReservedPythonNamedProvider } from '../../platform/interpreter/types';
 import { JupyterKernelStartFailureOverrideReservedName } from '../../platform/interpreter/constants';
 import { DataScienceErrorHandler } from './kernelErrorHandler';
 import { getDisplayPath } from '../../platform/common/platform/fs-paths';
+import { JupyterConnection } from '../jupyter/jupyterConnection';
 
 /**
  * Common code for handling errors. This one is node specific.
@@ -40,6 +41,7 @@ export class DataScienceErrorHandlerNode extends DataScienceErrorHandler {
         @inject(ICommandManager) commandManager: ICommandManager,
         @inject(IsWebExtension) isWebExtension: boolean,
         @inject(IExtensions) extensions: IExtensions,
+        @inject(JupyterConnection) jupyterConnection: JupyterConnection,
         @inject(IReservedPythonNamedProvider) private readonly reservedPythonNames: IReservedPythonNamedProvider
     ) {
         super(
@@ -50,6 +52,7 @@ export class DataScienceErrorHandlerNode extends DataScienceErrorHandler {
             kernelDependency,
             workspaceService,
             serverUriStorage,
+            jupyterConnection,
             commandManager,
             isWebExtension,
             extensions

--- a/src/kernels/errors/kernelErrorHandler.ts
+++ b/src/kernels/errors/kernelErrorHandler.ts
@@ -20,7 +20,7 @@ import {
 } from '../../platform/common/types';
 import { DataScience, Common } from '../../platform/common/utils/localize';
 import { sendTelemetryEvent, Telemetry } from '../../telemetry';
-import { Commands } from '../../platform/common/constants';
+import { Commands, Identifiers } from '../../platform/common/constants';
 import { getDisplayNameOrNameOfKernelConnection } from '../helpers';
 import { translateProductToModule } from '../installer/utils';
 import { ProductNames } from '../installer/productNames';
@@ -50,7 +50,11 @@ import {
     IJupyterServerUriStorage,
     JupyterInterpreterDependencyResponse
 } from '../jupyter/types';
-import { handleExpiredCertsError, handleSelfCertsError } from '../jupyter/jupyterUtils';
+import {
+    extractJupyterServerHandleAndId,
+    handleExpiredCertsError,
+    handleSelfCertsError
+} from '../jupyter/jupyterUtils';
 import { getFilePath } from '../../platform/common/platform/fs-paths';
 import { isCancellationError } from '../../platform/common/cancellation';
 import { JupyterExpiredCertsError } from '../../platform/errors/jupyterExpiredCertsError';
@@ -59,6 +63,7 @@ import { RemoteJupyterServerUriProviderError } from './remoteJupyterServerUriPro
 import { InvalidRemoteJupyterServerUriHandleError } from './invalidRemoteJupyterServerUriHandleError';
 import { BaseKernelError, IDataScienceErrorHandler, WrappedKernelError } from './types';
 import { sendKernelTelemetryEvent } from '../telemetry/sendKernelTelemetryEvent';
+import { JupyterConnection } from '../jupyter/jupyterConnection';
 
 /***
  * Common code for handling errors.
@@ -76,6 +81,7 @@ export abstract class DataScienceErrorHandler implements IDataScienceErrorHandle
         private readonly kernelDependency: IKernelDependencyService | undefined,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IJupyterServerUriStorage) private readonly serverUriStorage: IJupyterServerUriStorage,
+        @inject(JupyterConnection) private readonly jupyterConnection: JupyterConnection,
         @inject(ICommandManager) private readonly commandManager: ICommandManager,
         @inject(IsWebExtension) private readonly isWebExtension: boolean,
         @inject(IExtensions) private readonly extensions: IExtensions
@@ -110,6 +116,12 @@ export abstract class DataScienceErrorHandler implements IDataScienceErrorHandle
             this.applicationShell
                 .showErrorMessage(DataScience.jupyterNotebookRemoteConnectFailedWeb().format(err.baseUrl))
                 .then(noop, noop);
+        } else if (err instanceof RemoteJupyterServerConnectionError) {
+            const message = await this.handleJupyterServerConnectionError(err, undefined);
+            this.applicationShell.showErrorMessage(message).then(noop, noop);
+        } else if (err instanceof RemoteJupyterServerUriProviderError) {
+            const message = await this.handleJupyterServerUriProviderError(err, undefined);
+            this.applicationShell.showErrorMessage(message).then(noop, noop);
         } else {
             // Some errors have localized and/or formatted error messages.
             const message = getCombinedErrorMessage(err.message || err.toString());
@@ -177,27 +189,10 @@ export abstract class DataScienceErrorHandler implements IDataScienceErrorHandle
                 }
                 return messageParts.join('\n');
             }
-        } else if (
-            error instanceof RemoteJupyterServerConnectionError ||
-            error instanceof RemoteJupyterServerUriProviderError
-        ) {
-            const savedList = await this.serverUriStorage.getSavedUriList();
-            const message =
-                error instanceof RemoteJupyterServerConnectionError
-                    ? error.originalError.message || ''
-                    : error.originalError?.message || error.message;
-            const serverId = error instanceof RemoteJupyterServerConnectionError ? error.serverId : error.serverId;
-            const displayName = savedList.find((item) => item.serverId === serverId)?.displayName;
-            const baseUrl = error instanceof RemoteJupyterServerConnectionError ? error.baseUrl : '';
-            const idAndHandle =
-                error instanceof RemoteJupyterServerUriProviderError ? `${error.providerId}:${error.handle}` : '';
-            const serverName =
-                displayName && baseUrl ? `${displayName} (${baseUrl})` : displayName || baseUrl || idAndHandle;
-
-            return getUserFriendlyErrorMessage(
-                DataScience.remoteJupyterConnectionFailedWithServerWithError().format(serverName, message),
-                errorContext
-            );
+        } else if (error instanceof RemoteJupyterServerConnectionError) {
+            return this.handleJupyterServerConnectionError(error, errorContext);
+        } else if (error instanceof RemoteJupyterServerUriProviderError) {
+            return this.handleJupyterServerUriProviderError(error, errorContext);
         } else if (error instanceof InvalidRemoteJupyterServerUriHandleError) {
             const extensionName =
                 this.extensions.getExtension(error.extensionId)?.packageJSON.displayName || error.extensionId;
@@ -208,6 +203,55 @@ export abstract class DataScienceErrorHandler implements IDataScienceErrorHandle
         }
 
         return getUserFriendlyErrorMessage(error, errorContext);
+    }
+    private async handleJupyterServerUriProviderError(
+        error: RemoteJupyterServerUriProviderError,
+        errorContext?: KernelAction
+    ) {
+        const savedList = await this.serverUriStorage.getSavedUriList();
+        const message = error.originalError?.message || error.message;
+        const serverId = error.serverId;
+        const displayName = savedList.find((item) => item.serverId === serverId)?.displayName;
+        const idAndHandle = `${error.providerId}:${error.handle}`;
+        const serverName = displayName || idAndHandle;
+
+        return getUserFriendlyErrorMessage(
+            DataScience.remoteJupyterConnectionFailedWithServerWithError().format(serverName, message),
+            errorContext
+        );
+    }
+    private async handleJupyterServerConnectionError(
+        error: RemoteJupyterServerConnectionError,
+        errorContext?: KernelAction
+    ) {
+        const savedList = await this.serverUriStorage.getSavedUriList();
+        const message = error.originalError.message || '';
+        const serverId = error.serverId;
+        const displayName = savedList.find((item) => item.serverId === serverId)?.displayName;
+
+        if (error.baseUrl === Identifiers.REMOTE_URI) {
+            // 3rd party server uri error
+            const serverInfo = this.jupyterConnection.getServerUri(error.url);
+            const serverName =
+                serverInfo?.displayName ?? this.generateJupyterIdAndHandleErrorName(error.url) ?? error.url;
+            return getUserFriendlyErrorMessage(
+                DataScience.remoteJupyterConnectionFailedWithServerWithError().format(serverName, message),
+                errorContext
+            );
+        } else {
+            const baseUrl = error.baseUrl;
+            const serverName = displayName && baseUrl ? `${displayName} (${baseUrl})` : displayName || baseUrl;
+
+            return getUserFriendlyErrorMessage(
+                DataScience.remoteJupyterConnectionFailedWithServerWithError().format(serverName, message),
+                errorContext
+            );
+        }
+    }
+    private generateJupyterIdAndHandleErrorName(url: string): string | undefined {
+        const idAndHandle = extractJupyterServerHandleAndId(url);
+
+        return idAndHandle ? `${idAndHandle.id}:${idAndHandle.handle}` : undefined;
     }
     public async handleKernelError(
         err: Error,

--- a/src/kernels/jupyter/jupyterConnection.ts
+++ b/src/kernels/jupyter/jupyterConnection.ts
@@ -129,7 +129,7 @@ export class JupyterConnection implements IExtensionSyncActivationService {
         }
     }
 
-    private getServerUri(uri: string): IJupyterServerUri | undefined {
+    public getServerUri(uri: string): IJupyterServerUri | undefined {
         const idAndHandle = extractJupyterServerHandleAndId(uri);
         if (idAndHandle) {
             return this.uriToJupyterServerUri.get(uri);

--- a/src/platform/errors/remoteJupyterServerConnectionError.ts
+++ b/src/platform/errors/remoteJupyterServerConnectionError.ts
@@ -16,7 +16,7 @@ import { BaseError } from './types';
  */
 export class RemoteJupyterServerConnectionError extends BaseError {
     public readonly baseUrl: string;
-    constructor(url: string, public readonly serverId: string, public readonly originalError: Error) {
+    constructor(readonly url: string, public readonly serverId: string, public readonly originalError: Error) {
         super(
             'remotejupyterserverconnection',
             DataScience.remoteJupyterConnectionFailedWithServerWithError().format(

--- a/src/test/datascience/errorHandler.unit.test.ts
+++ b/src/test/datascience/errorHandler.unit.test.ts
@@ -38,6 +38,7 @@ import { Commands } from '../../platform/common/constants';
 import { RemoteJupyterServerUriProviderError } from '../../kernels/errors/remoteJupyterServerUriProviderError';
 import { IReservedPythonNamedProvider } from '../../platform/interpreter/types';
 import { DataScienceErrorHandlerNode } from '../../kernels/errors/kernelErrorHandler.node';
+import { JupyterConnection } from '../../kernels/jupyter/jupyterConnection';
 
 suite('DataScience Error Handler Unit Tests', () => {
     let applicationShell: IApplicationShell;
@@ -49,6 +50,7 @@ suite('DataScience Error Handler Unit Tests', () => {
     let jupyterInterpreterService: JupyterInterpreterService;
     let kernelDependencyInstaller: IKernelDependencyService;
     let uriStorage: IJupyterServerUriStorage;
+    let jupyterConnection: JupyterConnection;
     let cmdManager: ICommandManager;
     let extensions: IExtensions;
     let reservedPythonNames: IReservedPythonNamedProvider;
@@ -88,6 +90,7 @@ suite('DataScience Error Handler Unit Tests', () => {
             instance(cmdManager),
             false,
             instance(extensions),
+            instance(jupyterConnection),
             instance(reservedPythonNames)
         );
         when(applicationShell.showErrorMessage(anything())).thenResolve();


### PR DESCRIPTION
Fixes #11675. When a server url is from 3rd party (baseUrl is `https://remote`), we should try to resolve its display name.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
