### PR TITLE
Change deprecated telemetry.enableTelemetry in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The extension is available in multiple languages: `de`, `en`, `es`, `fa`, `fr`, 
 
 ## Data and telemetry
 
-The Microsoft Jupyter Extension for Visual Studio Code collects usage data and sends it to Microsoft to help improve our products and services. Read our [privacy statement](https://privacy.microsoft.com/privacystatement) to learn more. This extension respects the `telemetry.enableTelemetry` setting which you can learn more about at https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting.
+The Microsoft Jupyter Extension for Visual Studio Code collects usage data and sends it to Microsoft to help improve our products and services. Read our [privacy statement](https://privacy.microsoft.com/privacystatement) to learn more. This extension respects the `telemetry.telemetryLevel` setting which you can learn more about at https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting.
 
 ## Trademarks
 

--- a/news/2 Fixes/11811.md
+++ b/news/2 Fixes/11811.md
@@ -1,0 +1,1 @@
+Changed `telemetry.telemetryEnabled` to `telemetry.telemetryLevel` in `README.md` under "Data and telemetry".


### PR DESCRIPTION
VS Code's `telemetry.enableTelemetry` [has been marked for deprecation](https://code.visualstudio.com/updates/v1_61#_telemetry-settings) in favor of the new setting `telemetry.telemetryLevel`. [The link given in `README.md`](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting) does not reference `telemetry.enableTelemetry` anymore and the comment in VS Code's settings tell that the setting is deprecated in favor of the new setting.

![image](https://user-images.githubusercontent.com/22539418/198029437-0d5620df-ac7c-48f3-bce3-a8fb32aaff21.png)




<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] ~Appropriate comments and documentation strings in the code.~
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for feature-requests.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
