### PR TITLE
Polish server picker wording and back button.

### DIFF
--- a/src/notebooks/controllers/kernelSource/notebookKernelSourceSelector.ts
+++ b/src/notebooks/controllers/kernelSource/notebookKernelSourceSelector.ts
@@ -244,7 +244,7 @@ export class NotebookKernelSourceSelector implements INotebookKernelSourceSelect
         >({
             items: items,
             placeholder: '',
-            title: `Select a Jupyter Server from ${provider.displayName ?? provider.id}`,
+            title: 'Select a Jupyter Server',
             supportBackInFirstStep: true,
             onDidTriggerItemButton: async (e) => {
                 if ('type' in e.item && e.item.type === KernelFinderEntityQuickPickType.KernelFinder) {
@@ -268,8 +268,16 @@ export class NotebookKernelSourceSelector implements INotebookKernelSourceSelect
                 case KernelFinderEntityQuickPickType.KernelFinder:
                     return this.selectKernelFromKernelFinder.bind(this, selectedSource.kernelFinderInfo, token);
                 case KernelFinderEntityQuickPickType.UriProviderQuickPick:
-                    return this.selectRemoteServerFromRemoteKernelFinder(selectedSource, state, token);
-
+                    try {
+                        const ret = await this.selectRemoteServerFromRemoteKernelFinder(selectedSource, state, token);
+                        return ret;
+                    } catch (ex) {
+                        if (ex === InputFlowAction.back) {
+                            return this.getRemoteServersFromProvider(provider, token, multiStep, state);
+                        } else {
+                            throw ex;
+                        }
+                    }
                 default:
                     break;
             }


### PR DESCRIPTION
As title.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
