### PR TITLE
Remove named-js-group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
                 "jsonc-parser": "^2.0.3",
                 "lodash": "^4.17.21",
                 "marked": "^4.0.10",
-                "named-js-regexp": "^1.3.3",
                 "node-fetch": "^2.6.7",
                 "node-stream-zip": "^1.6.0",
                 "pdfkit": "^0.13.0",
@@ -16312,11 +16311,6 @@
             "engines": {
                 "node": ">= 0.10"
             }
-        },
-        "node_modules/named-js-regexp": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/named-js-regexp/-/named-js-regexp-1.3.5.tgz",
-            "integrity": "sha512-XO0DPujDP9IWpkt690iWLreKztb/VB811DGl5N3z7BfhkMJuiVZXOi6YN/fEB9qkvtMVTgSZDW8pzdVt8vj/FA=="
         },
         "node_modules/nan": {
             "version": "2.15.0",
@@ -37227,11 +37221,6 @@
             "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
             "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
             "dev": true
-        },
-        "named-js-regexp": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/named-js-regexp/-/named-js-regexp-1.3.5.tgz",
-            "integrity": "sha512-XO0DPujDP9IWpkt690iWLreKztb/VB811DGl5N3z7BfhkMJuiVZXOi6YN/fEB9qkvtMVTgSZDW8pzdVt8vj/FA=="
         },
         "nan": {
             "version": "2.15.0",

--- a/package.json
+++ b/package.json
@@ -2163,7 +2163,6 @@
         "jsonc-parser": "^2.0.3",
         "lodash": "^4.17.21",
         "marked": "^4.0.10",
-        "named-js-regexp": "^1.3.3",
         "node-fetch": "^2.6.7",
         "node-stream-zip": "^1.6.0",
         "pdfkit": "^0.13.0",

--- a/src/kernels/helpers.ts
+++ b/src/kernels/helpers.ts
@@ -5,8 +5,6 @@
 
 // Helper functions for dealing with kernels and kernelspecs
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-const NamedRegexp = require('named-js-regexp') as typeof import('named-js-regexp');
 import * as path from '../platform/vscode-path/path';
 import * as uriPath from '../platform/vscode-path/resources';
 import * as nbformat from '@jupyterlab/nbformat';
@@ -574,7 +572,7 @@ export function areKernelConnectionsEqual(
 }
 // Check if a name is a default python kernel name and pull the version
 export function detectDefaultKernelName(name: string) {
-    const regEx = NamedRegexp('python\\s*(?<version>(\\d+))', 'g');
+    const regEx = new RegExp('python\\s*(?<version>(\\d+))', 'g');
     return regEx.exec(name.toLowerCase());
 }
 

--- a/src/kernels/jupyter/launcher/jupyterConnection.node.ts
+++ b/src/kernels/jupyter/launcher/jupyterConnection.node.ts
@@ -22,9 +22,7 @@ import { getJupyterConnectionDisplayName } from './helpers';
 import { arePathsSame } from '../../../platform/common/platform/fileUtils';
 import { getFilePath } from '../../../platform/common/platform/fs-paths';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, @typescript-eslint/no-explicit-any
-const namedRegexp = require('named-js-regexp');
-const urlMatcher = namedRegexp(RegExpValues.UrlPatternRegEx);
+const urlMatcher = new RegExp(RegExpValues.UrlPatternRegEx);
 
 /**
  * When starting a local jupyter server, this object waits for the server to come up.

--- a/src/platform/common/constants.ts
+++ b/src/platform/common/constants.ts
@@ -329,8 +329,6 @@ export namespace EditorContexts {
 export namespace RegExpValues {
     export const PythonCellMarker = /^(#\s*%%|#\s*\<codecell\>|#\s*In\[\d*?\]|#\s*In\[ \])/;
     export const PythonMarkdownCellMarker = /^(#\s*%%\s*\[markdown\]|#\s*\<markdowncell\>)/;
-    // This next one has to be a string because uglifyJS isn't handling the groups. We use named-js-regexp to parse it
-    // instead.
     export const UrlPatternRegEx =
         '(?<PREFIX>https?:\\/\\/)((\\(.+\\s+or\\s+(?<IP>.+)\\))|(?<LOCAL>[^\\s]+))(?<REST>:.+)';
     export interface IUrlPatternGroupType {


### PR DESCRIPTION
uglify-js doesn't appear to be in the project anymore and it seems that was the only reason it was included based on a comment? Regardless, support is good for named capture group in all browsers/node now.

Part of #11996

![image](https://user-images.githubusercontent.com/2193314/202011517-df208a45-1e5b-4df3-bfee-9147870b56b7.png)

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#browser_compatibility