### PR TITLE
:lipstick: protect length mismatch or empty server list.

### DIFF
--- a/src/standalone/userJupyterServer/userServerUrlProvider.ts
+++ b/src/standalone/userJupyterServer/userServerUrlProvider.ts
@@ -153,14 +153,14 @@ export class UserJupyterServerUrlProvider implements IExtensionSyncActivationSer
                 UserJupyterServerUriListKey
             );
 
-            if (!cache || !serverList) {
+            if (!cache || !serverList || serverList.length === 0) {
                 resolve();
                 return;
             }
 
             const encryptedList = cache.split(Settings.JupyterServerRemoteLaunchUriSeparator);
 
-            if (encryptedList.length === 0) {
+            if (encryptedList.length === 0 || encryptedList.length !== serverList.length) {
                 traceError('Invalid server list, unable to retrieve server info');
                 resolve();
                 return;


### PR DESCRIPTION
the update of global memento or encrypted storage is not a transaction so they might be mismatch.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
