### PR TITLE
Debt: -Universal.

### DIFF
--- a/src/kernels/jupyter/finder/remoteKernelFinder.ts
+++ b/src/kernels/jupyter/finder/remoteKernelFinder.ts
@@ -46,7 +46,7 @@ import { disposeAllDisposables } from '../../../platform/common/helpers';
 const REMOTE_KERNEL_REFRESH_INTERVAL = 2_000;
 
 // This class watches a single jupyter server URI and returns kernels from it
-export class UniversalRemoteKernelFinder implements IRemoteKernelFinder, IContributedKernelFinderInfo, IDisposable {
+export class RemoteKernelFinder implements IRemoteKernelFinder, IContributedKernelFinderInfo, IDisposable {
     /**
      * List of ids of kernels that should be hidden from the kernel picker.
      */

--- a/src/kernels/jupyter/finder/remoteKernelFinder.unit.test.ts
+++ b/src/kernels/jupyter/finder/remoteKernelFinder.unit.test.ts
@@ -41,12 +41,12 @@ import { KernelRankingHelper } from '../../../notebooks/controllers/kernelRankin
 import { IExtensions } from '../../../platform/common/types';
 import { takeTopRankKernel } from '../../raw/finder/localKernelFinder.unit.test';
 import { createEventHandler, TestEventHandler } from '../../../test/common';
-import { UniversalRemoteKernelFinder } from './universalRemoteKernelFinder';
+import { RemoteKernelFinder } from './remoteKernelFinder';
 
 suite(`Remote Kernel Finder`, () => {
     let disposables: Disposable[] = [];
     let preferredRemoteKernelIdProvider: PreferredRemoteKernelIdProvider;
-    let remoteKernelFinder: UniversalRemoteKernelFinder;
+    let remoteKernelFinder: RemoteKernelFinder;
     let localKernelFinder: ILocalKernelFinder;
     let kernelFinder: KernelFinder;
     let kernelRankHelper: IKernelRankingHelper;
@@ -170,7 +170,7 @@ suite(`Remote Kernel Finder`, () => {
         disposables.push(kernelsChanged);
         kernelRankHelper = new KernelRankingHelper(preferredRemoteKernelIdProvider);
 
-        remoteKernelFinder = new UniversalRemoteKernelFinder(
+        remoteKernelFinder = new RemoteKernelFinder(
             'currentremote',
             'Local Kernels',
             RemoteKernelSpecsCacheKey,

--- a/src/kernels/jupyter/finder/remoteKernelFinderController.ts
+++ b/src/kernels/jupyter/finder/remoteKernelFinderController.ts
@@ -26,7 +26,7 @@ import { noop } from '../../../platform/common/utils/misc';
 import { IApplicationEnvironment } from '../../../platform/common/application/types';
 import { KernelFinder } from '../../kernelFinder';
 import { IExtensionSingleActivationService } from '../../../platform/activation/types';
-import { UniversalRemoteKernelFinder } from './universalRemoteKernelFinder';
+import { RemoteKernelFinder } from './remoteKernelFinder';
 import { ContributedKernelFinderKind } from '../../internalTypes';
 import * as localize from '../../../platform/common/utils/localize';
 import { RemoteKernelSpecsCacheKey } from '../../common/commonFinder';
@@ -38,10 +38,7 @@ interface IRemoteKernelFinderRegistrationStrategy {
 }
 
 class MultiServerStrategy implements IRemoteKernelFinderRegistrationStrategy {
-    private serverFinderMapping: Map<string, UniversalRemoteKernelFinder> = new Map<
-        string,
-        UniversalRemoteKernelFinder
-    >();
+    private serverFinderMapping: Map<string, RemoteKernelFinder> = new Map<string, RemoteKernelFinder>();
 
     constructor(
         private jupyterSessionManagerFactory: IJupyterSessionManagerFactory,
@@ -78,7 +75,7 @@ class MultiServerStrategy implements IRemoteKernelFinderRegistrationStrategy {
         }
 
         if (!this.serverFinderMapping.has(serverUri.serverId)) {
-            const finder = new UniversalRemoteKernelFinder(
+            const finder = new RemoteKernelFinder(
                 `${ContributedKernelFinderKind.Remote}-${serverUri.serverId}`,
                 localize.DataScience.universalRemoteKernelFinderDisplayName().format(
                     serverUri.displayName || serverUri.uri
@@ -120,7 +117,7 @@ class MultiServerStrategy implements IRemoteKernelFinderRegistrationStrategy {
 }
 
 class SingleServerStrategy implements IRemoteKernelFinderRegistrationStrategy {
-    private _activeServerFinder: { entry: IJupyterServerUriEntry; finder: UniversalRemoteKernelFinder } | undefined;
+    private _activeServerFinder: { entry: IJupyterServerUriEntry; finder: RemoteKernelFinder } | undefined;
     constructor(
         private jupyterSessionManagerFactory: IJupyterSessionManagerFactory,
         private interpreterService: IInterpreterService,
@@ -170,7 +167,7 @@ class SingleServerStrategy implements IRemoteKernelFinderRegistrationStrategy {
         }
 
         this._activeServerFinder?.finder.dispose();
-        const finder = new UniversalRemoteKernelFinder(
+        const finder = new RemoteKernelFinder(
             'currentremote',
             localize.DataScience.remoteKernelFinderDisplayName(),
             RemoteKernelSpecsCacheKey,
@@ -203,7 +200,7 @@ class SingleServerStrategy implements IRemoteKernelFinderRegistrationStrategy {
 
 // This class creates RemoteKernelFinders for all registered Jupyter Server URIs
 @injectable()
-export class UniversalRemoteKernelFinderController implements IExtensionSingleActivationService {
+export class RemoteKernelFinderController implements IExtensionSingleActivationService {
     private _strategy: IRemoteKernelFinderRegistrationStrategy;
 
     constructor(

--- a/src/kernels/jupyter/serviceRegistry.node.ts
+++ b/src/kernels/jupyter/serviceRegistry.node.ts
@@ -63,7 +63,7 @@ import {
     IJupyterRemoteCachedKernelValidator
 } from './types';
 import { IJupyterCommandFactory, IJupyterSubCommandExecutionService } from './types.node';
-import { UniversalRemoteKernelFinderController } from './finder/universalRemoteKernelFinderController';
+import { RemoteKernelFinderController } from './finder/remoteKernelFinderController';
 
 export function registerTypes(serviceManager: IServiceManager, _isDevMode: boolean) {
     serviceManager.add<IJupyterCommandFactory>(IJupyterCommandFactory, JupyterCommandFactory);
@@ -151,6 +151,6 @@ export function registerTypes(serviceManager: IServiceManager, _isDevMode: boole
     serviceManager.addSingleton<IDataScienceErrorHandler>(IDataScienceErrorHandler, DataScienceErrorHandlerNode);
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,
-        UniversalRemoteKernelFinderController
+        RemoteKernelFinderController
     );
 }

--- a/src/kernels/jupyter/serviceRegistry.web.ts
+++ b/src/kernels/jupyter/serviceRegistry.web.ts
@@ -41,7 +41,7 @@ import {
     IJupyterRemoteCachedKernelValidator
 } from './types';
 import { CellOutputMimeTypeTracker } from './jupyterCellOutputMimeTypeTracker';
-import { UniversalRemoteKernelFinderController } from './finder/universalRemoteKernelFinderController';
+import { RemoteKernelFinderController } from './finder/remoteKernelFinderController';
 
 export function registerTypes(serviceManager: IServiceManager, _isDevMode: boolean) {
     serviceManager.addSingleton<IJupyterNotebookProvider>(IJupyterNotebookProvider, JupyterNotebookProvider);
@@ -87,6 +87,6 @@ export function registerTypes(serviceManager: IServiceManager, _isDevMode: boole
     );
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,
-        UniversalRemoteKernelFinderController
+        RemoteKernelFinderController
     );
 }

--- a/src/kernels/raw/finder/localKernelFinder.unit.test.ts
+++ b/src/kernels/raw/finder/localKernelFinder.unit.test.ts
@@ -52,7 +52,7 @@ import { getDisplayPathFromLocalFile } from '../../../platform/common/platform/f
 import { PythonExtensionChecker } from '../../../platform/api/pythonApi';
 import { KernelFinder } from '../../../kernels/kernelFinder';
 import { PreferredRemoteKernelIdProvider } from '../../../kernels/jupyter/preferredRemoteKernelIdProvider';
-import { UniversalRemoteKernelFinder } from '../../../kernels/jupyter/finder/universalRemoteKernelFinder';
+import { RemoteKernelFinder } from '../../jupyter/finder/remoteKernelFinder';
 import { IJupyterServerUriStorage } from '../../../kernels/jupyter/types';
 import { IPythonExecutionFactory, IPythonExecutionService } from '../../../platform/common/process/types.node';
 import { getUserHomeDir } from '../../../platform/common/utils/platform.node';
@@ -67,7 +67,7 @@ import { createEventHandler, TestEventHandler } from '../../../test/common';
 [false, true].forEach((isWindows) => {
     suite(`Local Kernel Finder ${isWindows ? 'Windows' : 'Unix'}`, () => {
         let localKernelFinder: LocalKernelFinder;
-        let remoteKernelFinder: UniversalRemoteKernelFinder;
+        let remoteKernelFinder: RemoteKernelFinder;
         let kernelFinder: KernelFinder;
         let interpreterService: IInterpreterService;
         let platformService: IPlatformService;
@@ -111,7 +111,7 @@ import { createEventHandler, TestEventHandler } from '../../../test/common';
             const getOSTypeStub = sinon.stub(platform, 'getOSType');
             getOSTypeStub.returns(isWindows ? platform.OSType.Windows : platform.OSType.Linux);
             interpreterService = mock(InterpreterService);
-            remoteKernelFinder = mock(UniversalRemoteKernelFinder);
+            remoteKernelFinder = mock(RemoteKernelFinder);
             onDidChangeInterpreter = new EventEmitter<void>();
             onDidChangeInterpreters = new EventEmitter<void>();
             disposables.push(onDidChangeInterpreter);


### PR DESCRIPTION
We now merged the legacy and universal remote kernel finder, last step is naming update.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] Has telemetry for feature-requests.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
