### PR TITLE
Experiment: manual jupyter server connection through uri server provider api

### DIFF
--- a/package.json
+++ b/package.json
@@ -276,6 +276,12 @@
                 "enablement": "jupyter.development"
             },
             {
+                "command": "dataScience.ClearUserProviderJupyterServerCache",
+                "title": "%jupyter.command.dataScience.clearUserProviderJupyterServerCache.title%",
+                "category": "Jupyter (Dev)",
+                "enablement": "jupyter.development"
+            },
+            {
                 "command": "jupyter.replayPylanceLog",
                 "title": "%jupyter.command.jupyter.replayPylanceLog.title%",
                 "category": "Jupyter (Dev)",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1138,5 +1138,8 @@
     "DataScience.universalRemoteKernelFinderDisplayName": "Remote - {0}",
     "DataScience.remoteKernelFinderDisplayName": "Current Remote",
     "DataScience.kernelPickerSelectSourceTitle": "Select Kernel Source",
-    "DataScience.kernelPickerSelectKernelTitle": "Select Kernel"
+    "DataScience.kernelPickerSelectKernelTitle": "Select Kernel",
+    "DataScience.UserJupyterServerUrlProviderDisplayName": "Existing Jupyter Server",
+    "DataScience.UserJupyterServerUrlProviderDetail": "Connect to an existing Jupyter Server",
+    "DataScience.UserJupyterServerUrlAlreadyExistError": "A Jupyter Server with the same URL already exists."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -35,6 +35,7 @@
     },
     "contributes.walkthroughs.jupyterWelcome.steps.jupyter.dataScienceLearnMore.media.altText": "Image representing our documentation page and mailing list resources.",
     "jupyter.command.dataScience.clearCache.title": "Clear Cache",
+    "jupyter.command.dataScience.clearUserProviderJupyterServerCache.title": "Clear User Jupyter Server Cache",
     "jupyter.command.jupyter.replayPylanceLog.title": "Replay Pylance Log",
     "jupyter.command.jupyter.replayPylanceLogStep.title": "Step Pylance Log",
     "jupyter.command.jupyter.exportAsPythonScript.title": "Export to Python Script",

