### PR TITLE
Refactor Controller interface into a narrower interface for reduced coupling and easier testing

### DIFF
--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -77,6 +77,7 @@ import { updateNotebookMetadata } from '../kernels/execution/helpers';
 import { chainWithPendingUpdates } from '../kernels/execution/notebookUpdater';
 import { initializeInteractiveOrNotebookTelemetryBasedOnUserAction } from '../kernels/telemetry/helper';
 import { generateMarkdownFromCodeLines, parseForComments } from '../platform/common/utils';
+import { KernelController } from '../kernels/kernelController';
 
 /**
  * ViewModel for an interactive window from the Jupyter extension's point of view.
@@ -277,7 +278,9 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
                     return;
                 }
                 // Id may be different if the user switched controllers
-                this.currentKernelInfo.controller = k.controller;
+                this.currentKernelInfo.controller = this.controllerRegistration.registered.find(
+                    (item) => item.id === k.controller.id
+                )!.controller;
                 this.currentKernelInfo.metadata = k.kernelConnectionMetadata;
                 !!this.pendingCellAdd && this.setPendingCellAdd(this.pendingCellAdd);
                 this.updateSysInfoMessage(
@@ -297,7 +300,9 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
                 'jupyterExtension',
                 onStartKernel
             );
-            this.currentKernelInfo.controller = kernel.controller;
+            this.currentKernelInfo.controller = this.controllerRegistration.registered.find(
+                (item) => item.id === kernel.controller.id
+            )!.controller;
             this.currentKernelInfo.metadata = kernel.kernelConnectionMetadata;
 
             const kernelEventHookForRestart = async (ev: KernelHooks) => {
@@ -510,7 +515,10 @@ export class InteractiveWindow implements IInteractiveWindowLoadable {
             edit.set(this.notebookDocument.uri, [nbEdit]);
             await workspace.applyEdit(edit);
         } else {
-            const execution = CellExecutionCreator.getOrCreate(notebookCell, controller.controller);
+            const execution = CellExecutionCreator.getOrCreate(
+                notebookCell,
+                new KernelController(controller.controller)
+            );
             if (!execution.started) {
                 execution.start(notebookCell.executionSummary?.timing?.startTime);
             }

--- a/src/kernels/execution/cellExecution.ts
+++ b/src/kernels/execution/cellExecution.ts
@@ -8,7 +8,6 @@ import {
     NotebookCell,
     NotebookCellExecution,
     workspace,
-    NotebookController,
     NotebookCellOutput,
     NotebookCellExecutionState,
     Event,
@@ -29,7 +28,12 @@ import { getDisplayNameOrNameOfKernelConnection, isPythonKernelConnection } from
 import { isCancellationError } from '../../platform/common/cancellation';
 import { activeNotebookCellExecution, CellExecutionMessageHandler } from './cellExecutionMessageHandler';
 import { CellExecutionMessageHandlerService } from './cellExecutionMessageHandlerService';
-import { IKernelConnectionSession, KernelConnectionMetadata, NotebookCellRunState } from '../../kernels/types';
+import {
+    IKernelConnectionSession,
+    IKernelController,
+    KernelConnectionMetadata,
+    NotebookCellRunState
+} from '../../kernels/types';
 import { NotebookCellStateTracker, traceCellMessage } from './helpers';
 import { getDisplayPath } from '../../platform/common/platform/fs-paths';
 
@@ -38,7 +42,7 @@ import { getDisplayPath } from '../../platform/common/platform/fs-paths';
  */
 export class CellExecutionFactory {
     constructor(
-        private readonly controller: NotebookController,
+        private readonly controller: IKernelController,
         private readonly requestListener: CellExecutionMessageHandlerService
     ) {}
 
@@ -84,7 +88,7 @@ export class CellExecution implements IDisposable {
         public readonly cell: NotebookCell,
         private readonly codeOverride: string | undefined,
         private readonly kernelConnection: Readonly<KernelConnectionMetadata>,
-        private readonly controller: NotebookController,
+        private readonly controller: IKernelController,
         private readonly requestListener: CellExecutionMessageHandlerService
     ) {
         workspace.onDidCloseTextDocument(
@@ -130,7 +134,7 @@ export class CellExecution implements IDisposable {
         cell: NotebookCell,
         code: string | undefined,
         metadata: Readonly<KernelConnectionMetadata>,
-        controller: NotebookController,
+        controller: IKernelController,
         requestListener: CellExecutionMessageHandlerService
     ) {
         return new CellExecution(cell, code, metadata, controller, requestListener);

--- a/src/kernels/execution/cellExecutionCreator.ts
+++ b/src/kernels/execution/cellExecutionCreator.ts
@@ -8,9 +8,9 @@ import {
     NotebookCell,
     NotebookCellExecution,
     NotebookCellOutput,
-    NotebookCellOutputItem,
-    NotebookController
+    NotebookCellOutputItem
 } from 'vscode';
+import { IKernelController } from '../types';
 
 /**
  * Wrapper class around NotebookCellExecution that allows us to
@@ -81,7 +81,7 @@ export class NotebookCellExecutionWrapper implements NotebookCellExecution {
  */
 export class CellExecutionCreator {
     private static _map = new Map<string, NotebookCellExecutionWrapper>();
-    static getOrCreate(cell: NotebookCell, controller: NotebookController) {
+    static getOrCreate(cell: NotebookCell, controller: IKernelController) {
         let cellExecution: NotebookCellExecutionWrapper | undefined;
         const key = cell.document.uri.toString();
         cellExecution = this.get(cell);
@@ -110,7 +110,7 @@ export class CellExecutionCreator {
         return CellExecutionCreator._map.get(key);
     }
 
-    private static create(key: string, cell: NotebookCell, controller: NotebookController) {
+    private static create(key: string, cell: NotebookCell, controller: IKernelController) {
         const result = new NotebookCellExecutionWrapper(
             controller.createNotebookCellExecution(cell),
             controller.id,

--- a/src/kernels/execution/cellExecutionMessageHandler.ts
+++ b/src/kernels/execution/cellExecutionMessageHandler.ts
@@ -13,7 +13,6 @@ import {
     NotebookCellExecutionSummary,
     NotebookDocument,
     workspace,
-    NotebookController,
     WorkspaceEdit,
     NotebookCellData,
     Range,
@@ -40,7 +39,7 @@ import {
 } from './helpers';
 import { swallowExceptions } from '../../platform/common/utils/decorators';
 import { noop } from '../../platform/common/utils/misc';
-import { ITracebackFormatter } from '../../kernels/types';
+import { IKernelController, ITracebackFormatter } from '../../kernels/types';
 import { handleTensorBoardDisplayDataOutput } from './executionHelpers';
 import isObject = require('lodash/isObject');
 import { Identifiers, WIDGET_MIMETYPE } from '../../platform/common/constants';
@@ -173,7 +172,7 @@ export class CellExecutionMessageHandler implements IDisposable {
     constructor(
         public readonly cell: NotebookCell,
         private readonly applicationService: IApplicationShell,
-        private readonly controller: NotebookController,
+        private readonly controller: IKernelController,
         private readonly context: IExtensionContext,
         private readonly formatters: ITracebackFormatter[],
         private readonly kernel: Kernel.IKernelConnection,

--- a/src/kernels/execution/cellExecutionMessageHandlerService.ts
+++ b/src/kernels/execution/cellExecutionMessageHandlerService.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 import { Kernel, KernelMessage } from '@jupyterlab/services';
-import { NotebookCell, NotebookCellExecution, NotebookController, NotebookDocument, workspace } from 'vscode';
-import { ITracebackFormatter } from '../../kernels/types';
+import { NotebookCell, NotebookCellExecution, NotebookDocument, workspace } from 'vscode';
+import { IKernelController, ITracebackFormatter } from '../../kernels/types';
 import { IApplicationShell } from '../../platform/common/application/types';
 import { disposeAllDisposables } from '../../platform/common/helpers';
 import { IDisposable, IExtensionContext } from '../../platform/common/types';
@@ -18,7 +18,7 @@ export class CellExecutionMessageHandlerService {
     private readonly messageHandlers = new WeakMap<NotebookCell, CellExecutionMessageHandler>();
     constructor(
         private readonly appShell: IApplicationShell,
-        private readonly controller: NotebookController,
+        private readonly controller: IKernelController,
         private readonly context: IExtensionContext,
         private readonly formatters: ITracebackFormatter[]
     ) {

--- a/src/kernels/execution/helpers.ts
+++ b/src/kernels/execution/helpers.ts
@@ -10,8 +10,7 @@ import {
     NotebookCell,
     NotebookCellData,
     NotebookCellKind,
-    NotebookCellExecutionState,
-    NotebookController
+    NotebookCellExecutionState
 } from 'vscode';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import { KernelMessage } from '@jupyterlab/services';
@@ -27,7 +26,7 @@ import { getInterpreterHash } from '../../platform/pythonEnvironments/info/inter
 import { sendTelemetryEvent, Telemetry } from '../../telemetry';
 import { createOutputWithErrorMessageForDisplay } from '../../platform/errors/errorUtils';
 import { CellExecutionCreator } from './cellExecutionCreator';
-import { KernelConnectionMetadata } from '../types';
+import { IKernelController, KernelConnectionMetadata } from '../types';
 import {
     isPythonKernelConnection,
     getInterpreterFromKernelConnectionMetadata,
@@ -845,7 +844,7 @@ export async function updateNotebookMetadata(
 
 export async function endCellAndDisplayErrorsInCell(
     cell: NotebookCell,
-    controller: NotebookController,
+    controller: IKernelController,
     errorMessage: string,
     isCancelled: boolean
 ) {

--- a/src/kernels/kernel.ts
+++ b/src/kernels/kernel.ts
@@ -11,7 +11,6 @@ import {
     Event,
     EventEmitter,
     NotebookCell,
-    NotebookController,
     ColorThemeKind,
     Disposable,
     Uri,
@@ -51,7 +50,8 @@ import {
     IBaseKernel,
     KernelActionSource,
     KernelHooks,
-    IKernelSettings
+    IKernelSettings,
+    IKernelController
 } from './types';
 import { Cancellation, isCancellationError } from '../platform/common/cancellation';
 import { KernelProgressReporter } from '../platform/progress/kernelProgressReporter';
@@ -713,7 +713,7 @@ export class Kernel extends BaseKernel<KernelExecution> implements IKernel {
         notebookProvider: INotebookProvider,
         kernelSettings: IKernelSettings,
         appShell: IApplicationShell,
-        public readonly controller: NotebookController,
+        public readonly controller: IKernelController,
         context: IExtensionContext,
         formatters: ITracebackFormatter[],
         startupCodeProviders: IStartupCodeProvider[],

--- a/src/kernels/kernel.ts
+++ b/src/kernels/kernel.ts
@@ -684,7 +684,11 @@ export class ThirdPartyKernel extends BaseKernel<ThirdPartyKernelExecution> {
             startupCodeProviders,
             '3rdPartyExtension'
         );
-        this.kernelExecution = new ThirdPartyKernelExecution(this, this.kernelSettings.interruptTimeout);
+        this.kernelExecution = new ThirdPartyKernelExecution(
+            resourceUri,
+            kernelConnectionMetadata,
+            this.kernelSettings.interruptTimeout
+        );
         this.disposables.push(this.kernelExecution);
     }
 }
@@ -731,7 +735,10 @@ export class Kernel extends BaseKernel<KernelExecution> implements IKernel {
         );
 
         this.kernelExecution = new KernelExecution(
-            this,
+            controller,
+            resourceUri,
+            kernelConnectionMetadata,
+            notebook,
             appShell,
             this.kernelSettings.interruptTimeout,
             context,

--- a/src/kernels/kernelController.ts
+++ b/src/kernels/kernelController.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { NotebookCell, NotebookCellExecution, NotebookController } from 'vscode';
+import { IKernelController } from './types';
+
+export class KernelController implements IKernelController {
+    constructor(private readonly controller: NotebookController) {}
+    public get id() {
+        return this.controller.id;
+    }
+    createNotebookCellExecution(cell: NotebookCell): NotebookCellExecution {
+        return this.controller.createNotebookCellExecution(cell);
+    }
+}

--- a/src/kernels/types.ts
+++ b/src/kernels/types.ts
@@ -11,6 +11,7 @@ import type {
     Disposable,
     Event,
     NotebookCell,
+    NotebookCellExecution,
     NotebookController,
     NotebookDocument,
     Uri
@@ -192,7 +193,7 @@ export interface IKernel extends IBaseKernel {
     /**
      * Controller associated with this kernel
      */
-    readonly controller: NotebookController;
+    readonly controller: IKernelController;
     readonly creator: 'jupyterExtension';
     /**
      * @param cell Cell to execute
@@ -665,3 +666,8 @@ export interface IKernelSettings {
     interruptTimeout: number;
     runStartupCommands: string | string[];
 }
+
+export type IKernelController = {
+    id: string;
+    createNotebookCellExecution(cell: NotebookCell): NotebookCellExecution;
+};

--- a/src/notebooks/controllers/vscodeNotebookController.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.ts
@@ -66,6 +66,7 @@ import {
 } from '../../kernels/helpers';
 import {
     IKernel,
+    IKernelController,
     IKernelProvider,
     isLocalConnection,
     KernelConnectionMetadata,
@@ -91,6 +92,7 @@ import { IDataScienceErrorHandler } from '../../kernels/errors/types';
 import { IJupyterServerUriStorage } from '../../kernels/jupyter/types';
 import { ITrustedKernelPaths } from '../../kernels/raw/finder/types';
 import { IPlatformService } from '../../platform/common/platform/types';
+import { KernelController } from '../../kernels/kernelController';
 
 /**
  * Our implementation of the VSCode Notebook Controller. Called by VS code to execute cells in a notebook. Also displayed
@@ -475,7 +477,7 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
             .then(noop, (ex) => console.error(ex));
     }
 
-    private createCellExecutionIfNecessary(cell: NotebookCell, controller: NotebookController) {
+    private createCellExecutionIfNecessary(cell: NotebookCell, controller: IKernelController) {
         // Only have one cell in the 'running' state for this notebook
         let currentExecution = this.runningCellExecutions.get(cell.notebook);
         if (!currentExecution || currentExecution.cell === cell) {
@@ -496,12 +498,12 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
     private async executeCell(doc: NotebookDocument, cell: NotebookCell) {
         traceVerbose(`Execute Cell ${cell.index} ${getDisplayPath(cell.notebook.uri)}`);
         // Start execution now (from the user's point of view)
-        let exec = this.createCellExecutionIfNecessary(cell, this.controller);
+        let exec = this.createCellExecutionIfNecessary(cell, new KernelController(this.controller));
 
         // Connect to a matching kernel if possible (but user may pick a different one)
         let currentContext: 'start' | 'execution' = 'start';
         let kernel: IKernel | undefined;
-        let controller = this.controller;
+        let controller: IKernelController = new KernelController(this.controller);
         let kernelStarted = false;
         try {
             kernel = await this.connectToKernel(doc, new DisplayOptions(false));

--- a/src/platform/api/pythonApi.ts
+++ b/src/platform/api/pythonApi.ts
@@ -77,6 +77,7 @@ export function pythonEnvToJupyterEnv(env: ResolvedEnvironment): PythonEnvironme
         }
     }
     if (!env.executable.uri) {
+        console.error(`Python environment ${env.id} excluded as Uri is undefined`);
         return;
     }
 


### PR DESCRIPTION
today we pass the VS Code `NotebookController` object around in a number of places
This is a heavy class with a lot of members, however I found that only a tiny fraction of those members are required, in a majority of the places just 2 are required (1 property & 1 method).

This PR ensures we have a new interafce that reflects this requirement, so as to reduce the coupling of the heavier object, reducing the coupling and making it easier to test & maintian.