### PR TITLE
Intercept debugpyAttach message to avoid error

### DIFF
--- a/src/interactive-window/debugger/jupyter/debugCellController.ts
+++ b/src/interactive-window/debugger/jupyter/debugCellController.ts
@@ -5,7 +5,10 @@ import { NotebookCell } from 'vscode';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { INotebookKernelExecution } from '../../../kernels/types';
 import { DebuggingTelemetry } from '../../../notebooks/debugger/constants';
-import { isJustMyCodeNotification } from '../../../notebooks/debugger/controllers/debugCellController';
+import {
+    isDebugpyAttachRequest,
+    isJustMyCodeNotification
+} from '../../../notebooks/debugger/controllers/debugCellController';
 import { IDebuggingDelegate, IKernelDebugAdapter } from '../../../notebooks/debugger/debuggingTypes';
 import { cellDebugSetup } from '../../../notebooks/debugger/helper';
 import { createDeferred } from '../../../platform/common/utils/async';
@@ -35,6 +38,11 @@ export class DebugCellController implements IDebuggingDelegate {
     }
 
     public async willSendEvent(msg: DebugProtocol.Event): Promise<boolean> {
+        if (isDebugpyAttachRequest(msg)) {
+            this.trace('intercept', 'debugpyAttach request for subprocess, not supported');
+            return true;
+        }
+
         if (msg.event === 'output') {
             if (isJustMyCodeNotification(msg.body.output)) {
                 this.trace('intercept', 'justMyCode notification');

--- a/src/notebooks/debugger/controllers/debugCellController.ts
+++ b/src/notebooks/debugger/controllers/debugCellController.ts
@@ -16,6 +16,10 @@ export function isJustMyCodeNotification(msg: string): boolean {
     return msg.includes('Frame skipped from debugging during step-in');
 }
 
+export function isDebugpyAttachRequest(msg: DebugProtocol.Event): boolean {
+    return msg.event === 'debugpyAttach';
+}
+
 /**
  * Controls starting execution on a cell when debugging a cell.
  */
@@ -34,6 +38,11 @@ export class DebugCellController implements IDebuggingDelegate {
     }
 
     public async willSendEvent(msg: DebugProtocol.Event): Promise<boolean> {
+        if (isDebugpyAttachRequest(msg)) {
+            this.trace('intercept', 'debugpyAttach request for subprocess, not supported');
+            return true;
+        }
+
         if (msg.event === 'output') {
             if (isJustMyCodeNotification(msg.body.output)) {
                 this.trace('intercept', 'justMyCode notification');


### PR DESCRIPTION
for unsupported subprocess debugging
For microsoft/vscode-jupyter#9886
