### PR TITLE
Replace deprecated `set-output` github

### DIFF
--- a/.github/actions/set-python-conda/action.yml
+++ b/.github/actions/set-python-conda/action.yml
@@ -20,7 +20,7 @@ runs:
       id: python_run
       # Use `bash -l {0}` when using the conda actions.
       shell: bash -l {0}
-      run: python -c "import sys;print('::set-output name=python_path::' + sys.executable)"
+      run: python -c "import sys;print('python_path=' + sys.executable)" >> $GITHUB_OUTPUT
 
     - name: Push to environment
       # Use `bash -l {0}` when using the conda actions.

--- a/.github/actions/set-python/action.yml
+++ b/.github/actions/set-python/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Output python path
       id: python_run
       shell: bash
-      run: python -c "import sys;print('::set-output name=python_path::' + sys.executable)"
+      run: python -c "import sys;print('python_path=' + sys.executable)" >> $GITHUB_OUTPUT
 
     - name: Push to environment
       shell: bash

--- a/.github/workflows/assignIssue.yml
+++ b/.github/workflows/assignIssue.yml
@@ -19,7 +19,7 @@ jobs:
         env:
             ISSUE_OWNER: ${{github.event.issue.user.login}}
         run: |
-          echo ::set-output name=result::$(node -p -e "['amunger', 'DonJayamanne', 'minsa110', 'rebornix', 'roblourens', 'kieferrm'].filter(item => process.env.ISSUE_OWNER.toLowerCase() === item.toLowerCase()).length > 0 ? 1 : 0")
+          echo result=$(node -p -e "['amunger', 'DonJayamanne', 'minsa110', 'rebornix', 'roblourens', 'kieferrm'].filter(item => process.env.ISSUE_OWNER.toLowerCase() === item.toLowerCase()).length > 0 ? 1 : 0") >> $GITHUB_OUTPUT
         shell: bash
       - name: Should we proceed
         id: proceed
@@ -28,25 +28,25 @@ jobs:
             ISSUE_ASSIGNEES: ${{toJson(github.event.issue.assignees)}}
             ISSUE_IS_INTERNAL: ${{steps.internal.outputs.result}}
         run: |
-          echo ::set-output name=result::$(node -p -e "process.env.ISSUE_IS_INTERNAL === '0' && JSON.parse(process.env.ISSUE_ASSIGNEES).length === 0 ? 1 : 0")
+          echo result=$(node -p -e "process.env.ISSUE_IS_INTERNAL === '0' && JSON.parse(process.env.ISSUE_ASSIGNEES).length === 0 ? 1 : 0") >> $GITHUB_OUTPUT
         shell: bash
       - name: Day of week
         if: steps.proceed.outputs.result == 1
         id: day
         run: |
-          echo ::set-output name=number::$(node -p -e "new Date().getDay()")
+          echo 'number::$(node -p -e "new Date().getDay()")' >> $GITHUB_OUTPUT
         shell: bash
       - name: Hour of day
         if: steps.proceed.outputs.result == 1
         id: hour
         run: |
-          echo ::set-output name=hour::$(node -p -e "(new Date().getUTCHours() - 7)%24")
+          echo 'hour::$(node -p -e "(new Date().getUTCHours() - 7)%24")' >> $GITHUB_OUTPUT
         shell: bash
       - name: Week Number
         if: steps.proceed.outputs.result == 1
         id: week
         run: |
-          echo ::set-output name=odd::$(node .github/workflows/week.js)
+          echo "odd=$(node .github/workflows/week.js)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Print day and week
         if: steps.proceed.outputs.result == 1

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -222,7 +222,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         id: npm-cache
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - name: Cache npm on windows
         uses: actions/cache@v3
         if: matrix.os == 'windows-latest'
@@ -501,7 +501,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         id: npm-cache
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - name: Cache npm on windows
         uses: actions/cache@v3
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
action command

Fixes #12960

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] Has telemetry for feature-requests.
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
