### PR TITLE
Don't show variable viewer by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1483,7 +1483,7 @@
                 },
                 "jupyter.showVariableViewWhenDebugging": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "%jupyter.configuration.jupyter.showVariableViewWhenDebugging.description%",
                     "scope": "application"
                 },


### PR DESCRIPTION
Fix #11986