### PR TITLE
clear IW cells from .py file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1456,7 +1456,7 @@
                 },
                 {
                     "command": "jupyter.interactive.clearAllCells",
-                    "when": "activeEditor == 'workbench.editor.interactive' && isWorkspaceTrusted"
+                    "when": "editorFocus && editorLangId == python || activeEditor == 'workbench.editor.interactive'"
                 },
                 {
                     "command": "jupyter.switchToRemoteKernels",


### PR DESCRIPTION
Fixes #6996

make the command also show up with py files, there is another when clause to prevent it from showing unless a kernel is active: https://github.com/microsoft/vscode-jupyter/blob/feaa38a7324ce22bb5ad0e64e5d831c6122e7fe7/package.json#L989