### PR TITLE
migrate and organize Interactive window settings 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1580,6 +1580,13 @@
                     "type": "boolean",
                     "default": false,
                     "description": "%jupyter.configuration.jupyter.sendSelectionToInteractiveWindow.description%",
+                    "deprecationMessage": "%jupyter.configuration.jupyter.sendSelectionToInteractiveWindow.deprecationMessage%",
+                    "scope": "resource"
+                },
+                "jupyter.interactiveWindow.textEditor.executeSelection": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%jupyter.configuration.jupyter.sendSelectionToInteractiveWindow.description%",
                     "scope": "resource"
                 },
                 "jupyter.variableExplorerExclude": {
@@ -1592,15 +1599,36 @@
                     "type": "string",
                     "default": "^(#\\s*%%|#\\s*\\<codecell\\>|#\\s*In\\[\\d*?\\]|#\\s*In\\[ \\])",
                     "description": "%jupyter.configuration.jupyter.codeRegularExpression.description%",
+                    "deprecationMessage": "%jupyter.configuration.jupyter.codeRegularExpression.deprecationMessage%",
+                    "scope": "resource"
+                },
+                "jupyter.interactiveWindow.cellMarker.codeRegex": {
+                    "type": "string",
+                    "default": "^(#\\s*%%|#\\s*\\<codecell\\>|#\\s*In\\[\\d*?\\]|#\\s*In\\[ \\])",
+                    "description": "%jupyter.configuration.jupyter.codeRegularExpression.description%",
                     "scope": "resource"
                 },
                 "jupyter.defaultCellMarker": {
                     "type": "string",
                     "default": "# %%",
                     "description": "%jupyter.configuration.jupyter.defaultCellMarker.description%",
+                    "deprecationMessage": "%jupyter.configuration.jupyter.defaultCellMarker.deprecationMessage%",
+                    "scope": "resource"
+                },
+                "jupyter.interactiveWindow.cellMarker.default": {
+                    "type": "string",
+                    "default": "# %%",
+                    "description": "%jupyter.configuration.jupyter.defaultCellMarker.description%",
                     "scope": "resource"
                 },
                 "jupyter.markdownRegularExpression": {
+                    "type": "string",
+                    "default": "^(#\\s*%%\\s*\\[markdown\\]|#\\s*\\<markdowncell\\>)",
+                    "description": "%jupyter.configuration.jupyter.markdownRegularExpression.description%",
+                    "deprecationMessage": "%jupyter.configuration.jupyter.markdownRegularExpression.deprecationMessage%",
+                    "scope": "resource"
+                },
+                "jupyter.interactiveWindow.cellMarker.markdownRegex": {
                     "type": "string",
                     "default": "^(#\\s*%%\\s*\\[markdown\\]|#\\s*\\<markdowncell\\>)",
                     "description": "%jupyter.configuration.jupyter.markdownRegularExpression.description%",
@@ -1621,15 +1649,36 @@
                     "type": "boolean",
                     "default": true,
                     "description": "%jupyter.configuration.jupyter.decorateCells.description%",
+                    "deprecationMessage": "%jupyter.configuration.jupyter.decorateCells.deprecationMessage%",
+                    "scope": "resource"
+                },
+                "jupyter.interactiveWindow.cellMarker.decorateCells": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%jupyter.configuration.jupyter.decorateCells.description%",
                     "scope": "resource"
                 },
                 "jupyter.enableCellCodeLens": {
                     "type": "boolean",
                     "default": true,
                     "description": "%jupyter.configuration.jupyter.enableCellCodeLens.description%",
+                    "deprecationMessage": "%jupyter.configuration.jupyter.enableCellCodeLens.deprecationMessage%",
+                    "scope": "resource"
+                },
+                "jupyter.interactiveWindow.codeLens.enable": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%jupyter.configuration.jupyter.enableCellCodeLens.description%",
                     "scope": "resource"
                 },
                 "jupyter.enableAutoMoveToNextCell": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%jupyter.configuration.jupyter.enableAutoMoveToNextCell.description%",
