### PR TITLE
Re-query interpreter list after workspace is trusted

### DIFF
--- a/src/platform/api/pythonApi.ts
+++ b/src/platform/api/pythonApi.ts
@@ -396,9 +396,7 @@ export class InterpreterService implements IInterpreterService {
             this.status = this.refreshPromises.isComplete ? 'idle' : 'refreshing';
         });
         this.workspace.onDidGrantWorkspaceTrust(
-            () => {
-                this.populateCachedListOfInterpreters(true).catch(noop);
-            },
+            () => this.populateCachedListOfInterpreters(true).catch(noop),
             this,
             this.disposables
         );

--- a/src/platform/api/pythonApi.ts
+++ b/src/platform/api/pythonApi.ts
@@ -395,9 +395,13 @@ export class InterpreterService implements IInterpreterService {
         this.refreshPromises.onStateChange(() => {
             this.status = this.refreshPromises.isComplete ? 'idle' : 'refreshing';
         });
-        this.workspace.onDidGrantWorkspaceTrust(() => {
-            this.populateCachedListOfInterpreters(true).catch(noop);
-        }, this, this.disposables)
+        this.workspace.onDidGrantWorkspaceTrust(
+            () => {
+                this.populateCachedListOfInterpreters(true).catch(noop);
+            },
+            this,
+            this.disposables
+        );
     }
     public get onDidChangeInterpreter(): Event<void> {
         this.hookupOnDidChangeInterpreterEvent();

--- a/src/platform/api/pythonApi.ts
+++ b/src/platform/api/pythonApi.ts
@@ -395,6 +395,9 @@ export class InterpreterService implements IInterpreterService {
         this.refreshPromises.onStateChange(() => {
             this.status = this.refreshPromises.isComplete ? 'idle' : 'refreshing';
         });
+        this.workspace.onDidGrantWorkspaceTrust(() => {
+            this.populateCachedListOfInterpreters(true).catch(noop);
+        }, this, this.disposables)
     }
     public get onDidChangeInterpreter(): Event<void> {
         this.hookupOnDidChangeInterpreterEvent();


### PR DESCRIPTION
Fixes #12661