### PR TITLE
setting to disable python file cell folding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1920,6 +1920,12 @@
                     "description": "%jupyter.configuration.jupyter.interactiveWindowMode.description%",
                     "default": "multiple"
                 },
+                "jupyter.pythonCellFolding": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%jupyter.configuration.jupyter.pythonCellFolding.description%",
+                    "scope": "resource"
+                },
                 "jupyter.interactiveWindowViewColumn": {
                     "type": "string",
                     "enum": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -345,6 +345,9 @@
         "message": "Behavior of the Interactive Window. 'perFile' will create a new interactive window for every file that runs a cell. 'single' allows a single window. 'multiple' allows the creation of multiple.",
         "comment": ["{Locked='perFile'}", "{Locked=\"'single'\"}", "{Locked=\"'multiple'\"}"]
     },
+    "jupyter.configuration.jupyter.pythonCellFolding.description": {
+        "message": "Enable folding regions for code cells in Python files. This setting requires a reload of VS Code."
+    },
     "jupyter.configuration.jupyter.interactiveWindowViewColumn.description": {
         "message": "Where to open an Interactive Window that is not associated with a python file. 'beside' will open the interactive window to the right of the active editor. 'active' will open the interactive window in place of the active editor. 'secondGroup' will open the interactive window in the second editor group.",
         "comment": ["{Locked='beside'}", "{Locked=\"'active'\"}", "{Locked=\"'secondGroup'\"}"]

--- a/src/interactive-window/editor-integration/pythonCellFoldingProvider.ts
+++ b/src/interactive-window/editor-integration/pythonCellFoldingProvider.ts
@@ -14,20 +14,24 @@ import {
 } from 'vscode';
 import { IExtensionSyncActivationService } from '../../platform/activation/types';
 import { InteractiveInputScheme, NotebookCellScheme, PYTHON_FILE_ANY_SCHEME } from '../../platform/common/constants';
-import { IExtensionContext } from '../../platform/common/types';
+import { IConfigurationService, IExtensionContext } from '../../platform/common/types';
 import { IDataScienceCodeLensProvider } from './types';
 
 @injectable()
 export class PythonCellFoldingProvider implements IExtensionSyncActivationService, FoldingRangeProvider {
     constructor(
         @inject(IDataScienceCodeLensProvider) private dataScienceCodeLensProvider: IDataScienceCodeLensProvider,
-        @inject(IExtensionContext) private extensionContext: IExtensionContext
+        @inject(IExtensionContext) private extensionContext: IExtensionContext,
+        @inject(IConfigurationService) private configurationService: IConfigurationService
     ) {}
 
     public activate() {
-        this.extensionContext.subscriptions.push(
-            languages.registerFoldingRangeProvider([PYTHON_FILE_ANY_SCHEME], this)
-        );
+        const enabled = this.configurationService.getSettings().pythonCellFolding;
+        if (enabled) {
+            this.extensionContext.subscriptions.push(
+                languages.registerFoldingRangeProvider([PYTHON_FILE_ANY_SCHEME], this)
+            );
+        }
     }
 
     provideFoldingRanges(

--- a/src/platform/common/configSettings.ts
+++ b/src/platform/common/configSettings.ts
@@ -93,6 +93,7 @@ export class JupyterSettings implements IWatchableJupyterSettings {
     public jupyterCommandLineArguments: string[] = [];
     public widgetScriptSources: WidgetCDNs[] = [];
     public interactiveWindowMode: InteractiveWindowMode = 'multiple';
+    public pythonCellFolding: boolean = true;
     public interactiveWindowViewColumn: InteractiveWindowViewColumn = 'secondGroup';
     // Hidden settings not surfaced in package.json
     public disableZMQSupport: boolean = false;

--- a/src/platform/common/types.ts
+++ b/src/platform/common/types.ts
@@ -102,6 +102,7 @@ export interface IJupyterSettings {
     readonly jupyterCommandLineArguments: string[];
     readonly widgetScriptSources: WidgetCDNs[];
     readonly interactiveWindowMode: InteractiveWindowMode;
+    readonly pythonCellFolding: boolean;
     readonly interactiveWindowViewColumn: InteractiveWindowViewColumn;
     readonly disableZMQSupport: boolean;
     readonly forceIPyKernelDebugger?: boolean;


### PR DESCRIPTION
For #11703

Jupyter's code folding for code cells in python files seems to be able to interfere with python's standard code folding provider. This will allow users to disable code cell folding.