+                    "deprecationMessage": "%jupyter.configuration.jupyter.enableAutoMoveToNextCell.deprecationMessage%",
+                    "scope": "resource"
+                },
+                "jupyter.interactiveWindow.textEditor.autoMoveToNextCell": {
                     "type": "boolean",
                     "default": true,
                     "description": "%jupyter.configuration.jupyter.enableAutoMoveToNextCell.description%",
@@ -1651,9 +1700,23 @@
                     "type": "string",
                     "default": "jupyter.runcell, jupyter.runallcellsabove, jupyter.debugcell",
                     "description": "%jupyter.configuration.jupyter.codeLenses.description%",
+                    "deprecationMessage": "%jupyter.configuration.jupyter.codeLenses.deprecationMessage%",
+                    "scope": "resource"
+                },
+                "jupyter.interactiveWindow.codeLens.commands": {
+                    "type": "string",
+                    "default": "jupyter.runcell, jupyter.runallcellsabove, jupyter.debugcell",
+                    "description": "%jupyter.configuration.jupyter.codeLenses.description%",
                     "scope": "resource"
                 },
                 "jupyter.debugCodeLenses": {
+                    "type": "string",
+                    "default": "jupyter.debugcontinue, jupyter.debugstop, jupyter.debugstepover",
+                    "description": "%jupyter.configuration.jupyter.debugCodeLenses.description%",
+                    "deprecationMessage": "%jupyter.configuration.jupyter.debugCodeLenses.deprecationMessage%",
+                    "scope": "resource"
+                },
+                "jupyter.interactiveWindow.codeLes.debugCommands": {
                     "type": "string",
                     "default": "jupyter.debugcontinue, jupyter.debugstop, jupyter.debugstepover",
                     "description": "%jupyter.configuration.jupyter.debugCodeLenses.description%",
@@ -1684,6 +1747,13 @@
                     "description": "%jupyter.configuration.jupyter.disableJupyterAutoStart.description%"
                 },
                 "jupyter.addGotoCodeLenses": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%jupyter.configuration.jupyter.addGotoCodeLenses.description%",
+                    "deprecationMessage": "%jupyter.configuration.jupyter.addGotoCodeLenses.description%",
+                    "scope": "resource"
+                },
+                "jupyter.interactiveWindow.codeLens.enableGotoCell": {
                     "type": "boolean",
                     "default": true,
                     "description": "%jupyter.configuration.jupyter.addGotoCodeLenses.description%",
@@ -1763,9 +1833,28 @@
                     ],
                     "scope": "resource",
                     "description": "%jupyter.configuration.jupyter.interactiveWindowMode.description%",
+                    "deprecationMessage": "%jupyter.configuration.jupyter.interactiveWindowMode.deprecationMessage%",
+                    "default": "multiple"
+                },
+                "jupyter.interactiveWindow.creationMode": {
+                    "type": "string",
+                    "enum": [
+                        "perFile",
+                        "single",
+                        "multiple"
+                    ],
+                    "scope": "resource",
+                    "description": "%jupyter.configuration.jupyter.interactiveWindowMode.description%",
                     "default": "multiple"
                 },
                 "jupyter.pythonCellFolding": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%jupyter.configuration.jupyter.pythonCellFolding.description%",
+                    "deprecationMessage": "%jupyter.configuration.jupyter.pythonCellFolding.deprecationMessage%",
+                    "scope": "resource"
+                },
+                "jupyter.interactiveWindow.textEditor.cellFolding": {
                     "type": "boolean",
                     "default": true,
                     "description": "%jupyter.configuration.jupyter.pythonCellFolding.description%",
@@ -1780,9 +1869,27 @@
                     ],
                     "scope": "resource",
                     "description": "%jupyter.configuration.jupyter.interactiveWindowViewColumn.description%",