--- a/src/kernels/jupyter/jupyterUriProviderWrapper.ts
+++ b/src/kernels/jupyter/jupyterUriProviderWrapper.ts
@@ -43,6 +43,9 @@ export class JupyterUriProviderWrapper implements IJupyterUriProvider {
     public get displayName(): string | undefined {
         return this.provider.displayName;
     }
+    public get detail(): string | undefined {
+        return this.provider.detail;
+    }
     public getQuickPickEntryItems(): vscode.QuickPickItem[] {
         if (!this.provider.getQuickPickEntryItems) {
             return [];

--- a/src/kernels/jupyter/serverSelector.ts
+++ b/src/kernels/jupyter/serverSelector.ts
@@ -60,7 +60,7 @@ interface IJupyterServerSelector {
     ): Promise<InputFlowAction | undefined | InputStep<{}> | void>;
 
     setJupyterURIToLocal(): Promise<void>;
-    setJupyterURIToRemote(userURI: string | undefined, ignoreValidation?: boolean): Promise<void>;
+    setJupyterURIToRemote(userURI: string | undefined, ignoreValidation?: boolean, displayName?: string): Promise<void>;
 }
 
 export type SelectJupyterUriCommandSource =
@@ -71,6 +71,57 @@ export type SelectJupyterUriCommandSource =
     | 'nativeNotebookToolbar'
     | 'errorHandler'
     | 'prompt';
+
+export async function validateSelectJupyterURI(
+    jupyterConnection: JupyterConnection,
+    applicationShell: IApplicationShell,
+    configService: IConfigurationService,
+    isWebExtension: boolean,
+    inputText: string
+): Promise<string | undefined> {
+    inputText = inputText.trim();
+    try {
+        new URL(inputText);
+    } catch {
+        return DataScience.jupyterSelectURIInvalidURI();
+    }
+
+    // Double check http
+    if (!inputText.toLowerCase().startsWith('http')) {
+        return DataScience.validationErrorMessageForRemoteUrlProtocolNeedsToBeHttpOrHttps();
+    }
+    // Double check this server can be connected to. Might need a password, might need a allowUnauthorized
+    try {
+        await jupyterConnection.validateRemoteUri(inputText);
+    } catch (err) {
+        traceWarning('Uri verification error', err);
+        if (JupyterSelfCertsError.isSelfCertsError(err)) {
+            sendTelemetryEvent(Telemetry.ConnectRemoteSelfCertFailedJupyter);
+            const handled = await handleSelfCertsError(applicationShell, configService, err.message);
+            if (!handled) {
+                return DataScience.jupyterSelfCertFailErrorMessageOnly();
+            }
+        } else if (JupyterSelfCertsExpiredError.isSelfCertsExpiredError(err)) {
+            sendTelemetryEvent(Telemetry.ConnectRemoteSelfCertFailedJupyter);
+            const handled = await handleExpiredCertsError(applicationShell, configService, err.message);
+            if (!handled) {
+                return DataScience.jupyterSelfCertExpiredErrorMessageOnly();
+            }
+        } else {
+            // Notify the user of web extension specific connection help
+            if (isWebExtension) {
+                applicationShell
+                    .showErrorMessage(DataScience.remoteJupyterConnectionFailedWebExtension())
+                    .then(noop, noop);
+            }
+
+            // Return the general connection error to show in the validation box
+            return DataScience.remoteJupyterConnectionFailedWithoutServerWithError().format(
+                err.message || err.toString()
+            );
+        }
+    }
+}
 
 /**
  * Provides the UI for picking a remote server. Multiplexes to one of two implementations based on the 'showOnlyOneTypeOfKernel' experiment.
@@ -114,8 +165,12 @@ export class JupyterServerSelector {
         return this.impl.setJupyterURIToLocal();
     }
 
-    public setJupyterURIToRemote(userURI: string | undefined, ignoreValidation?: boolean): Promise<void> {
-        return this.impl.setJupyterURIToRemote(userURI, ignoreValidation);
+    public setJupyterURIToRemote(
+        userURI: string | undefined,
+        ignoreValidation?: boolean,
+        displayName?: string
+    ): Promise<void> {
+        return this.impl.setJupyterURIToRemote(userURI, ignoreValidation, displayName);
     }
 
     private createImpl(kernelPickerType: KernelPickerType) {
@@ -314,7 +369,13 @@ class JupyterServerSelector_Original implements IJupyterServerSelector {
         const uri = await input.showInputBox({
             title: DataScience.jupyterSelectURIPrompt(),
             value: initialValue || defaultUri,
-            validate: this.validateSelectJupyterURI,
+            validate: validateSelectJupyterURI.bind(
+                this,
+                this.jupyterConnection,
+                this.applicationShell,
+                this.configService,
+                this.isWebExtension
+            ),
             prompt: ''
         });
 
@@ -328,51 +389,6 @@ class JupyterServerSelector_Original implements IJupyterServerSelector {
             await this.setJupyterURIToRemote(uri, true, newDisplayName || uri);
         }
     }
-
-    public validateSelectJupyterURI = async (inputText: string): Promise<string | undefined> => {
-        inputText = inputText.trim();
-        try {
-            new URL(inputText);
-        } catch {
-            return DataScience.jupyterSelectURIInvalidURI();
-        }
-
-        // Double check http
-        if (!inputText.toLowerCase().startsWith('http')) {
-            return DataScience.validationErrorMessageForRemoteUrlProtocolNeedsToBeHttpOrHttps();
-        }
-        // Double check this server can be connected to. Might need a password, might need a allowUnauthorized
-        try {
-            await this.jupyterConnection.validateRemoteUri(inputText);
-        } catch (err) {
-            traceWarning('Uri verification error', err);
-            if (JupyterSelfCertsError.isSelfCertsError(err)) {
-                sendTelemetryEvent(Telemetry.ConnectRemoteSelfCertFailedJupyter);
-                const handled = await handleSelfCertsError(this.applicationShell, this.configService, err.message);
-                if (!handled) {
-                    return DataScience.jupyterSelfCertFailErrorMessageOnly();
-                }
-            } else if (JupyterSelfCertsExpiredError.isSelfCertsExpiredError(err)) {
-                sendTelemetryEvent(Telemetry.ConnectRemoteSelfCertFailedJupyter);
-                const handled = await handleExpiredCertsError(this.applicationShell, this.configService, err.message);
-                if (!handled) {
-                    return DataScience.jupyterSelfCertExpiredErrorMessageOnly();
-                }
-            } else {
-                // Notify the user of web extension specific connection help
-                if (this.isWebExtension) {
-                    this.applicationShell
-                        .showErrorMessage(DataScience.remoteJupyterConnectionFailedWebExtension())
-                        .then(noop, noop);
-                }
-
-                // Return the general connection error to show in the validation box
-                return DataScience.remoteJupyterConnectionFailedWithoutServerWithError().format(
-                    err.message || err.toString()
-                );
-            }
-        }
-    };
 
     private async getUriPickList(
         allowLocal: boolean,

--- a/src/kernels/jupyter/types.ts
+++ b/src/kernels/jupyter/types.ts
@@ -212,6 +212,7 @@ export interface IJupyterUriProvider {
      */
     readonly id: string;
     readonly displayName?: string;
+    readonly detail?: string;
     onDidChangeHandles?: Event<void>;
     getQuickPickEntryItems?(): QuickPickItem[];
     handleQuickPick?(item: QuickPickItem, backEnabled: boolean): Promise<JupyterServerUriHandle | 'back' | undefined>;

--- a/src/notebooks/controllers/kernelSource/notebookKernelSourceSelector.ts
+++ b/src/notebooks/controllers/kernelSource/notebookKernelSourceSelector.ts
@@ -30,6 +30,7 @@ import { DataScience } from '../../../platform/common/utils/localize';
 import {
     IMultiStepInput,
     IMultiStepInputFactory,
+    InputFlowAction,
     InputStep,
     IQuickPickParameters
 } from '../../../platform/common/utils/multiStepInput';
@@ -63,10 +64,6 @@ interface LocalPythonEnvSourceQuickPickItem extends QuickPickItem {
     kernelFinderInfo: IContributedKernelFinder<PythonKernelConnectionMetadata>;
 }
 
-interface LocalJupyterServerSourceQuickPickItem extends QuickPickItem {
-    type: KernelSourceQuickPickType.LocalServer;
-}
-
 interface KernelProviderInfoQuickPickItem extends QuickPickItem {
     type: KernelSourceQuickPickType.ServerUriProvider;
     provider: IJupyterUriProvider;
@@ -75,10 +72,6 @@ interface KernelProviderInfoQuickPickItem extends QuickPickItem {
 interface ContributedKernelFinderQuickPickItem extends QuickPickItem {
     type: KernelFinderEntityQuickPickType.KernelFinder;
     kernelFinderInfo: IContributedKernelFinder;
-}
-
-interface LocalJupyterServerQuickPickItem extends QuickPickItem {
-    type: KernelFinderEntityQuickPickType.LocalServer;
 }
 
 interface KernelProviderItemsQuickPickItem extends QuickPickItem {
@@ -90,8 +83,7 @@ interface KernelProviderItemsQuickPickItem extends QuickPickItem {
 type KernelSourceQuickPickItem =
     | LocalKernelSpecSourceQuickPickItem
     | LocalPythonEnvSourceQuickPickItem
-    | KernelProviderInfoQuickPickItem
-    | LocalJupyterServerSourceQuickPickItem;
+    | KernelProviderInfoQuickPickItem;
 
 // type KernelFinderEntityQuickPickItem =
 //     | ContributedKernelFinderQuickPickItem
@@ -185,20 +177,13 @@ export class NotebookKernelSourceSelector implements INotebookKernelSourceSelect
             });
         }
 
-        // Manual remote server kernel finder
-        items.push({
-            type: KernelSourceQuickPickType.LocalServer,
-            label: 'Existing Jupyter Server',
-            detail: DataScience.jupyterSelectURINewDetail()
-        });
-
         // 3rd party remote server uri providers
         const providers = await this.uriProviderRegistration.getProviders();
         providers.forEach((p) => {
             items.push({
                 type: KernelSourceQuickPickType.ServerUriProvider,
                 label: p.displayName ?? p.id,
-                detail: `Connect to Jupyter servers from ${p.displayName ?? p.id}`,
+                detail: p.detail ?? `Connect to Jupyter servers from ${p.displayName ?? p.id}`,
                 provider: p
             });
         });
@@ -232,82 +217,8 @@ export class NotebookKernelSourceSelector implements INotebookKernelSourceSelect
                         },
                         token
                     );
-                case KernelSourceQuickPickType.LocalServer:
-                    return this.getUserProvidedJupyterServers.bind(this, notebookType, token);
                 case KernelSourceQuickPickType.ServerUriProvider:
                     return this.getRemoteServersFromProvider.bind(this, selectedSource.provider, notebookType, token);
-                default:
-                    break;
-            }
-        }
-    }
-
-    private async getUserProvidedJupyterServers(
-        notebookType: typeof JupyterNotebookView | typeof InteractiveWindowView,
-        token: CancellationToken,
-        multiStep: IMultiStepInput<MultiStepResult>,
-        state: MultiStepResult
-    ) {
-        const servers = this.kernelFinder.registered.filter((info) => {
-            return info.kind === 'remote' && (info as IRemoteKernelFinder).serverUri.uri;
-        }) as IRemoteKernelFinder[];
-        const items: (ContributedKernelFinderQuickPickItem | LocalJupyterServerQuickPickItem | QuickPickItem)[] = [];
-
-        for (const server of servers) {
-            // remote server
-            const savedURIList = await this.serverUriStorage.getSavedUriList();
-            const savedURI = savedURIList.find((uri) => uri.uri === server.serverUri.uri);
-            if (savedURI) {
-                const idAndHandle = extractJupyterServerHandleAndId(savedURI.uri);
-                if (!idAndHandle) {
-                    const uriDate = new Date(savedURI.time);
-                    items.push({
-                        kernelFinderInfo: server,
-                        label: server.displayName,
-                        type: KernelFinderEntityQuickPickType.KernelFinder,
-                        detail: DataScience.jupyterSelectURIMRUDetail().format(uriDate.toLocaleString())
-                    });
-                }
-            }
-        }
-
-        if (items.length > 0) {
-            // insert separator
-            items.push({ label: 'More', kind: QuickPickItemKind.Separator });
-        }
-
-        items.push({
-            type: KernelFinderEntityQuickPickType.LocalServer,
-            label: 'Connect to a Jupyter Server',
-            detail: DataScience.jupyterSelectURINewDetail()
-        });
-
-        const selectedSource = await multiStep.showQuickPick<
-            ContributedKernelFinderQuickPickItem | LocalJupyterServerQuickPickItem | QuickPickItem,
-            IQuickPickParameters<ContributedKernelFinderQuickPickItem | LocalJupyterServerQuickPickItem | QuickPickItem>
-        >({
-            items: items,
-            placeholder: '',
-            title: 'Select a Jupyter Server'
-        });
-
-        if (token.isCancellationRequested) {
-            return;
-        }
-
-        if (selectedSource && 'type' in selectedSource) {
-            switch (selectedSource.type) {
-                case KernelFinderEntityQuickPickType.KernelFinder:
-                    state.source = selectedSource.kernelFinderInfo;
-                    return this.getKernel.bind(
-                        this,
-                        async () => {
-                            return this.getMatchingControllers(selectedSource.kernelFinderInfo, notebookType);
-                        },
-                        token
-                    );
-                case KernelFinderEntityQuickPickType.LocalServer:
-                    break;
                 default:
                     break;
             }
@@ -409,6 +320,10 @@ export class NotebookKernelSourceSelector implements INotebookKernelSourceSelect
                                 true
                             );
 
+                            if (handle === 'back') {
+                                throw InputFlowAction.back;
+                            }
+
                             if (token.isCancellationRequested) {
                                 return [];
                             }
@@ -450,11 +365,11 @@ export class NotebookKernelSourceSelector implements INotebookKernelSourceSelect
         multiStep: IMultiStepInput<MultiStepResult>,
         state: MultiStepResult
     ): Promise<InputStep<MultiStepResult> | void> {
+        const matchingControllers = await getMatchingControllers();
+
         if (!state.source) {
             return;
         }
-
-        const matchingControllers = await getMatchingControllers();
 
         if (token.isCancellationRequested) {
             return;

--- a/src/platform/common/utils/localize.ts
+++ b/src/platform/common/utils/localize.ts
@@ -1423,6 +1423,12 @@ export namespace DataScience {
         localize('DataScience.localPythonEnvironments', 'Local Python Environments');
     export const pickLocalKernelPythonEnvTitle = () =>
         localize('DataScience.pickLocalKernelPythonEnvTitle', `Select a Local Python Environment`);
+    export const UserJupyterServerUrlProviderDisplayName = () =>
+        localize('DataScience.UserJupyterServerUrlProviderDisplayName', 'Existing Jupyter Server');
+    export const UserJupyterServerUrlProviderDetail = () =>
+        localize('DataScience.UserJupyterServerUrlProviderDetail', 'Connect to an existing Jupyter Server');
+    export const UserJupyterServerUrlAlreadyExistError = () =>
+        localize('DataScience.UserJupyterServerUrlAlreadyExistError', 'A Jupyter Server with this URL already exists');
     export const universalRemoteKernelFinderDisplayName = () =>
         localize('DataScience.universalRemoteKernelFinderDisplayName', 'Remote - {0}');
     export const remoteKernelFinderDisplayName = () =>

--- a/src/standalone/serviceRegistry.node.ts
+++ b/src/standalone/serviceRegistry.node.ts
@@ -25,10 +25,11 @@ import { ApiAccessService } from './api/apiAccessService';
 import { WorkspaceActivation } from './activation/workspaceActivation.node';
 import { ExtensionActivationManager } from './activation/activationManager';
 import { DataScienceSurveyBanner, ISurveyBanner } from './survey/dataScienceSurveyBanner.node';
-import { IExtensionContext } from '../platform/common/types';
+import { IConfigurationService, IExtensionContext } from '../platform/common/types';
 import { registerTypes as registerDevToolTypes } from './devTools/serviceRegistry';
 import { registerTypes as registerIntellisenseTypes } from './intellisense/serviceRegistry.node';
 import { PythonExtensionRestartNotification } from './notification/pythonExtensionRestartNotification';
+import { UserJupyterServerUrlProvider } from './userJupyterServer/userServerUrlProvider';
 
 export function registerTypes(context: IExtensionContext, serviceManager: IServiceManager, isDevMode: boolean) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, GlobalActivation);
@@ -85,4 +86,13 @@ export function registerTypes(context: IExtensionContext, serviceManager: IServi
 
     // Dev Tools
     registerDevToolTypes(context, serviceManager, isDevMode);
+
+    const configuration = serviceManager.get<IConfigurationService>(IConfigurationService);
+    if (configuration.getSettings().kernelPickerType === 'Insiders') {
+        // User jupyter server url provider
+        serviceManager.addSingleton<IExtensionSyncActivationService>(
+            IExtensionSyncActivationService,
+            UserJupyterServerUrlProvider
+        );
+    }
 }

--- a/src/standalone/serviceRegistry.web.ts
+++ b/src/standalone/serviceRegistry.web.ts
@@ -20,10 +20,11 @@ import { IExportedKernelServiceFactory } from './api/api';
 import { ApiAccessService } from './api/apiAccessService';
 import { ExtensionActivationManager } from './activation/activationManager';
 import { registerTypes as registerDevToolTypes } from './devTools/serviceRegistry';
-import { IExtensionContext } from '../platform/common/types';
+import { IConfigurationService, IExtensionContext } from '../platform/common/types';
 import { registerTypes as registerIntellisenseTypes } from './intellisense/serviceRegistry.web';
 import { PythonExtensionRestartNotification } from './notification/pythonExtensionRestartNotification';
 import { ImportTracker } from './import-export/importTracker';
+import { UserJupyterServerUrlProvider } from './userJupyterServer/userServerUrlProvider';
 
 export function registerTypes(context: IExtensionContext, serviceManager: IServiceManager, isDevMode: boolean) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, GlobalActivation);
@@ -62,4 +63,13 @@ export function registerTypes(context: IExtensionContext, serviceManager: IServi
 
     // Dev Tools
     registerDevToolTypes(context, serviceManager, isDevMode);
+
+    const configuration = serviceManager.get<IConfigurationService>(IConfigurationService);
+    if (configuration.getSettings().kernelPickerType === 'Insiders') {
+        // User jupyter server url provider
+        serviceManager.addSingleton<IExtensionSyncActivationService>(
+            IExtensionSyncActivationService,
+            UserJupyterServerUrlProvider
+        );
+    }
 }

--- a/src/standalone/userJupyterServer/userServerUrlProvider.ts
+++ b/src/standalone/userJupyterServer/userServerUrlProvider.ts
@@ -25,6 +25,7 @@ import {
     GLOBAL_MEMENTO,
     IConfigurationService,
     IDisposable,
+    IDisposableRegistry,
     IMemento,
     IsWebExtension
 } from '../../platform/common/types';
@@ -41,7 +42,6 @@ export class UserJupyterServerUrlProvider implements IExtensionSyncActivationSer
     readonly detail: string = DataScience.UserJupyterServerUrlProviderDetail();
     private _onDidChangeHandles = new EventEmitter<void>();
     onDidChangeHandles: Event<void> = this._onDidChangeHandles.event;
-    private readonly _globalDisposables: IDisposable[] = [];
     private _servers: { handle: string; uri: string; serverInfo: IJupyterServerUri }[] = [];
     private _cachedServerInfoInitialized: Promise<void> | undefined;
 
@@ -54,14 +54,15 @@ export class UserJupyterServerUrlProvider implements IExtensionSyncActivationSer
         @inject(JupyterConnection) private readonly jupyterConnection: JupyterConnection,
         @inject(IsWebExtension) private readonly isWebExtension: boolean,
         @inject(IEncryptedStorage) private readonly encryptedStorage: IEncryptedStorage,
-        @inject(IMemento) @named(GLOBAL_MEMENTO) private readonly globalMemento: Memento
+        @inject(IMemento) @named(GLOBAL_MEMENTO) private readonly globalMemento: Memento,
+        @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry
     ) {}
 
     activate() {
         this.uriProviderRegistration.registerProvider(this);
         this._servers = [];
 
-        this._globalDisposables.push(
+        this.disposables.push(
             commands.registerCommand('dataScience.ClearUserProviderJupyterServerCache', async () => {
                 await this.encryptedStorage.store(
                     Settings.JupyterServerRemoteLaunchService,

--- a/src/standalone/userJupyterServer/userServerUrlProvider.ts
+++ b/src/standalone/userJupyterServer/userServerUrlProvider.ts
@@ -1,0 +1,209 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+'use strict';
+import { inject, injectable } from 'inversify';
+import { Disposable, QuickInputButtons, QuickPickItem, Uri, window } from 'vscode';
+import { JupyterConnection } from '../../kernels/jupyter/jupyterConnection';
+import { validateSelectJupyterURI } from '../../kernels/jupyter/serverSelector';
+import { IJupyterServerUri, IJupyterUriProvider, IJupyterUriProviderRegistration } from '../../kernels/jupyter/types';
+import { IExtensionSyncActivationService } from '../../platform/activation/types';
+import { IApplicationShell, IClipboard, IEncryptedStorage } from '../../platform/common/application/types';
+import { Settings } from '../../platform/common/constants';
+import { IConfigurationService, IDisposable, IsWebExtension } from '../../platform/common/types';
+import { DataScience } from '../../platform/common/utils/localize';
+
+export const UserJupyterServerUriListKey = 'user-jupyter-server-uri-list';
+
+@injectable()
+export class UserJupyterServerUrlProvider implements IExtensionSyncActivationService, IDisposable, IJupyterUriProvider {
+    readonly id: string = '_builtin.jupyterServerUrlProvider';
+    readonly displayName: string = DataScience.UserJupyterServerUrlProviderDisplayName();
+    readonly detail: string = DataScience.UserJupyterServerUrlProviderDetail();
+    private _servers: { handle: string; serverInfo: IJupyterServerUri }[] = [];
+    private _initialized: Promise<void> | undefined;
+
+    constructor(
+        @inject(IClipboard) private readonly clipboard: IClipboard,
+        @inject(IJupyterUriProviderRegistration)
+        private readonly uriProviderRegistration: IJupyterUriProviderRegistration,
+        @inject(IApplicationShell) private readonly applicationShell: IApplicationShell,
+        @inject(IConfigurationService) private readonly configService: IConfigurationService,
+        @inject(JupyterConnection) private readonly jupyterConnection: JupyterConnection,
+        @inject(IsWebExtension) private readonly isWebExtension: boolean,
+        @inject(IEncryptedStorage) private readonly encryptedStorage: IEncryptedStorage
+    ) {}
+
+    activate() {
+        this.uriProviderRegistration.registerProvider(this);
+        this._initialized = new Promise(async (resolve) => {
+            const cache = await this.encryptedStorage.retrieve(
+                Settings.JupyterServerRemoteLaunchService,
+                UserJupyterServerUriListKey
+            );
+
+            if (cache) {
+                const servers = cache.split(Settings.JupyterServerRemoteLaunchUriSeparator);
+                for (let server of servers) {
+                    const serverInfo = await this.parseUri(server);
+                    if (serverInfo) {
+                        this._servers.push({ handle: server, serverInfo });
+                    }
+                }
+            }
+
+            resolve();
+        });
+    }
+
+    getQuickPickEntryItems(): QuickPickItem[] {
+        return [
+            {
+                label: DataScience.jupyterSelectURIPrompt(),
+                detail: DataScience.jupyterSelectURINewDetail()
+            }
+        ];
+    }
+
+    async handleQuickPick(item: QuickPickItem, backEnabled: boolean): Promise<string | undefined> {
+        await this._initialized;
+        if (item.label !== DataScience.jupyterSelectURIPrompt()) {
+            return undefined;
+        }
+
+        let initialValue = '';
+        try {
+            const text = await this.clipboard.readText().catch(() => '');
+            const parsedUri = Uri.parse(text.trim(), true);
+            // Only display http/https uris.
+            initialValue = text && parsedUri && parsedUri.scheme.toLowerCase().startsWith('http') ? text : '';
+        } catch {
+            // We can ignore errors.
+        }
+
+        const disposables: Disposable[] = [];
+
+        // Ask the user to enter a URI to connect to.
+        const input = window.createInputBox();
+        input.title = DataScience.jupyterSelectURIPrompt();
+        input.value = initialValue;
+        input.ignoreFocusOut = true;
+
+        return new Promise<string | undefined>((resolve) => {
+            if (backEnabled) {
+                input.buttons = [QuickInputButtons.Back];
+                disposables.push(
+                    input.onDidTriggerButton((item) => {
+                        if (item === QuickInputButtons.Back) {
+                            resolve('back');
+                        } else {
+                            resolve(undefined);
+                        }
+                    })
+                );
+            }
+
+            disposables.push(
+                input.onDidAccept(async () => {
+                    const uri = input.value;
+
+                    if (this._servers.find((s) => s.handle === uri)) {
+                        // already exist
+                        input.validationMessage = DataScience.UserJupyterServerUrlAlreadyExistError();
+                        return;
+                    }
+
+                    const message = await validateSelectJupyterURI(
+                        this.jupyterConnection,
+                        this.applicationShell,
+                        this.configService,
+                        this.isWebExtension,
+                        uri
+                    );
+
+                    if (message) {
+                        input.validationMessage = message;
+                    } else {
+                        const serverInfo = this.parseUri(uri);
+                        if (serverInfo) {
+                            this._servers.push({ handle: uri, serverInfo });
+                            await this.updateMemento();
+                            resolve(uri);
+                        } else {
+                            resolve(undefined);
+                        }
+                    }
+                }),
+                input.onDidHide(() => {
+                    resolve(undefined);
+                })
+            );
+
+            input.show();
+        }).finally(() => {
+            disposables.forEach((d) => d.dispose());
+        });
+    }
+
+    private parseUri(uri: string): IJupyterServerUri | undefined {
+        let url: URL;
+        try {
+            url = new URL(uri);
+
+            // Special case for URI's ending with 'lab'. Remove this from the URI. This is not
+            // the location for connecting to jupyterlab
+            const baseUrl = `${url.protocol}//${url.host}${url.pathname === '/lab' ? '' : url.pathname}`;
+
+            const token = `${url.searchParams.get('token')}`;
+            const authorizationHeader = {
+                Authorization: `token ${token}`
+            };
+            const hostName = url.hostname;
+
+            return {
+                baseUrl: baseUrl,
+                token: token,
+                displayName: hostName,
+                authorizationHeader
+            };
+        } catch (err) {
+            // This should already have been parsed when set, so just throw if it's not right here
+            return undefined;
+        }
+    }
+
+    async getServerUri(handle: string): Promise<IJupyterServerUri> {
+        await this._initialized;
+
+        const server = this._servers.find((s) => s.handle === handle);
+
+        if (!server) {
+            throw new Error('Server not found');
+        }
+
+        return server.serverInfo;
+    }
+
+    async getHandles(): Promise<string[]> {
+        await this._initialized;
+
+        return this._servers.map((s) => s.handle);
+    }
+
+    private async updateMemento() {
+        // Sort based on time. Newest time first
+
+        // Write the uris to the storage in one big blob (max length issues?)
+        // This is because any part of the URI may be a secret (we don't know it's just token values for instance)
+        const blob = this._servers.map((e) => `${e.handle}`).join(Settings.JupyterServerRemoteLaunchUriSeparator);
+        return this.encryptedStorage.store(
+            Settings.JupyterServerRemoteLaunchService,
+            UserJupyterServerUriListKey,
+            blob
+        );
+    }
+
+    dispose(): void {
+        return;
+    }
+}

--- a/src/standalone/userJupyterServer/userServerUrlProvider.ts
+++ b/src/standalone/userJupyterServer/userServerUrlProvider.ts
@@ -191,10 +191,6 @@ export class UserJupyterServerUrlProvider implements IExtensionSyncActivationSer
     }
 
     private async updateMemento() {
-        // Sort based on time. Newest time first
-
-        // Write the uris to the storage in one big blob (max length issues?)
-        // This is because any part of the URI may be a secret (we don't know it's just token values for instance)
         const blob = this._servers.map((e) => `${e.handle}`).join(Settings.JupyterServerRemoteLaunchUriSeparator);
         return this.encryptedStorage.store(
             Settings.JupyterServerRemoteLaunchService,


### PR DESCRIPTION
Implemented the manual jupyter server support through uri server provider api in `src/standalone`. Previously we had this support as a builtin concept (in other words, a special case), but now it is treated like other uri server provider (e.g. AZML).  The implementation is not perfect yet but can be used to drive the improvement for

* Jupyter server uri provider API
  * Reconnect/validation
  * Disconnect/dispose
* Kernel picker multi step workflow

This feature is behind the same setting as experimental kernel picker, so won't affect Insider users yet.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
