### PR TITLE
title run menu contribution to run file in IW

### DIFF
--- a/package.json
+++ b/package.json
@@ -527,6 +527,7 @@
             {
                 "command": "jupyter.runFileInteractive",
                 "title": "%jupyter.command.jupyter.runFileInteractive.title%",
+                "icon": "$(play)",
                 "category": "Jupyter",
                 "enablement": "isWorkspaceTrusted"
             },
@@ -1462,6 +1463,13 @@
                     "command": "jupyter.showDataViewer",
                     "group": "1_view",
                     "when": "debugProtocolVariableMenuContext == 'viewableInDataViewer'"
+                }
+            ],
+            "editor/title/run": [
+                {
+                    "command": "jupyter.runFileInteractive",
+                    "group": "jupyter",
+                    "when": "resourceLangId == python && !isInDiffEditor && !notebookEditorFocused && isWorkspaceTrusted"
                 }
             ]
         },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-jupyter/issues/7683

add a launch contribution to run a python file in the interactive window.

The title should be changed to match up with Python's wording better, but the title only seems to be pulled from where the command is contributed, not the specific menu item contribution.