### PR TITLE
Revert "Faster buildsx (#11909)"

### DIFF
--- a/build/webpack/common.js
+++ b/build/webpack/common.js
@@ -6,7 +6,15 @@ const glob = require('glob');
 const path = require('path');
 const webpack_bundle_analyzer = require('webpack-bundle-analyzer');
 const constants = require('../constants');
-exports.nodeModulesToExternalize = ['pdfkit/js/pdfkit.standalone', 'crypto-js', 'fontkit', 'png-js', 'zeromq'];
+exports.nodeModulesToExternalize = [
+    '@jupyterlab/services',
+    'node-stream-zip',
+    'pdfkit/js/pdfkit.standalone',
+    'crypto-js',
+    'fontkit',
+    'png-js',
+    'zeromq'
+];
 exports.nodeModulesToReplacePaths = [...exports.nodeModulesToExternalize];
 function getDefaultPlugins(name) {
     const plugins = [];

--- a/build/webpack/webpack.extension.web.config.js
+++ b/build/webpack/webpack.extension.web.config.js
@@ -7,7 +7,6 @@ const tsconfig_paths_webpack_plugin = require('tsconfig-paths-webpack-plugin');
 const webpack = require('webpack');
 const constants = require('../constants');
 const CleanTerminalPlugin = require('clean-terminal-webpack-plugin');
-const common = require('./common');
 
 const devEntry = {
     extension: './src/extension.web.ts'
@@ -90,7 +89,6 @@ const config = {
     },
     externals: ['vscode', 'commonjs', 'electron'], // Don't bundle these
     plugins: [
-        ...common.getDefaultPlugins('web'),
         // Work around for Buffer is undefined:
         new webpack.ProvidePlugin({
             Buffer: ['buffer', 'Buffer']


### PR DESCRIPTION
This reverts commit cc2b776e649bb72ba4baaf7c5ddd4f6ca6b2eb5f.

Fixes #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
