### PR TITLE
Manually select right kernel in Smoke Tests

### DIFF
--- a/src/test/smoke/datascience.smoke.test.ts
+++ b/src/test/smoke/datascience.smoke.test.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs-extra';
 import * as path from '../../platform/vscode-path/path';
 import * as vscode from 'vscode';
 import { IInteractiveWindowProvider } from '../../interactive-window/types';
-import { traceInfo } from '../../platform/logging';
+import { traceInfo, traceVerbose } from '../../platform/logging';
 import { IInterpreterService } from '../../platform/interpreter/contracts';
 import { IExtensionTestApi, PYTHON_PATH, setAutoSaveDelayInWorkspaceRoot, waitForCondition } from '../common.node';
 import { EXTENSION_ROOT_DIR_FOR_TESTS, IS_SMOKE_TEST } from '../constants.node';
@@ -107,6 +107,8 @@ suite('Smoke Tests', () => {
             id: controllerId,
             extension: 'ms-toolsai.jupyter'
         });
+
+        traceVerbose(`Selected kernel ${controllerId}`);
         await vscode.commands.executeCommand<void>('notebook.execute');
         const checkIfFileHasBeenCreated = () => fs.pathExists(outputFile);
         await waitForCondition(checkIfFileHasBeenCreated, timeoutForCellToRun, `"${outputFile}" file not created`);