+                    "deprecationMessage": "%jupyter.configuration.jupyter.interactiveWindowViewColumn.deprecationMessage",
+                    "default": "secondGroup"
+                },
+                "jupyter.interactiveWindow.viewColumn": {
+                    "type": "string",
+                    "enum": [
+                        "beside",
+                        "active",
+                        "secondGroup"
+                    ],
+                    "scope": "resource",
+                    "description": "%jupyter.configuration.jupyter.interactiveWindowViewColumn.description%",
                     "default": "secondGroup"
                 },
                 "jupyter.magicCommandsAsComments": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%jupyter.configuration.jupyter.magicCommandsAsComments.description%",
+                    "deprecationMessage": "%jupyter.configuration.jupyter.magicCommandsAsComments.deprecationMessage%"
+                },
+                "jupyter.interactiveWindow.textEditor.magicCommandsAsComments": {
                     "type": "boolean",
                     "default": false,
                     "description": "%jupyter.configuration.jupyter.magicCommandsAsComments.description%"
@@ -1816,6 +1923,13 @@
                     "description": "%jupyter.configuration.jupyter.showOutlineButtonInNotebookToolbar.description%"
                 },
                 "jupyter.newCellOnRunLast": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%jupyter.configuration.jupyter.newCellOnRunLast.description%",
+                    "deprecationMessage": "%jupyter.configuration.jupyter.newCellOnRunLast.deprecationMessage%",
+                    "scope": "resource"
+                },
+                "jupyter.interactiveWindow.textEditor.autoAddNewCell": {
                     "type": "boolean",
                     "default": true,
                     "description": "%jupyter.configuration.jupyter.newCellOnRunLast.description%",

--- a/package.json
+++ b/package.json
@@ -1750,7 +1750,7 @@
                     "type": "boolean",
                     "default": true,
                     "description": "%jupyter.configuration.jupyter.addGotoCodeLenses.description%",
-                    "deprecationMessage": "%jupyter.configuration.jupyter.addGotoCodeLenses.description%",
+                    "deprecationMessage": "%jupyter.configuration.jupyter.addGotoCodeLenses.deprecationMessage%",
                     "scope": "resource"
                 },
                 "jupyter.interactiveWindow.codeLens.enableGotoCell": {
@@ -1869,7 +1869,7 @@
                     ],
                     "scope": "resource",
                     "description": "%jupyter.configuration.jupyter.interactiveWindowViewColumn.description%",
-                    "deprecationMessage": "%jupyter.configuration.jupyter.interactiveWindowViewColumn.deprecationMessage",
+                    "deprecationMessage": "%jupyter.configuration.jupyter.interactiveWindowViewColumn.deprecationMessage%",
                     "default": "secondGroup"
                 },
                 "jupyter.interactiveWindow.viewColumn": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -175,7 +175,7 @@
     "jupyter.configuration.jupyter.notebookFileRoot.description": "Set the root directory for running notebooks and the Interactive window.",
     "jupyter.configuration.jupyter.searchForJupyter.deprecationMessage": "This setting is deprecated and will be removed in a future release.",
     "jupyter.configuration.jupyter.searchForJupyter.description": "Search all installed Python interpreters for a Jupyter installation when starting the Interactive window",
-    "jupyter.configuration.jupyter.useDefaultConfigForJupyter.description": "When running Jupyter locally, create a default empty Jupyter config for the Interactive window",
+    "jupyter.configuration.jupyter.useDefaultConfigForJupyter.description": "When running Jupyter locally, create a default empty Jupyter config",
     "jupyter.configuration.jupyter.jupyterInterruptTimeout.description": "Amount of time (in ms) to wait for an interrupt before asking to restart the Jupyter kernel.",
     "jupyter.configuration.jupyter.sendSelectionToInteractiveWindow.description": "When pressing shift+enter, send selected code in a Python file to the Jupyter interactive window as opposed to the Python terminal.",
     "jupyter.configuration.jupyter.variableExplorerExclude.description": "Types to exclude from showing in the Interactive variable explorer",

--- a/package.nls.json
+++ b/package.nls.json
@@ -178,21 +178,30 @@
     "jupyter.configuration.jupyter.useDefaultConfigForJupyter.description": "When running Jupyter locally, create a default empty Jupyter config",
     "jupyter.configuration.jupyter.jupyterInterruptTimeout.description": "Amount of time (in ms) to wait for an interrupt before asking to restart the Jupyter kernel.",
     "jupyter.configuration.jupyter.sendSelectionToInteractiveWindow.description": "When pressing shift+enter, send selected code in a Python file to the Jupyter interactive window as opposed to the Python terminal.",
