### PR TITLE
Type shaking: -IContributedKernelFinderInfo

### DIFF
--- a/src/kernels/internalTypes.ts
+++ b/src/kernels/internalTypes.ts
@@ -11,13 +11,10 @@ export enum ContributedKernelFinderKind {
     Local = 'local'
 }
 
-export interface IContributedKernelFinder<T extends KernelConnectionMetadata> extends IContributedKernelFinderInfo {
+export interface IContributedKernelFinder<T extends KernelConnectionMetadata = KernelConnectionMetadata> {
+    id: string;
+    displayName: string;
     kind: ContributedKernelFinderKind;
     onDidChangeKernels: Event<void>;
     kernels: T[];
-}
-
-export interface IContributedKernelFinderInfo {
-    id: string;
-    displayName: string;
 }

--- a/src/kernels/jupyter/finder/remoteKernelFinder.ts
+++ b/src/kernels/jupyter/finder/remoteKernelFinder.ts
@@ -38,7 +38,7 @@ import { noop } from '../../../platform/common/utils/misc';
 import { IApplicationEnvironment } from '../../../platform/common/application/types';
 import { KernelFinder } from '../../kernelFinder';
 import { removeOldCachedItems } from '../../common/commonFinder';
-import { ContributedKernelFinderKind, IContributedKernelFinderInfo } from '../../internalTypes';
+import { ContributedKernelFinderKind } from '../../internalTypes';
 import { disposeAllDisposables } from '../../../platform/common/helpers';
 
 // Even after shutting down a kernel, the server API still returns the old information.
@@ -46,7 +46,7 @@ import { disposeAllDisposables } from '../../../platform/common/helpers';
 const REMOTE_KERNEL_REFRESH_INTERVAL = 2_000;
 
 // This class watches a single jupyter server URI and returns kernels from it
-export class RemoteKernelFinder implements IRemoteKernelFinder, IContributedKernelFinderInfo, IDisposable {
+export class RemoteKernelFinder implements IRemoteKernelFinder, IDisposable {
     /**
      * List of ids of kernels that should be hidden from the kernel picker.
      */

--- a/src/kernels/kernelFinder.ts
+++ b/src/kernels/kernelFinder.ts
@@ -5,7 +5,7 @@ import { inject, injectable } from 'inversify';
 import { Event, EventEmitter } from 'vscode';
 import { IDisposable, IDisposableRegistry } from '../platform/common/types';
 import { traceInfoIfCI } from '../platform/logging';
-import { IContributedKernelFinder, IContributedKernelFinderInfo } from './internalTypes';
+import { IContributedKernelFinder } from './internalTypes';
 import { IKernelFinder, KernelConnectionMetadata } from './types';
 
 /**
@@ -14,9 +14,9 @@ import { IKernelFinder, KernelConnectionMetadata } from './types';
 @injectable()
 export class KernelFinder implements IKernelFinder {
     private _finders: IContributedKernelFinder<KernelConnectionMetadata>[] = [];
-    private connectionFinderMapping: Map<string, IContributedKernelFinderInfo> = new Map<
+    private connectionFinderMapping: Map<string, IContributedKernelFinder> = new Map<
         string,
-        IContributedKernelFinderInfo
+        IContributedKernelFinder
     >();
 
     private _onDidChangeKernels = new EventEmitter<void>();
@@ -74,12 +74,12 @@ export class KernelFinder implements IKernelFinder {
 
     // Check our mappings to see what connection supplies this metadata, since metadatas can be created outside of finders
     // allow for undefined as a return value
-    public getFinderForConnection(kernelMetadata: KernelConnectionMetadata): IContributedKernelFinderInfo | undefined {
+    public getFinderForConnection(kernelMetadata: KernelConnectionMetadata): IContributedKernelFinder | undefined {
         return this.connectionFinderMapping.get(kernelMetadata.id);
     }
 
     // Give the info for what kernel finders are currently registered
-    public get registered(): IContributedKernelFinderInfo[] {
-        return this._finders as IContributedKernelFinderInfo[];
+    public get registered(): IContributedKernelFinder[] {
+        return this._finders;
     }
 }

--- a/src/kernels/types.ts
+++ b/src/kernels/types.ts
@@ -20,8 +20,8 @@ import { PythonEnvironment } from '../platform/pythonEnvironments/info';
 import { IAsyncDisposable, IDisplayOptions, IDisposable, ReadWrite, Resource } from '../platform/common/types';
 import { IBackupFile, IJupyterKernel } from './jupyter/types';
 import { PythonEnvironment_PythonApi } from '../platform/api/types';
-import { IContributedKernelFinderInfo } from './internalTypes';
 import { deserializePythonEnvironment, serializePythonEnvironment } from '../platform/api/pythonApi';
+import { IContributedKernelFinder } from './internalTypes';
 
 export type WebSocketData = string | Buffer | ArrayBuffer | Buffer[];
 
@@ -798,11 +798,11 @@ export interface IKernelFinder {
     /*
      * For a given kernel connection metadata return what kernel finder found it
      */
-    getFinderForConnection(kernelMetadata: KernelConnectionMetadata): IContributedKernelFinderInfo | undefined;
+    getFinderForConnection(kernelMetadata: KernelConnectionMetadata): IContributedKernelFinder | undefined;
     /*
      * Return basic info on all currently registered kernel finders
      */
-    registered: IContributedKernelFinderInfo[];
+    registered: IContributedKernelFinder[];
 }
 
 export type KernelAction = 'start' | 'interrupt' | 'restart' | 'execution';

--- a/src/notebooks/controllers/kernelSource/notebookKernelSourceSelector.ts
+++ b/src/notebooks/controllers/kernelSource/notebookKernelSourceSelector.ts
@@ -5,7 +5,7 @@
 
 import { inject, injectable } from 'inversify';
 import { NotebookDocument, QuickPickItem, QuickPickItemKind } from 'vscode';
-import { IContributedKernelFinderInfo } from '../../../kernels/internalTypes';
+import { IContributedKernelFinder } from '../../../kernels/internalTypes';
 import { IKernelFinder } from '../../../kernels/types';
 import { ICommandManager } from '../../../platform/common/application/types';
 import { InteractiveWindowView, JupyterNotebookView, JVSC_EXTENSION_ID } from '../../../platform/common/constants';
@@ -23,7 +23,7 @@ import {
 } from '../types';
 
 interface KernelFinderQuickPickItem extends QuickPickItem {
-    kernelFinderInfo: IContributedKernelFinderInfo;
+    kernelFinderInfo: IContributedKernelFinder;
 }
 
 interface ControllerQuickPickItem extends QuickPickItem {
@@ -31,7 +31,7 @@ interface ControllerQuickPickItem extends QuickPickItem {
 }
 
 // The return type of our multistep selection process
-type MultiStepResult = { source?: IContributedKernelFinderInfo; controller?: IVSCodeNotebookController };
+type MultiStepResult = { source?: IContributedKernelFinder; controller?: IVSCodeNotebookController };
 
 // Provides the UI to select a Kernel Source for a given notebook document
 @injectable()
@@ -137,7 +137,7 @@ export class NotebookKernelSourceSelector implements INotebookKernelSourceSelect
 
     // Get all registered controllers that match a specific finder
     private getMatchingControllers(
-        kernelSource: IContributedKernelFinderInfo,
+        kernelSource: IContributedKernelFinder,
         notebookType: typeof JupyterNotebookView | typeof InteractiveWindowView
     ): IVSCodeNotebookController[] {
         return this.controllerRegistration.registered.filter((controller) => {
@@ -160,7 +160,7 @@ export class NotebookKernelSourceSelector implements INotebookKernelSourceSelect
     }
 
     // Convert a kernel finder info in a quick pick item
-    toQuickPickItem(kernelFinderInfo: IContributedKernelFinderInfo): KernelFinderQuickPickItem {
+    toQuickPickItem(kernelFinderInfo: IContributedKernelFinder): KernelFinderQuickPickItem {
         return { kernelFinderInfo, label: kernelFinderInfo.displayName };
     }
 }

--- a/src/notebooks/controllers/kernelSource/notebookKernelSourceTracker.ts
+++ b/src/notebooks/controllers/kernelSource/notebookKernelSourceTracker.ts
@@ -5,7 +5,7 @@
 
 import { inject, injectable } from 'inversify';
 import { NotebookControllerAffinity2, NotebookDocument, workspace } from 'vscode';
-import { IContributedKernelFinderInfo } from '../../../kernels/internalTypes';
+import { IContributedKernelFinder } from '../../../kernels/internalTypes';
 import { IKernelFinder } from '../../../kernels/types';
 import { IExtensionSyncActivationService } from '../../../platform/activation/types';
 import { IDisposableRegistry } from '../../../platform/common/types';
@@ -14,9 +14,9 @@ import { IControllerRegistration, INotebookKernelSourceTracker, IVSCodeNotebookC
 // Controls which kernel source is associated with each document, and controls hiding and showing kernel sources for them.
 @injectable()
 export class NotebookKernelSourceTracker implements INotebookKernelSourceTracker, IExtensionSyncActivationService {
-    private documentSourceMapping: Map<NotebookDocument, IContributedKernelFinderInfo | undefined> = new Map<
+    private documentSourceMapping: Map<NotebookDocument, IContributedKernelFinder | undefined> = new Map<
         NotebookDocument,
-        IContributedKernelFinderInfo | undefined
+        IContributedKernelFinder | undefined
     >();
 
     constructor(
@@ -34,10 +34,10 @@ export class NotebookKernelSourceTracker implements INotebookKernelSourceTracker
         workspace.notebookDocuments.forEach(this.onDidOpenNotebookDocument.bind(this));
     }
 
-    public getKernelSourceForNotebook(notebook: NotebookDocument): IContributedKernelFinderInfo | undefined {
+    public getKernelSourceForNotebook(notebook: NotebookDocument): IContributedKernelFinder | undefined {
         return this.documentSourceMapping.get(notebook);
     }
-    public setKernelSourceForNotebook(notebook: NotebookDocument, kernelSource: IContributedKernelFinderInfo): void {
+    public setKernelSourceForNotebook(notebook: NotebookDocument, kernelSource: IContributedKernelFinder): void {
         this.documentSourceMapping.set(notebook, kernelSource);
 
         // After setting the kernelsource we now need to change the affinity of the controllers to hide all controllers not from that finder
@@ -57,7 +57,7 @@ export class NotebookKernelSourceTracker implements INotebookKernelSourceTracker
         });
     }
 
-    private updateControllerAffinity(notebook: NotebookDocument, kernelSource: IContributedKernelFinderInfo) {
+    private updateControllerAffinity(notebook: NotebookDocument, kernelSource: IContributedKernelFinder) {
         // Find the controller associated with the given kernel source
         const nonAssociatedControllers = this.controllerRegistration.registered.filter(
             (controller) => !this.controllerMatchesKernelSource(controller, kernelSource)
@@ -80,7 +80,7 @@ export class NotebookKernelSourceTracker implements INotebookKernelSourceTracker
     // Matching function to filter if controllers match a specific source
     private controllerMatchesKernelSource(
         controller: IVSCodeNotebookController,
-        kernelSource: IContributedKernelFinderInfo
+        kernelSource: IContributedKernelFinder
     ): boolean {
         const controllerFinderInfo = this.kernelFinder.getFinderForConnection(controller.connection);
         if (controllerFinderInfo && controllerFinderInfo.id === kernelSource.id) {

--- a/src/notebooks/controllers/types.ts
+++ b/src/notebooks/controllers/types.ts
@@ -9,7 +9,7 @@ import { KernelConnectionMetadata } from '../../kernels/types';
 import { JupyterNotebookView, InteractiveWindowView } from '../../platform/common/constants';
 import { IDisposable, Resource } from '../../platform/common/types';
 import { PythonEnvironment } from '../../platform/pythonEnvironments/info';
-import { IContributedKernelFinderInfo } from '../../kernels/internalTypes';
+import { IContributedKernelFinder } from '../../kernels/internalTypes';
 
 export const InteractiveControllerIdSuffix = ' (Interactive)';
 
@@ -186,6 +186,6 @@ export interface INotebookKernelSourceSelector {
 // Track what kernel source is selected for each open notebook document and persist that data
 export const INotebookKernelSourceTracker = Symbol('INotebookKernelSourceTracker');
 export interface INotebookKernelSourceTracker {
-    getKernelSourceForNotebook(notebook: vscode.NotebookDocument): IContributedKernelFinderInfo | undefined;
-    setKernelSourceForNotebook(notebook: vscode.NotebookDocument, kernelFinderInfo: IContributedKernelFinderInfo): void;
+    getKernelSourceForNotebook(notebook: vscode.NotebookDocument): IContributedKernelFinder | undefined;
+    setKernelSourceForNotebook(notebook: vscode.NotebookDocument, kernelFinderInfo: IContributedKernelFinder): void;
 }


### PR DESCRIPTION
`IContributedKernelFinderInfo` is unnecessary. `IContributedKernelFinder` will be the only type we talk about in the kernel picker world.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] Has telemetry for feature-requests.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
