### PR TITLE
Fix #11681. Emit change event when multiple kernels are registered.

### DIFF
--- a/src/notebooks/controllers/controllerLoader.ts
+++ b/src/notebooks/controllers/controllerLoader.ts
@@ -130,9 +130,7 @@ export class ControllerLoader implements IControllerLoader, IExtensionSyncActiva
         traceVerbose(`Creating ${kernelConnections?.length} controllers`);
 
         try {
-            kernelConnections.forEach((value) => {
-                this.registration.add(value, viewTypes);
-            });
+            this.registration.batchAdd(kernelConnections, viewTypes);
         } catch (ex) {
             if (!isCancellationError(ex, true)) {
                 // This can happen in the tests, and these get bubbled upto VSC and are logged as unhandled exceptions.

--- a/src/notebooks/controllers/controllerRegistration.ts
+++ b/src/notebooks/controllers/controllerRegistration.ts
@@ -29,7 +29,12 @@ import { traceError, traceVerbose } from '../../platform/logging';
 import { sendTelemetryEvent, Telemetry } from '../../telemetry';
 import { NotebookCellLanguageService } from '../languages/cellLanguageService';
 import { KernelFilterService } from './kernelFilter/kernelFilterService';
-import { IControllerRegistration, InteractiveControllerIdSuffix, IVSCodeNotebookController } from './types';
+import {
+    IControllerRegistration,
+    InteractiveControllerIdSuffix,
+    IVSCodeNotebookController,
+    IVSCodeNotebookControllerUpdateEvent
+} from './types';
 import { VSCodeNotebookController } from './vscodeNotebookController';
 
 /**
@@ -43,11 +48,15 @@ export class ControllerRegistration implements IControllerRegistration {
     }
     private registeredControllers = new Map<string, VSCodeNotebookController>();
     private creationEmitter = new EventEmitter<IVSCodeNotebookController>();
+    private changeEmitter = new EventEmitter<IVSCodeNotebookControllerUpdateEvent>();
     private registeredMetadatas = new Map<string, KernelConnectionMetadata>();
     private inKernelExperiment = false;
 
     public get onCreated(): Event<IVSCodeNotebookController> {
         return this.creationEmitter.event;
+    }
+    public get onChanged(): Event<IVSCodeNotebookControllerUpdateEvent> {
+        return this.changeEmitter.event;
     }
     public get registered(): IVSCodeNotebookController[] {
         return [...this.registeredControllers.values()];
@@ -82,6 +91,15 @@ export class ControllerRegistration implements IControllerRegistration {
         this.serverUriStorage.onDidRemoveUris(this.onDidRemoveUris, this, this.disposables);
         this.workspace.onDidChangeConfiguration(this.onDidChangeConfiguration, this, this.disposables);
         this.inKernelExperiment = this.configuration.getSettings().kernelPickerType === 'OnlyOneTypeOfKernel';
+    }
+    batchAdd(metadatas: KernelConnectionMetadata[], types: ('jupyter-notebook' | 'interactive')[]) {
+        const added: IVSCodeNotebookController[] = [];
+        metadatas.forEach((metadata) => {
+            added.push(...this.add(metadata, types));
+        });
+
+        this.changeEmitter.fire({ added, removed: [] });
+        return added;
     }
     add(
         metadata: KernelConnectionMetadata,

--- a/src/notebooks/controllers/types.ts
+++ b/src/notebooks/controllers/types.ts
@@ -35,6 +35,12 @@ export interface IVSCodeNotebookController extends IDisposable {
     updateConnection(connection: KernelConnectionMetadata): void;
     setPendingCellAddition(notebook: vscode.NotebookDocument, promise: Promise<void>): void;
 }
+
+export interface IVSCodeNotebookControllerUpdateEvent {
+    added: IVSCodeNotebookController[];
+    removed: IVSCodeNotebookController[];
+}
+
 export const IControllerRegistration = Symbol('IControllerRegistration');
 
 export interface IControllerRegistration {
@@ -46,6 +52,15 @@ export interface IControllerRegistration {
      * Gets every registered connection metadata
      */
     all: KernelConnectionMetadata[];
+    /**
+     * Batch registers new controllers. Disposing a controller unregisters it.
+     * @param a list of metadatas
+     * @param types Types of notebooks to create the controller for
+     */
+    batchAdd(
+        metadatas: KernelConnectionMetadata[],
+        types: (typeof JupyterNotebookView | typeof InteractiveWindowView)[]
+    ): IVSCodeNotebookController[];
     /**
      * Registers a new controller. Disposing a controller unregisters it.
      * @param metadata
@@ -68,6 +83,10 @@ export interface IControllerRegistration {
      * Event fired when a controller is created
      */
     onCreated: vscode.Event<IVSCodeNotebookController>;
+    /**
+     * Event fired when controllers are added or removed
+     */
+    onChanged: vscode.Event<IVSCodeNotebookControllerUpdateEvent>;
 }
 
 export const IControllerSelection = Symbol('IControllerSelection');


### PR DESCRIPTION
Fixes #11681.

This PR made two changes:

* Emit change event when multiple notebook controllers are created in a kernel finder update event cycle.
* Ensure that we have controllers registered from a remote server when the remote server is added

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
