### PR TITLE
Add "delete temp debugging files" to @mandatory

### DIFF
--- a/src/test/datascience/debugger.vscode.test.ts
+++ b/src/test/datascience/debugger.vscode.test.ts
@@ -98,7 +98,7 @@ suite('Run By Line @debugger', function () {
     // Cleanup after suite is finished
     suiteTeardown(() => closeNotebooksAndCleanUpAfterTests(disposables));
 
-    test('Delete temp debugging files', async function () {
+    test('Delete temp debugging files @mandatory', async function () {
         let tempWatcher;
         let folderName;
         try {


### PR DESCRIPTION
to ensure that it runs on Windows and also so that we have a debugging test in @mandatory
Fix #10041
