### PR TITLE
Remove jupyter error renderer contribution.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1920,15 +1920,6 @@
                     "application/vnd.jupyter.widget-view+json"
                 ],
                 "requiresMessaging": "always"
-            },
-            {
-                "id": "jupyter-error-renderer",
-                "entrypoint": "./out/webviews/webview-side/errorRenderer/errorRenderer.js",
-                "displayName": "%jupyter.notebookRenderer.Error.displayName%",
-                "requiresMessaging": "always",
-                "mimeTypes": [
-                    "application/vnd.code.notebook.error"
-                ]
             }
         ],
         "viewsContainers": {


### PR DESCRIPTION
As prep for removing the jupyter error renderer completely.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