+    "jupyter.configuration.jupyter.sendSelectionToInteractiveWindow.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.textEditor.executeSelection.",
     "jupyter.configuration.jupyter.variableExplorerExclude.description": "Types to exclude from showing in the Interactive variable explorer",
     "jupyter.configuration.jupyter.codeRegularExpression.description": "Regular expression used to identify code cells. All code until the next match is considered part of this cell.",
+    "jupyter.configuration.jupyter.codeRegularExpression.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.cellMarker.codeRegex.",
     "jupyter.configuration.jupyter.defaultCellMarker.description": "Cell marker used for delineating a cell in a python file.",
+    "jupyter.configuration.jupyter.defaultCellMarker.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.cellMarker.default",
     "jupyter.configuration.jupyter.markdownRegularExpression.description": "Regular expression used to identify markdown cells. All comments after this expression are considered part of the markdown.",
+    "jupyter.configuration.jupyter.markdownRegularExpression.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.cellMarker.markdownRegex.",
     "jupyter.configuration.jupyter.ignoreVscodeTheme.deprecationMessage": "This setting is deprecated and will be removed in the next release.",
     "jupyter.configuration.jupyter.ignoreVscodeTheme.description": "Don't use the VS Code theme in the Interactive window (requires reload of VS Code). This forces the Interactive window to use 'Light +(default light)' and disables matplotlib defaults.",
     "jupyter.configuration.jupyter.themeMatplotlibPlots.description": "In the Interactive window and Notebook Editor theme matplotlib outputs to match the VS Code editor theme.",
     "jupyter.configuration.jupyter.decorateCells.description": "Draw a highlight behind the currently active cell.",
+    "jupyter.configuration.jupyter.decorateCells.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.cellMarker.decorateCells.",
     "jupyter.configuration.jupyter.enableCellCodeLens.description": "Enables code lens for 'cells' in a python file.",
+    "jupyter.configuration.jupyter.enableCellCodeLens.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.codeLens.enable.",
     "jupyter.configuration.jupyter.enableAutoMoveToNextCell.description": "Enables moving to the next cell when clicking on a 'Run Cell' code lens.",
+    "jupyter.configuration.jupyter.enableAutoMoveToNextCell.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.textEditor.autoMoveToNextCell.",
     "jupyter.configuration.jupyter.allowUnauthorizedRemoteConnection.description": "Allow for connecting the Interactive window to a https Jupyter server that does not have valid certificates. This can be a security risk, so only use for known and trusted servers.",
     "jupyter.configuration.jupyter.generateSVGPlots.description": "Generate SVG output for notebook plots. This allows for better display in the plot viewer at the cost of generation speed and file size.",
     "jupyter.configuration.jupyter.generateSVGPlots.deprecationMessage": "This setting is deprecated and will be removed in the next release.",
     "jupyter.configuration.jupyter.codeLenses.description": "Set of commands to put as code lens above a cell.",
+    "jupyter.configuration.jupyter.codeLenses.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.codeLens.commands.",
     "jupyter.configuration.jupyter.debugCodeLenses.description": "Set of debug commands to put as code lens above a cell while debugging.",
+    "jupyter.configuration.jupyter.debugCodeLenses.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.codeLes.debugCommands.",
     "jupyter.configuration.jupyter.debugpyDistPath.description": "Path to debugpy bits for debugging cells.",
     "jupyter.configuration.jupyter.stopOnFirstLineWhileDebugging.description": "When debugging a cell, stop on the first line.",
     "jupyter.configuration.jupyter.remoteDebuggerPort.description": "When debugging a cell, open this port on the remote box. If -1 is specified, a random port between 8889 and 9000 will be attempted.",
@@ -204,6 +213,7 @@
             "{Locked='Goto'}"
         ]
     },
