### PR TITLE
Skip uploading coverage reports in PRs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -854,7 +854,7 @@ jobs:
   coverage:
     name: Coverage reports upload
     runs-on: ubuntu-latest
-    if: "(success() || failure()) && !contains(github.ref, 'refs/heads/release')"
+    if: (success() || failure()) && !contains(github.ref, 'refs/heads/release') && github.event_name != 'pull_request'
     needs: [ts_tests, vscodeTests, smoke-tests]
     steps:
       - name: Checkout


### PR DESCRIPTION
Disabling uploading of coverage reports saves around 2m from the over all CI job.