### PR TITLE
Experimental MRU setting from core

### DIFF
--- a/src/extension.node.ts
+++ b/src/extension.node.ts
@@ -60,7 +60,7 @@ import {
     IDisposableRegistry,
     IExperimentService,
     IExtensionContext,
-    IFeatureDeprecationManager,
+    IFeaturesManager,
     IMemento,
     IOutputChannel,
     IsCodeSpace,
@@ -363,9 +363,9 @@ async function activateLegacy(
     manager.activateSync();
     const activationPromise = manager.activate();
 
-    const deprecationMgr = serviceContainer.get<IFeatureDeprecationManager>(IFeatureDeprecationManager);
-    deprecationMgr.initialize();
-    context.subscriptions.push(deprecationMgr);
+    const featureManager = serviceContainer.get<IFeaturesManager>(IFeaturesManager);
+    featureManager.initialize();
+    context.subscriptions.push(featureManager);
 
     return activationPromise;
 }

--- a/src/extension.web.ts
+++ b/src/extension.web.ts
@@ -66,7 +66,7 @@ import {
     IDisposableRegistry,
     IExperimentService,
     IExtensionContext,
-    IFeatureDeprecationManager,
+    IFeaturesManager,
     IMemento,
     IOutputChannel,
     IsCodeSpace,
@@ -337,11 +337,9 @@ async function activateLegacy(
     context.subscriptions.push(manager);
     manager.activateSync();
     const activationPromise = manager.activate();
-
-    const deprecationMgr = serviceContainer.get<IFeatureDeprecationManager>(IFeatureDeprecationManager);
-    deprecationMgr.initialize();
-    context.subscriptions.push(deprecationMgr);
-
+    const featureManager = serviceContainer.get<IFeaturesManager>(IFeaturesManager);
+    featureManager.initialize();
+    context.subscriptions.push(featureManager);
     return activationPromise;
 }
 

--- a/src/kernels/jupyter/finder/remoteKernelFinderController.ts
+++ b/src/kernels/jupyter/finder/remoteKernelFinderController.ts
@@ -8,9 +8,9 @@ import { Memento } from 'vscode';
 import { IKernelFinder, IKernelProvider, INotebookProvider } from '../../types';
 import {
     GLOBAL_MEMENTO,
-    IConfigurationService,
     IDisposableRegistry,
     IExtensions,
+    IFeaturesManager,
     IMemento,
     IsWebExtension
 } from '../../../platform/common/types';
@@ -204,7 +204,6 @@ export class RemoteKernelFinderController implements IExtensionSingleActivationS
     private _strategy: IRemoteKernelFinderRegistrationStrategy;
 
     constructor(
-        @inject(IConfigurationService) readonly configurationService: IConfigurationService,
         @inject(IJupyterSessionManagerFactory)
         private readonly jupyterSessionManagerFactory: IJupyterSessionManagerFactory,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
@@ -219,14 +218,15 @@ export class RemoteKernelFinderController implements IExtensionSingleActivationS
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
         @inject(IKernelProvider) private readonly kernelProvider: IKernelProvider,
         @inject(IExtensions) private readonly extensions: IExtensions,
-        @inject(IsWebExtension) private readonly isWebExtension: boolean
+        @inject(IsWebExtension) private readonly isWebExtension: boolean,
+        @inject(IFeaturesManager) private readonly featuresManager: IFeaturesManager
     ) {
         this._strategy = this.getStrategy();
         this.disposables.push(this._strategy);
     }
 
     private getStrategy(): IRemoteKernelFinderRegistrationStrategy {
-        if (this.configurationService.getSettings().kernelPickerType === 'Insiders') {
+        if (this.featuresManager.features.kernelPickerType === 'Insiders') {
             return new MultiServerStrategy(
                 this.jupyterSessionManagerFactory,
                 this.interpreterService,

--- a/src/kernels/jupyter/serverSelector.ts
+++ b/src/kernels/jupyter/serverSelector.ts
@@ -31,6 +31,7 @@ import { IDataScienceErrorHandler } from '../errors/types';
 import {
     IConfigurationService,
     IDisposableRegistry,
+    IFeaturesManager,
     IsWebExtension,
     KernelPickerType
 } from '../../platform/common/types';
@@ -142,13 +143,14 @@ export class JupyterServerSelector {
         @inject(JupyterConnection) private readonly jupyterConnection: JupyterConnection,
         @inject(IsWebExtension) private readonly isWebExtension: boolean,
         @inject(IWorkspaceService) readonly workspaceService: IWorkspaceService,
-        @inject(IDisposableRegistry) readonly disposableRegistry: IDisposableRegistry
+        @inject(IDisposableRegistry) readonly disposableRegistry: IDisposableRegistry,
+        @inject(IFeaturesManager) featuresManager: IFeaturesManager
     ) {
-        this.createImpl(this.configService.getSettings().kernelPickerType);
+        this.createImpl(featuresManager.features.kernelPickerType);
         this.disposableRegistry.push(
-            this.configService.getSettings().onDidChange(() => {
+            featuresManager.onDidChangeFeatures(() => {
                 // Create impl will ignore if the setting has not changed
-                this.createImpl(this.configService.getSettings().kernelPickerType);
+                this.createImpl(featuresManager.features.kernelPickerType);
             })
         );
     }

--- a/src/kernels/raw/finder/contributedKerneFinder.node.unit.test.ts
+++ b/src/kernels/raw/finder/contributedKerneFinder.node.unit.test.ts
@@ -32,7 +32,7 @@ import { IPythonExtensionChecker } from '../../../platform/api/types';
 import { PYTHON_LANGUAGE } from '../../../platform/common/constants';
 import * as platform from '../../../platform/common/utils/platform';
 import { CancellationTokenSource, Disposable, EventEmitter, Memento, Uri } from 'vscode';
-import { IDisposable, IExtensionContext, IExtensions } from '../../../platform/common/types';
+import { IDisposable, IExtensionContext, IExtensions, IFeaturesManager } from '../../../platform/common/types';
 import { getInterpreterHash } from '../../../platform/pythonEnvironments/info/interpreter';
 import { disposeAllDisposables } from '../../../platform/common/helpers';
 import {
@@ -270,6 +270,8 @@ import { KernelPickerType } from '../../../platform/common/kernelPickerType';
                     kernelFinder = new KernelFinder([]);
                     const trustedKernels = mock<ITrustedKernelPaths>();
                     when(trustedKernels.isTrusted(anything())).thenReturn(true);
+                    const featuresManager = mock<IFeaturesManager>();
+                    when(featuresManager.features).thenReturn({ kernelPickerType: 'Stable' });
                     localPythonAndRelatedKernelFinder = new LocalPythonAndRelatedNonPythonKernelSpecFinder(
                         instance(interpreterService),
                         instance(fs),
@@ -280,7 +282,8 @@ import { KernelPickerType } from '../../../platform/common/kernelPickerType';
                         instance(memento),
                         disposables,
                         instance(env),
-                        instance(trustedKernels)
+                        instance(trustedKernels),
+                        instance(featuresManager)
                     );
                     const localKernelSpecFinder = new ContributedLocalKernelSpecFinder(
                         nonPythonKernelSpecFinder,

--- a/src/kernels/raw/finder/localPythonAndRelatedNonPythonKernelSpecFinder.node.unit.test.ts
+++ b/src/kernels/raw/finder/localPythonAndRelatedNonPythonKernelSpecFinder.node.unit.test.ts
@@ -8,7 +8,7 @@ import { IPythonExtensionChecker } from '../../../platform/api/types';
 import { IApplicationEnvironment, IWorkspaceService } from '../../../platform/common/application/types';
 import { disposeAllDisposables } from '../../../platform/common/helpers';
 import { KernelPickerType } from '../../../platform/common/kernelPickerType';
-import { IDisposable } from '../../../platform/common/types';
+import { IDisposable, IFeaturesManager } from '../../../platform/common/types';
 import { IInterpreterService } from '../../../platform/interpreter/contracts';
 import { LocalKernelSpecConnectionMetadata, PythonKernelConnectionMetadata } from '../../types';
 import { LocalKnownPathKernelSpecFinder } from './localKnownPathKernelSpecFinder.node';
@@ -107,6 +107,9 @@ suite('Local Python and related kernels (new Kernel Picker)', () => {
         when(env.extensionVersion).thenReturn('1');
         when(fs.exists(anything())).thenResolve(true);
 
+        const featuresManager = mock<IFeaturesManager>();
+        when(featuresManager.features).thenReturn({ kernelPickerType: 'Stable' });
+
         const stub = sinon.stub(KernelPickerType, 'useNewKernelPicker').returns(true);
         clock = fakeTimers.install();
 
@@ -123,7 +126,8 @@ suite('Local Python and related kernels (new Kernel Picker)', () => {
             instance(globalState),
             disposables,
             instance(env),
-            instance(trustedKernels)
+            instance(trustedKernels),
+            instance(featuresManager)
         );
     });
     teardown(() => disposeAllDisposables(disposables));

--- a/src/notebooks/controllers/connectionTracker.ts
+++ b/src/notebooks/controllers/connectionTracker.ts
@@ -6,7 +6,7 @@ import { NotebookControllerAffinity2, NotebookDocument, workspace } from 'vscode
 import { KernelConnectionMetadata } from '../../kernels/types';
 import { IExtensionSyncActivationService } from '../../platform/activation/types';
 import { InteractiveWindowView, JupyterNotebookView } from '../../platform/common/constants';
-import { IConfigurationService, IDisposableRegistry, KernelPickerType } from '../../platform/common/types';
+import { IDisposableRegistry, IFeaturesManager, KernelPickerType } from '../../platform/common/types';
 import { getNotebookMetadata, isJupyterNotebook } from '../../platform/common/utils';
 import { swallowExceptions } from '../../platform/common/utils/decorators';
 import {
@@ -27,9 +27,9 @@ export class ConnectionTracker implements IExtensionSyncActivationService, IConn
         @inject(IControllerRegistration) private readonly controllerRegistration: IControllerRegistration,
         @inject(IKernelRankingHelper) private readonly kernelRankingHelper: IKernelRankingHelper,
         @inject(IConnectionMru) private readonly notebookConnectionMru: IConnectionMru,
-        @inject(IConfigurationService) configuration: IConfigurationService
+        @inject(IFeaturesManager) featuresManager: IFeaturesManager
     ) {
-        this.kernelPickerType = configuration.getSettings(undefined).kernelPickerType;
+        this.kernelPickerType = featuresManager.features.kernelPickerType;
     }
 
     activate(): void {

--- a/src/notebooks/controllers/connectionTracker.unit.test.ts
+++ b/src/notebooks/controllers/connectionTracker.unit.test.ts
@@ -6,7 +6,7 @@ import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { Disposable, EventEmitter, NotebookController, NotebookControllerAffinity2, NotebookDocument } from 'vscode';
 import { LocalKernelSpecConnectionMetadata } from '../../kernels/types';
 import { disposeAllDisposables } from '../../platform/common/helpers';
-import { IConfigurationService, IDisposable } from '../../platform/common/types';
+import { IDisposable, IFeaturesManager } from '../../platform/common/types';
 import { TestNotebookDocument } from '../../test/datascience/notebook/executionHelper';
 import { mockedVSCodeNamespaces } from '../../test/vscode-mock';
 import { ConnectionTracker } from './connectionTracker';
@@ -46,14 +46,14 @@ suite('Connection Tracker', () => {
         when(mockedVSCodeNamespaces.workspace.onDidOpenNotebookDocument).thenReturn(onDidOpenNotebookDocument.event);
         when(mockedVSCodeNamespaces.workspace.notebookDocuments).thenReturn([]);
         when(controllerRegistrations.onChanged).thenReturn(onChanged.event);
-        const configService = mock<IConfigurationService>();
-        when(configService.getSettings(anything())).thenReturn({ kernelPickerType: 'Insiders' } as any);
+        const featureManager = mock<IFeaturesManager>();
+        when(featureManager.features).thenReturn({ kernelPickerType: 'Insiders' });
         tracker = new ConnectionTracker(
             disposables,
             instance(controllerRegistrations),
             instance(rankingHelper),
             instance(mru),
-            instance(configService)
+            instance(featureManager)
         );
         tracker.activate();
         clock = fakeTimers.install();

--- a/src/notebooks/controllers/controllerLoader.ts
+++ b/src/notebooks/controllers/controllerLoader.ts
@@ -12,7 +12,7 @@ import { IPythonExtensionChecker } from '../../platform/api/types';
 import { IVSCodeNotebook } from '../../platform/common/application/types';
 import { isCancellationError } from '../../platform/common/cancellation';
 import { InteractiveWindowView, JupyterNotebookView } from '../../platform/common/constants';
-import { IConfigurationService, IDisposableRegistry } from '../../platform/common/types';
+import { IDisposableRegistry, IFeaturesManager } from '../../platform/common/types';
 import { getNotebookMetadata } from '../../platform/common/utils';
 import { noop } from '../../platform/common/utils/misc';
 import { IInterpreterService } from '../../platform/interpreter/contracts';
@@ -36,7 +36,7 @@ export class ControllerLoader implements IControllerLoader, IExtensionSyncActiva
         @inject(IPythonExtensionChecker) private readonly extensionChecker: IPythonExtensionChecker,
         @inject(IInterpreterService) private readonly interpreters: IInterpreterService,
         @inject(IControllerRegistration) private readonly registration: IControllerRegistration,
-        @inject(IConfigurationService) private readonly configService: IConfigurationService,
+        @inject(IFeaturesManager) private readonly featuresManager: IFeaturesManager,
         @inject(IJupyterServerUriStorage) private readonly serverUriStorage: IJupyterServerUriStorage
     ) {}
 
@@ -75,7 +75,7 @@ export class ControllerLoader implements IControllerLoader, IExtensionSyncActiva
         }
 
         if (isPythonNotebook(getNotebookMetadata(document)) && this.extensionChecker.isPythonExtensionInstalled) {
-            const useNewKernelPicker = this.configService.getSettings().kernelPickerType === 'Insiders';
+            const useNewKernelPicker = this.featuresManager.features.kernelPickerType === 'Insiders';
             // No need to always display active python env in VS Codes controller list.
             if (!useNewKernelPicker) {
                 // If we know we're dealing with a Python notebook, load the active interpreter as a kernel asap.
@@ -97,7 +97,7 @@ export class ControllerLoader implements IControllerLoader, IExtensionSyncActiva
 
                 // First thing is to always create the controller for the active interpreter only if we don't have any remote connections.
                 // This reduces flickering (changing controllers from one to another).
-                const useNewKernelPicker = this.configService.getSettings().kernelPickerType === 'Insiders';
+                const useNewKernelPicker = this.featuresManager.features.kernelPickerType === 'Insiders';
                 if (this.serverUriStorage.isLocalLaunch && !useNewKernelPicker) {
                     await createActiveInterpreterController(
                         JupyterNotebookView,

--- a/src/notebooks/controllers/controllerRegistration.ts
+++ b/src/notebooks/controllers/controllerRegistration.ts
@@ -21,7 +21,8 @@ import {
     IDisposableRegistry,
     IConfigurationService,
     IExtensionContext,
-    IBrowserService
+    IBrowserService,
+    IFeaturesManager
 } from '../../platform/common/types';
 import { IServiceContainer } from '../../platform/ioc/types';
 import { traceError, traceVerbose } from '../../platform/logging';
@@ -62,6 +63,7 @@ export class ControllerRegistration implements IControllerRegistration {
         @inject(IVSCodeNotebook) private readonly notebook: IVSCodeNotebook,
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
         @inject(IConfigurationService) private readonly configuration: IConfigurationService,
+        @inject(IFeaturesManager) private readonly featuresManager: IFeaturesManager,
         @inject(ICommandManager) private readonly commandManager: ICommandManager,
         @inject(KernelFilterService) private readonly kernelFilter: KernelFilterService,
         @inject(IExtensionContext) private readonly context: IExtensionContext,
@@ -218,7 +220,7 @@ export class ControllerRegistration implements IControllerRegistration {
         const userFiltered = this.kernelFilter.isKernelHidden(metadata);
         const urlFiltered = isRemoteConnection(metadata) && this.serverUriStorage.currentServerId !== metadata.serverId;
 
-        if (this.configuration.getSettings().kernelPickerType === 'Insiders') {
+        if (this.featuresManager.features.kernelPickerType === 'Insiders') {
             // In the 'Insiders' experiment remove the url filters as we want to register everything.
             return userFiltered;
         }

--- a/src/notebooks/controllers/kernelRanking/kernelRankingHelper.unit.test.ts
+++ b/src/notebooks/controllers/kernelRanking/kernelRankingHelper.unit.test.ts
@@ -24,7 +24,7 @@ import { IPythonExtensionChecker } from '../../../platform/api/types';
 import { PYTHON_LANGUAGE } from '../../../platform/common/constants';
 import * as platform from '../../../platform/common/utils/platform';
 import { CancellationTokenSource, EventEmitter, Memento, Uri } from 'vscode';
-import { IDisposable, IExtensionContext, IExtensions } from '../../../platform/common/types';
+import { IDisposable, IExtensionContext, IExtensions, IFeaturesManager } from '../../../platform/common/types';
 import { disposeAllDisposables } from '../../../platform/common/helpers';
 import {
     KernelConnectionMetadata,
@@ -242,6 +242,8 @@ import { ITrustedKernelPaths } from '../../../kernels/raw/finder/types';
             kernelFinder = new KernelFinder([]);
             const trustedKernels = mock<ITrustedKernelPaths>();
             when(trustedKernels.isTrusted(anything())).thenReturn(true);
+            const featuresManager = mock<IFeaturesManager>();
+            when(featuresManager.features).thenReturn({ kernelPickerType: 'Stable' });
 
             localPythonAndRelatedKernelFinder = new LocalPythonAndRelatedNonPythonKernelSpecFinder(
                 instance(interpreterService),
@@ -253,7 +255,8 @@ import { ITrustedKernelPaths } from '../../../kernels/raw/finder/types';
                 instance(memento),
                 disposables,
                 instance(env),
-                instance(trustedKernels)
+                instance(trustedKernels),
+                instance(featuresManager)
             );
             localKernelFinder = new ContributedLocalKernelSpecFinder(
                 nonPythonKernelSpecFinder,

--- a/src/notebooks/controllers/serviceRegistry.node.ts
+++ b/src/notebooks/controllers/serviceRegistry.node.ts
@@ -23,7 +23,7 @@ import {
 } from './types';
 import { registerTypes as registerWidgetTypes } from './ipywidgets/serviceRegistry.node';
 import { KernelRankingHelper } from './kernelRanking/kernelRankingHelper';
-import { IConfigurationService } from '../../platform/common/types';
+import { IFeaturesManager } from '../../platform/common/types';
 import { NotebookKernelSourceSelector } from './kernelSource/notebookKernelSourceSelector';
 import { ConnectionTracker } from './connectionTracker';
 import { ConnectionMru } from './connectionMru.node';
@@ -44,8 +44,8 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
     );
 
     // Register our kernel source selectors only on the Insiders picker type
-    const configuration = serviceManager.get<IConfigurationService>(IConfigurationService);
-    if (configuration.getSettings().kernelPickerType === 'Insiders') {
+    const featureManager = serviceManager.get<IFeaturesManager>(IFeaturesManager);
+    if (featureManager.features.kernelPickerType === 'Insiders') {
         serviceManager.addSingleton<INotebookKernelSourceSelector>(
             INotebookKernelSourceSelector,
             NotebookKernelSourceSelector

--- a/src/notebooks/controllers/serviceRegistry.web.ts
+++ b/src/notebooks/controllers/serviceRegistry.web.ts
@@ -23,7 +23,7 @@ import {
 } from './types';
 import { registerTypes as registerWidgetTypes } from './ipywidgets/serviceRegistry.web';
 import { KernelRankingHelper } from './kernelRanking/kernelRankingHelper';
-import { IConfigurationService } from '../../platform/common/types';
+import { IFeaturesManager } from '../../platform/common/types';
 import { NotebookKernelSourceSelector } from './kernelSource/notebookKernelSourceSelector';
 import { ConnectionTracker } from './connectionTracker';
 import { ConnectionMru } from './connectionMru.web';
@@ -44,8 +44,8 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
     );
 
     // Register our kernel source selectors only on the Insiders picker type
-    const configuration = serviceManager.get<IConfigurationService>(IConfigurationService);
-    if (configuration.getSettings().kernelPickerType === 'Insiders') {
+    const featureManager = serviceManager.get<IFeaturesManager>(IFeaturesManager);
+    if (featureManager.features.kernelPickerType === 'Insiders') {
         serviceManager.addSingleton<INotebookKernelSourceSelector>(
             INotebookKernelSourceSelector,
             NotebookKernelSourceSelector

--- a/src/notebooks/serviceRegistry.node.ts
+++ b/src/notebooks/serviceRegistry.node.ts
@@ -7,7 +7,7 @@ import { ITracebackFormatter } from '../kernels/types';
 import { IJupyterVariables } from '../kernels/variables/types';
 import { IExtensionSingleActivationService, IExtensionSyncActivationService } from '../platform/activation/types';
 import { Identifiers } from '../platform/common/constants';
-import { IConfigurationService, IDataScienceCommandListener } from '../platform/common/types';
+import { IDataScienceCommandListener, IFeaturesManager } from '../platform/common/types';
 import { IServiceManager } from '../platform/ioc/types';
 import { InstallPythonControllerCommands } from './controllers/commands/installPythonControllerCommands';
 import { KernelFilterService } from './controllers/kernelFilter/kernelFilterService';
@@ -149,8 +149,8 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
     serviceManager.addSingleton<ExportUtil>(ExportUtil, ExportUtil);
     serviceManager.addSingleton<IExportDialog>(IExportDialog, ExportDialog);
 
-    const configuration = serviceManager.get<IConfigurationService>(IConfigurationService);
-    if (configuration.getSettings().kernelPickerType === 'Insiders') {
+    const featureManager = serviceManager.get<IFeaturesManager>(IFeaturesManager);
+    if (featureManager.features.kernelPickerType === 'Insiders') {
         serviceManager.addSingleton<IExtensionSingleActivationService>(
             IExtensionSingleActivationService,
             PickDocumentKernelSourceCommand

--- a/src/notebooks/serviceRegistry.web.ts
+++ b/src/notebooks/serviceRegistry.web.ts
@@ -7,7 +7,7 @@ import { ITracebackFormatter } from '../kernels/types';
 import { IJupyterVariables } from '../kernels/variables/types';
 import { IExtensionSingleActivationService, IExtensionSyncActivationService } from '../platform/activation/types';
 import { Identifiers } from '../platform/common/constants';
-import { IConfigurationService, IDataScienceCommandListener } from '../platform/common/types';
+import { IDataScienceCommandListener, IFeaturesManager } from '../platform/common/types';
 import { IServiceManager } from '../platform/ioc/types';
 import { KernelFilterService } from './controllers/kernelFilter/kernelFilterService';
 import { KernelFilterUI } from './controllers/kernelFilter/kernelFilterUI';
@@ -124,8 +124,8 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
     serviceManager.addSingleton<INbConvertExport>(INbConvertExport, ExportToPython, ExportFormat.python);
     serviceManager.addSingleton<ExportUtilBase>(ExportUtilBase, ExportUtilBase);
 
-    const configuration = serviceManager.get<IConfigurationService>(IConfigurationService);
-    if (configuration.getSettings().kernelPickerType === 'Insiders') {
+    const featureManager = serviceManager.get<IFeaturesManager>(IFeaturesManager);
+    if (featureManager.features.kernelPickerType === 'Insiders') {
         serviceManager.addSingleton<IExtensionSingleActivationService>(
             IExtensionSingleActivationService,
             PickDocumentKernelSourceCommand

--- a/src/platform/common/featureManager.ts
+++ b/src/platform/common/featureManager.ts
@@ -46,7 +46,7 @@ const deprecatedFeatures: DeprecatedFeatureInfo[] = [
 export class FeatureManager implements IFeaturesManager {
     private _onDidChangeFeatures = new Emitter<void>();
     readonly onDidChangeFeatures = this._onDidChangeFeatures.event;
-    private _features: IFeatureSet;
+    private _features: IFeatureSet = { kernelPickerType: 'Stable' };
     get features(): IFeatureSet {
         return this._features;
     }
@@ -84,7 +84,7 @@ export class FeatureManager implements IFeaturesManager {
 
     private _updateFeatures() {
         const kernelPickerType =
-            this.workspace.getConfiguration('notebook.experimental.kernelPicker.mru') ||
+            this.workspace.getConfiguration('notebook.experimental.kernelPicker').get('mru') ||
             this.configService.getSettings().kernelPickerType === 'Insiders'
                 ? 'Insiders'
                 : 'Stable';

--- a/src/platform/common/featureManager.ts
+++ b/src/platform/common/featureManager.ts
@@ -10,9 +10,12 @@ import { Deprecated } from './utils/localize';
 import {
     DeprecatedFeatureInfo,
     DeprecatedSettingAndValue,
-    IFeatureDeprecationManager,
+    IConfigurationService,
+    IFeaturesManager,
+    IFeatureSet,
     IPersistentStateFactory
 } from './types';
+import { Emitter } from 'vscode-jsonrpc';
 
 const deprecatedFeatures: DeprecatedFeatureInfo[] = [
     {
@@ -36,17 +39,60 @@ const deprecatedFeatures: DeprecatedFeatureInfo[] = [
 ];
 
 /**
- * Manages deprecation of features. Commands that are deprecated end up here.
+ * Manages experimental and deprecated of features.
+ * Commands that are deprecated end up here.
  */
 @injectable()
-export class FeatureDeprecationManager implements IFeatureDeprecationManager {
+export class FeatureManager implements IFeaturesManager {
+    private _onDidChangeFeatures = new Emitter<void>();
+    readonly onDidChangeFeatures = this._onDidChangeFeatures.event;
+    private _features: IFeatureSet;
+    get features(): IFeatureSet {
+        return this._features;
+    }
+
+    set features(newFeatures: IFeatureSet) {
+        if (newFeatures.kernelPickerType === this._features.kernelPickerType) {
+            return;
+        }
+
+        this._features = newFeatures;
+        this._onDidChangeFeatures.fire();
+    }
+
     private disposables: Disposable[] = [];
     constructor(
         @inject(IPersistentStateFactory) private persistentStateFactory: IPersistentStateFactory,
         @inject(ICommandManager) private cmdMgr: ICommandManager,
+        @inject(IConfigurationService) private configService: IConfigurationService,
         @inject(IWorkspaceService) private workspace: IWorkspaceService,
         @inject(IApplicationShell) private appShell: IApplicationShell
-    ) {}
+    ) {
+        this._updateFeatures();
+
+        this.disposables.push(
+            this.configService.getSettings().onDidChange(() => {
+                this._updateFeatures();
+            })
+        );
+        this.disposables.push(
+            this.workspace.onDidChangeConfiguration(() => {
+                this._updateFeatures();
+            })
+        );
+    }
+
+    private _updateFeatures() {
+        const kernelPickerType =
+            this.workspace.getConfiguration('notebook.experimental.kernelPicker.mru') ||
+            this.configService.getSettings().kernelPickerType === 'Insiders'
+                ? 'Insiders'
+                : 'Stable';
+
+        this.features = {
+            kernelPickerType
+        };
+    }
 
     public dispose() {
         this.disposables.forEach((disposable) => disposable.dispose());

--- a/src/platform/common/serviceRegistry.node.ts
+++ b/src/platform/common/serviceRegistry.node.ts
@@ -26,7 +26,7 @@ import {
 import { AsyncDisposableRegistry } from './asyncDisposableRegistry';
 import { CryptoUtils } from './crypto';
 import { ExperimentService } from './experiments/service';
-import { FeatureDeprecationManager } from './featureDeprecationManager';
+import { FeatureManager } from './featureManager';
 import { BrowserService } from './net/browser';
 import { HttpClient } from './net/httpClient';
 import { PersistentStateFactory } from './persistentState';
@@ -38,7 +38,7 @@ import {
     IBrowserService,
     ICryptoUtils,
     IExtensions,
-    IFeatureDeprecationManager,
+    IFeaturesManager,
     IPersistentStateFactory,
     IsWindows
 } from './types';
@@ -74,7 +74,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IDataFrameScriptGenerator>(IDataFrameScriptGenerator, DataFrameScriptGenerator);
     serviceManager.addSingleton<IVariableScriptGenerator>(IVariableScriptGenerator, VariableScriptGenerator);
 
-    serviceManager.addSingleton<IFeatureDeprecationManager>(IFeatureDeprecationManager, FeatureDeprecationManager);
+    serviceManager.addSingleton<IFeaturesManager>(IFeaturesManager, FeatureManager);
 
     serviceManager.addSingleton<IAsyncDisposableRegistry>(IAsyncDisposableRegistry, AsyncDisposableRegistry);
     serviceManager.addSingleton<IMultiStepInputFactory>(IMultiStepInputFactory, MultiStepInputFactory);

--- a/src/platform/common/serviceRegistry.web.ts
+++ b/src/platform/common/serviceRegistry.web.ts
@@ -3,12 +3,12 @@
 
 import { IServiceManager } from '../ioc/types';
 import { ExperimentService } from './experiments/service';
-import { FeatureDeprecationManager } from './featureDeprecationManager';
+import { FeatureManager } from './featureManager';
 import { PersistentStateFactory } from './persistentState';
 import {
     IsWindows,
     IExperimentService,
-    IFeatureDeprecationManager,
+    IFeaturesManager,
     IPersistentStateFactory,
     IExtensions,
     ICryptoUtils,
@@ -37,7 +37,7 @@ import { VariableScriptGenerator } from './variableScriptGenerator';
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingletonInstance<boolean>(IsWindows, false);
     serviceManager.addSingleton<IExperimentService>(IExperimentService, ExperimentService);
-    serviceManager.addSingleton<IFeatureDeprecationManager>(IFeatureDeprecationManager, FeatureDeprecationManager);
+    serviceManager.addSingleton<IFeaturesManager>(IFeaturesManager, FeatureManager);
     serviceManager.addSingleton<IPersistentStateFactory>(IPersistentStateFactory, PersistentStateFactory);
     serviceManager.addSingleton<IExtensions>(IExtensions, Extensions);
     serviceManager.addSingleton<ICryptoUtils>(ICryptoUtils, CryptoUtils);

--- a/src/platform/common/types.ts
+++ b/src/platform/common/types.ts
@@ -267,9 +267,15 @@ export type DeprecatedFeatureInfo = {
     setting?: DeprecatedSettingAndValue;
 };
 
-export const IFeatureDeprecationManager = Symbol('IFeatureDeprecationManager');
+export interface IFeatureSet {
+    readonly kernelPickerType: KernelPickerType;
+}
 
-export interface IFeatureDeprecationManager extends Disposable {
+export const IFeaturesManager = Symbol('IFeaturesManager');
+
+export interface IFeaturesManager extends Disposable {
+    readonly features: IFeatureSet;
+    readonly onDidChangeFeatures: Event<void>;
     initialize(): void;
     registerDeprecation(deprecatedInfo: DeprecatedFeatureInfo): void;
 }

--- a/src/standalone/serviceRegistry.node.ts
+++ b/src/standalone/serviceRegistry.node.ts
@@ -25,7 +25,7 @@ import { ApiAccessService } from './api/apiAccessService';
 import { WorkspaceActivation } from './activation/workspaceActivation.node';
 import { ExtensionActivationManager } from './activation/activationManager';
 import { DataScienceSurveyBanner, ISurveyBanner } from './survey/dataScienceSurveyBanner.node';
-import { IConfigurationService, IExtensionContext } from '../platform/common/types';
+import { IExtensionContext, IFeaturesManager } from '../platform/common/types';
 import { registerTypes as registerDevToolTypes } from './devTools/serviceRegistry';
 import { registerTypes as registerIntellisenseTypes } from './intellisense/serviceRegistry.node';
 import { PythonExtensionRestartNotification } from './notification/pythonExtensionRestartNotification';
@@ -87,8 +87,8 @@ export function registerTypes(context: IExtensionContext, serviceManager: IServi
     // Dev Tools
     registerDevToolTypes(context, serviceManager, isDevMode);
 
-    const configuration = serviceManager.get<IConfigurationService>(IConfigurationService);
-    if (configuration.getSettings().kernelPickerType === 'Insiders') {
+    const featureManager = serviceManager.get<IFeaturesManager>(IFeaturesManager);
+    if (featureManager.features.kernelPickerType === 'Insiders') {
         // User jupyter server url provider
         serviceManager.addSingleton<IExtensionSyncActivationService>(
             IExtensionSyncActivationService,

--- a/src/standalone/serviceRegistry.web.ts
+++ b/src/standalone/serviceRegistry.web.ts
@@ -20,7 +20,7 @@ import { IExportedKernelServiceFactory } from './api/api';
 import { ApiAccessService } from './api/apiAccessService';
 import { ExtensionActivationManager } from './activation/activationManager';
 import { registerTypes as registerDevToolTypes } from './devTools/serviceRegistry';
-import { IConfigurationService, IExtensionContext } from '../platform/common/types';
+import { IExtensionContext, IFeaturesManager } from '../platform/common/types';
 import { registerTypes as registerIntellisenseTypes } from './intellisense/serviceRegistry.web';
 import { PythonExtensionRestartNotification } from './notification/pythonExtensionRestartNotification';
 import { ImportTracker } from './import-export/importTracker';
@@ -64,8 +64,8 @@ export function registerTypes(context: IExtensionContext, serviceManager: IServi
     // Dev Tools
     registerDevToolTypes(context, serviceManager, isDevMode);
 
-    const configuration = serviceManager.get<IConfigurationService>(IConfigurationService);
-    if (configuration.getSettings().kernelPickerType === 'Insiders') {
+    const featureManager = serviceManager.get<IFeaturesManager>(IFeaturesManager);
+    if (featureManager.features.kernelPickerType === 'Insiders') {
         // User jupyter server url provider
         serviceManager.addSingleton<IExtensionSyncActivationService>(
             IExtensionSyncActivationService,

--- a/src/test/datascience/jupyter/serverSelector.unit.test.ts
+++ b/src/test/datascience/jupyter/serverSelector.unit.test.ts
@@ -28,7 +28,12 @@ import { JupyterServerSelector } from '../../../kernels/jupyter/serverSelector';
 import { JupyterUriProviderRegistration } from '../../../kernels/jupyter/jupyterUriProviderRegistration';
 import { Settings } from '../../../platform/common/constants';
 import { DataScienceErrorHandler } from '../../../kernels/errors/kernelErrorHandler';
-import { IConfigurationService, IDisposable, IWatchableJupyterSettings } from '../../../platform/common/types';
+import {
+    IConfigurationService,
+    IDisposable,
+    IFeaturesManager,
+    IWatchableJupyterSettings
+} from '../../../platform/common/types';
 import { disposeAllDisposables } from '../../../platform/common/helpers';
 import { JupyterConnection } from '../../../kernels/jupyter/jupyterConnection';
 import { JupyterSettings } from '../../../platform/common/configSettings';
@@ -93,6 +98,8 @@ suite('Jupyter Server URI Selector', () => {
             instance(configService),
             instance(jupyterUriProviderRegistration)
         );
+        const featuresManager = mock<IFeaturesManager>();
+        when(featuresManager.features).thenReturn({ kernelPickerType: 'Stable' });
         const selector = new JupyterServerSelector(
             instance(clipboard),
             multiStepFactory,
@@ -104,7 +111,8 @@ suite('Jupyter Server URI Selector', () => {
             instance(connection),
             false,
             instance(workspaceService),
-            disposables
+            disposables,
+            instance(featuresManager)
         );
         return { selector, storage };
     }


### PR DESCRIPTION
It's bad code smell that we are reading this setting in dozens of files, indicating we might need to see how to decouple them a bit. With that said, this PR doesn't try to solve this but only introducing a global place for checking if we are using the new kernel picker.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