--- a/src/test/smoke/datascience.smoke.test.ts
+++ b/src/test/smoke/datascience.smoke.test.ts
@@ -25,8 +25,11 @@ suite('Smoke Tests', () => {
         if (!IS_SMOKE_TEST()) {
             return this.skip();
         }
+        traceInfo(`Start Smoke tests1.`);
         api = await initialize();
+        traceInfo(`Start Smoke tests2.`);
         await setAutoSaveDelayInWorkspaceRoot(1);
+        traceInfo(`Start Smoke tests3.`);
     });
     setup(async function () {
         traceInfo(`Start Test ${this.currentTest?.title}`);
@@ -40,7 +43,7 @@ suite('Smoke Tests', () => {
             await captureScreenShot(this);
         }
         await closeActiveWindows();
-        traceInfo(`End Test Compelete ${this.currentTest?.title}`);
+        traceInfo(`End Test Complete ${this.currentTest?.title}`);
     });
 
     // test('Run Cell in interactive window', async () => {
@@ -87,6 +90,7 @@ suite('Smoke Tests', () => {
         if (await fs.pathExists(outputFile)) {
             await fs.unlink(outputFile);
         }
+        traceInfo(`Opening notebook file ${file}`);
         await vscode.commands.executeCommand('vscode.openWith', vscode.Uri.file(file), 'jupyter-notebook');
 
         // Wait for 15 seconds for notebook to launch.

--- a/src/test/smoke/datascience.smoke.test.ts
+++ b/src/test/smoke/datascience.smoke.test.ts
@@ -25,11 +25,8 @@ suite('Smoke Tests', () => {
         if (!IS_SMOKE_TEST()) {
             return this.skip();
         }
-        traceInfo(`Start Smoke tests1.`);
         api = await initialize();
-        traceInfo(`Start Smoke tests2.`);
         await setAutoSaveDelayInWorkspaceRoot(1);
-        traceInfo(`Start Smoke tests3.`);
     });
     setup(async function () {
         traceInfo(`Start Test ${this.currentTest?.title}`);

--- a/src/test/smoke/datascience.smoke.test.ts
+++ b/src/test/smoke/datascience.smoke.test.ts
@@ -5,14 +5,14 @@
 
 import { assert } from 'chai';
 /* eslint-disable , no-invalid-this, @typescript-eslint/no-explicit-any */
-
+import * as os from 'os';
 import * as fs from 'fs-extra';
 import * as path from '../../platform/vscode-path/path';
 import * as vscode from 'vscode';
 import { IInteractiveWindowProvider } from '../../interactive-window/types';
 import { traceInfo } from '../../platform/logging';
 import { IInterpreterService } from '../../platform/interpreter/contracts';
-import { IExtensionTestApi, setAutoSaveDelayInWorkspaceRoot, waitForCondition } from '../common.node';
+import { IExtensionTestApi, PYTHON_PATH, setAutoSaveDelayInWorkspaceRoot, waitForCondition } from '../common.node';
 import { EXTENSION_ROOT_DIR_FOR_TESTS, IS_SMOKE_TEST } from '../constants.node';
 import { sleep } from '../core';
 import { closeActiveWindows, initialize, initializeTest } from '../initialize.node';
@@ -93,6 +93,20 @@ suite('Smoke Tests', () => {
         // Unfortunately there's no way to know for sure it has completely loaded.
         await sleep(15_000);
 
+        let controllerId = '';
+        let pythonPath = PYTHON_PATH;
+        if (os.platform() === 'darwin') {
+            controllerId = `.jvsc74a57bd0396cba01897a9f2acbbfe0a6dcd789f4a066d92b27f41a29bade356faf26eba1.${pythonPath}.${pythonPath}.-m#ipykernel_launcher`;
+        } else if (os.platform() === 'linux') {
+            controllerId = `.jvsc74a57bd066f2b7bf0b1c80ed7c830b1a5555ddbc4af5468303d89f7ea039ef5384a7a529.${pythonPath}.${pythonPath}.-m#ipykernel_launcher`;
+        } else {
+            pythonPath = `${PYTHON_PATH.substring(0, 1).toLowerCase()}${PYTHON_PATH.substring(1)}`;
+            controllerId = `.jvsc74a57bd0d7b94230321e1e373f0403eaf807487012707ff7aa985439f4989b5650fe770c.${pythonPath}.${pythonPath}.-m#ipykernel_launcher`;
+        }
+        await vscode.commands.executeCommand('notebook.selectKernel', {
+            id: controllerId,
+            extension: 'ms-toolsai.jupyter'
+        });
         await vscode.commands.executeCommand<void>('notebook.execute');
         const checkIfFileHasBeenCreated = () => fs.pathExists(outputFile);
         await waitForCondition(checkIfFileHasBeenCreated, timeoutForCellToRun, `"${outputFile}" file not created`);

--- a/src/test/smoke/datascience.smoke.test.ts
+++ b/src/test/smoke/datascience.smoke.test.ts
@@ -99,16 +99,11 @@ suite('Smoke Tests', () => {
 
         let controllerId = '';
         let pythonPath = PYTHON_PATH;
-        const hash = await getInterpreterHash(vscode.Uri.file(pythonPath));
-        console.error('Interpreter Hash', hash);
-        if (os.platform() === 'darwin') {
-            controllerId = `.jvsc74a57bd0396cba01897a9f2acbbfe0a6dcd789f4a066d92b27f41a29bade356faf26eba1.${pythonPath}.${pythonPath}.-m#ipykernel_launcher`;
-        } else if (os.platform() === 'linux') {
-            controllerId = `.jvsc74a57bd066f2b7bf0b1c80ed7c830b1a5555ddbc4af5468303d89f7ea039ef5384a7a529.${pythonPath}.${pythonPath}.-m#ipykernel_launcher`;
-        } else {
+        if (os.platform() !== 'darwin' && os.platform() !== 'linux') {
             pythonPath = `${PYTHON_PATH.substring(0, 1).toLowerCase()}${PYTHON_PATH.substring(1)}`;
-            controllerId = `.jvsc74a57bd0d7b94230321e1e373f0403eaf807487012707ff7aa985439f4989b5650fe770c.${pythonPath}.${pythonPath}.-m#ipykernel_launcher`;
         }
+        const hash = await getInterpreterHash(vscode.Uri.file(pythonPath));
+        controllerId = `.jvsc74a57bd0${hash}.${pythonPath}.${pythonPath}.-m#ipykernel_launcher`;
         traceVerbose(`Before selected kernel ${controllerId}`);
         await vscode.commands.executeCommand('notebook.selectKernel', {
             id: controllerId,

--- a/src/test/smoke/datascience.smoke.test.ts
+++ b/src/test/smoke/datascience.smoke.test.ts
@@ -103,6 +103,7 @@ suite('Smoke Tests', () => {
             pythonPath = `${PYTHON_PATH.substring(0, 1).toLowerCase()}${PYTHON_PATH.substring(1)}`;
             controllerId = `.jvsc74a57bd0d7b94230321e1e373f0403eaf807487012707ff7aa985439f4989b5650fe770c.${pythonPath}.${pythonPath}.-m#ipykernel_launcher`;
         }
+        traceVerbose(`Before selected kernel ${controllerId}`);
         await vscode.commands.executeCommand('notebook.selectKernel', {
             id: controllerId,
             extension: 'ms-toolsai.jupyter'

--- a/src/test/smoke/datascience.smoke.test.ts
+++ b/src/test/smoke/datascience.smoke.test.ts
@@ -99,6 +99,8 @@ suite('Smoke Tests', () => {
 
         let controllerId = '';
         let pythonPath = PYTHON_PATH;
+        const hash = await getInterpreterHash(vscode.Uri.file(pythonPath));
+        console.error('Interpreter Hash', hash);
         if (os.platform() === 'darwin') {
             controllerId = `.jvsc74a57bd0396cba01897a9f2acbbfe0a6dcd789f4a066d92b27f41a29bade356faf26eba1.${pythonPath}.${pythonPath}.-m#ipykernel_launcher`;
         } else if (os.platform() === 'linux') {
@@ -159,4 +161,63 @@ suite('Smoke Tests', () => {
         //     'Interactive window not created with newly selected interpreter'
         // );
     });
+    async function computeHash(data: string, algorithm: 'SHA-512' | 'SHA-256' | 'SHA-1'): Promise<string> {
+        const inputBuffer = new TextEncoder().encode(data);
+        const hashBuffer = await require('node:crypto').webcrypto.subtle.digest({ name: algorithm }, inputBuffer);
+
+        // Turn into hash string (got this logic from https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest)
+        const hashArray = Array.from(new Uint8Array(hashBuffer));
+        return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+    }
+
+    function getInterpreterHash(uri: vscode.Uri) {
+        const interpreterPath = getNormalizedInterpreterPath(uri);
+        return computeHash(interpreterPath.path, 'SHA-256');
+    }
+    /**
+     * Sometimes on CI, we have paths such as (this could happen on user machines as well)
+     *  - /opt/hostedtoolcache/Python/3.8.11/x64/python
+     *  - /opt/hostedtoolcache/Python/3.8.11/x64/bin/python
+     *  They are both the same.
+     * This function will take that into account.
+     */
+    function getNormalizedInterpreterPath(path: vscode.Uri, forceLowerCase: boolean = false) {
+        let fsPath = getFilePath(path);
+        if (forceLowerCase) {
+            fsPath = fsPath.toLowerCase();
+        }
+
+        // No need to generate hashes, its unnecessarily slow.
+        if (!fsPath.endsWith('/bin/python')) {
+            return vscode.Uri.file(fsPath);
+        }
+        // Sometimes on CI, we have paths such as (this could happen on user machines as well)
+        // - /opt/hostedtoolcache/Python/3.8.11/x64/python
+        // - /opt/hostedtoolcache/Python/3.8.11/x64/bin/python
+        // They are both the same.
+        // To ensure we treat them as the same, lets drop the `bin` on unix.
+        const isWindows = /^win/.test(process.platform);
+        if (!isWindows) {
+            // We need to exclude paths such as `/usr/bin/python`
+            return fsPath.endsWith('/bin/python') && fsPath.split('/').length > 4
+                ? vscode.Uri.file(fsPath.replace('/bin/python', '/python'))
+                : vscode.Uri.file(fsPath);
+        }
+        return vscode.Uri.file(fsPath);
+    }
+    function getFilePath(file: vscode.Uri | undefined) {
+        const isWindows = /^win/.test(process.platform);
+        if (file) {
+            const fsPath = file.path;
+
+            // Remove separator on the front if not a network drive.
+            // Example, if you create a URI with Uri.file('hello world'), the fsPath will come out as '\Hello World' on windows. We don't want that
+            // However if you create a URI from a network drive, like '\\mydrive\foo\bar\python.exe', we want to keep the \\ on the front.
+            if (fsPath && fsPath.startsWith(path.sep) && fsPath.length > 1 && fsPath[1] !== path.sep && isWindows) {
+                return fsPath.slice(1);
+            }
+            return fsPath || '';
+        }
+        return '';
+    }
 });

--- a/src/test/standardTest.node.ts
+++ b/src/test/standardTest.node.ts
@@ -110,7 +110,9 @@ async function createSettings(): Promise<string> {
         // Disable the restart ask so that restart just happens
         'jupyter.askForKernelRestart': false,
         // To get widgets working.
-        'jupyter.widgetScriptSources': ['jsdelivr.com', 'unpkg.com']
+        'jupyter.widgetScriptSources': ['jsdelivr.com', 'unpkg.com'],
+        // New Kernel Picker.
+        'notebook.kernelPicker.type': 'mru'
     };
     fs.ensureDirSync(path.dirname(settingsFile));
     fs.writeFileSync(settingsFile, JSON.stringify(defaultSettings, undefined, 4));

--- a/src/test/standardTest.node.ts
+++ b/src/test/standardTest.node.ts
@@ -110,9 +110,7 @@ async function createSettings(): Promise<string> {
         // Disable the restart ask so that restart just happens
         'jupyter.askForKernelRestart': false,
         // To get widgets working.
-        'jupyter.widgetScriptSources': ['jsdelivr.com', 'unpkg.com'],
-        // New Kernel Picker.
-        'notebook.kernelPicker.type': 'mru'
+        'jupyter.widgetScriptSources': ['jsdelivr.com', 'unpkg.com']
     };
     fs.ensureDirSync(path.dirname(settingsFile));
     fs.writeFileSync(settingsFile, JSON.stringify(defaultSettings, undefined, 4));


### PR DESCRIPTION
Required for new kernel picker, and makes this test future proof (for new kernel pikcker)

In older kernel picker VS Code automatically selects the preferred kernel, things are different in new kernel picker - User MUST select a kernel.

Hence here (smoke test) we now forcefully select a kernel,