### PR TITLE
Fix #11686. Trigger a cache update immediately after reading from cache.

### DIFF
--- a/src/kernels/jupyter/finder/remoteKernelFinder.ts
+++ b/src/kernels/jupyter/finder/remoteKernelFinder.ts
@@ -162,6 +162,8 @@ export class RemoteKernelFinder implements IRemoteKernelFinder, IExtensionSingle
         // If we finish the cache first, and we don't have any items, in the cache, then load without cache.
         if (Array.isArray(kernelsFromCache) && kernelsFromCache.length > 0) {
             kernels = kernelsFromCache;
+            // kick off a cache update request
+            this.updateCache().then(noop, noop);
         } else {
             try {
                 const kernelsWithoutCachePromise = (async () => {


### PR DESCRIPTION
Fixes #11686.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
