### PR TITLE
Ensure vscode logs and test result artificats map to test runs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -337,6 +337,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Generate Tag Variable
+        run:
+          echo "TAGSVAR=${{ matrix.tags }}}" >> $GITHUB_ENV
+
+      - name: Generate Friendly Variable
+        run:
+          echo "TAGS_NAME=${TAGSVAR//[^a-zA-Z]/}" >> $GITHUB_ENV
 
       - name: Use Python ${{matrix.pythonVersion}}
         uses: actions/setup-python@v4
@@ -666,7 +673,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: VSCodeLogs-${{matrix.jupyterConnection}}-${{matrix.python}}-${{matrix.pythonVersion}}-${{matrix.packageVersion}}-${{matrix.os}}
+          name: VSCodeLogs-${{matrix.jupyterConnection}}-${{matrix.python}}-${{matrix.pythonVersion}}-${{matrix.packageVersion}}-${{matrix.os}}-${{env.TAGS_NAME}}
           path: '${{env.VSC_JUPYTER_USER_DATA_DIR}}/logs/**/*'
           retention-days: 1
 
@@ -678,7 +685,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: TestLogs-${{matrix.jupyterConnection}}-${{matrix.python}}-${{matrix.pythonVersion}}-${{matrix.packageVersion}}-${{matrix.os}}
+          name: TestLogs-${{matrix.jupyterConnection}}-${{matrix.python}}-${{matrix.pythonVersion}}-${{matrix.packageVersion}}-${{matrix.os}}-${{env.TAGS_NAME}}
           path: './logs/*'
           retention-days: 60
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -343,6 +343,7 @@ jobs:
 
       - name: Generate Friendly Variable
         run:
+          # Generate a file friendly tag name for the test run (used for the artifacts)
           echo "TAGS_NAME=${TAGSVAR//[^a-zA-Z]/}" >> $GITHUB_ENV
 
       - name: Use Python ${{matrix.pythonVersion}}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -344,7 +344,7 @@ jobs:
       - name: Generate Friendly Variable
         run:
           # Generate a file friendly tag name for the test run (used for the artifacts)
-          echo "TAGS_NAME=${TAGSVAR//[^a-zA-Z]/}" >> $GITHUB_ENV
+          echo "TAGS_NAME=${TAGSVAR//[^a-zA-Z]/_}" >> $GITHUB_ENV
 
       - name: Use Python ${{matrix.pythonVersion}}
         uses: actions/setup-python@v4


### PR DESCRIPTION
As can be seen below, we now have all the logs for each job.

![Screenshot 2022-11-18 at 18 14 04](https://user-images.githubusercontent.com/1948812/202643255-14cc24b2-e8c9-47ea-a471-d2e424f8636a.png)
