### PR TITLE
Fix restart when the notebook editor is not active.

### DIFF
--- a/src/notebooks/debugger/controllers/restartController.ts
+++ b/src/notebooks/debugger/controllers/restartController.ts
@@ -47,7 +47,7 @@ export class RestartController implements IDebuggingDelegate {
                     .disconnect()
                     .then(() => {
                         this.trace('restart', 'doRestart');
-                        return this.debuggingManager.tryToStartDebugging(this.mode, this.debugCell);
+                        return this.debuggingManager.tryToStartDebugging(this.mode, this.debugCell, true);
                     })
                     .catch((err) => {
                         this.error('restart', `Error restarting: ${err}`);

--- a/src/notebooks/debugger/debuggingManager.ts
+++ b/src/notebooks/debugger/debuggingManager.ts
@@ -124,14 +124,19 @@ export class DebuggingManager
         this.debugDocuments.set(Array.from(debugDocumentUris.values())).ignoreErrors();
     }
 
-    public async tryToStartDebugging(mode: KernelDebugMode, cell: NotebookCell) {
+    public async tryToStartDebugging(mode: KernelDebugMode, cell: NotebookCell, skipIpykernelCheck = false) {
         traceInfo(`Starting debugging with mode ${mode}`);
 
-        const ipykernelResult = await this.checkIpykernelAndPrompt(cell);
-        if (ipykernelResult === IpykernelCheckResult.Ok) {
-            if (mode === KernelDebugMode.RunByLine || mode === KernelDebugMode.Cell) {
-                await this.startDebuggingCell(mode, cell!);
+        if (!skipIpykernelCheck) {
+            const ipykernelResult = await this.checkIpykernelAndPrompt(cell);
+            if (ipykernelResult !== IpykernelCheckResult.Ok) {
+                traceInfo(`Ipykernel check failed: ${IpykernelCheckResult[ipykernelResult]}`);
+                return;
             }
+        }
+
+        if (mode === KernelDebugMode.RunByLine || mode === KernelDebugMode.Cell) {
+            await this.startDebuggingCell(mode, cell!);
         }
     }
 

--- a/src/notebooks/debugger/debuggingTypes.ts
+++ b/src/notebooks/debugger/debuggingTypes.ts
@@ -82,7 +82,7 @@ export interface IDebuggingManager {
 
 export const INotebookDebuggingManager = Symbol('INotebookDebuggingManager');
 export interface INotebookDebuggingManager extends IDebuggingManager {
-    tryToStartDebugging(mode: KernelDebugMode, cell: NotebookCell): Promise<void>;
+    tryToStartDebugging(mode: KernelDebugMode, cell: NotebookCell, skipIpykernelCheck?: boolean): Promise<void>;
     runByLineNext(cell: NotebookCell): void;
     runByLineStop(cell: NotebookCell): void;
 }


### PR DESCRIPTION
Skip ipykernel check on restart to avoiding needing an editor.
Fix #11789