### PR TITLE
Change no-unused-vars lint rule to a warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -179,7 +179,7 @@ module.exports = {
         '@typescript-eslint/no-explicit-any': 'error',
         '@typescript-eslint/no-non-null-assertion': 'off',
         'no-unused-vars': 'off',
-        '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '_\\w*' }],
+        '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '_\\w*' }],
         'no-use-before-define': 'off',
         '@typescript-eslint/no-use-before-define': [
             'error',


### PR DESCRIPTION
It's quite distracting having an unused variable error appear, this should be a warning as it's normally just a dev time thing. Committing should reject all warnings anyway.

![image](https://user-images.githubusercontent.com/2193314/202288706-cb0f9865-9d16-4420-823f-f1417774f98a.png)
