### PR TITLE
Exclude python from path

### DIFF
--- a/src/platform/common/process/globalPythonSiteService.node.ts
+++ b/src/platform/common/process/globalPythonSiteService.node.ts
@@ -69,7 +69,7 @@ export class GlobalPythonSiteService {
             let sitePath = Uri.file(output);
             if (this.platform.isWindows) {
                 sitePath = Uri.file(path.join(path.dirname(sitePath.fsPath), 'Scripts'));
-            } else if (sitePath.fsPath.endsWith('lib/python/site-packages')) {
+            } else if (sitePath.fsPath.endsWith('site-packages')) {
                 sitePath = Uri.file(path.join(path.dirname(path.dirname(path.dirname(sitePath.fsPath))), 'bin'));
             }
             if (!this.fs.exists(sitePath)) {


### PR DESCRIPTION
For #12808 (more details here https://github.com/microsoft/vscode-jupyter/issues/12632)
Basically we are looking for path `lib/python/site-packages` however if the version of Pytohn is 3.10, then the path could be `lib/python310/site-packages`, hence the change is to stop looking for `lib/python` and just look for `site-packages`

Without this fix, users might not be able to start any kernel on Linux in some cases (see the affected user below).

**This is a very safe fix, and only affects users**
* with machines where zmq is not supported (few)
* only unix machines
* & only global python environments (not virtual environments,. not conda, )


