### PR TITLE
Use micromamba instead of miniconda for conda env tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -349,7 +349,7 @@ jobs:
           python-version: ${{matrix.pythonVersion}}
 
       - name: Install Conda environment from environment.yml
-        uses: mamba-org/provision-with-micromamba@v14
+        uses: mamba-org/provision-with-micromamba@f347426e5745fe3dfc13ec5baf20496990d0281f
         if: matrix.python == 'conda'
         with:
           cache-downloads: true

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -349,7 +349,7 @@ jobs:
           python-version: ${{matrix.pythonVersion}}
 
       - name: Install Conda environment from environment.yml
-        uses: mamba-org/provision-with-micromamba
+        uses: mamba-org/provision-with-micromamba@v14
         if: matrix.python == 'conda'
         with:
           cache-downloads: true

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -348,23 +348,15 @@ jobs:
         with:
           python-version: ${{matrix.pythonVersion}}
 
-      - name: Cache conda on linux
-        uses: actions/cache@v2
+      - name: Install Conda environment from environment.yml
+        uses: mamba-org/provision-with-micromamba@main
         if: matrix.python == 'conda'
         with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-${{
-            hashFiles('./build/conda-test-requirements.yml') }}
-
-      - name: Use Conda Python ${{matrix.pythonVersion}}
-        uses: conda-incubator/setup-miniconda@v2
-        if: matrix.python == 'conda'
-        with:
-          auto-update-conda: true
-          activate-environment: functional_test_env
-          channels: conda-forge,default
+          cache-downloads: true
+          environment-name: functional_test_env
           environment-file: ./build/conda-test-requirements.yml
-          python-version: ${{matrix.pythonVersion}}
+          extra-specs: |
+            python=${{matrix.pythonVersion}}
 
       - name: Set CI Path
         uses: ./.github/actions/set-python
@@ -483,13 +475,11 @@ jobs:
         shell: bash -l {0}
         if: matrix.python == 'conda'
         run: |
-          conda init bash
-          conda activate functional_test_env
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r ./requirements.txt
           python -m pip --disable-pip-version-check install -r build/conda-nonconda-test-requirements.txt
           python ./pythonFiles/install_debugpy.py
           beakerx_kernel_java install
-          conda install pytorch cpuonly -c pytorch
+          micromamba install pytorch cpuonly -c pytorch
 
       - name: Install pythreejs and matplotlib widgets into user and system paths
         if: matrix.os == 'ubuntu-latest' && matrix.python != 'conda' && matrix.python != 'noPython' && matrix.packageVersion != 'prerelease' && matrix.tags != '^[^@]+$|@mandatory'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -349,7 +349,7 @@ jobs:
           python-version: ${{matrix.pythonVersion}}
 
       - name: Install Conda environment from environment.yml
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/provision-with-micromamba
         if: matrix.python == 'conda'
         with:
           cache-downloads: true

--- a/build/conda-test-requirements.yml
+++ b/build/conda-test-requirements.yml
@@ -1,4 +1,7 @@
 # Functional requirements using a conda environment file
+channels:
+  - conda-forge
+  - defaults
 dependencies:
   - ipywidgets=7.7.2 # Pinned per ipywidget 8 support: https://github.com/microsoft/vscode-jupyter/issues/11598
   - pandas


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-jupyter/issues/9464
Previously the conda CI job would take 10 minutes to setup Conda, now that same step takes <2 minutes.