### PR TITLE
Avoid creating controllers from cache if uri is not validated yet.

### DIFF
--- a/src/kernels/jupyter/finder/remoteKernelFinder.ts
+++ b/src/kernels/jupyter/finder/remoteKernelFinder.ts
@@ -155,6 +155,12 @@ export class RemoteKernelFinder implements IRemoteKernelFinder, IExtensionSingle
             return;
         }
 
+        const uri = await this.serverUriStorage.getRemoteUri();
+        if (!uri || !uri.isValidated) {
+            await this.writeToCache([]);
+            return;
+        }
+
         const kernelsFromCache = await this.getFromCache();
 
         let kernels: RemoteKernelConnectionMetadata[] = [];


### PR DESCRIPTION
Cache is populated automatically on startup before the cache is validated through providers, this PR fixes that.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
