### PR TITLE
improve code lens provider performance

### DIFF
--- a/TELEMETRY.csv
+++ b/TELEMETRY.csv
@@ -683,7 +683,8 @@ Used to detect the popularity of a mime type, that would help determine which mi
 E.g. if we see widget mimetype, then we know how many use ipywidgets and the like and helps us prioritize widget issues,
 or prioritize rendering of widgets when opening an existing notebook or the like.","Telemetry.CellOutputMimeType","donjayamanne","N/A","","","when","Whether the package was detected in an existing file (upon open, upon save, upon close) or when it was being used during execution.","","'onExecution' 
 'onOpenCloseOrSave' ",false
-"DS_INTERNAL.CODE_LENS_ACQ_TIME","How long on average we spent parsing code lens. Sent on shutdown.","Telemetry.CodeLensAverageAcquisitionTime","amunger","InteractiveWindow","","","duration","Duration of a measure in milliseconds.
+"DS_INTERNAL.CODE_LENS_ACQ_TIME","How long on average we spent parsing code lens. Sent on shutdown.
+We should be able to deprecate in favor of DocumentWithCodeCells, but we should compare the numbers first.","Telemetry.CodeLensAverageAcquisitionTime","amunger","InteractiveWindow","","","duration","Duration of a measure in milliseconds.
 Common measurement used across a number of events.","number","",false
 "DS_INTERNAL.COMMAND_EXECUTED","A command that the extension contributes is executed.","Telemetry.CommandExecuted","amunger","N/A","","","command","Name of the command executed.","string","",false
 "DS_INTERNAL.CONNECTFAILEDJUPYTER","Sent when we have failed to connect to the local Jupyter server we started.","Telemetry.ConnectFailedJupyter","donjayamanne","N/A","KernelStartup","","failed","Whether there was a failure.
@@ -717,6 +718,8 @@ Common to most of the events.","string","",true
 Common to most of the events.","string","",true
 "DS_INTERNAL.CONNECTREMOTEJUPYTER_VIA_LOCALHOST","Connecting to an existing Jupyter server, but connecting to localhost.","Telemetry.ConnectRemoteJupyterViaLocalHost","donjayamanne","N/A","KernelStartup","","","","","",""
 "DS_INTERNAL.CONNECTREMOTESELFCERTFAILEDJUPYTER","Jupyter server's certificate is not from a trusted authority.","Telemetry.ConnectRemoteSelfCertFailedJupyter","donjayamanne","N/A","KernelStartup","","","","","",""
