### PR TITLE
Support remote jupyter server working directory mapping

### DIFF
--- a/src/kernels/jupyter/jupyterUtils.ts
+++ b/src/kernels/jupyter/jupyterUtils.ts
@@ -127,6 +127,7 @@ export function createRemoteConnectionInfo(
         },
         dispose: noop,
         rootDirectory: Uri.file(''),
+        workingDirectory: serverUri?.workingDirectory,
         getAuthHeader: serverUri ? () => getJupyterServerUri(uri)?.authorizationHeader : undefined,
         url: uri
     };

--- a/src/kernels/jupyter/session/jupyterSession.ts
+++ b/src/kernels/jupyter/session/jupyterSession.ts
@@ -252,7 +252,7 @@ export class JupyterSession extends BaseJupyterSession implements IJupyterKernel
                     this.connInfo.workingDirectory
                 );
             }
-        } 
+        }
         if (!remoteFilePath) {
             // Create our backing file for the notebook
             backingFile = await this.backingFileCreator.createBackingFile(

--- a/src/kernels/jupyter/session/jupyterSession.ts
+++ b/src/kernels/jupyter/session/jupyterSession.ts
@@ -252,7 +252,8 @@ export class JupyterSession extends BaseJupyterSession implements IJupyterKernel
                     this.connInfo.workingDirectory
                 );
             }
-        } else {
+        } 
+        if (!remoteFilePath) {
             // Create our backing file for the notebook
             backingFile = await this.backingFileCreator.createBackingFile(
                 this.resource,

--- a/src/kernels/jupyter/types.ts
+++ b/src/kernels/jupyter/types.ts
@@ -202,6 +202,7 @@ export interface IJupyterServerUri {
     authorizationHeader: any; // JSON object for authorization header.
     expiration?: Date; // Date/time when header expires and should be refreshed.
     displayName: string;
+    workingDirectory?: string;
 }
 
 export type JupyterServerUriHandle = string;

--- a/src/kernels/types.ts
+++ b/src/kernels/types.ts
@@ -511,6 +511,7 @@ export interface IJupyterConnection extends Disposable {
     readonly url: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getAuthHeader?(): any; // Snould be a json object
+    readonly workingDirectory?: string;
 }
 
 export type INotebookProviderConnection = IRawConnection | IJupyterConnection;


### PR DESCRIPTION
Allow already synced file to be used instead of creating backup file.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
