### PR TITLE
Show remote switcher in stable only

### DIFF
--- a/src/notebooks/serviceRegistry.node.ts
+++ b/src/notebooks/serviceRegistry.node.ts
@@ -57,7 +57,6 @@ import { PickDocumentKernelSourceCommand } from './controllers/commands/pickDocu
 
 export function registerTypes(serviceManager: IServiceManager, isDevMode: boolean) {
     registerControllerTypes(serviceManager, isDevMode);
-    serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, RemoteSwitcher);
     serviceManager.addSingleton<IExtensionSyncActivationService>(IExtensionSyncActivationService, KernelFilterUI);
 
     serviceManager.addSingleton<KernelFilterService>(KernelFilterService, KernelFilterService);
@@ -154,6 +153,11 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
         serviceManager.addSingleton<IExtensionSingleActivationService>(
             IExtensionSingleActivationService,
             PickDocumentKernelSourceCommand
+        );
+    } else {
+        serviceManager.addSingleton<IExtensionSingleActivationService>(
+            IExtensionSingleActivationService,
+            RemoteSwitcher
         );
     }
 }

--- a/src/notebooks/serviceRegistry.web.ts
+++ b/src/notebooks/serviceRegistry.web.ts
@@ -52,7 +52,6 @@ import { PickDocumentKernelSourceCommand } from './controllers/commands/pickDocu
 
 export function registerTypes(serviceManager: IServiceManager, isDevMode: boolean) {
     registerControllerTypes(serviceManager, isDevMode);
-    serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, RemoteSwitcher);
     serviceManager.addSingleton<IExtensionSyncActivationService>(IExtensionSyncActivationService, KernelFilterUI);
 
     serviceManager.addSingleton<KernelFilterService>(KernelFilterService, KernelFilterService);
@@ -129,6 +128,11 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
         serviceManager.addSingleton<IExtensionSingleActivationService>(
             IExtensionSingleActivationService,
             PickDocumentKernelSourceCommand
+        );
+    } else {
+        serviceManager.addSingleton<IExtensionSingleActivationService>(
+            IExtensionSingleActivationService,
+            RemoteSwitcher
         );
     }
 }


### PR DESCRIPTION
Show remote/server status bar item only in Stable kernel picker.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
