### PR TITLE
Ensure getSuggestedController always calculates on all kernel picker types.

### DIFF
--- a/src/kernels/jupyter/finder/remoteKernelFinder.ts
+++ b/src/kernels/jupyter/finder/remoteKernelFinder.ts
@@ -293,7 +293,6 @@ export class RemoteKernelFinder implements IRemoteKernelFinder, IDisposable {
                     results = values.kernels.map((item) =>
                         BaseKernelConnectionMetadata.fromJSON(item)
                     ) as RemoteKernelConnectionMetadata[];
-                    this.cache = results;
                 }
             }
 

--- a/src/standalone/api/api.ts
+++ b/src/standalone/api/api.ts
@@ -14,12 +14,13 @@ import { IDataViewerDataProvider, IDataViewerFactory } from '../../webviews/exte
 import { IExportedKernelService } from './extension';
 import { IPythonApiProvider, PythonApi } from '../../platform/api/types';
 import { isTestExecution, Telemetry } from '../../platform/common/constants';
-import { IExtensionContext, IExtensions } from '../../platform/common/types';
+import { IExtensionContext, IExtensions, IFeaturesManager } from '../../platform/common/types';
 import { IServiceContainer, IServiceManager } from '../../platform/ioc/types';
 import { traceError } from '../../platform/logging';
 import { IControllerPreferredService, IControllerRegistration } from '../../notebooks/controllers/types';
 import { sendTelemetryEvent } from '../../telemetry';
 import { noop } from '../../platform/common/utils/misc';
+import { ControllerPreferredService } from '../../notebooks/controllers/controllerPreferredService';
 
 export const IExportedKernelServiceFactory = Symbol('IExportedKernelServiceFactory');
 export interface IExportedKernelServiceFactory {
@@ -148,11 +149,19 @@ export function buildApi(
             notebook: NotebookDocument
         ) => {
             sendApiUsageTelemetry(extensions, 'getSuggestedController');
-            const controllers = serviceContainer.get<IControllerPreferredService>(IControllerPreferredService);
             const controllerRegistration = serviceContainer.get<IControllerRegistration>(IControllerRegistration);
             const connection = serviceContainer.get<JupyterConnection>(JupyterConnection);
             const uri = generateUriFromRemoteProvider(providerId, handle);
             const serverId = await computeServerId(uri);
+            const featuresManager = serviceContainer.get<IFeaturesManager>(IFeaturesManager);
+            const preferredService =
+                featuresManager.features.kernelPickerType === 'Stable'
+                    ? serviceContainer.get<IControllerPreferredService>(IControllerPreferredService)
+                    : (() => {
+                          const service = serviceContainer.get<ControllerPreferredService>(ControllerPreferredService);
+                          service.activate();
+                          return service;
+                      })();
 
             if (
                 controllerRegistration.all.find(
@@ -164,7 +173,7 @@ export function buildApi(
             ) {
                 // initial kernel detection finished already
                 await connection.updateServerUri(uri);
-                const { controller } = await controllers.computePreferred(notebook, serverId);
+                const { controller } = await preferredService.computePreferred(notebook, serverId);
                 return controller?.controller;
             } else {
                 // initial kernel detection didn't finish yet, wait for the first set of kernels to be registered
@@ -175,7 +184,7 @@ export function buildApi(
 
                 await connection.updateServerUri(uri);
                 await controllerCreatedPromise;
-                const { controller } = await controllers.computePreferred(notebook, serverId);
+                const { controller } = await preferredService.computePreferred(notebook, serverId);
                 return controller?.controller;
             }
         },
@@ -202,7 +211,7 @@ export function buildApi(
                             (metadata.kind === 'connectToLiveRemoteKernel' ||
                                 metadata.kind === 'startUsingRemoteKernelSpec') &&
                             metadata.serverId === serverId
-                    ) === undefined
+                    ) !== undefined
                 ) {
                     resolve();
                     return;


### PR DESCRIPTION
Fixes a few hidden bugs:

* Make sure we don't update cache without broadcasting events in remote kernel finder
* Make sure that we wait for controllers creation for remote jupyter server, when calling `addRemoteServer`
* Make sure we can calculate suggested controller no matter if we are using MRU kernel picker.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
