### PR TITLE
Delete leftover news entry

### DIFF
--- a/news/3 Code Health/12091.md
+++ b/news/3 Code Health/12091.md
@@ -1,2 +1,0 @@
-Sped up "Run Selection in Interactive" in single-line cases and when the Python interpreter is slow to start.
-(thanks [Tomer Chachamu](https://github.com/r3m0t/))


### PR DESCRIPTION
Seems this was added after the creation of my original PR to delete `news/`