+    "jupyter.configuration.jupyter.addGotoCodeLenses.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.codeLens.enableGotoCell.",
     "jupyter.configuration.jupyter.variableQueries.markdownDescription": {
         "message": "Language to query mapping for returning the list of active variables in a Jupyter kernel. Used by the Variable Explorer in both the Interactive Window and Notebooks. Example:\n```\n[\n  {\n    \"language\": \"python\",\n    \"query\": \"%who_ls\",\n    \"parseExpr\": \"'(\\\\w+)'\"\n  }\n]\n```",
         "comment": [
@@ -221,7 +231,9 @@
             "{Locked=\"'multiple'\"}"
         ]
     },
+    "jupyter.configuration.jupyter.interactiveWindowMode.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.creationMode.",
     "jupyter.configuration.jupyter.pythonCellFolding.description": "Enable folding regions for code cells in Python files. This setting requires a reload of VS Code.",
+    "jupyter.configuration.jupyter.pythonCellFolding.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.textEditor.cellFolding.",
     "jupyter.configuration.jupyter.interactiveWindowViewColumn.description": {
         "message": "Where to open an Interactive Window that is not associated with a python file. 'beside' will open the interactive window to the right of the active editor. 'active' will open the interactive window in place of the active editor. 'secondGroup' will open the interactive window in the second editor group.",
         "comment": [
@@ -230,7 +242,9 @@
             "{Locked=\"'secondGroup'\"}"
         ]
     },
+    "jupyter.configuration.jupyter.interactiveWindowViewColumn.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.viewColumn.",
     "jupyter.configuration.jupyter.magicCommandsAsComments.description": "Uncomment shell assignments (#!), line magic (#!%) and cell magic (#!%%) when parsing code cells.",
