### PR TITLE
Remove direct usages of the url package

### DIFF
--- a/src/kernels/jupyter/launcher/jupyterConnection.node.ts
+++ b/src/kernels/jupyter/launcher/jupyterConnection.node.ts
@@ -154,9 +154,6 @@ export class JupyterConnectionWaiter implements IDisposable {
             const host = groups.LOCAL ? groups.LOCAL : groups.IP;
             const uriString = `${groups.PREFIX}${host}${groups.REST}`;
 
-            // URL is not being found for some reason. Pull it in forcefully
-            // eslint-disable-next-line @typescript-eslint/no-require-imports
-            const URL = require('url').URL;
             let url: URL;
             try {
                 url = new URL(uriString);

--- a/src/kernels/jupyter/launcher/notebookStarter.node.ts
+++ b/src/kernels/jupyter/launcher/notebookStarter.node.ts
@@ -4,7 +4,6 @@
 'use strict';
 
 import * as cp from 'child_process';
-import * as url from 'url';
 import { inject, injectable, named } from 'inversify';
 import * as os from 'os';
 import * as path from '../../../platform/vscode-path/path';
@@ -153,7 +152,7 @@ export class NotebookStarter implements INotebookStarter {
             }
 
             try {
-                const port = parseInt(url.parse(connection.baseUrl).port || '0', 10);
+                const port = parseInt(new URL(connection.baseUrl).port || '0', 10);
                 if (port && !isNaN(port)) {
                     if (launchResult.proc) {
                         launchResult.proc.on('exit', () => NotebookStarter._usedPorts.delete(port));


### PR DESCRIPTION
Support for URL is good in all environments, it was actually only being referenced directly in .node.ts files and it's been available in node since v10. The package itself also has deprecated url.parse with advice to use the standard API instead.

It is still imported in tests only via rewiremock.

Part of #11996
