### PR TITLE
Add logging for failure to create interrupt proc

### DIFF
--- a/src/kernels/raw/finder/pythonKernelInterruptDaemon.node.ts
+++ b/src/kernels/raw/finder/pythonKernelInterruptDaemon.node.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import { logValue, traceDecoratorVerbose, traceError, traceVerbose, traceWarning } from '../../../platform/logging';
+import { traceError, traceVerbose, traceWarning } from '../../../platform/logging';
 import { IPythonExecutionFactory, ObservableExecutionResult } from '../../../platform/common/process/types.node';
 import { EnvironmentType, PythonEnvironment } from '../../../platform/pythonEnvironments/info';
 import { inject, injectable } from 'inversify';
@@ -12,7 +12,6 @@ import { IAsyncDisposable, IDisposableRegistry, IExtensionContext, Resource } fr
 import { createDeferred, Deferred } from '../../../platform/common/utils/async';
 import { Disposable, Uri } from 'vscode';
 import { EOL } from 'os';
-import { TraceOptions } from '../../../platform/logging/types';
 function isBestPythonInterpreterForAnInterruptDaemon(interpreter: PythonEnvironment) {
     // Give preference to globally installed python environments.
     // The assumption is that users are more likely to uninstall/delete local python environments
@@ -69,11 +68,7 @@ export class PythonKernelInterruptDaemon {
         @inject(IInterpreterService) private readonly interpreters: IInterpreterService,
         @inject(IExtensionContext) private readonly context: IExtensionContext
     ) {}
-    @traceDecoratorVerbose('Create interrupt daemon', TraceOptions.Arguments)
-    public async createInterrupter(
-        @logValue<PythonEnvironment>('id') pythonEnvironment: PythonEnvironment,
-        resource: Resource
-    ): Promise<Interrupter> {
+    public async createInterrupter(pythonEnvironment: PythonEnvironment, resource: Resource): Promise<Interrupter> {
         const interruptHandle = (await this.sendCommand(
             { command: 'INITIALIZE_INTERRUPT' },
             pythonEnvironment,

--- a/src/kernels/raw/launcher/kernelProcess.node.ts
+++ b/src/kernels/raw/launcher/kernelProcess.node.ts
@@ -548,10 +548,17 @@ export class KernelProcess implements IKernelProcess {
             // On windows, in order to support interrupt, we have to set an environment variable pointing to a WIN32 event handle
             if (os.platform() === 'win32') {
                 env = env || process.env;
-                const handle = await this.getWin32InterruptHandle();
+                try {
+                    const handle = await this.getWin32InterruptHandle();
 
-                // See the code ProcessPollingWindows inside of ipykernel for it listening to this event handle.
-                env.JPY_INTERRUPT_EVENT = `${handle}`;
+                    // See the code ProcessPollingWindows inside of ipykernel for it listening to this event handle.
+                    env.JPY_INTERRUPT_EVENT = `${handle}`;
+                } catch (ex) {
+                    traceError(
+                        `Failed to get interrupt handle kernel id ${this._kernelConnectionMetadata.id} for interpreter ${this._kernelConnectionMetadata.interpreter.id}`,
+                        ex
+                    );
+                }
             }
 
             // The kernelspec argv could be something like [python, main.py, --something, --something-else, -f,{connection_file}]


### PR DESCRIPTION
Even if we fail to create the interrupt proc, we should start the kernel and log errors .