### PR TITLE
Fix #12064. Hanlde python api exception and handle controllers early reg in api.

### DIFF
--- a/src/platform/api/pythonApi.ts
+++ b/src/platform/api/pythonApi.ts
@@ -212,7 +212,12 @@ export class PythonApiProvider implements IPythonApiProvider {
         if (activated) {
             this.didActivatePython.fire();
         }
-        pythonExtension.exports.jupyter.registerHooks();
+        if (!pythonExtension.exports?.jupyter) {
+            traceError(`Python extension is not exporting the jupyter API`);
+            this.api.reject(new Error('Python extension is not exporting the jupyter API'));
+        } else {
+            pythonExtension.exports.jupyter.registerHooks();
+        }
         this._pythonExtensionHooked.resolve();
     }
 }

--- a/src/standalone/api/api.ts
+++ b/src/standalone/api/api.ts
@@ -179,8 +179,20 @@ export function buildApi(
                 await connection.updateServerUri(uri);
                 await selector.setJupyterURIToRemote(uri);
 
-                await controllerCreatedPromise;
-                resolve();
+                if (
+                    controllerRegistration.all.find(
+                        (metadata) =>
+                            (metadata.kind === 'connectToLiveRemoteKernel' ||
+                                metadata.kind === 'startUsingRemoteKernelSpec') &&
+                            metadata.serverId === serverId
+                    ) === undefined
+                ) {
+                    resolve();
+                    return;
+                } else {
+                    await controllerCreatedPromise;
+                    resolve();
+                }
             });
         }
     };


### PR DESCRIPTION
Fixes #12064.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
