### PR TITLE
Ignore eslint in types folder

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
         '*.js',
         'vscode.d.ts',
         '**/*.test.ts',
+        'types',
         // TODO: Does this file need to be linted?
         'src/test/pythonFiles/formatting/dummy.ts'
     ],


### PR DESCRIPTION
This folder is for external typings so it shouldn't be linted
