### PR TITLE
Set all tsconfigs to target es2020

### DIFF
--- a/tsconfig.datascience-ui.json
+++ b/tsconfig.datascience-ui.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "baseUrl": ".",
-        "module": "esnext",
+        "module": "es2020",
         "moduleResolution": "node",
         "importHelpers": true,
         "target": "es5",

--- a/tsconfig.extension.node.json
+++ b/tsconfig.extension.node.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "baseUrl": ".",
         "module": "commonjs",
-        "target": "es6",
+        "target": "es2020",
         "outDir": "out",
         "lib": ["es6", "es2018", "ES2019", "ES2020"],
         "jsx": "react",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
             "*": ["types/*"]
         },
         "module": "commonjs",
-        "target": "es2018",
+        "target": "es2020",
         "outDir": "out",
         "lib": ["es6", "es2018", "dom", "ES2019", "ES2020"],
         "jsx": "react",


### PR DESCRIPTION
This upgrades the node/web packages to use es2020 and downgrades the webviews bundle from esnext because that target changes over time.

Part of #11996

---

This is mainly a change to enable features like dynamic importing, but comes with nice improvements to bundle size as well

- Before
  - extension.node.js: 3940KB
  - extension.web.js: 2229KB
- After
  - extension.node.js: 3911KB (-39KB)
  - extension.web.js: 2205KB (-24KB)