### PR TITLE
Add ability to create Python env from new Kernel QuickPick

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -125,6 +125,7 @@
     "jupyter.kernel.category.global": "Global Env",
     "jupyter.kernel.category.virtual": "Virtual Env",
     "jupyter.kernel.recommended": "Recommended",
+    "jupyter.kernel.createPythonEnvironment": "Create Python Environment",
     "jupyter.command.jupyter.viewLanguageServerOutput.title": "Show Language Server Output",
     "jupyter.command.jupyter.selectAndRunTestMethod.title": "Run Test Method ...",
     "jupyter.command.jupyter.selectAndDebugTestMethod.title": "Debug Test Method ...",

--- a/src/kernels/errors/kernelErrorHandler.ts
+++ b/src/kernels/errors/kernelErrorHandler.ts
@@ -308,15 +308,15 @@ export abstract class DataScienceErrorHandler implements IDataScienceErrorHandle
                 // auto start (ui hidden), now we need to display the error to the user.
                 const tokenSource = new CancellationTokenSource();
                 try {
-                    const cannotChangeKernel = actionSource === '3rdPartyExtension';
-                    return this.kernelDependency.installMissingDependencies(
+                    const cannotChangeKernels = actionSource === '3rdPartyExtension';
+                    return this.kernelDependency.installMissingDependencies({
                         resource,
                         kernelConnection,
-                        new DisplayOptions(false),
-                        tokenSource.token,
-                        true,
-                        cannotChangeKernel
-                    );
+                        ui: new DisplayOptions(false),
+                        token: tokenSource.token,
+                        ignoreCache: true,
+                        cannotChangeKernels
+                    });
                 } finally {
                     tokenSource.dispose();
                 }
@@ -430,15 +430,15 @@ export abstract class DataScienceErrorHandler implements IDataScienceErrorHandle
             this.sendKernelTelemetry(err, errorContext, resource, 'noipykernel');
             const tokenSource = new CancellationTokenSource();
             try {
-                const cannotChangeKernel = actionSource === '3rdPartyExtension';
-                return this.kernelDependency.installMissingDependencies(
+                const cannotChangeKernels = actionSource === '3rdPartyExtension';
+                return this.kernelDependency.installMissingDependencies({
                     resource,
                     kernelConnection,
-                    new DisplayOptions(false),
-                    tokenSource.token,
-                    true,
-                    cannotChangeKernel
-                );
+                    ui: new DisplayOptions(false),
+                    token: tokenSource.token,
+                    ignoreCache: true,
+                    cannotChangeKernels
+                });
             } finally {
                 tokenSource.dispose();
             }

