### PR TITLE
return undefined when no folding regions to return

### DIFF
--- a/src/interactive-window/editor-integration/pythonCellFoldingProvider.ts
+++ b/src/interactive-window/editor-integration/pythonCellFoldingProvider.ts
@@ -40,13 +40,13 @@ export class PythonCellFoldingProvider implements IExtensionSyncActivationServic
         token: CancellationToken
     ): ProviderResult<FoldingRange[]> {
         if ([NotebookCellScheme, InteractiveInputScheme].includes(document.uri.scheme)) {
-            return [];
+            return undefined;
         }
 
         const codeWatcher = this.dataScienceCodeLensProvider.getCodeWatcher(document);
         if (codeWatcher) {
             const codeLenses = codeWatcher.getCodeLenses();
-            if (token.isCancellationRequested) {
+            if (token.isCancellationRequested || codeLenses.length == 0) {
                 return undefined;
             }
             return codeLenses.map((codeLens) => {


### PR DESCRIPTION
This way we avoid overriding the default folding provider for no reason, as is happening in https://github.com/microsoft/vscode-jupyter/issues/12520

Still some weird behavior where if the jupyter extension ever sees a cell in a .py file, you would have to reload VS Code before getting the default folding ranges back - https://github.com/microsoft/vscode/issues/171012
