### PR TITLE
move server display name specifying code out of the picker experiment and into stable

### DIFF
--- a/src/kernels/jupyter/launcher/serverUriStorage.ts
+++ b/src/kernels/jupyter/launcher/serverUriStorage.ts
@@ -96,13 +96,11 @@ export class JupyterServerUriStorage implements IJupyterServerUriStorage, IServe
         const serverId = await computeServerId(uri);
 
         // Check if we have already found a display name for this server
-        if (this.configService.getSettings().kernelPickerType === 'Insiders') {
-            const existingEntry = uriList.find((entry) => {
-                return entry.serverId === serverId;
-            });
-            if (existingEntry && existingEntry.displayName) {
-                displayName = existingEntry.displayName;
-            }
+        const existingEntry = uriList.find((entry) => {
+            return entry.serverId === serverId;
+        });
+        if (existingEntry && existingEntry.displayName) {
+            displayName = existingEntry.displayName;
         }
 
         // Remove this uri if already found (going to add again with a new time)


### PR DESCRIPTION
Moves the code to allow for picking and showing a server display name out from the kernel picker experiment and into stable. It's independent code from the picker prototype work that is requested and doesn't need to be behind an experiment.
