### PR TITLE
Remove loading kernels from cache more than once

### DIFF
--- a/src/kernels/raw/finder/localPythonAndRelatedNonPythonKernelSpecFinder.node.ts
+++ b/src/kernels/raw/finder/localPythonAndRelatedNonPythonKernelSpecFinder.node.ts
@@ -114,14 +114,6 @@ export class LocalPythonAndRelatedNonPythonKernelSpecFinder
                         this,
                         this.disposables
                     );
-                    this.listKernelsFirstTimeFromMemento(LocalPythonKernelsCacheKey)
-                        .then((kernels) => {
-                            if (this._cachedKernels.length === 0 && kernels.length) {
-                                this._cachedKernels = kernels;
-                                this._onDidChangeKernels.fire();
-                            }
-                        })
-                        .ignoreErrors();
                 }
             });
     }


### PR DESCRIPTION
@rebornix This additional (duplicate) call to `listKenrlesFirstTimeFromMemento` might be an accident as a restul of some code merge, see here https://github.com/microsoft/vscode-jupyter/pull/11832/commits/ed787d870b9f5ddd176d6fd0a8e46412fd2d8cd8

This PR basically removes the duplicate call.