+"DS_INTERNAL.DOCUMENT_WITH_CODE_CELLS","Info about code lenses, count and average time to parse the document.","Telemetry.DocumentWithCodeCells","amunger","InteractiveWindow","","","codeLensUpdateTime","Average time taken to aquire code lenses for a document without using the cache","number","",false
+"DS_INTERNAL.DOCUMENT_WITH_CODE_CELLS","Info about code lenses, count and average time to parse the document.","Telemetry.DocumentWithCodeCells","amunger","InteractiveWindow","","","maxCellCount","Maximum number of code lenses returned for the document","number","",false
 "DS_INTERNAL.FAILED_TO_UPDATE_JUPYTER_KERNEL_SPEC","Sent when we fail to update the kernel spec json file.","Telemetry.FailedToUpdateKernelSpec","donjayamanne","N/A","KernelStartup","","failed","Whether there was a failure.
 Common to most of the events.","true","",false
 "DS_INTERNAL.FAILED_TO_UPDATE_JUPYTER_KERNEL_SPEC","Sent when we fail to update the kernel spec json file.","Telemetry.FailedToUpdateKernelSpec","donjayamanne","N/A","KernelStartup","","failureCategory","A reason that we generate (e.g. kerneldied, noipykernel, etc), more like a category of the error.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1698,6 +1698,7 @@ Expand each section to see more information about that event.
       Owner: [@amunger](https://github.com/amunger)  
     ```
     How long on average we spent parsing code lens. Sent on shutdown.  
+    We should be able to deprecate in favor of DocumentWithCodeCells, but we should compare the numbers first.  
     ```
 
     - Measures:  
@@ -1799,6 +1800,19 @@ Expand each section to see more information about that event.
     Jupyter server's certificate is not from a trusted authority.  
     ```
 
+
+
+* DS_INTERNAL.DOCUMENT_WITH_CODE_CELLS  (Telemetry.DocumentWithCodeCells)  
+      Owner: [@amunger](https://github.com/amunger)  
+    ```
+    Info about code lenses, count and average time to parse the document.  
+    ```
+
+    - Measures:  
+        - `codeLensUpdateTime`: `number`  
+        Average time taken to aquire code lenses for a document without using the cache  
+        - `maxCellCount`: `number`  
+        Maximum number of code lenses returned for the document  
 
 
 * DS_INTERNAL.FAILED_TO_UPDATE_JUPYTER_KERNEL_SPEC  (Telemetry.FailedToUpdateKernelSpec)  

--- a/news/3 Code Health/11433.md
+++ b/news/3 Code Health/11433.md
@@ -1,0 +1,1 @@
+Reduce the amount of work done for each code lens creation to help performance.

--- a/src/gdpr.ts
+++ b/src/gdpr.ts
@@ -1083,6 +1083,17 @@
      ]
    }
  */
+//Telemetry.DocumentWithCodeCells
+/* __GDPR__
+   "DS_INTERNAL.DOCUMENT_WITH_CODE_CELLS" : {
+     "codeLensUpdateTime": {"classification":"SystemMetaData","purpose":"PerformanceAndHealth","comment":"Average time taken to aquire code lenses for a document without using the cache","owner":"amunger","isMeasurement":true},
+     "maxCellCount": {"classification":"SystemMetaData","purpose":"FeatureInsight","comment":"Maximum number of code lenses returned for the document","owner":"amunger","isMeasurement":true},
+     "${include}": [
+       "${F1}"
+
+     ]
+   }
+ */
 //Telemetry.FailedToUpdateKernelSpec
 /* __GDPR__
    "DS_INTERNAL.FAILED_TO_UPDATE_JUPYTER_KERNEL_SPEC" : {

--- a/src/interactive-window/editor-integration/codeLensFactory.ts
+++ b/src/interactive-window/editor-integration/codeLensFactory.ts
@@ -11,8 +11,7 @@ import {
     NotebookCellExecutionState,
     NotebookCellExecutionStateChangeEvent,
     Range,
-    TextDocument,
-    workspace
+    TextDocument
 } from 'vscode';
 
 import { IDocumentManager, IVSCodeNotebook, IWorkspaceService } from '../../platform/common/application/types';
@@ -154,11 +153,6 @@ export class CodeLensFactory implements ICodeLensFactory {
             cache.gotoCellLens = [];
             cache.cachedExecutionCounts = new Set<number>(documentCounts);
             needUpdate = true;
-        }
-
-        // Do not generate interactive window codelenses for TextDocuments which are part of NotebookDocuments
-        if (workspace.notebookDocuments.find((notebook) => notebook.uri.toString() === document.uri.toString())) {
-            return cache;
         }
 
         // Generate our code lenses if necessary

--- a/src/interactive-window/editor-integration/codelensProviderActivator.ts
+++ b/src/interactive-window/editor-integration/codelensProviderActivator.ts
@@ -5,7 +5,7 @@ import { injectable, inject } from 'inversify';
 import { IExtensionSyncActivationService } from '../../platform/activation/types';
 import { IDataScienceCodeLensProvider } from './types';
 import { languages } from 'vscode';
-import { PYTHON_FILE, PYTHON_UNTITLED } from '../../platform/common/constants';
+import { PYTHON_FILE_ANY_SCHEME } from '../../platform/common/constants';
 import { IExtensionContext } from '../../platform/common/types';
 
 @injectable()
@@ -17,7 +17,7 @@ export class CodeLensProviderActivator implements IExtensionSyncActivationServic
 
     public activate() {
         this.extensionContext.subscriptions.push(
-            languages.registerCodeLensProvider([PYTHON_FILE, PYTHON_UNTITLED], this.dataScienceCodeLensProvider)
+            languages.registerCodeLensProvider([PYTHON_FILE_ANY_SCHEME], this.dataScienceCodeLensProvider)
         );
     }
 }

--- a/src/interactive-window/editor-integration/codelensProviderActivator.ts
+++ b/src/interactive-window/editor-integration/codelensProviderActivator.ts
@@ -5,7 +5,7 @@ import { injectable, inject } from 'inversify';
 import { IExtensionSyncActivationService } from '../../platform/activation/types';
 import { IDataScienceCodeLensProvider } from './types';
 import { languages } from 'vscode';
-import { PYTHON_FILE_ANY_SCHEME } from '../../platform/common/constants';
+import { PYTHON_FILE, PYTHON_UNTITLED } from '../../platform/common/constants';
 import { IExtensionContext } from '../../platform/common/types';
 
 @injectable()
@@ -17,7 +17,7 @@ export class CodeLensProviderActivator implements IExtensionSyncActivationServic
 
     public activate() {
         this.extensionContext.subscriptions.push(
-            languages.registerCodeLensProvider([PYTHON_FILE_ANY_SCHEME], this.dataScienceCodeLensProvider)
+            languages.registerCodeLensProvider([PYTHON_FILE, PYTHON_UNTITLED], this.dataScienceCodeLensProvider)
         );
     }
 }

--- a/src/interactive-window/editor-integration/codelensprovider.ts
+++ b/src/interactive-window/editor-integration/codelensprovider.ts
@@ -19,7 +19,7 @@ import { noop } from '../../platform/common/utils/misc';
 import { StopWatch } from '../../platform/common/utils/stopWatch';
 import { IServiceContainer } from '../../platform/ioc/types';
 import { sendTelemetryEvent } from '../../telemetry';
-import { traceInfoIfCI } from '../../platform/logging';
+import { traceInfoIfCI, traceVerbose } from '../../platform/logging';
 import {
     CodeLensCommands,
     EditorContexts,
@@ -42,6 +42,7 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
     private totalGetCodeLensCalls: number = 0;
     private activeCodeWatchers: ICodeWatcher[] = [];
     private didChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
+
     constructor(
         @inject(IServiceContainer) private serviceContainer: IServiceContainer,
         @inject(IDebugLocationTracker) @optional() private debugLocationTracker: IDebugLocationTracker | undefined,
@@ -74,6 +75,7 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
                 duration: this.totalExecutionTimeInMs / this.totalGetCodeLensCalls
             });
         }
+        disposeAllDisposables(this.activeCodeWatchers);
     }
 
     public get onDidChangeCodeLenses(): vscode.Event<void> {
@@ -106,7 +108,8 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
     private onDidCloseTextDocument(e: vscode.TextDocument) {
         const index = this.activeCodeWatchers.findIndex((item) => item.uri && item.uri.toString() === e.uri.toString());
         if (index >= 0) {
-            this.activeCodeWatchers.splice(index, 1);
+            const codewatcher = this.activeCodeWatchers.splice(index, 1);
+            codewatcher[0].dispose();
         }
     }
 
@@ -192,7 +195,7 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
             return codeWatcher.getCodeLenses();
         }
 
-        traceInfoIfCI(`Creating a new watcher for document ${document.uri}`);
+        traceVerbose(`Creating a new watcher for document ${document.uri}`);
         const newCodeWatcher = this.createNewCodeWatcher(document);
         return newCodeWatcher.getCodeLenses();
     }
@@ -206,7 +209,7 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
         // Create a new watcher for this file if we can find a matching document
         const possibleDocuments = this.documentManager.textDocuments.filter((d) => d.uri.toString() === uri.toString());
         if (possibleDocuments && possibleDocuments.length > 0) {
-            traceInfoIfCI(`creating new code watcher with matching document ${uri}`);
+            traceVerbose(`creating new code watcher with matching document ${uri}`);
             return this.createNewCodeWatcher(possibleDocuments[0]);
         }
 

--- a/src/interactive-window/editor-integration/pythonCellFoldingProvider.ts
+++ b/src/interactive-window/editor-integration/pythonCellFoldingProvider.ts
@@ -13,7 +13,7 @@ import {
     languages
 } from 'vscode';
 import { IExtensionSyncActivationService } from '../../platform/activation/types';
-import { PYTHON_FILE, PYTHON_UNTITLED } from '../../platform/common/constants';
+import { InteractiveInputScheme, NotebookCellScheme, PYTHON_FILE_ANY_SCHEME } from '../../platform/common/constants';
 import { IExtensionContext } from '../../platform/common/types';
 import { IDataScienceCodeLensProvider } from './types';
 
@@ -26,7 +26,7 @@ export class PythonCellFoldingProvider implements IExtensionSyncActivationServic
 
     public activate() {
         this.extensionContext.subscriptions.push(
-            languages.registerFoldingRangeProvider([PYTHON_FILE, PYTHON_UNTITLED], this)
+            languages.registerFoldingRangeProvider([PYTHON_FILE_ANY_SCHEME], this)
         );
     }
 
@@ -35,6 +35,10 @@ export class PythonCellFoldingProvider implements IExtensionSyncActivationServic
         _context: FoldingContext,
         token: CancellationToken
     ): ProviderResult<FoldingRange[]> {
+        if ([NotebookCellScheme, InteractiveInputScheme].includes(document.uri.scheme)) {
+            return [];
+        }
+
         const codeWatcher = this.dataScienceCodeLensProvider.getCodeWatcher(document);
         if (codeWatcher) {
             const codeLenses = codeWatcher.getCodeLenses();

--- a/src/interactive-window/editor-integration/pythonCellFoldingProvider.ts
+++ b/src/interactive-window/editor-integration/pythonCellFoldingProvider.ts
@@ -13,7 +13,7 @@ import {
     languages
 } from 'vscode';
 import { IExtensionSyncActivationService } from '../../platform/activation/types';
-import { PYTHON_FILE_ANY_SCHEME } from '../../platform/common/constants';
+import { PYTHON_FILE, PYTHON_UNTITLED } from '../../platform/common/constants';
 import { IExtensionContext } from '../../platform/common/types';
 import { IDataScienceCodeLensProvider } from './types';
 
@@ -26,7 +26,7 @@ export class PythonCellFoldingProvider implements IExtensionSyncActivationServic
 
     public activate() {
         this.extensionContext.subscriptions.push(
-            languages.registerFoldingRangeProvider([PYTHON_FILE_ANY_SCHEME], this)
+            languages.registerFoldingRangeProvider([PYTHON_FILE, PYTHON_UNTITLED], this)
         );
     }
 

--- a/src/interactive-window/editor-integration/types.ts
+++ b/src/interactive-window/editor-integration/types.ts
@@ -12,6 +12,12 @@ export interface IDataScienceCodeLensProvider extends CodeLensProvider {
     getCodeWatcher(document: TextDocument): ICodeWatcher | undefined;
 }
 
+export type CodeLensPerfMeasures = {
+    totalCodeLensUpdateTimeInMs: number;
+    codeLensUpdateCount: number;
+    maxCellCount: number;
+};
+
 // Wraps the Code Watcher API
 export const ICodeWatcher = Symbol('ICodeWatcher');
 export interface ICodeWatcher extends IDisposable {
@@ -56,6 +62,7 @@ export interface ICodeLensFactory {
     updateRequired: Event<void>;
     createCodeLenses(document: TextDocument): CodeLens[];
     getCellRanges(document: TextDocument): ICellRange[];
+    getPerfMeasures(): CodeLensPerfMeasures;
 }
 
 export interface IGeneratedCode {

--- a/src/platform/common/constants.ts
+++ b/src/platform/common/constants.ts
@@ -441,6 +441,7 @@ export enum Telemetry {
     OpenPlotViewer = 'DATASCIENCE.OPEN_PLOT_VIEWER',
     DebugCurrentCell = 'DATASCIENCE.DEBUG_CURRENT_CELL',
     CodeLensAverageAcquisitionTime = 'DS_INTERNAL.CODE_LENS_ACQ_TIME',
+    DocumentWithCodeCells = 'DS_INTERNAL.DOCUMENT_WITH_CODE_CELLS',
     /**
      * Telemetry sent when user selects an interpreter to be used for starting of Jupyter server.
      */

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -698,12 +698,42 @@ export class IEventNamePropertyMapping {
     };
     /**
      * How long on average we spent parsing code lens. Sent on shutdown.
+     * We should be able to deprecate in favor of DocumentWithCodeCells, but we should compare the numbers first.
      **/
     [Telemetry.CodeLensAverageAcquisitionTime]: TelemetryEventInfo<DurationMeasurement> = {
         owner: 'amunger',
         feature: ['InteractiveWindow'],
         source: 'User Action',
         measures: commonClassificationForDurationProperties()
+    };
+    /**
+     * Info about code lenses, count and average time to parse the document.
+     **/
+    [Telemetry.DocumentWithCodeCells]: TelemetryEventInfo<{
+        /**
+         * Average time taken to aquire code lenses for a document without using the cache
+         **/
+        codeLensUpdateTime: number;
+        /**
+         * Maximum number of code lenses returned for the document
+         **/
+        maxCellCount: number;
+    }> = {
+        owner: 'amunger',
+        feature: ['InteractiveWindow'],
+        source: 'N/A',
+        measures: {
+            codeLensUpdateTime: {
+                classification: 'SystemMetaData',
+                purpose: 'PerformanceAndHealth',
+                isMeasurement: true
+            },
+            maxCellCount: {
+                classification: 'SystemMetaData',
+                purpose: 'FeatureInsight',
+                isMeasurement: true
+            }
+        }
     };
     /**
      * Sent when we have failed to connect to the local Jupyter server we started.


### PR DESCRIPTION
for #11433 

When looking at a large file with many code lenses, most of the code lens provider's is spent creating the code lens objects that are returned, and resulting gc calls. Even more is spent serializing those objects for the response, but that is outside the extension's scope.

This change focuses on speeding up the iteration through code lens range, reducing the `getDocument` and `localize` calls.

Parsing the file itself to divide it into cells isn't that large of an impact, so I didn't spend the time implementing a more complex incremental update.