+    "jupyter.configuration.jupyter.magicCommandsAsComments.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.textEditor.magicCommandsAsComments.",
     "jupyter.configuration.jupyter.pythonExportMethod.description": {
         "message": "The method to use when exporting a notebook to a Python file. 'direct' will copy over the code directly as is. 'commentMagics' will comment out lines starting with line magics (%), cell magics (%%), and shell commands(!). 'nbconvert' will install nbconvert and use that for the conversion which can translate iPython syntax into Python syntax.",
         "comment": [
@@ -248,6 +262,7 @@
     "jupyter.configuration.jupyter.debugJustMyCode.description": "When debugging, only step through user-written code. Disable this to allow stepping into library code.",
     "jupyter.configuration.jupyter.showOutlineButtonInNotebookToolbar.description": "Show the Outline button in the Jupyter notebook toolbar.",
     "jupyter.configuration.jupyter.newCellOnRunLast.description": "Append a new empty cell to an interactive window file on running the currently last cell.",
+    "jupyter.configuration.jupyter.newCellOnRunLast.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.textEditor.autoAddNewCell.",
     "jupyter.configuration.jupyter.pythonCompletionTriggerCharacters.description": "Characters which trigger auto completion on a python jupyter kernel.",
     "jupyter.configuration.jupyter.logKernelOutputSeparately.description": "Creates separate output panels for kernels/jupyter server console output",
     "jupyter.configuration.jupyter.excludeUserSitePackages.description": {

--- a/src/interactive-window/interactiveWindowProvider.ts
+++ b/src/interactive-window/interactiveWindowProvider.ts
@@ -320,7 +320,7 @@ export class InteractiveWindowProvider
                 result = 'perFile';
                 this._windows[0].changeMode(result);
                 await this.configService.updateSetting(
-                    'interactiveWindowMode',
+                    'interactiveWindow.creationMode',
                     result,
                     resource,
                     ConfigurationTarget.Global

--- a/src/interactive-window/shiftEnterBanner.ts
+++ b/src/interactive-window/shiftEnterBanner.ts
@@ -93,7 +93,7 @@ export class InteractiveShiftEnterBanner implements IJupyterExtensionBanner {
     @captureUsageTelemetry(Telemetry.DisableInteractiveShiftEnter)
     public async disableInteractiveShiftEnter(): Promise<void> {
         await this.configuration.updateSetting(
-            'sendSelectionToInteractiveWindow',
+            'interactiveWindow.textEditor.executeSelection',
             false,
             undefined,
             ConfigurationTarget.Global
@@ -104,7 +104,7 @@ export class InteractiveShiftEnterBanner implements IJupyterExtensionBanner {
     @captureUsageTelemetry(Telemetry.EnableInteractiveShiftEnter)
     public async enableInteractiveShiftEnter(): Promise<void> {
         await this.configuration.updateSetting(
-            'sendSelectionToInteractiveWindow',
+            'interactiveWindow.textEditor.executeSelection',
             true,
             undefined,
             ConfigurationTarget.Global

--- a/src/platform/common/configMigration.ts
+++ b/src/platform/common/configMigration.ts
@@ -5,8 +5,6 @@ import { ConfigurationTarget, WorkspaceConfiguration } from 'vscode';
 import { traceWarning } from '../logging';
 
 export class ConfigMigration {
-    constructor(private readonly config: WorkspaceConfiguration) {}
-
     // old setting name: new setting name
     // omit the jupyter. prefix
     public static readonly migratedSettings: Record<string, string> = {
@@ -30,6 +28,8 @@ export class ConfigMigration {
         defaultCellMarker: 'interactiveWindow.cellMarker.default'
     };
 
+    constructor(private readonly jupyterConfig: WorkspaceConfiguration) {}
+
     public async migrateSettings() {
         for (let prop of Object.keys(ConfigMigration.migratedSettings)) {
             await this.migrateSetting(prop, ConfigMigration.migratedSettings[prop]);
@@ -37,31 +37,35 @@ export class ConfigMigration {
     }
 
     private async migrateSetting(oldSetting: string, newSetting: string) {
-        const oldDetails = this.config.inspect(oldSetting);
-        const newDetails = this.config.inspect(newSetting);
+        const oldDetails = this.jupyterConfig.inspect(oldSetting);
+        const newDetails = this.jupyterConfig.inspect(newSetting);
 
         try {
             if (oldDetails?.workspaceValue !== undefined) {
                 if (newDetails?.workspaceValue === undefined) {
-                    await this.config.update(newSetting, oldDetails.workspaceValue, ConfigurationTarget.Workspace);
+                    await this.jupyterConfig.update(
+                        newSetting,
+                        oldDetails.workspaceValue,
+                        ConfigurationTarget.Workspace
+                    );
                 }
-                await this.config.update(oldSetting, undefined, ConfigurationTarget.Workspace);
+                await this.jupyterConfig.update(oldSetting, undefined, ConfigurationTarget.Workspace);
             }
             if (oldDetails?.workspaceFolderValue !== undefined) {
                 if (newDetails?.workspaceFolderValue === undefined) {
-                    await this.config.update(
+                    await this.jupyterConfig.update(
                         newSetting,
                         oldDetails.workspaceFolderValue,
                         ConfigurationTarget.WorkspaceFolder
                     );
                 }
-                await this.config.update(oldSetting, undefined, ConfigurationTarget.WorkspaceFolder);
+                await this.jupyterConfig.update(oldSetting, undefined, ConfigurationTarget.WorkspaceFolder);
             }
             if (oldDetails?.globalValue !== undefined) {
                 if (newDetails?.globalValue === undefined) {
-                    await this.config.update(newSetting, oldDetails.globalValue, ConfigurationTarget.Global);
+                    await this.jupyterConfig.update(newSetting, oldDetails.globalValue, ConfigurationTarget.Global);
                 }
-                await this.config.update(oldSetting, undefined, ConfigurationTarget.Global);
+                await this.jupyterConfig.update(oldSetting, undefined, ConfigurationTarget.Global);
             }
         } catch (e) {
             traceWarning('Error migrating Jupyter configurations', e);

--- a/src/platform/common/configMigration.ts
+++ b/src/platform/common/configMigration.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ConfigurationTarget, WorkspaceConfiguration } from 'vscode';
+
+export class ConfigMigration {
+    constructor(private readonly config: WorkspaceConfiguration) {}
+
+    public async migrateSetting(oldSetting: string, newSetting: string) {
+        const oldDetails = this.config.inspect(oldSetting);
+        const newDetails = this.config.inspect(newSetting);
+
+        if (oldDetails?.workspaceValue) {
+            if (newDetails?.workspaceValue) {
+                await this.config.update(newSetting, oldDetails.workspaceValue, ConfigurationTarget.Workspace);
+            }
+            await this.config.update(oldSetting, undefined, ConfigurationTarget.Workspace);
+        }
+        if (oldDetails?.workspaceFolderValue) {
+            if (newDetails?.workspaceFolderValue) {
+                await this.config.update(newSetting, oldDetails.workspaceValue, ConfigurationTarget.WorkspaceFolder);
+            }
+            await this.config.update(oldSetting, undefined, ConfigurationTarget.WorkspaceFolder);
+        }
+        if (oldDetails?.globalValue) {
+            if (newDetails?.globalValue) {
+                await this.config.update(newSetting, oldDetails.workspaceValue, ConfigurationTarget.Global);
+            }
+            await this.config.update(oldSetting, undefined, ConfigurationTarget.Global);
+        }
+    }
+}

--- a/src/platform/common/configSettings.ts
+++ b/src/platform/common/configSettings.ts
@@ -133,7 +133,6 @@ export class JupyterSettings implements IWatchableJupyterSettings {
         let settings = JupyterSettings.jupyterSettings.get(workspaceFolderKey);
         if (!settings) {
             settings = new JupyterSettings(workspaceFolderUri, systemVariablesCtor, type, workspace);
-            settings.initialize();
             JupyterSettings.jupyterSettings.set(workspaceFolderKey, settings);
         } else if (settings._type === 'web' && type === 'node') {
             // Update to a node system variables if anybody every asks for a node one after
@@ -217,7 +216,7 @@ export class JupyterSettings implements IWatchableJupyterSettings {
         // The rest are all the same.
         const replacer = (k: string, config: WorkspaceConfiguration) => {
             const newKey = ConfigMigration.migratedSettings[k];
-            // Replace variables with their actual value.
+            // Configuration migration is asyncronous, so check the old configuration key if the new one isn't set
             const configValue = newKey && config.get(newKey) !== undefined ? config.get(newKey) : config.get(k);
             const val = systemVariables.resolveAny(configValue);
             if (k !== 'variableTooltipFields' || val) {

--- a/src/standalone/activation/globalActivation.ts
+++ b/src/standalone/activation/globalActivation.ts
@@ -124,7 +124,7 @@ export class GlobalActivation implements IExtensionSyncActivationService {
                 if (typeof currentValue === 'function') {
                     continue;
                 }
-                if (typeof currentValue === 'string' && k !== 'interactiveWindowMode') {
+                if (typeof currentValue === 'string' && k !== 'interactiveWindow.creationMode') {
                     const inspectResult = jupyterConfig.inspect<string>(`${k}`);
                     if (inspectResult && inspectResult.defaultValue !== currentValue) {
                         resultSettings[k] = 'non-default';

--- a/src/test/datascience/.vscode/settings.json
+++ b/src/test/datascience/.vscode/settings.json
@@ -26,8 +26,6 @@
     "jupyter.logging.level": "verbose",
     "python.logging.level": "debug",
     "webview.experimental.useIframes": true,
-    "jupyter.interactiveWindowMode": "multiple",
-    "jupyter.magicCommandsAsComments": false,
     // Python experiments have to be on for insiders to work
     "python.experiments.enabled": true,
     "jupyter.generateSVGPlots": false,
@@ -37,5 +35,7 @@
     "task.problemMatchers.neverPrompt": {
         "shell": true,
         "npm": true
-    }
+    },
+    "jupyter.interactiveWindow.creationMode": "multiple",
+    "jupyter.interactiveWindow.textEditor.magicCommandsAsComments": false,
 }

--- a/src/test/datascience/interactiveWindow.vscode.common.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.common.test.ts
@@ -79,7 +79,7 @@ suite(`Interactive window execution @iw`, async function () {
         await closeNotebooksAndCleanUpAfterTests(disposables);
         // restore the default value
         const settings = vscode.workspace.getConfiguration('jupyter', null);
-        await settings.update('interactiveWindowMode', 'multiple');
+        await settings.update('interactiveWindow.creationMode', 'multiple');
         traceInfo(`Ended Test (completed) ${this.currentTest?.title}`);
     });
     test.skip('__file__ exists even after restarting a kernel', async function () {
@@ -218,7 +218,7 @@ suite(`Interactive window execution @iw`, async function () {
 
     test('Multiple interactive windows', async () => {
         const settings = vscode.workspace.getConfiguration('jupyter', null);
-        await settings.update('interactiveWindowMode', 'multiple');
+        await settings.update('interactiveWindow.creationMode', 'multiple');
         const window1 = await interactiveWindowProvider.getOrCreate(undefined);
         const window2 = await interactiveWindowProvider.getOrCreate(undefined);
         assert.notEqual(
@@ -389,7 +389,7 @@ ${actualCode}
 
     test('Error stack traces have correct line hrefs with mix of cell sources', async function () {
         const settings = vscode.workspace.getConfiguration('jupyter', null);
-        await settings.update('interactiveWindowMode', 'single');
+        await settings.update('interactiveWindow.creationMode', 'single');
 
         const interactiveWindow = await createStandaloneInteractiveWindow(interactiveWindowProvider);
         await runInteractiveWindowInput('print(1)', interactiveWindow, 1);
@@ -559,7 +559,7 @@ ${actualCode}
         let runFilePromise = vscode.commands.executeCommand(Commands.RunFileInInteractiveWindows);
 
         const settings = vscode.workspace.getConfiguration('jupyter', null);
-        const mode = (await settings.get('interactiveWindowMode')) as InteractiveWindowMode;
+        const mode = (await settings.get('interactiveWindow.creationMode')) as InteractiveWindowMode;
         const interactiveWindow = interactiveWindowProvider.getExisting(tempFile.file, mode) as InteractiveWindow;
         await runInteractiveWindowInput('x = 5', interactiveWindow, 5);
         await runFilePromise;

--- a/src/test/datascience/shiftEnterBanner.unit.test.ts
+++ b/src/test/datascience/shiftEnterBanner.unit.test.ts
@@ -23,7 +23,7 @@ import {
 } from '../../platform/common/types';
 import { clearTelemetryReporter } from '../../telemetry';
 
-suite.only('Interactive Shift Enter Banner', () => {
+suite('Interactive Shift Enter Banner', () => {
     const oldValueOfVSC_JUPYTER_UNIT_TEST = isUnitTestExecution();
     const oldValueOfVSC_JUPYTER_CI_TEST = isTestExecution();
     let appShell: typemoq.IMock<IApplicationShell>;

--- a/src/test/datascience/shiftEnterBanner.unit.test.ts
+++ b/src/test/datascience/shiftEnterBanner.unit.test.ts
@@ -23,7 +23,7 @@ import {
 } from '../../platform/common/types';
 import { clearTelemetryReporter } from '../../telemetry';
 
-suite('Interactive Shift Enter Banner', () => {
+suite.only('Interactive Shift Enter Banner', () => {
     const oldValueOfVSC_JUPYTER_UNIT_TEST = isUnitTestExecution();
     const oldValueOfVSC_JUPYTER_CI_TEST = isTestExecution();
     let appShell: typemoq.IMock<IApplicationShell>;
@@ -157,7 +157,7 @@ function loadBanner(
     config
         .setup((c) =>
             c.updateSetting(
-                typemoq.It.isValue('sendSelectionToInteractiveWindow'),
+                typemoq.It.isValue('interactiveWindow.textEditor.executeSelection'),
                 typemoq.It.isAny(),
                 typemoq.It.isAny(),
                 typemoq.It.isAny()


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-jupyter/issues/12393

- Changed the configuration keys for IW settings, putting them in the Interactive Window section
- migrate the old setting names to the more descriptive ones, keeping the same scope.
- Still check the old setting name when retrieving settings since the migration is asynchronous, and reading a setting value is not