--- a/src/kernels/jupyter/jupyterKernelService.node.ts
+++ b/src/kernels/jupyter/jupyterKernelService.node.ts
@@ -75,14 +75,14 @@ export class JupyterKernelService implements IJupyterKernelService {
             kernel.interpreter &&
             kernel.kind !== 'startUsingRemoteKernelSpec'
         ) {
-            const result = await this.kernelDependencyService.installMissingDependencies(
+            const result = await this.kernelDependencyService.installMissingDependencies({
                 resource,
-                kernel,
+                kernelConnection: kernel,
                 ui,
-                cancelToken,
-                true,
+                token: cancelToken,
+                ignoreCache: true,
                 cannotChangeKernels
-            );
+            });
             switch (result) {
                 case KernelInterpreterDependencyResponse.cancel:
                 case KernelInterpreterDependencyResponse.selectDifferentKernel:

--- a/src/kernels/types.ts
+++ b/src/kernels/types.ts
@@ -799,14 +799,15 @@ export interface IKernelDependencyService {
     /**
      * @param {boolean} [ignoreCache] We cache the results of this call so we don't have to do it again (users rarely uninstall ipykernel).
      */
-    installMissingDependencies(
-        resource: Resource,
-        kernelConnection: KernelConnectionMetadata,
-        ui: IDisplayOptions,
-        token: CancellationToken,
-        ignoreCache?: boolean,
-        cannotChangeKernels?: boolean
-    ): Promise<KernelInterpreterDependencyResponse>;
+    installMissingDependencies(options: {
+        resource: Resource;
+        kernelConnection: KernelConnectionMetadata;
+        ui: IDisplayOptions;
+        token: CancellationToken;
+        ignoreCache?: boolean;
+        cannotChangeKernels?: boolean;
+        installWithoutPrompting?: boolean;
+    }): Promise<KernelInterpreterDependencyResponse>;
     /**
      * @param {boolean} [ignoreCache] We cache the results of this call so we don't have to do it again (users rarely uninstall ipykernel).
      */

--- a/src/notebooks/controllers/pythonEnvKernelConnectionCreator.ts
+++ b/src/notebooks/controllers/pythonEnvKernelConnectionCreator.ts
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { CancellationToken, commands, NotebookDocument, Uri } from 'vscode';
+import { DisplayOptions } from '../../kernels/displayOptions';
+import { ContributedKernelFinderKind, IContributedKernelFinder } from '../../kernels/internalTypes';
+import {
+    IKernelDependencyService,
+    IKernelFinder,
+    KernelInterpreterDependencyResponse,
+    PythonKernelConnectionMetadata
+} from '../../kernels/types';
+import { disposeAllDisposables } from '../../platform/common/helpers';
+import { getDisplayPath } from '../../platform/common/platform/fs-paths';
+import { IDisposable } from '../../platform/common/types';
+import { IInterpreterService } from '../../platform/interpreter/contracts';
+import { ServiceContainer } from '../../platform/ioc/container';
+import { traceWarning } from '../../platform/logging';
+import { PythonEnvironment } from '../../platform/pythonEnvironments/info';
+
+type CreateEnvironmentResult = {
+    path: string | undefined;
+};
+
+/**
+ * Responsible for creating a Python Environment for a given notebook & then finding the corresponding kernel connection for that env and returning that.
+ */
+export class PythonEnvKernelConnectionCreator {
+    private readonly disposables: IDisposable[] = [];
+    public dispose() {
+        disposeAllDisposables(this.disposables);
+    }
+    /**
+     * Creates a Python Environment & then returns the corresponding kernel connection for the newly created python env.
+     */
+    public async createPythonEnvFromKernelPicker(notebook: NotebookDocument, cancelToken: CancellationToken) {
+        let env: PythonEnvironment | undefined;
+
+        env = await this.createPythonEnvironment(cancelToken);
+        if (!env || cancelToken.isCancellationRequested) {
+            return;
+        }
+
+        const kernelConnection = await this.waitForPythonKernel(env, cancelToken);
+        if (!kernelConnection || cancelToken.isCancellationRequested) {
+            return;
+        }
+
+        const dependencyService = ServiceContainer.instance.get<IKernelDependencyService>(IKernelDependencyService);
+        const result = await dependencyService.installMissingDependencies({
+            resource: notebook.uri,
+            kernelConnection,
+            ui: new DisplayOptions(false),
+            token: cancelToken,
+            ignoreCache: false,
+            cannotChangeKernels: true,
+            installWithoutPrompting: true
+        });
+        if (result !== KernelInterpreterDependencyResponse.ok) {
+            traceWarning(
+                `Dependencies not installed for new Python Env ${getDisplayPath(env.uri)} for notebook ${getDisplayPath(
+                    notebook.uri
+                )}`
+            );
+        }
+
+        return kernelConnection;
+    }
+    private async waitForPythonKernel(env: PythonEnvironment, cancelToken: CancellationToken) {
+        const kernelFinder = ServiceContainer.instance.get<IKernelFinder>(IKernelFinder);
+        const finder = kernelFinder.registered.find(
+            (item) => item.kind === ContributedKernelFinderKind.LocalPythonEnvironment
+        ) as IContributedKernelFinder<PythonKernelConnectionMetadata>;
+        if (!finder) {
+            return;
+        }
+        return this.waitForPythonKernelFromFinder(env, finder, cancelToken);
+    }
+    private async waitForPythonKernelFromFinder(
+        env: PythonEnvironment,
+        finder: IContributedKernelFinder<PythonKernelConnectionMetadata>,
+        cancelToken: CancellationToken
+    ) {
+        const kernel = finder.kernels.find((item) => item.interpreter.id === env.id);
+        if (kernel) {
+            return kernel;
+        }
+
+        return new Promise<PythonKernelConnectionMetadata>((resolve) => {
+            const disposables: IDisposable[] = [];
+            disposables.push(
+                finder.onDidChangeKernels(
+                    () => {
+                        if (cancelToken.isCancellationRequested) {
+                            return;
+                        }
+                        const kernel = finder.kernels.find((item) => item.interpreter.id === env.id);
+                        if (kernel) {
+                            disposeAllDisposables(disposables);
+                            return resolve(kernel);
+                        }
+                        // Keep waiting, for ever, until another controller is selected for this notebook.
+                    },
+                    this,
+                    this.disposables
+                )
+            );
+
+            disposables.push(
+                cancelToken.onCancellationRequested(() => {
+                    disposeAllDisposables(disposables);
+                })
+            );
+        }).then((kernel) => {
+            if (cancelToken.isCancellationRequested) {
+                return;
+            }
+            if (!kernel) {
+                traceWarning(`New Python Environment ${getDisplayPath(env.uri)} not found as a kernel`);
+            }
+            return kernel;
+        });
+    }
+    private async createPythonEnvironment(cancelToken: CancellationToken) {
+        const result: CreateEnvironmentResult = await commands.executeCommand('python.createEnvironment');
+        const path = result?.path;
+        if (cancelToken.isCancellationRequested) {
+            return;
+        }
+        if (!path) {
+            traceWarning(
+                `Python Environment not created, either user cancelled the creation or there was an error in the Python Extension`
+            );
+            return;
+        }
+
+        const interpreterService = ServiceContainer.instance.get<IInterpreterService>(IInterpreterService);
+        return interpreterService.getInterpreterDetails({ path }).then((env) => {
+            if (cancelToken.isCancellationRequested) {
+                return;
+            }
+            if (!env) {
+                traceWarning(`No interpreter details for New Python Environment ${getDisplayPath(Uri.file(path))}`);
+            }
+            return env;
+        });
+    }
+}

--- a/src/notebooks/controllers/pythonEnvKernelConnectionCreator.unit.test.ts
+++ b/src/notebooks/controllers/pythonEnvKernelConnectionCreator.unit.test.ts
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { assert } from 'chai';
+import * as sinon from 'sinon';
+import { anything, capture, deepEqual, instance, mock, verify, when } from 'ts-mockito';
+import { CancellationTokenSource, Disposable, EventEmitter, NotebookDocument, Uri } from 'vscode';
+import { ContributedKernelFinderKind, IContributedKernelFinder } from '../../kernels/internalTypes';
+import {
+    IKernelDependencyService,
+    IKernelFinder,
+    KernelInterpreterDependencyResponse,
+    PythonKernelConnectionMetadata
+} from '../../kernels/types';
+import { disposeAllDisposables } from '../../platform/common/helpers';
+import { IDisposable } from '../../platform/common/types';
+import { IInterpreterService } from '../../platform/interpreter/contracts';
+import { ServiceContainer } from '../../platform/ioc/container';
+import { EnvironmentType } from '../../platform/pythonEnvironments/info';
+import { TestNotebookDocument } from '../../test/datascience/notebook/executionHelper';
+import { mockedVSCodeNamespaces } from '../../test/vscode-mock';
+import { PythonEnvKernelConnectionCreator } from './pythonEnvKernelConnectionCreator';
+
+suite('Python Environment Kernel Connection Creator', () => {
+    let pythonEnvKernelConnectionCreator: PythonEnvKernelConnectionCreator;
+    let kernelDependencyService: IKernelDependencyService;
+    let kernelFinder: IKernelFinder;
+    let localPythonEnvFinder: IContributedKernelFinder<PythonKernelConnectionMetadata>;
+    let interpreterService: IInterpreterService;
+    let onDidChangePythonKernels: EventEmitter<void>;
+    const disposables: IDisposable[] = [];
+    let notebook: NotebookDocument;
+    let cancellation: CancellationTokenSource;
+    const venvPythonKernel = PythonKernelConnectionMetadata.create({
+        id: 'venvPython',
+        kernelSpec: {
+            argv: [],
+            display_name: 'Venv Python',
+            executable: '',
+            name: 'venvName',
+            language: 'python'
+        },
+        interpreter: {
+            id: 'venv',
+            sysPrefix: '',
+            uri: Uri.file('venv')
+        }
+    });
+    const newCondaPythonKernel = PythonKernelConnectionMetadata.create({
+        id: 'condaPython',
+        kernelSpec: {
+            argv: [],
+            display_name: 'Conda Python',
+            executable: '',
+            name: 'condaName',
+            language: 'python'
+        },
+        interpreter: {
+            id: 'conda',
+            sysPrefix: '',
+            uri: Uri.file('.conda/bin/python'),
+            envType: EnvironmentType.Conda
+        }
+    });
+
+    setup(() => {
+        const serviceContainer = mock<ServiceContainer>();
+        const iocStub = sinon.stub(ServiceContainer, 'instance').get(() => instance(serviceContainer));
+        disposables.push(new Disposable(() => iocStub.restore()));
+        cancellation = new CancellationTokenSource();
+        disposables.push(cancellation);
+        notebook = new TestNotebookDocument(undefined, 'jupyter-notebook');
+
+        kernelFinder = mock<IKernelFinder>();
+        localPythonEnvFinder = mock<IContributedKernelFinder<PythonKernelConnectionMetadata>>();
+        interpreterService = mock<IInterpreterService>();
+        kernelDependencyService = mock<IKernelDependencyService>();
+
+        onDidChangePythonKernels = new EventEmitter<void>();
+        disposables.push(onDidChangePythonKernels);
+
+        when(serviceContainer.get<IKernelFinder>(IKernelFinder)).thenReturn(instance(kernelFinder));
+        when(serviceContainer.get<IInterpreterService>(IInterpreterService)).thenReturn(instance(interpreterService));
+        when(serviceContainer.get<IKernelDependencyService>(IKernelDependencyService)).thenReturn(
+            instance(kernelDependencyService)
+        );
+        when(localPythonEnvFinder.kind).thenReturn(ContributedKernelFinderKind.LocalPythonEnvironment);
+        when(localPythonEnvFinder.onDidChangeKernels).thenReturn(onDidChangePythonKernels.event);
+        when(kernelFinder.registered).thenReturn([instance(localPythonEnvFinder)]);
+
+        pythonEnvKernelConnectionCreator = new PythonEnvKernelConnectionCreator();
+        disposables.push(pythonEnvKernelConnectionCreator);
+    });
+    teardown(() => disposeAllDisposables(disposables));
+    test('Not does create a Python Env when Python extension fails to create it', async () => {
+        when(mockedVSCodeNamespaces.commands.executeCommand('python.createEnvironment')).thenResolve(undefined);
+
+        const kernel = await pythonEnvKernelConnectionCreator.createPythonEnvFromKernelPicker(
+            notebook,
+            cancellation.token
+        );
+
+        assert.isUndefined(kernel);
+    });
+    test('Can cancel after creation of the Environment', async () => {
+        const newCondaEnvPath = '<workspaceFolder>/.conda';
+        when(mockedVSCodeNamespaces.commands.executeCommand('python.createEnvironment')).thenResolve({
+            path: newCondaEnvPath
+        } as any);
+        when(localPythonEnvFinder.kernels).thenReturn([venvPythonKernel]);
+        when(localPythonEnvFinder.status).thenReturn('idle');
+        when(interpreterService.getInterpreterDetails(deepEqual({ path: newCondaEnvPath }))).thenCall(() => {
+            cancellation.cancel();
+            return Promise.resolve(newCondaPythonKernel.interpreter);
+        });
+
+        const kernelPromise = pythonEnvKernelConnectionCreator.createPythonEnvFromKernelPicker(
+            notebook,
+            cancellation.token
+        );
+
+        assert.isUndefined(await kernelPromise);
+        verify(interpreterService.getInterpreterDetails(deepEqual({ path: newCondaEnvPath }))).once();
+    });
+    test('Installs missing dependencies and returns the kernel connection', async () => {
+        const newCondaEnvPath = '<workspaceFolder>/.conda';
+        when(mockedVSCodeNamespaces.commands.executeCommand('python.createEnvironment')).thenResolve({
+            path: newCondaEnvPath
+        } as any);
+        when(localPythonEnvFinder.kernels).thenReturn([venvPythonKernel, newCondaPythonKernel]);
+        when(localPythonEnvFinder.status).thenReturn('idle');
+        when(interpreterService.getInterpreterDetails(deepEqual({ path: newCondaEnvPath }))).thenResolve(
+            newCondaPythonKernel.interpreter
+        );
+        when(kernelDependencyService.installMissingDependencies(anything())).thenResolve(
+            KernelInterpreterDependencyResponse.ok
+        );
+
+        const kernel = await pythonEnvKernelConnectionCreator.createPythonEnvFromKernelPicker(
+            notebook,
+            cancellation.token
+        );
+
+        assert.strictEqual(kernel, newCondaPythonKernel);
+        verify(interpreterService.getInterpreterDetails(deepEqual({ path: newCondaEnvPath }))).once();
+        verify(kernelDependencyService.installMissingDependencies(anything())).once();
+        const args = capture(kernelDependencyService.installMissingDependencies).first()[0];
+        assert.strictEqual(args.cannotChangeKernels, true);
+        assert.strictEqual(args.installWithoutPrompting, true);
+        assert.strictEqual(args.kernelConnection, newCondaPythonKernel);
+        assert.strictEqual(args.resource, notebook.uri);
+        assert.strictEqual(args.ui.disableUI, false);
+    });
+});

--- a/src/platform/common/cancellation.ts
+++ b/src/platform/common/cancellation.ts
@@ -65,24 +65,20 @@ export function createPromiseFromCancellation<T>(
 
 /**
  * Create a single unified cancellation token that wraps multiple cancellation tokens.
- *
- * @export
- * @param {(...(CancellationToken | undefined)[])} tokens
- * @returns {CancellationToken}
  */
-export function wrapCancellationTokens(...tokens: (CancellationToken | undefined)[]): CancellationToken {
+export function wrapCancellationTokens(...tokens: CancellationToken[]) {
     const wrappedCancellationToken = new CancellationTokenSource();
     for (const token of tokens) {
         if (!token) {
             continue;
         }
         if (token.isCancellationRequested) {
-            return token;
+            wrappedCancellationToken.cancel();
         }
         token.onCancellationRequested(() => wrappedCancellationToken.cancel());
     }
 
-    return wrappedCancellationToken.token;
+    return wrappedCancellationToken;
 }
 
 export namespace Cancellation {

--- a/src/platform/common/utils/localize.ts
+++ b/src/platform/common/utils/localize.ts
@@ -812,6 +812,9 @@ export namespace DataScience {
             'Choose the kernels that are available in the kernel picker.'
         );
     export const recommendedKernelCategoryInQuickPick = () => localize('jupyter.kernel.recommended', 'Recommended');
+    export const createPythonEnvironmentInQuickPick = () =>
+        localize('jupyter.kernel.createPythonEnvironment', 'Create Python Environment');
+
     export const selectDifferentJupyterInterpreter = () =>
         localize('DataScience.selectDifferentJupyterInterpreter', 'Change Interpreter');
     export const localJupyterServer = () => localize('DataScience.localJupyterServer', 'local');

--- a/src/platform/interpreter/environmentCreator.ts
+++ b/src/platform/interpreter/environmentCreator.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { commands, Uri } from 'vscode';
+import { ServiceContainer } from '../ioc/container';
+import { PythonEnvironment } from '../pythonEnvironments/info';
+import { IInterpreterService } from './contracts';
+
+type CreateEnvironmentResult = {
+    path: string | undefined;
+    uri: Uri | undefined;
+};
+
+export class EnvironmentCreator {
+    public async createPythonEnvironment(): Promise<PythonEnvironment | undefined> {
+        const result: CreateEnvironmentResult = await commands.executeCommand('python.createEnvironment');
+
+        if (!result) {
+            return;
+        }
+
+        const interpreterService = ServiceContainer.instance.get<IInterpreterService>(IInterpreterService);
+        return interpreterService.getInterpreterDetails(result.uri!);
+    }
+}

--- a/src/test/datascience/jupyter/kernels/jupyterKernelService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/jupyterKernelService.unit.test.ts
@@ -426,16 +426,9 @@ suite('JupyterKernelService', () => {
             })
         );
         token.dispose();
-        verify(
-            kernelDependencyService.installMissingDependencies(
-                anything(),
-                anything(),
-                anything(),
-                anything(),
-                anything(),
-                anything()
-            )
-        ).times(kernels.filter((k) => k.interpreter).length);
+        verify(kernelDependencyService.installMissingDependencies(anything())).times(
+            kernels.filter((k) => k.interpreter).length
+        );
     });
     test('Kernel installed when spec comes from interpreter', async () => {
         const kernelsWithInvalidName = kernels.filter(

--- a/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
@@ -102,12 +102,12 @@ suite('Kernel Dependency Service', () => {
             test('Check if ipykernel is installed', async () => {
                 when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(true);
 
-                await dependencyService.installMissingDependencies(
+                await dependencyService.installMissingDependencies({
                     resource,
-                    metadata,
-                    new DisplayOptions(false),
-                    token.token
-                );
+                    kernelConnection: metadata,
+                    ui: new DisplayOptions(false),
+                    token: token.token
+                });
 
                 verify(installer.isInstalled(Product.ipykernel, interpreter)).once();
                 verify(installer.isInstalled(anything(), anything())).once();
@@ -115,12 +115,12 @@ suite('Kernel Dependency Service', () => {
             test('Do not prompt if if ipykernel is installed', async () => {
                 when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(true);
 
-                await dependencyService.installMissingDependencies(
+                await dependencyService.installMissingDependencies({
                     resource,
-                    metadata,
-                    new DisplayOptions(false),
-                    token.token
-                );
+                    kernelConnection: metadata,
+                    ui: new DisplayOptions(false),
+                    token: token.token
+                });
 
                 verify(appShell.showInformationMessage(anything(), anything(), anything())).never();
             });
@@ -128,12 +128,12 @@ suite('Kernel Dependency Service', () => {
                 when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
                 when(appShell.showInformationMessage(anything(), anything())).thenResolve(Common.install() as any);
 
-                const result = await dependencyService.installMissingDependencies(
-                    Uri.file('one.ipynb'),
-                    metadata,
-                    new DisplayOptions(false),
-                    token.token
-                );
+                const result = await dependencyService.installMissingDependencies({
+                    resource: Uri.file('one.ipynb'),
+                    kernelConnection: metadata,
+                    ui: new DisplayOptions(false),
+                    token: token.token
+                });
                 assert.strictEqual(result, KernelInterpreterDependencyResponse.cancel);
 
                 verify(appShell.showInformationMessage(anything(), anything(), anything())).never();
@@ -150,12 +150,12 @@ suite('Kernel Dependency Service', () => {
                     Common.install() as any
                 );
 
-                await dependencyService.installMissingDependencies(
+                await dependencyService.installMissingDependencies({
                     resource,
-                    metadata,
-                    new DisplayOptions(false),
-                    token.token
-                );
+                    kernelConnection: metadata,
+                    ui: new DisplayOptions(false),
+                    token: token.token
+                });
             });
             test('Install ipykernel second time should result in a re-install', async () => {
                 when(memento.get(anything(), anything())).thenReturn(true);
@@ -170,12 +170,12 @@ suite('Kernel Dependency Service', () => {
                     Common.install() as any
                 );
 
-                await dependencyService.installMissingDependencies(
+                await dependencyService.installMissingDependencies({
                     resource,
-                    metadata,
-                    new DisplayOptions(false),
-                    token.token
-                );
+                    kernelConnection: metadata,
+                    ui: new DisplayOptions(false),
+                    token: token.token
+                });
             });
             test('Bubble installation errors', async () => {
                 when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
@@ -192,12 +192,12 @@ suite('Kernel Dependency Service', () => {
                     appShell.showInformationMessage(anything(), anything(), anything(), anything(), anything())
                 ).thenResolve(Common.install() as any);
 
-                const result = await dependencyService.installMissingDependencies(
+                const result = await dependencyService.installMissingDependencies({
                     resource,
-                    metadata,
-                    new DisplayOptions(false),
-                    token.token
-                );
+                    kernelConnection: metadata,
+                    ui: new DisplayOptions(false),
+                    token: token.token
+                });
 
                 assert.equal(result, KernelInterpreterDependencyResponse.failed);
             });
@@ -212,12 +212,12 @@ suite('Kernel Dependency Service', () => {
                     appShell.showInformationMessage(anything(), anything(), anything(), anything(), anything())
                 ).thenResolve(DataScience.selectKernel() as any);
 
-                const result = await dependencyService.installMissingDependencies(
+                const result = await dependencyService.installMissingDependencies({
                     resource,
-                    metadata,
-                    new DisplayOptions(false),
-                    token.token
-                );
+                    kernelConnection: metadata,
+                    ui: new DisplayOptions(false),
+                    token: token.token
+                });
                 assert.strictEqual(
                     result,
                     KernelInterpreterDependencyResponse.selectDifferentKernel,
@@ -233,12 +233,12 @@ suite('Kernel Dependency Service', () => {
                 when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
                 when(appShell.showInformationMessage(anything(), anything(), anything(), anything())).thenResolve();
 
-                const result = await dependencyService.installMissingDependencies(
+                const result = await dependencyService.installMissingDependencies({
                     resource,
-                    metadata,
-                    new DisplayOptions(false),
-                    token.token
-                );
+                    kernelConnection: metadata,
+                    ui: new DisplayOptions(false),
+                    token: token.token
+                });
 
                 assert.equal(result, KernelInterpreterDependencyResponse.cancel, 'Wasnt sCanceled');
                 verify(cmdManager.executeCommand('notebook.selectKernel', anything())).never();


### PR DESCRIPTION
Fixes #12003 

# NOTE
Should be reviewed after https://github.com/microsoft/vscode-jupyter/pull/12004
### OR
Please review commit `Add create Python env in kernel picker` (ignoring the first commit, as thats the chagnes from https://github.com/microsoft/vscode-jupyter/pull/12004)

Work flow:
* User hits run cell
* They are presented with quick pick to select a kenel
* User selects the option to create a new env
* A new env is created
* The necessary dependencies are installed
* The cell is executed

I.e. user doesn't need to run cell again, it is one single smooth flow (though creation of env and installing packages takes a while).

![Screenshot 2022-11-14 at 15 19 42](https://user-images.githubusercontent.com/1948812/201574416-8b13940b-5d64-4e1c-be49-cada8096c281.png)

