### PR TITLE
Support server removal in new kernel picker

### DIFF
--- a/src/kernels/jupyter/jupyterUriProviderWrapper.ts
+++ b/src/kernels/jupyter/jupyterUriProviderWrapper.ts
@@ -13,6 +13,7 @@ import { IJupyterUriProvider, JupyterServerUriHandle, IJupyterServerUri } from '
 export class JupyterUriProviderWrapper implements IJupyterUriProvider {
     onDidChangeHandles?: vscode.Event<void>;
     getHandles?(): Promise<JupyterServerUriHandle[]>;
+    removeHandle?(handle: JupyterServerUriHandle): Promise<void>;
 
     constructor(
         private readonly provider: IJupyterUriProvider,
@@ -34,6 +35,12 @@ export class JupyterUriProviderWrapper implements IJupyterUriProvider {
         if (provider.getHandles) {
             this.getHandles = async () => {
                 return provider.getHandles!();
+            };
+        }
+
+        if (provider.removeHandle) {
+            this.removeHandle = (handle: JupyterServerUriHandle) => {
+                return provider.removeHandle!(handle);
             };
         }
     }

--- a/src/kernels/jupyter/types.ts
+++ b/src/kernels/jupyter/types.ts
@@ -224,6 +224,10 @@ export interface IJupyterUriProvider {
      * Gets a list of all valid Jupyter Server handles that can be passed into the `getServerUri` method.
      */
     getHandles?(): Promise<JupyterServerUriHandle[]>;
+    /**
+     * Users request to remove a handle.
+     */
+    removeHandle?(handle: JupyterServerUriHandle): Promise<void>;
 }
 
 export const IJupyterUriProviderRegistration = Symbol('IJupyterUriProviderRegistration');

--- a/src/standalone/userJupyterServer/userServerUrlProvider.ts
+++ b/src/standalone/userJupyterServer/userServerUrlProvider.ts
@@ -270,6 +270,12 @@ export class UserJupyterServerUrlProvider implements IExtensionSyncActivationSer
         return this._servers.map((s) => s.handle);
     }
 
+    async removeHandle(handle: string): Promise<void> {
+        this._servers = this._servers.filter((s) => s.handle !== handle);
+        await this.updateMemento();
+        this._onDidChangeHandles.fire();
+    }
+
     private async updateMemento() {
         const blob = this._servers.map((e) => `${e.uri}`).join(Settings.JupyterServerRemoteLaunchUriSeparator);
         const mementoList = this._servers.map((v, i) => ({ index: i, handle: v.handle }));


### PR DESCRIPTION
Support server removal from the new kernel picker, then we can later remove the server picker from the status bar.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
