### PR TITLE
Install Python should only be visible when we can not find any python interpreter.

### DIFF
--- a/src/notebooks/controllers/commands/installPythonControllerCommands.ts
+++ b/src/notebooks/controllers/commands/installPythonControllerCommands.ts
@@ -107,6 +107,11 @@ export class InstallPythonControllerCommands implements IExtensionSingleActivati
                     return;
                 }
 
+                // Python extension is installed, let's wait for interpreters to be detected
+                if (this.interpreterService.environments.length === 0) {
+                    await this.interpreterService.waitForAllInterpretersToLoad();
+                }
+
                 if (this.interpreterService.environments.length === 0) {
                     // Extension is installed, but we didn't find any python connections
                     // recommend installing python in this case


### PR DESCRIPTION
Otherwise between Python extension activation and the first python interpreter is detected, we always show "Install Python" in the kernel picker.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
