### PR TITLE
Stop using the Python API to get custom env vars

### DIFF
--- a/src/platform/common/variables/customEnvironmentVariablesProvider.node.unit.test.ts
+++ b/src/platform/common/variables/customEnvironmentVariablesProvider.node.unit.test.ts
@@ -93,7 +93,7 @@ suite('Custom Environment Variables Provider', () => {
             disposables,
             instance(workspace),
             pythonExtChecker,
-            instance(pythonApiProvider),
+            // instance(pythonApiProvider),
             cacheDuration
         );
     }


### PR DESCRIPTION
Fixes #12714

This PR basically reverts a PR that makes use of the Python API to get the env variables.