### PR TITLE
Handle 3rd party server uri removal.

### DIFF
--- a/src/kernels/jupyter/jupyterUriProviderRegistration.ts
+++ b/src/kernels/jupyter/jupyterUriProviderRegistration.ts
@@ -46,6 +46,12 @@ export class JupyterUriProviderRegistration implements IJupyterUriProviderRegist
         return Promise.all([...this.providers.values()]);
     }
 
+    public async getProvider(id: string): Promise<IJupyterUriProvider | undefined> {
+        await this.checkOtherExtensions();
+
+        return this.providers.get(id);
+    }
+
     public async registerProvider(provider: IJupyterUriProvider) {
         if (!this.providers.has(provider.id)) {
             this.providers.set(provider.id, this.createProvider(provider));

--- a/src/kernels/jupyter/launcher/serverUriStorage.ts
+++ b/src/kernels/jupyter/launcher/serverUriStorage.ts
@@ -283,6 +283,12 @@ export class JupyterServerUriStorage implements IJupyterServerUriStorage, IServe
             return;
         }
     }
+    public async getUriForServer(id: string): Promise<IJupyterServerUriEntry | undefined> {
+        const savedList = await this.getSavedUriList();
+        const uriItem = savedList.find((item) => item.serverId === id);
+
+        return uriItem;
+    }
     public async setUriToLocal(): Promise<void> {
         traceInfoIfCI(`setUriToLocal`);
         await this.setUri(Settings.JupyterServerLocalLaunch, undefined);

--- a/src/kernels/jupyter/types.ts
+++ b/src/kernels/jupyter/types.ts
@@ -229,6 +229,7 @@ export const IJupyterUriProviderRegistration = Symbol('IJupyterUriProviderRegist
 export interface IJupyterUriProviderRegistration {
     onDidChangeProviders: Event<void>;
     getProviders(): Promise<ReadonlyArray<IJupyterUriProvider>>;
+    getProvider(id: string): Promise<IJupyterUriProvider | undefined>;
     registerProvider(picker: IJupyterUriProvider): void;
     getJupyterServerUri(id: string, handle: JupyterServerUriHandle): Promise<IJupyterServerUri>;
 }
@@ -270,6 +271,7 @@ export interface IJupyterServerUriStorage {
     removeUri(uri: string): Promise<void>;
     clearUriList(): Promise<void>;
     getRemoteUri(): Promise<IJupyterServerUriEntry | undefined>;
+    getUriForServer(id: string): Promise<IJupyterServerUriEntry | undefined>;
     setUriToLocal(): Promise<void>;
     setUriToRemote(uri: string, displayName: string): Promise<void>;
     setUriToNone(): Promise<void>;

--- a/src/kernels/kernelProvider.node.ts
+++ b/src/kernels/kernelProvider.node.ts
@@ -26,6 +26,7 @@ import {
     KernelOptions,
     ThirdPartyKernelOptions
 } from './types';
+import { IJupyterServerUriStorage } from './jupyter/types';
 
 /**
  * Node version of a kernel provider. Needed in order to create the node version of a kernel.
@@ -42,10 +43,13 @@ export class KernelProvider extends BaseCoreKernelProvider {
         @inject(IVSCodeNotebook) notebook: IVSCodeNotebook,
         @inject(IStatusProvider) private readonly statusProvider: IStatusProvider,
         @inject(IExtensionContext) private readonly context: IExtensionContext,
-        @multiInject(ITracebackFormatter) private readonly formatters: ITracebackFormatter[],
+        @inject(IJupyterServerUriStorage) jupyterServerUriStorage: IJupyterServerUriStorage,
+        @multiInject(ITracebackFormatter)
+        private readonly formatters: ITracebackFormatter[],
         @multiInject(IStartupCodeProvider) private readonly startupCodeProviders: IStartupCodeProvider[]
     ) {
         super(asyncDisposables, disposables, notebook);
+        disposables.push(jupyterServerUriStorage.onDidRemoveUris(this.handleUriRemoval.bind(this)));
     }
 
     public getOrCreate(notebook: NotebookDocument, options: KernelOptions): IKernel {

--- a/src/kernels/kernelProvider.web.ts
+++ b/src/kernels/kernelProvider.web.ts
@@ -25,6 +25,7 @@ import {
     KernelOptions,
     ThirdPartyKernelOptions
 } from './types';
+import { IJupyterServerUriStorage } from './jupyter/types';
 
 /**
  * Web version of a kernel provider. Needed in order to create the web version of a kernel.
@@ -41,10 +42,12 @@ export class KernelProvider extends BaseCoreKernelProvider {
         @inject(IVSCodeNotebook) notebook: IVSCodeNotebook,
         @inject(IStatusProvider) private readonly statusProvider: IStatusProvider,
         @inject(IExtensionContext) private readonly context: IExtensionContext,
+        @inject(IJupyterServerUriStorage) jupyterServerUriStorage: IJupyterServerUriStorage,
         @multiInject(ITracebackFormatter) private readonly formatters: ITracebackFormatter[],
         @multiInject(IStartupCodeProvider) private readonly startupCodeProviders: IStartupCodeProvider[]
     ) {
         super(asyncDisposables, disposables, notebook);
+        disposables.push(jupyterServerUriStorage.onDidRemoveUris(this.handleUriRemoval.bind(this)));
     }
 
     public getOrCreate(notebook: NotebookDocument, options: KernelOptions): IKernel {

--- a/src/test/kernels/kernelProvider.node.unit.test.ts
+++ b/src/test/kernels/kernelProvider.node.unit.test.ts
@@ -5,6 +5,7 @@ import { assert } from 'chai';
 import { anything, instance, mock, when } from 'ts-mockito';
 import { EventEmitter, NotebookController, NotebookDocument, Uri } from 'vscode';
 import { CellOutputDisplayIdTracker } from '../../kernels/execution/cellDisplayIdTracker';
+import { IJupyterServerUriStorage } from '../../kernels/jupyter/types';
 import { KernelProvider, ThirdPartyKernelProvider } from '../../kernels/kernelProvider.node';
 import {
     IThirdPartyKernelProvider,
@@ -38,6 +39,7 @@ suite('KernelProvider Node', () => {
     let outputTracker: CellOutputDisplayIdTracker;
     let vscNotebook: IVSCodeNotebook;
     let statusProvider: IStatusProvider;
+    let jupyterServerUriStorage: IJupyterServerUriStorage;
     let context: IExtensionContext;
     let onDidCloseNotebookDocument: EventEmitter<NotebookDocument>;
     const sampleUri1 = Uri.file('sample1.ipynb');
@@ -71,6 +73,7 @@ suite('KernelProvider Node', () => {
         outputTracker = mock<CellOutputDisplayIdTracker>();
         vscNotebook = mock<IVSCodeNotebook>();
         statusProvider = mock<IStatusProvider>();
+        jupyterServerUriStorage = mock<IJupyterServerUriStorage>();
         context = mock<IExtensionContext>();
         const configSettings = mock<IWatchableJupyterSettings>();
         when(vscNotebook.onDidCloseNotebookDocument).thenReturn(onDidCloseNotebookDocument.event);
@@ -91,6 +94,7 @@ suite('KernelProvider Node', () => {
             instance(vscNotebook),
             instance(statusProvider),
             instance(context),
+            instance(jupyterServerUriStorage),
             [],
             []
         );


### PR DESCRIPTION
3rd party server uri provider might not be instant in updating its server uri list but when we find we can't connect to it, we should ask the uri provider to double confirm instead of throwing errors to users.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
