### PR TITLE
Ensure we catch unhandled promise errors

### DIFF
--- a/src/interactive-window/debugger/jupyter/kernelDebugAdapter.ts
+++ b/src/interactive-window/debugger/jupyter/kernelDebugAdapter.ts
@@ -15,6 +15,7 @@ import { getInteractiveCellMetadata } from '../../../interactive-window/helpers'
 import { KernelDebugAdapterBase } from '../../../notebooks/debugger/kernelDebugAdapterBase';
 import { InteractiveCellMetadata } from '../../editor-integration/types';
 import { IDebugService } from '../../../platform/common/application/types';
+import { noop } from '../../../platform/common/utils/misc';
 /**
  * KernelDebugAdapter listens to debug messages in order to translate file requests into real files
  * (Interactive Window generally executes against a real file)
@@ -67,7 +68,7 @@ export class KernelDebugAdapter extends KernelDebugAdapterBase {
         }
     }
 
-    override handleMessage(message: DebugProtocol.ProtocolMessage): Promise<KernelMessage.IDebugReplyMsg | undefined> {
+    override handleMessage(message: DebugProtocol.ProtocolMessage) {
         traceInfoIfCI(`KernelDebugAdapter::handleMessage ${JSON.stringify(message, undefined, ' ')}`);
         if (message.type === 'request' && this.debugLocationTracker?.onWillReceiveMessage) {
             this.debugLocationTracker.onWillReceiveMessage(message);
@@ -75,7 +76,11 @@ export class KernelDebugAdapter extends KernelDebugAdapterBase {
         if (message.type === 'response' && this.debugLocationTracker?.onDidSendMessage) {
             this.debugLocationTracker.onDidSendMessage(message);
         }
-        return super.handleMessage(message);
+        const promise = super.handleMessage(message);
+        // The VS Code debugger class does not support an async `handleMessage`, its supposed to be sync.
+        // As a result, any errors here will not be handled and they'll be treated as unhandled errors.
+        promise.catch(noop);
+        return promise;
     }
 
     // Dump content of given cell into a tmp file and return path to file.


### PR DESCRIPTION
@roblourens Found that `handleMessage` is returning a promise and sometimes in our tests these methods can throw errors, however VS Code doesn't handle the promises returned, after all VS Code is expecting this method to be sync.

As a result of this, we now have unhandled promise rejections in the extesnion (which node.js doesn't like & I too hate such warnings)

This PR ensures we swallow the promise exceptions from the `handleMessage` metjod (which is ideally supposed to be a sync method).
I'll leave it upto you to either clean this up to ensure the super method is not async, but this should fix failreus due to `unhandled rejections`

Took me a few days to figure out this failure (when I've been running into this locally and sometimes on CI)