### PR TITLE
Disable error renderer webview communications.

### DIFF
--- a/src/notebooks/outputs/errorRendererComms.ts
+++ b/src/notebooks/outputs/errorRendererComms.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { inject, injectable } from 'inversify';
+import { inject } from 'inversify';
 import {
     commands,
     NotebookCell,
@@ -29,7 +29,7 @@ import { linkCommandAllowList, LineQueryRegex } from './linkProvider';
 /**
  * Registers comm channel to the error renderer to handle link clicking
  */
-@injectable()
+// @injectable()
 export class ErrorRendererCommunicationHandler implements IExtensionSyncActivationService {
     constructor(
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,

--- a/src/notebooks/serviceRegistry.node.ts
+++ b/src/notebooks/serviceRegistry.node.ts
@@ -46,7 +46,6 @@ import { NotebookCellLanguageService } from './languages/cellLanguageService';
 import { EmptyNotebookCellLanguageService } from './languages/emptyNotebookCellLanguageService';
 import { NotebookCommandListener } from './notebookCommandListener';
 import { NotebookEditorProvider } from './notebookEditorProvider';
-// import { ErrorRendererCommunicationHandler } from './outputs/errorRendererComms';
 import { NotebookTracebackFormatter } from './outputs/tracebackFormatter';
 import { JupyterServerSelectorCommand } from './serverSelectorCommand';
 import { InterpreterPackageTracker } from './telemetry/interpreterPackageTracker';
@@ -60,10 +59,6 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
     serviceManager.addSingleton<KernelFilterService>(KernelFilterService, KernelFilterService);
     serviceManager.addSingleton<IExtensionSyncActivationService>(IExtensionSyncActivationService, LiveKernelSwitcher);
     serviceManager.addSingleton<IDataScienceCommandListener>(IDataScienceCommandListener, NotebookCommandListener);
-    // serviceManager.addSingleton<IExtensionSyncActivationService>(
-    //     IExtensionSyncActivationService,
-    //     ErrorRendererCommunicationHandler
-    // );
     serviceManager.addSingleton<INotebookEditorProvider>(INotebookEditorProvider, NotebookEditorProvider);
     serviceManager.addBinding(INotebookCompletionProvider, IExtensionSyncActivationService);
     serviceManager.addSingleton<IExtensionSyncActivationService>(

--- a/src/notebooks/serviceRegistry.node.ts
+++ b/src/notebooks/serviceRegistry.node.ts
@@ -46,7 +46,7 @@ import { NotebookCellLanguageService } from './languages/cellLanguageService';
 import { EmptyNotebookCellLanguageService } from './languages/emptyNotebookCellLanguageService';
 import { NotebookCommandListener } from './notebookCommandListener';
 import { NotebookEditorProvider } from './notebookEditorProvider';
-import { ErrorRendererCommunicationHandler } from './outputs/errorRendererComms';
+// import { ErrorRendererCommunicationHandler } from './outputs/errorRendererComms';
 import { NotebookTracebackFormatter } from './outputs/tracebackFormatter';
 import { JupyterServerSelectorCommand } from './serverSelectorCommand';
 import { InterpreterPackageTracker } from './telemetry/interpreterPackageTracker';
@@ -60,10 +60,10 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
     serviceManager.addSingleton<KernelFilterService>(KernelFilterService, KernelFilterService);
     serviceManager.addSingleton<IExtensionSyncActivationService>(IExtensionSyncActivationService, LiveKernelSwitcher);
     serviceManager.addSingleton<IDataScienceCommandListener>(IDataScienceCommandListener, NotebookCommandListener);
-    serviceManager.addSingleton<IExtensionSyncActivationService>(
-        IExtensionSyncActivationService,
-        ErrorRendererCommunicationHandler
-    );
+    // serviceManager.addSingleton<IExtensionSyncActivationService>(
+    //     IExtensionSyncActivationService,
+    //     ErrorRendererCommunicationHandler
+    // );
     serviceManager.addSingleton<INotebookEditorProvider>(INotebookEditorProvider, NotebookEditorProvider);
     serviceManager.addBinding(INotebookCompletionProvider, IExtensionSyncActivationService);
     serviceManager.addSingleton<IExtensionSyncActivationService>(

--- a/src/notebooks/serviceRegistry.web.ts
+++ b/src/notebooks/serviceRegistry.web.ts
@@ -41,7 +41,7 @@ import { NotebookCellLanguageService } from './languages/cellLanguageService';
 import { EmptyNotebookCellLanguageService } from './languages/emptyNotebookCellLanguageService';
 import { NotebookCommandListener } from './notebookCommandListener';
 import { NotebookEditorProvider } from './notebookEditorProvider';
-import { ErrorRendererCommunicationHandler } from './outputs/errorRendererComms';
+// import { ErrorRendererCommunicationHandler } from './outputs/errorRendererComms';
 import { NotebookTracebackFormatter } from './outputs/tracebackFormatter';
 import { JupyterServerSelectorCommand } from './serverSelectorCommand';
 import { InterpreterPackageTracker } from './telemetry/interpreterPackageTracker';
@@ -103,10 +103,10 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
     );
     serviceManager.addSingleton<IExtensionSyncActivationService>(IExtensionSyncActivationService, CommandRegistry);
 
-    serviceManager.addSingleton<IExtensionSyncActivationService>(
-        IExtensionSyncActivationService,
-        ErrorRendererCommunicationHandler
-    );
+    // serviceManager.addSingleton<IExtensionSyncActivationService>(
+    //     IExtensionSyncActivationService,
+    //     ErrorRendererCommunicationHandler
+    // );
 
     serviceManager.addSingleton<ExportFileOpener>(ExportFileOpener, ExportFileOpener);
     serviceManager.addSingleton<IExportBase>(IExportBase, ExportBase);

--- a/src/notebooks/serviceRegistry.web.ts
+++ b/src/notebooks/serviceRegistry.web.ts
@@ -41,7 +41,6 @@ import { NotebookCellLanguageService } from './languages/cellLanguageService';
 import { EmptyNotebookCellLanguageService } from './languages/emptyNotebookCellLanguageService';
 import { NotebookCommandListener } from './notebookCommandListener';
 import { NotebookEditorProvider } from './notebookEditorProvider';
-// import { ErrorRendererCommunicationHandler } from './outputs/errorRendererComms';
 import { NotebookTracebackFormatter } from './outputs/tracebackFormatter';
 import { JupyterServerSelectorCommand } from './serverSelectorCommand';
 import { InterpreterPackageTracker } from './telemetry/interpreterPackageTracker';
@@ -102,11 +101,6 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
         Identifiers.DEBUGGER_VARIABLES
     );
     serviceManager.addSingleton<IExtensionSyncActivationService>(IExtensionSyncActivationService, CommandRegistry);
-
-    // serviceManager.addSingleton<IExtensionSyncActivationService>(
-    //     IExtensionSyncActivationService,
-    //     ErrorRendererCommunicationHandler
-    // );
 
     serviceManager.addSingleton<ExportFileOpener>(ExportFileOpener, ExportFileOpener);
     serviceManager.addSingleton<IExportBase>(IExportBase, ExportBase);

--- a/src/webviews/extension-side/error-renderer/index.ts
+++ b/src/webviews/extension-side/error-renderer/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { inject, injectable } from 'inversify';
+import { inject } from 'inversify';
 import * as vscode from 'vscode';
 import { ErrorRendererMessageType, Localizations } from '../../../messageTypes';
 import { IExtensionSyncActivationService } from '../../../platform/activation/types';
@@ -13,7 +13,7 @@ import { noop } from '../../../platform/common/utils/misc';
 /**
  * Responsible for sending loc data to renderers
  */
-@injectable()
+// @injectable()
 export class ExtensionSideRenderer implements IDisposable, IExtensionSyncActivationService {
     private disposables: IDisposable[] = [];
     constructor(@inject(IDisposableRegistry) disposables: IDisposableRegistry) {

--- a/src/webviews/extension-side/serviceRegistry.node.ts
+++ b/src/webviews/extension-side/serviceRegistry.node.ts
@@ -16,7 +16,6 @@ import {
     IJupyterVariableDataProvider,
     IJupyterVariableDataProviderFactory
 } from './dataviewer/types';
-// import { ExtensionSideRenderer } from './error-renderer';
 import { IPyWidgetRendererComms } from './ipywidgets/rendererComms';
 import { PlotViewer } from './plotting/plotViewer.node';
 import { PlotViewerProvider } from './plotting/plotViewerProvider';
@@ -60,10 +59,6 @@ export function registerTypes(serviceManager: IServiceManager) {
         IExtensionSyncActivationService,
         VariableViewActivationService
     );
-    // serviceManager.addSingleton<IExtensionSyncActivationService>(
-    //     IExtensionSyncActivationService,
-    //     ExtensionSideRenderer
-    // );
     serviceManager.addSingleton<IExtensionSyncActivationService>(
         IExtensionSyncActivationService,
         IPyWidgetRendererComms

--- a/src/webviews/extension-side/serviceRegistry.node.ts
+++ b/src/webviews/extension-side/serviceRegistry.node.ts
@@ -16,7 +16,7 @@ import {
     IJupyterVariableDataProvider,
     IJupyterVariableDataProviderFactory
 } from './dataviewer/types';
-import { ExtensionSideRenderer } from './error-renderer';
+// import { ExtensionSideRenderer } from './error-renderer';
 import { IPyWidgetRendererComms } from './ipywidgets/rendererComms';
 import { PlotViewer } from './plotting/plotViewer.node';
 import { PlotViewerProvider } from './plotting/plotViewerProvider';
@@ -60,10 +60,10 @@ export function registerTypes(serviceManager: IServiceManager) {
         IExtensionSyncActivationService,
         VariableViewActivationService
     );
-    serviceManager.addSingleton<IExtensionSyncActivationService>(
-        IExtensionSyncActivationService,
-        ExtensionSideRenderer
-    );
+    // serviceManager.addSingleton<IExtensionSyncActivationService>(
+    //     IExtensionSyncActivationService,
+    //     ExtensionSideRenderer
+    // );
     serviceManager.addSingleton<IExtensionSyncActivationService>(
         IExtensionSyncActivationService,
         IPyWidgetRendererComms

--- a/src/webviews/extension-side/serviceRegistry.web.ts
+++ b/src/webviews/extension-side/serviceRegistry.web.ts
@@ -28,7 +28,6 @@ import { PlotViewHandler } from './plotView/plotViewHandler';
 import { RendererCommunication } from './plotView/rendererCommunication';
 import { IPlotSaveHandler } from './plotView/types';
 import { IPyWidgetRendererComms } from './ipywidgets/rendererComms';
-// import { ExtensionSideRenderer } from './error-renderer';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(
@@ -60,10 +59,6 @@ export function registerTypes(serviceManager: IServiceManager) {
         IExtensionSyncActivationService,
         VariableViewActivationService
     );
-    // serviceManager.addSingleton<IExtensionSyncActivationService>(
-    //     IExtensionSyncActivationService,
-    //     ExtensionSideRenderer
-    // );
     serviceManager.addSingleton<IExtensionSyncActivationService>(
         IExtensionSyncActivationService,
         IPyWidgetRendererComms

--- a/src/webviews/extension-side/serviceRegistry.web.ts
+++ b/src/webviews/extension-side/serviceRegistry.web.ts
@@ -28,7 +28,7 @@ import { PlotViewHandler } from './plotView/plotViewHandler';
 import { RendererCommunication } from './plotView/rendererCommunication';
 import { IPlotSaveHandler } from './plotView/types';
 import { IPyWidgetRendererComms } from './ipywidgets/rendererComms';
-import { ExtensionSideRenderer } from './error-renderer';
+// import { ExtensionSideRenderer } from './error-renderer';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(
@@ -60,10 +60,10 @@ export function registerTypes(serviceManager: IServiceManager) {
         IExtensionSyncActivationService,
         VariableViewActivationService
     );
-    serviceManager.addSingleton<IExtensionSyncActivationService>(
-        IExtensionSyncActivationService,
-        ExtensionSideRenderer
-    );
+    // serviceManager.addSingleton<IExtensionSyncActivationService>(
+    //     IExtensionSyncActivationService,
+    //     ExtensionSideRenderer
+    // );
     serviceManager.addSingleton<IExtensionSyncActivationService>(
         IExtensionSyncActivationService,
         IPyWidgetRendererComms


### PR DESCRIPTION
It will fail all extension tests when the communication channel can not be created.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
