### PR TITLE
Simplify Kernel dependencies

### DIFF
--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -36,6 +36,7 @@ import {
     isLocalConnection,
     KernelAction,
     KernelConnectionMetadata,
+    KernelHooks,
     NotebookCellRunState
 } from '../kernels/types';
 import { chainable } from '../platform/common/utils/decorators';
@@ -299,7 +300,7 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
             this.currentKernelInfo.controller = kernel.controller;
             this.currentKernelInfo.metadata = kernel.kernelConnectionMetadata;
 
-            const kernelEventHookForRestart = async (ev: 'willRestart' | 'willInterrupt') => {
+            const kernelEventHookForRestart = async (ev: KernelHooks) => {
                 if (ev === 'willRestart' && this.notebookDocument && this.currentKernelInfo.metadata) {
                     this._insertSysInfoPromise = undefined;
                     // If we're about to restart, insert a 'restarting' message as it happens

--- a/src/kernels/execution/cellDisplayIdTracker.ts
+++ b/src/kernels/execution/cellDisplayIdTracker.ts
@@ -1,21 +1,35 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { NotebookCell, NotebookCellOutput, NotebookDocument, workspace } from 'vscode';
+import { IExtensionSyncActivationService } from '../../platform/activation/types';
+import { disposeAllDisposables } from '../../platform/common/helpers';
+import { IDisposable, IDisposableRegistry } from '../../platform/common/types';
 import { isJupyterNotebook } from '../../platform/common/utils';
 
 /**
  * Tracks a cell's display id. Some messages are sent to other cells and the display id is used to identify them.
  */
 @injectable()
-export class CellOutputDisplayIdTracker {
-    private displayIdCellOutputMappingPerDocument = new WeakMap<
+export class CellOutputDisplayIdTracker implements IExtensionSyncActivationService {
+    private static displayIdCellOutputMappingPerDocument = new WeakMap<
         NotebookDocument,
         Map<string, { output: NotebookCellOutput; cell: NotebookCell }>
     >();
-    private cellToDisplayIdMapping = new WeakMap<NotebookCell, string>();
-    constructor() {
+    private static cellToDisplayIdMapping = new WeakMap<NotebookCell, string>();
+    private static disposables: IDisposable[] = [];
+    public static dispose() {
+        disposeAllDisposables(CellOutputDisplayIdTracker.disposables);
+    }
+    constructor(@inject(IDisposableRegistry) disposables: IDisposableRegistry) {
+        disposables.push({
+            dispose: () => {
+                CellOutputDisplayIdTracker.dispose();
+            }
+        });
+    }
+    public activate(): void {
         workspace.onDidChangeNotebookDocument((e) => {
             if (!isJupyterNotebook(e.notebook)) {
                 return;
@@ -25,10 +39,12 @@ export class CellOutputDisplayIdTracker {
                 .filter((change) => change.outputs?.length === 0)
                 .map((change) => {
                     // If a cell was cleared, then remove the mapping, the output cannot exist anymore.
-                    const displayIdToDelete = this.cellToDisplayIdMapping.get(change.cell);
+                    const displayIdToDelete = CellOutputDisplayIdTracker.cellToDisplayIdMapping.get(change.cell);
                     if (displayIdToDelete) {
-                        this.cellToDisplayIdMapping.delete(change.cell);
-                        this.displayIdCellOutputMappingPerDocument.get(e.notebook)?.delete(displayIdToDelete);
+                        CellOutputDisplayIdTracker.cellToDisplayIdMapping.delete(change.cell);
+                        CellOutputDisplayIdTracker.displayIdCellOutputMappingPerDocument
+                            .get(e.notebook)
+                            ?.delete(displayIdToDelete);
                     }
                 });
         });
@@ -38,20 +54,22 @@ export class CellOutputDisplayIdTracker {
      * When we need to update this display, we can resolve the promise & access the output.
      * The return value is a promise that needs to be resolved with the associated output thats been added to the DOM
      */
-    public trackOutputByDisplayId(cell: NotebookCell, displayId: string, output: NotebookCellOutput) {
-        let mapOfDisplayIdToOutput = this.displayIdCellOutputMappingPerDocument.get(cell.notebook);
+    public static trackOutputByDisplayId(cell: NotebookCell, displayId: string, output: NotebookCellOutput) {
+        let mapOfDisplayIdToOutput = CellOutputDisplayIdTracker.displayIdCellOutputMappingPerDocument.get(
+            cell.notebook
+        );
         if (!mapOfDisplayIdToOutput) {
             mapOfDisplayIdToOutput = new Map<string, { output: NotebookCellOutput; cell: NotebookCell }>();
-            this.displayIdCellOutputMappingPerDocument.set(cell.notebook, mapOfDisplayIdToOutput);
+            CellOutputDisplayIdTracker.displayIdCellOutputMappingPerDocument.set(cell.notebook, mapOfDisplayIdToOutput);
         }
         mapOfDisplayIdToOutput.set(displayId, { output, cell: cell });
-        this.cellToDisplayIdMapping.set(cell, displayId);
+        CellOutputDisplayIdTracker.cellToDisplayIdMapping.set(cell, displayId);
     }
     /**
      * We return a promise, as we need to wait until the output is part of the DOM before we can update it.
      */
-    public getMappedOutput(notebook: NotebookDocument, displayId: string): NotebookCellOutput | undefined {
-        const mapOfDisplayIdToOutput = this.displayIdCellOutputMappingPerDocument.get(notebook);
+    public static getMappedOutput(notebook: NotebookDocument, displayId: string): NotebookCellOutput | undefined {
+        const mapOfDisplayIdToOutput = CellOutputDisplayIdTracker.displayIdCellOutputMappingPerDocument.get(notebook);
         if (!mapOfDisplayIdToOutput) {
             return;
         }

--- a/src/kernels/execution/cellExecutionMessageHandler.ts
+++ b/src/kernels/execution/cellExecutionMessageHandler.ts
@@ -26,7 +26,6 @@ import {
 } from 'vscode';
 
 import { Kernel } from '@jupyterlab/services';
-import { CellOutputDisplayIdTracker } from './cellDisplayIdTracker';
 import { CellExecutionCreator } from './cellExecutionCreator';
 import { IApplicationShell } from '../../platform/common/application/types';
 import { disposeAllDisposables } from '../../platform/common/helpers';
@@ -46,6 +45,7 @@ import { handleTensorBoardDisplayDataOutput } from './executionHelpers';
 import isObject = require('lodash/isObject');
 import { Identifiers, WIDGET_MIMETYPE } from '../../platform/common/constants';
 import { Lazy } from '../../platform/common/utils/lazy';
+import { CellOutputDisplayIdTracker } from './cellDisplayIdTracker';
 
 // Helper interface for the set_next_input execute reply payload
 interface ISetNextInputPayload {
@@ -174,7 +174,6 @@ export class CellExecutionMessageHandler implements IDisposable {
         public readonly cell: NotebookCell,
         private readonly applicationService: IApplicationShell,
         private readonly controller: NotebookController,
-        private readonly outputDisplayIdTracker: CellOutputDisplayIdTracker,
         private readonly context: IExtensionContext,
         private readonly formatters: ITracebackFormatter[],
         private readonly kernel: Kernel.IKernelConnection,
@@ -507,7 +506,7 @@ export class CellExecutionMessageHandler implements IDisposable {
         this.clearOutputIfNecessary(this.execution);
         // Keep track of the display_id against the output item, we might need this to update this later.
         if (displayId) {
-            this.outputDisplayIdTracker.trackOutputByDisplayId(this.cell, displayId, cellOutput);
+            CellOutputDisplayIdTracker.trackOutputByDisplayId(this.cell, displayId, cellOutput);
         }
 
         // Append to the data (we would push here but VS code requires a recreation of the array)
@@ -936,7 +935,7 @@ export class CellExecutionMessageHandler implements IDisposable {
         if (!displayId) {
             return;
         }
-        const outputToBeUpdated = this.outputDisplayIdTracker.getMappedOutput(this.cell.notebook, displayId);
+        const outputToBeUpdated = CellOutputDisplayIdTracker.getMappedOutput(this.cell.notebook, displayId);
         if (!outputToBeUpdated) {
             return;
         }

--- a/src/kernels/execution/cellExecutionMessageHandlerService.ts
+++ b/src/kernels/execution/cellExecutionMessageHandlerService.ts
@@ -7,7 +7,6 @@ import { ITracebackFormatter } from '../../kernels/types';
 import { IApplicationShell } from '../../platform/common/application/types';
 import { disposeAllDisposables } from '../../platform/common/helpers';
 import { IDisposable, IExtensionContext } from '../../platform/common/types';
-import { CellOutputDisplayIdTracker } from './cellDisplayIdTracker';
 import { CellExecutionMessageHandler } from './cellExecutionMessageHandler';
 
 /**
@@ -20,7 +19,6 @@ export class CellExecutionMessageHandlerService {
     constructor(
         private readonly appShell: IApplicationShell,
         private readonly controller: NotebookController,
-        private readonly outputDisplayIdTracker: CellOutputDisplayIdTracker,
         private readonly context: IExtensionContext,
         private readonly formatters: ITracebackFormatter[]
     ) {
@@ -60,7 +58,6 @@ export class CellExecutionMessageHandlerService {
             cell,
             this.appShell,
             this.controller,
-            this.outputDisplayIdTracker,
             this.context,
             this.formatters,
             options.kernel,

--- a/src/kernels/execution/kernelExecution.ts
+++ b/src/kernels/execution/kernelExecution.ts
@@ -14,7 +14,6 @@ import { createDeferred, waitForPromise } from '../../platform/common/utils/asyn
 import { StopWatch } from '../../platform/common/utils/stopWatch';
 import { sendKernelTelemetryEvent } from '../telemetry/sendKernelTelemetryEvent';
 import { Telemetry } from '../../telemetry';
-import { CellOutputDisplayIdTracker } from './cellDisplayIdTracker';
 import {
     IKernelConnectionSession,
     IThirdPartyKernel,
@@ -200,7 +199,6 @@ export class KernelExecution extends BaseKernelExecution<IKernel> {
         kernel: IKernel,
         appShell: IApplicationShell,
         interruptTimeout: number,
-        outputTracker: CellOutputDisplayIdTracker,
         context: IExtensionContext,
         formatters: ITracebackFormatter[]
     ) {
@@ -208,7 +206,6 @@ export class KernelExecution extends BaseKernelExecution<IKernel> {
         const requestListener = new CellExecutionMessageHandlerService(
             appShell,
             kernel.controller,
-            outputTracker,
             context,
             formatters
         );

--- a/src/kernels/kernelSettings.ts
+++ b/src/kernels/kernelSettings.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { IConfigurationService, Resource } from '../platform/common/types';
+import { IKernelSettings } from './types';
+
+export function createKernelSettings(configService: IConfigurationService, resource: Resource): IKernelSettings {
+    return {
+        get enableExtendedKernelCompletions() {
+            return configService.getSettings(resource).enableExtendedKernelCompletions;
+        },
+        get generateSVGPlots() {
+            return configService.getSettings(resource).generateSVGPlots;
+        },
+        get ignoreVscodeTheme() {
+            return configService.getSettings(resource).ignoreVscodeTheme;
+        },
+        get interruptTimeout() {
+            return configService.getSettings(resource).jupyterInterruptTimeout;
+        },
+        get launchTimeout() {
+            return configService.getSettings(resource).jupyterLaunchTimeout;
+        },
+        get runStartupCommands() {
+            return configService.getSettings(resource).runStartupCommands;
+        },
+        get themeMatplotlibPlots() {
+            return configService.getSettings(resource).themeMatplotlibPlots;
+        }
+    };
+}

--- a/src/kernels/kernelStatusProvider.ts
+++ b/src/kernels/kernelStatusProvider.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { inject } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { IExtensionSyncActivationService } from '../platform/activation/types';
 import { disposeAllDisposables } from '../platform/common/helpers';
 import { IDisposable, IDisposableRegistry } from '../platform/common/types';
@@ -11,6 +11,7 @@ import { IStatusProvider } from '../platform/progress/types';
 import { getDisplayNameOrNameOfKernelConnection } from './helpers';
 import { IKernel, IKernelProvider } from './types';
 
+@injectable()
 export class KernelStatusProvider implements IExtensionSyncActivationService {
     private readonly disposables: IDisposable[] = [];
     private readonly restartStatus = new WeakMap<IKernel, IDisposable>();

--- a/src/kernels/kernelStatusProvider.ts
+++ b/src/kernels/kernelStatusProvider.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { inject } from 'inversify';
+import { IExtensionSyncActivationService } from '../platform/activation/types';
+import { disposeAllDisposables } from '../platform/common/helpers';
+import { IDisposable, IDisposableRegistry } from '../platform/common/types';
+import { DataScience } from '../platform/common/utils/localize';
+import { KernelProgressReporter } from '../platform/progress/kernelProgressReporter';
+import { IStatusProvider } from '../platform/progress/types';
+import { getDisplayNameOrNameOfKernelConnection } from './helpers';
+import { IKernel, IKernelProvider } from './types';
+
+export class KernelStatusProvider implements IExtensionSyncActivationService {
+    private readonly disposables: IDisposable[] = [];
+    private readonly restartStatus = new WeakMap<IKernel, IDisposable>();
+    private readonly restartProgress = new WeakMap<IKernel, IDisposable>();
+    private readonly interruptStatus = new WeakMap<IKernel, IDisposable>();
+    constructor(
+        @inject(IKernelProvider) private readonly kernelProvider: IKernelProvider,
+        @inject(IDisposableRegistry) disposables: IDisposableRegistry,
+        @inject(IStatusProvider) protected readonly statusProvider: IStatusProvider
+    ) {
+        disposables.push(this);
+    }
+    public dispose(): void {
+        disposeAllDisposables(this.disposables);
+    }
+    activate(): void {
+        this.kernelProvider.onDidCreateKernel(this.onDidCreateKernel, this, this.disposables);
+    }
+    private onDidCreateKernel(kernel: IKernel) {
+        // Restart status.
+        kernel.addEventHook(async (e) => {
+            switch (e) {
+                case 'willRestart': {
+                    this.restartStatus.get(kernel)?.dispose();
+                    this.restartProgress.get(kernel)?.dispose();
+                    const status = this.statusProvider.set(DataScience.restartingKernelStatus().format(''));
+                    this.restartStatus.set(kernel, status);
+                    const progress = KernelProgressReporter.createProgressReporter(
+                        kernel.resourceUri,
+                        DataScience.restartingKernelStatus().format(
+                            `: ${getDisplayNameOrNameOfKernelConnection(kernel.kernelConnectionMetadata)}`
+                        )
+                    );
+                    this.restartProgress.set(kernel, progress);
+                    break;
+                }
+                case 'restartCompleted': {
+                    this.restartStatus.get(kernel)?.dispose();
+                    this.restartProgress.get(kernel)?.dispose();
+                    break;
+                }
+                case 'willInterrupt': {
+                    this.interruptStatus.get(kernel)?.dispose();
+                    const status = this.statusProvider.set(DataScience.interruptKernelStatus());
+                    this.interruptStatus.set(kernel, status);
+                    break;
+                }
+                case 'interruptCompleted': {
+                    this.interruptStatus.get(kernel)?.dispose();
+                    break;
+                }
+            }
+        });
+    }
+}

--- a/src/kernels/serviceRegistry.node.ts
+++ b/src/kernels/serviceRegistry.node.ts
@@ -47,6 +47,7 @@ import { DebugStartupCodeProvider } from './debuggerStartupCodeProvider';
 import { KernelWorkingFolder } from './kernelWorkingFolder.node';
 import { TrustedKernelPaths } from './raw/finder/trustedKernelPaths.node';
 import { ITrustedKernelPaths } from './raw/finder/types';
+import { KernelStatusProvider } from './kernelStatusProvider';
 
 export function registerTypes(serviceManager: IServiceManager, isDevMode: boolean) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, Activation);
@@ -84,6 +85,7 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
         LocalPythonAndRelatedNonPythonKernelSpecFinder
     );
     serviceManager.addBinding(LocalPythonAndRelatedNonPythonKernelSpecFinder, IExtensionSyncActivationService);
+    serviceManager.addSingleton<IExtensionSyncActivationService>(IExtensionSyncActivationService, KernelStatusProvider);
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,
         PreWarmActivatedJupyterEnvironmentVariables
@@ -120,7 +122,10 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
     );
     const rawService = serviceManager.get<IRawNotebookSupportedService>(IRawNotebookSupportedService);
     setSharedProperty('rawKernelSupported', rawService.isSupported ? 'true' : 'false');
-    serviceManager.addSingleton<CellOutputDisplayIdTracker>(CellOutputDisplayIdTracker, CellOutputDisplayIdTracker);
+    serviceManager.addSingleton<IExtensionSyncActivationService>(
+        IExtensionSyncActivationService,
+        CellOutputDisplayIdTracker
+    );
 
     serviceManager.addSingleton<IStartupCodeProvider>(IStartupCodeProvider, KernelStartupCodeProvider);
     serviceManager.addSingleton<IStartupCodeProvider>(IStartupCodeProvider, DebugStartupCodeProvider);

--- a/src/kernels/serviceRegistry.web.ts
+++ b/src/kernels/serviceRegistry.web.ts
@@ -25,6 +25,7 @@ import { KernelAutoReconnectMonitor } from './kernelAutoReConnectMonitor';
 import { DebugStartupCodeProvider } from './debuggerStartupCodeProvider';
 import { TrustedKernelPaths } from './raw/finder/trustedKernelPaths.web';
 import { ITrustedKernelPaths } from './raw/finder/types';
+import { KernelStatusProvider } from './kernelStatusProvider';
 
 @injectable()
 class RawNotebookSupportedService implements IRawNotebookSupportedService {
@@ -55,6 +56,7 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
     serviceManager.addSingleton<IJupyterVariables>(IJupyterVariables, KernelVariables, Identifiers.KERNEL_VARIABLES);
 
     serviceManager.addSingleton<IExtensionSyncActivationService>(IExtensionSyncActivationService, KernelCrashMonitor);
+    serviceManager.addSingleton<IExtensionSyncActivationService>(IExtensionSyncActivationService, KernelStatusProvider);
     serviceManager.addSingleton<IExtensionSyncActivationService>(
         IExtensionSyncActivationService,
         KernelAutoReconnectMonitor
@@ -71,6 +73,9 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
     // Subdirectories
     registerJupyterTypes(serviceManager, isDevMode);
 
-    serviceManager.addSingleton<CellOutputDisplayIdTracker>(CellOutputDisplayIdTracker, CellOutputDisplayIdTracker);
+    serviceManager.addSingleton<IExtensionSyncActivationService>(
+        IExtensionSyncActivationService,
+        CellOutputDisplayIdTracker
+    );
     serviceManager.addSingleton<IStartupCodeProvider>(IStartupCodeProvider, DebugStartupCodeProvider);
 }

--- a/src/kernels/types.ts
+++ b/src/kernels/types.ts
@@ -124,6 +124,7 @@ export function isRemoteConnection(
     return !isLocalConnection(kernelConnection);
 }
 
+export type KernelHooks = 'willRestart' | 'willInterrupt' | 'restartCompleted' | 'interruptCompleted';
 export interface IBaseKernel extends IAsyncDisposable {
     readonly uri: Uri;
     /**
@@ -170,8 +171,8 @@ export interface IBaseKernel extends IAsyncDisposable {
     start(options?: IDisplayOptions): Promise<void>;
     interrupt(): Promise<void>;
     restart(): Promise<void>;
-    addEventHook(hook: (event: 'willRestart' | 'willInterrupt') => Promise<void>): void;
-    removeEventHook(hook: (event: 'willRestart' | 'willInterrupt') => Promise<void>): void;
+    addEventHook(hook: (event: KernelHooks) => Promise<void>): void;
+    removeEventHook(hook: (event: KernelHooks) => Promise<void>): void;
 }
 
 /**
@@ -653,4 +654,14 @@ export const IStartupCodeProvider = Symbol('IStartupCodeProvider');
 export interface IStartupCodeProvider {
     priority: StartupCodePriority;
     getCode(kernel: IBaseKernel): Promise<string[]>;
+}
+
+export interface IKernelSettings {
+    enableExtendedKernelCompletions: boolean;
+    themeMatplotlibPlots: boolean;
+    ignoreVscodeTheme: boolean;
+    generateSVGPlots: boolean;
+    launchTimeout: number;
+    interruptTimeout: number;
+    runStartupCommands: string | string[];
 }

--- a/src/notebooks/debugger/kernelDebugAdapterBase.ts
+++ b/src/notebooks/debugger/kernelDebugAdapterBase.ts
@@ -23,7 +23,7 @@ import {
 } from 'vscode';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { executeSilently } from '../../kernels/helpers';
-import { IKernel, IKernelConnectionSession } from '../../kernels/types';
+import { IKernel, IKernelConnectionSession, KernelHooks } from '../../kernels/types';
 import { IDebugService } from '../../platform/common/application/types';
 import { IPlatformService } from '../../platform/common/platform/types';
 import { IDisposable } from '../../platform/common/types';
@@ -67,7 +67,11 @@ export abstract class KernelDebugAdapterBase implements DebugAdapter, IKernelDeb
     onDidEndSession: Event<DebugSession> = this.endSession.event;
     public readonly debugCell: NotebookCell | undefined;
     private disconnected: boolean = false;
-    private kernelEventHook = (_event: 'willRestart' | 'willInterrupt') => this.disconnect();
+    private kernelEventHook = async (e: KernelHooks) => {
+        if (e === 'willRestart' || e === 'willInterrupt') {
+            await this.disconnect();
+        }
+    };
     constructor(
         protected session: DebugSession,
         protected notebookDocument: NotebookDocument,

--- a/src/test/kernels/kernelProvider.node.unit.test.ts
+++ b/src/test/kernels/kernelProvider.node.unit.test.ts
@@ -24,7 +24,6 @@ import {
     IExtensionContext,
     IWatchableJupyterSettings
 } from '../../platform/common/types';
-import { IStatusProvider } from '../../platform/progress/types';
 import { createEventHandler } from '../common.node';
 import { mockedVSCodeNamespaces } from '../vscode-mock';
 
@@ -36,9 +35,7 @@ suite('KernelProvider Node', () => {
     let notebookProvider: INotebookProvider;
     let configService: IConfigurationService;
     let appShell: IApplicationShell;
-    let outputTracker: CellOutputDisplayIdTracker;
     let vscNotebook: IVSCodeNotebook;
-    let statusProvider: IStatusProvider;
     let jupyterServerUriStorage: IJupyterServerUriStorage;
     let context: IExtensionContext;
     let onDidCloseNotebookDocument: EventEmitter<NotebookDocument>;
@@ -70,9 +67,7 @@ suite('KernelProvider Node', () => {
         notebookProvider = mock<INotebookProvider>();
         configService = mock<IConfigurationService>();
         appShell = mock<IApplicationShell>();
-        outputTracker = mock<CellOutputDisplayIdTracker>();
         vscNotebook = mock<IVSCodeNotebook>();
-        statusProvider = mock<IStatusProvider>();
         jupyterServerUriStorage = mock<IJupyterServerUriStorage>();
         context = mock<IExtensionContext>();
         const configSettings = mock<IWatchableJupyterSettings>();
@@ -90,9 +85,7 @@ suite('KernelProvider Node', () => {
             instance(notebookProvider),
             instance(configService),
             instance(appShell),
-            instance(outputTracker),
             instance(vscNotebook),
-            instance(statusProvider),
             instance(context),
             instance(jupyterServerUriStorage),
             [],
@@ -105,12 +98,12 @@ suite('KernelProvider Node', () => {
             instance(configService),
             instance(appShell),
             instance(vscNotebook),
-            instance(statusProvider),
             []
         );
     });
     teardown(async () => {
         when(mockedVSCodeNamespaces.workspace.notebookDocuments).thenReturn([]);
+        CellOutputDisplayIdTracker.dispose();
         disposeAllDisposables(disposables);
         await asyncDisposables.dispose();
     });


### PR DESCRIPTION
Simplify by removing some functionality into another class
* E.g. displaying status of the kernel can be done outside the kernel class

This simple change reduces the coupling and the number of arguments passed all around