### PR TITLE
async getQuickPickItems

### DIFF
--- a/src/kernels/jupyter/jupyterUriProviderWrapper.ts
+++ b/src/kernels/jupyter/jupyterUriProviderWrapper.ts
@@ -53,11 +53,11 @@ export class JupyterUriProviderWrapper implements IJupyterUriProvider {
     public get detail(): string | undefined {
         return this.provider.detail;
     }
-    public getQuickPickEntryItems(): vscode.QuickPickItem[] {
+    public async getQuickPickEntryItems(): Promise<vscode.QuickPickItem[]> {
         if (!this.provider.getQuickPickEntryItems) {
             return [];
         }
-        return this.provider.getQuickPickEntryItems().map((q) => {
+        return (await this.provider.getQuickPickEntryItems()).map((q) => {
             return {
                 ...q,
                 // Add the package name onto the description

--- a/src/kernels/jupyter/serverSelector.ts
+++ b/src/kernels/jupyter/serverSelector.ts
@@ -399,15 +399,15 @@ class JupyterServerSelector_Original implements IJupyterServerSelector {
         let providerItems: ISelectUriQuickPickItem[] = [];
         const providers = await this.extraUriProviders.getProviders();
         if (providers) {
-            providers.forEach((p) => {
-                if (!p.getQuickPickEntryItems) {
-                    return;
+            for (const p of providers) {
+                if (p.getQuickPickEntryItems && p.handleQuickPick) {
+                    const items = await p.getQuickPickEntryItems();
+                    const newProviderItems = items.map((i) => {
+                        return { ...i, newChoice: false, provider: p };
+                    });
+                    providerItems = providerItems.concat(newProviderItems);
                 }
-                const newProviderItems = p.getQuickPickEntryItems().map((i) => {
-                    return { ...i, newChoice: false, provider: p };
-                });
-                providerItems = providerItems.concat(newProviderItems);
-            });
+            }
         }
 
         // Always have 'local' and 'add new'
@@ -688,15 +688,15 @@ class JupyterServerSelector_Insiders implements IJupyterServerSelector {
         let providerItems: ISelectUriQuickPickItem[] = [];
         const providers = await this.extraUriProviders.getProviders();
         if (providers) {
-            providers.forEach((p) => {
-                if (!p.getQuickPickEntryItems) {
-                    return;
+            for (const p of providers) {
+                if (p.getQuickPickEntryItems && p.handleQuickPick) {
+                    const items = await p.getQuickPickEntryItems();
+                    const newProviderItems = items.map((i) => {
+                        return { ...i, newChoice: false, provider: p };
+                    });
+                    providerItems = providerItems.concat(newProviderItems);
                 }
-                const newProviderItems = p.getQuickPickEntryItems().map((i) => {
-                    return { ...i, newChoice: false, provider: p };
-                });
-                providerItems = providerItems.concat(newProviderItems);
-            });
+            }
         }
 
         // Always have 'local' and 'add new'

--- a/src/kernels/jupyter/types.ts
+++ b/src/kernels/jupyter/types.ts
@@ -214,7 +214,7 @@ export interface IJupyterUriProvider {
     readonly displayName?: string;
     readonly detail?: string;
     onDidChangeHandles?: Event<void>;
-    getQuickPickEntryItems?(): QuickPickItem[];
+    getQuickPickEntryItems?(): Promise<QuickPickItem[]> | QuickPickItem[];
     handleQuickPick?(item: QuickPickItem, backEnabled: boolean): Promise<JupyterServerUriHandle | 'back' | undefined>;
     /**
      * Given the handle, returns the Jupyter Server information.

--- a/src/notebooks/controllers/kernelSource/notebookKernelSourceSelector.ts
+++ b/src/notebooks/controllers/kernelSource/notebookKernelSourceSelector.ts
@@ -223,16 +223,18 @@ export class NotebookKernelSourceSelector implements INotebookKernelSourceSelect
                 items.push({ label: 'More', kind: QuickPickItemKind.Separator });
             }
 
-            const newProviderItems: KernelProviderItemsQuickPickItem[] = provider.getQuickPickEntryItems().map((i) => {
-                return {
-                    ...i,
-                    provider: provider,
-                    type: KernelFinderEntityQuickPickType.UriProviderQuickPick,
-                    description: undefined,
-                    originalItem: i,
-                    detail: provider.displayName
-                };
-            });
+            const newProviderItems: KernelProviderItemsQuickPickItem[] = (await provider.getQuickPickEntryItems()).map(
+                (i) => {
+                    return {
+                        ...i,
+                        provider: provider,
+                        type: KernelFinderEntityQuickPickType.UriProviderQuickPick,
+                        description: undefined,
+                        originalItem: i,
+                        detail: provider.displayName
+                    };
+                }
+            );
             items.push(...newProviderItems);
         }
 

--- a/src/test/datascience/jupyterUriProviderRegistration.unit.test.ts
+++ b/src/test/datascience/jupyterUriProviderRegistration.unit.test.ts
@@ -101,7 +101,7 @@ suite('URI Picker', () => {
         const registration = await createRegistration(['1']);
         const pickers = await registration.getProviders();
         assert.equal(pickers.length, 1, 'Default picker should be there');
-        const quickPick = pickers[0].getQuickPickEntryItems!();
+        const quickPick = await pickers[0].getQuickPickEntryItems!();
         assert.equal(quickPick.length, 1, 'No quick pick items added');
         const handle = await pickers[0].handleQuickPick!(quickPick[0], false);
         assert.ok(handle, 'Handle not set');
@@ -114,7 +114,7 @@ suite('URI Picker', () => {
         const registration = await createRegistration(['1']);
         const pickers = await registration.getProviders();
         assert.equal(pickers.length, 1, 'Default picker should be there');
-        const quickPick = pickers[0].getQuickPickEntryItems!();
+        const quickPick = await pickers[0].getQuickPickEntryItems!();
         assert.equal(quickPick.length, 1, 'No quick pick items added');
         const handle = await pickers[0].handleQuickPick!(quickPick[0], true);
         assert.equal(handle, 'back', 'Should be sending back');
@@ -123,7 +123,7 @@ suite('URI Picker', () => {
         const registration = await createRegistration(['1']);
         const pickers = await registration.getProviders();
         assert.equal(pickers.length, 1, 'Default picker should be there');
-        const quickPick = pickers[0].getQuickPickEntryItems!();
+        const quickPick = await pickers[0].getQuickPickEntryItems!();
         assert.equal(quickPick.length, 1, 'No quick pick items added');
         try {
             await registration.getJupyterServerUri('1', 'foobar');


### PR DESCRIPTION
Support both async and sync getQuickPickItems.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-jupyter/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
