### PR TITLE
Fix #12233. Hide builtin kernel picker provider from the traditional server selector.

### DIFF
--- a/src/kernels/jupyter/serverSelector.ts
+++ b/src/kernels/jupyter/serverSelector.ts
@@ -553,7 +553,10 @@ class JupyterServerSelector_Insiders implements IJupyterServerSelector {
 
         // Get the list of items and show what the current value is
         const remoteUri = await this.serverUriStorage.getRemoteUri();
-        const items = await this.getUriPickList(allowLocal, remoteUri);
+        // filter out the builtin providers which are only now used in the MRU quick pick.
+        const items = (await this.getUriPickList(allowLocal, remoteUri)).filter(
+            (item) => !item.provider?.id.startsWith('_builtin')
+        );
         const activeItem = items.find((i) => i.url === remoteUri || (i.label === this.localLabel && !remoteUri));
         const currentValue = !remoteUri ? DataScience.jupyterSelectURINoneLabel : activeItem?.label;
         const placeholder = currentValue // This will show at the top (current value really)


### PR DESCRIPTION
Fixes #12233.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
