### PR TITLE
delete dead commands and contexts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1276,18 +1276,6 @@
                     "when": "jupyter.ispythonorinteractiveeactive && isWorkspaceTrusted"
                 },
                 {
-                    "command": "jupyter.notebookeditor.undocells",
-                    "title": "%jupyter.command.jupyter.undocells.title%",
-                    "category": "Notebook",
-                    "when": "jupyter.haveinteractivecells && jupyter.isnativeactive && !notebookEditorFocused && isWorkspaceTrusted"
-                },
-                {
-                    "command": "jupyter.notebookeditor.redocells",
-                    "title": "%jupyter.command.jupyter.redocells.title%",
-                    "category": "Notebook",
-                    "when": "jupyter.havenativeredoablecells && jupyter.isnativeactive && !notebookEditorFocused&& isWorkspaceTrusted"
-                },
-                {
                     "command": "jupyter.notebookeditor.removeallcells",
                     "title": "%jupyter.command.jupyter.notebookeditor.removeallcells.title%",
                     "category": "Notebook",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -43,8 +43,6 @@ interface ICommandNameWithoutArgumentTypeMapping {
     [DSCommands.CreateNewInteractive]: [];
     [DSCommands.InterruptKernel]: [{ notebookEditor: { notebookUri: Uri } } | undefined];
     [DSCommands.RestartKernel]: [{ notebookEditor: { notebookUri: Uri } } | undefined];
-    [DSCommands.NotebookEditorUndoCells]: [];
-    [DSCommands.NotebookEditorRedoCells]: [];
     [DSCommands.NotebookEditorRemoveAllCells]: [];
     [DSCommands.NotebookEditorRestartKernel]: [{ notebookEditor: { notebookUri: Uri } } | undefined | Uri];
     [DSCommands.NotebookEditorRunAllCells]: [];

--- a/src/notebooks/notebookCommandListener.ts
+++ b/src/notebooks/notebookCommandListener.ts
@@ -56,12 +56,6 @@ export class NotebookCommandListener implements IDataScienceCommandListener {
 
     public register(commandManager: ICommandManager): void {
         this.disposableRegistry.push(
-            commandManager.registerCommand(Commands.NotebookEditorUndoCells, () => this.undoCells())
-        );
-        this.disposableRegistry.push(
-            commandManager.registerCommand(Commands.NotebookEditorRedoCells, () => this.redoCells())
-        );
-        this.disposableRegistry.push(
             commandManager.registerCommand(Commands.NotebookEditorRemoveAllCells, () => this.removeAllCells())
         );
         this.disposableRegistry.push(
@@ -113,18 +107,6 @@ export class NotebookCommandListener implements IDataScienceCommandListener {
     private addCellBelow() {
         if (this.notebooks.activeNotebookEditor) {
             this.commandManager.executeCommand('notebook.cell.insertCodeCellBelow').then(noop, noop);
-        }
-    }
-
-    private undoCells() {
-        if (this.notebooks.activeNotebookEditor) {
-            this.commandManager.executeCommand('notebook.undo').then(noop, noop);
-        }
-    }
-
-    private redoCells() {
-        if (this.notebooks.activeNotebookEditor) {
-            this.commandManager.executeCommand('notebook.redo').then(noop, noop);
         }
     }
 

--- a/src/platform/common/constants.ts
+++ b/src/platform/common/constants.ts
@@ -218,8 +218,6 @@ export namespace Commands {
     export const ExportFileAndOutputAsNotebook = 'jupyter.exportfileandoutputasnotebook';
     export const InterruptKernel = 'jupyter.interruptkernel';
     export const RestartKernel = 'jupyter.restartkernel';
-    export const NotebookEditorUndoCells = 'jupyter.notebookeditor.undocells';
-    export const NotebookEditorRedoCells = 'jupyter.notebookeditor.redocells';
     export const NotebookEditorRemoveAllCells = 'jupyter.notebookeditor.removeallcells';
     export const NotebookEditorRestartKernel = 'jupyter.notebookeditor.restartkernel';
     export const NotebookEditorRunAllCells = 'jupyter.notebookeditor.runallcells';
@@ -298,13 +296,9 @@ export namespace CodeLensCommands {
 
 export namespace EditorContexts {
     export const HasCodeCells = 'jupyter.hascodecells';
-    export const HaveInteractiveCells = 'jupyter.haveinteractivecells';
-    export const HaveRedoableCells = 'jupyter.haveredoablecells';
-    export const HaveInteractive = 'jupyter.haveinteractive';
     export const IsInteractiveActive = 'jupyter.isinteractiveactive';
     export const OwnsSelection = 'jupyter.ownsSelection';
     export const HaveNativeCells = 'jupyter.havenativecells';
-    export const HaveNativeRedoableCells = 'jupyter.havenativeredoablecells';
     export const HaveNative = 'jupyter.havenative';
     export const IsNativeActive = 'jupyter.isnativeactive';
     export const IsInteractiveOrNativeActive = 'jupyter.isinteractiveornativeactive';


### PR DESCRIPTION
Fixes #7242

`notebook.undo` and `notebook.redo` don't exist in core, so these commands weren't doing anything (and swallowing the errors)