### PR TITLE
Fix #12859. Allow user filter kernels in MRU.

### DIFF
--- a/src/notebooks/controllers/kernelSource/notebookKernelSourceSelector.ts
+++ b/src/notebooks/controllers/kernelSource/notebookKernelSourceSelector.ts
@@ -42,6 +42,7 @@ import {
     MultiStepInput
 } from '../../../platform/common/utils/multiStepInput';
 import { ServiceContainer } from '../../../platform/ioc/container';
+import { KernelFilterService } from '../kernelFilter/kernelFilterService';
 import { INotebookKernelSourceSelector } from '../types';
 import { CreateAndSelectItemFromQuickPick, KernelSelector } from './kernelSelector';
 import { QuickPickKernelItemProvider } from './quickPickKernelItemProvider';
@@ -82,6 +83,7 @@ export class NotebookKernelSourceSelector implements INotebookKernelSourceSelect
         private readonly uriProviderRegistration: IJupyterUriProviderRegistration,
         @inject(IJupyterServerUriStorage) private readonly serverUriStorage: IJupyterServerUriStorage,
         @inject(JupyterServerSelector) private readonly serverSelector: JupyterServerSelector,
+        @inject(KernelFilterService) private readonly kernelFilter: KernelFilterService,
         @inject(IWorkspaceService) private readonly workspace: IWorkspaceService
     ) {}
     public async selectLocalKernel(
@@ -362,7 +364,8 @@ export class NotebookKernelSourceSelector implements INotebookKernelSourceSelect
         const provider = new QuickPickKernelItemProvider(
             state.notebook,
             ContributedKernelFinderKind.Remote,
-            finderPromise
+            finderPromise,
+            this.kernelFilter
         );
         provider.status = 'discovering';
         state.disposables.push(provider);
@@ -376,7 +379,7 @@ export class NotebookKernelSourceSelector implements INotebookKernelSourceSelect
         state: MultiStepResult
     ) {
         state.source = source;
-        const provider = new QuickPickKernelItemProvider(state.notebook, source.kind, source);
+        const provider = new QuickPickKernelItemProvider(state.notebook, source.kind, source, this.kernelFilter);
         state.disposables.push(provider);
         return this.selectKernel(provider, token, multiStep, state);
     }

--- a/src/notebooks/controllers/kernelSource/quicPickKernelItemProvider.unit.test.ts
+++ b/src/notebooks/controllers/kernelSource/quicPickKernelItemProvider.unit.test.ts
@@ -3,7 +3,7 @@
 
 import { assert } from 'chai';
 import * as fakeTimers from '@sinonjs/fake-timers';
-import { instance, mock, verify, when } from 'ts-mockito';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { Disposable, EventEmitter, NotebookDocument } from 'vscode';
 import { ContributedKernelFinderKind, IContributedKernelFinder } from '../../../kernels/internalTypes';
 import { IDisposable } from '../../../platform/common/types';
@@ -12,6 +12,7 @@ import { QuickPickKernelItemProvider } from './quickPickKernelItemProvider';
 import { disposeAllDisposables } from '../../../platform/common/helpers';
 import { KernelConnectionMetadata } from '../../../kernels/types';
 import { noop } from '../../../platform/common/utils/misc';
+import { KernelFilterService } from '../kernelFilter/kernelFilterService';
 
 suite('Quick Pick Kernel Item Provider', () => {
     [
@@ -27,6 +28,8 @@ suite('Quick Pick Kernel Item Provider', () => {
             let onDidChangeStatus: EventEmitter<void>;
             const disposables: IDisposable[] = [];
             let clock: fakeTimers.InstalledClock;
+            const kernelFilter = mock<KernelFilterService>();
+            when(kernelFilter.isKernelHidden(anything())).thenReturn(false);
             const kernelConnection1 = instance(mock<KernelConnectionMetadata>());
             const kernelConnection2 = instance(mock<KernelConnectionMetadata>());
             const kernelConnection3 = instance(mock<KernelConnectionMetadata>());
@@ -64,7 +67,8 @@ suite('Quick Pick Kernel Item Provider', () => {
                 provider = new QuickPickKernelItemProvider(
                     instance(notebook),
                     kind,
-                    kind === ContributedKernelFinderKind.Remote ? Promise.resolve(instance(finder)) : instance(finder)
+                    kind === ContributedKernelFinderKind.Remote ? Promise.resolve(instance(finder)) : instance(finder),
+                    instance(kernelFilter)
                 );
             }
             teardown(() => disposeAllDisposables(disposables));


### PR DESCRIPTION
Fixes #12859

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
