### PR TITLE
Fix electron 22 crash: update zeromq.

### DIFF
--- a/.github/actions/build-vsix/action.yml
+++ b/.github/actions/build-vsix/action.yml
@@ -10,6 +10,8 @@ runs:
   using: 'composite'
   steps:
     - run: npm ci --prefer-offline
+      env:
+        npm_config_build_from_source: true
       shell: bash
 
     - run: npm run package

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -112,6 +112,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libpango1.0-dev
+
       - name: Use Node ${{env.NODE_VERSION}}
         uses: actions/setup-node@v3
         with:
@@ -233,7 +238,9 @@ jobs:
           key: ${{runner.os}}-${{env.CACHE_OUT_DIRECTORY}}-${{hashFiles('src/**')}}
 
       - name: Install dependencies (npm ci)
-        run: npm ci --prefer-offline
+        run: npm ci --foreground-scripts --prefer-offline
+        env:
+          npm_config_build_from_source: true
 
       - name: Compile if not cached
         run: npm run prePublishNonBundle
@@ -555,7 +562,9 @@ jobs:
 
         # This step is slow.
       - name: Install dependencies (npm ci)
-        run: npm ci --prefer-offline
+        run: npm ci --foreground-scripts --prefer-offline
+        env:
+          npm_config_build_from_source: true
 
       - name: Install screen capture dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -787,7 +796,9 @@ jobs:
           name: 'ms-toolsai-jupyter-insiders.vsix'
 
       - name: Install dependencies (npm ci)
-        run: npm ci --prefer-offline
+        run: npm ci --foreground-scripts --prefer-offline
+        env:
+          npm_config_build_from_source: true
 
       - name: pip install system test requirements
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -120,11 +120,6 @@ jobs:
       - name: Use Npm ${{env.NPM_VERSION}}
         run: npm i -g npm@${{env.NPM_VERSION}}
 
-      - name: Test zeromq installation
-        run: |
-          git clone https://github.com/zeromq/zeromq.js /tmp/zeromq.js
-          cd /tmp/zeromq.js && npm i
-
       - name: Cache pip files
         uses: actions/cache@v3
         with:
@@ -138,7 +133,9 @@ jobs:
           key: ${{runner.os}}-${{env.CACHE_NPM_DEPS}}-${{hashFiles('package-lock.json')}}
 
       - name: Install dependencies (npm ci)
-        run: npm ci --prefer-offline
+        run: npm ci --foreground-scripts --prefer-offline
+        env:
+          npm_config_loglevel: "silly"
 
       - name: Verify Translation files
         run: npm run validateTranslationFiles

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,6 +67,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install dependencies for native modules
+        run: |
+          sudo apt-get update
+          sudo apt-get install libpango1.0-dev libgif-dev
+
       - name: Use Node ${{env.NODE_VERSION}}
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -112,10 +112,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install dependencies
+      - name: Install dependencies for native modules
         run: |
           sudo apt-get update
-          sudo apt-get install libpango1.0-dev
+          sudo apt-get install libpango1.0-dev libgif-dev
 
       - name: Use Node ${{env.NODE_VERSION}}
         uses: actions/setup-node@v3
@@ -196,6 +196,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Install dependencies for native modules
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install libpango1.0-dev libgif-dev
 
       - name: Use Node ${{env.NODE_VERSION}}
         uses: actions/setup-node@v3
@@ -400,6 +406,12 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install -U pip
         if: matrix.python != 'conda' && matrix.python != 'noPython'
+
+      - name: Install dependencies for native modules
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install libpango1.0-dev libgif-dev
 
       - name: Use Node ${{env.NODE_VERSION}}
         uses: actions/setup-node@v3
@@ -781,6 +793,12 @@ jobs:
 
       - name: Upgrade pip
         run: python -m pip install -U pip
+
+      - name: Install dependencies for native modules
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install libpango1.0-dev libgif-dev
 
       - name: Use Node ${{env.NODE_VERSION}}
         uses: actions/setup-node@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Install dependencies (npm ci)
         run: npm ci --foreground-scripts --prefer-offline
         env:
-          npm_config_loglevel: "silly"
+          npm_config_build_from_source: true
 
       - name: Verify Translation files
         run: npm run validateTranslationFiles

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -120,6 +120,11 @@ jobs:
       - name: Use Npm ${{env.NPM_VERSION}}
         run: npm i -g npm@${{env.NPM_VERSION}}
 
+      - name: Test zeromq installation
+        run: |
+          git clone https://github.com/zeromq/zeromq.js /tmp/zeromq.js
+          cd /tmp/zeromq.js && npm i
+
       - name: Cache pip files
         uses: actions/cache@v3
         with:

--- a/build/webpack/webpack.extension.node.config.js
+++ b/build/webpack/webpack.extension.node.config.js
@@ -129,6 +129,7 @@ const config = {
         new copyWebpackPlugin({ patterns: [{ from: './node_modules/zeromq/**/*.node' }] }),
         new copyWebpackPlugin({ patterns: [{ from: './node_modules/zeromq/**/*.json' }] }),
         new copyWebpackPlugin({ patterns: [{ from: './node_modules/node-gyp-build/**/*' }] }),
+        new copyWebpackPlugin({ patterns: [{ from: './node_modules/@aminya/node-gyp-build/**/*' }] }),
         new webpack.DefinePlugin({
             IS_PRE_RELEASE_VERSION_OF_JUPYTER_EXTENSION: JSON.stringify(
                 typeof process.env.IS_PRE_RELEASE_VERSION_OF_JUPYTER_EXTENSION === 'string'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -437,7 +437,7 @@ gulp.task('validatePackageLockJson', async () => {
         console.error('old Content\n' + oldContents + '\n');
         console.error('new Content\n' + newContents + '\n');
 
-        throw new Error('package-lock.json has changed after running `npm install`');
+        // throw new Error('package-lock.json has changed after running `npm install`');
     }
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -434,7 +434,7 @@ gulp.task('validatePackageLockJson', async () => {
     spawnSync('npm', ['install', '--build-from-source']);
     const newContents = fs.readFileSync(fileName).toString();
     if (oldContents.trim() !== newContents.trim()) {
-        throw new Error('package-lock.json has changed after running `npm install`');
+        throw new Error('package-lock.json has changed after running `npm install`\n' + newContents);
     }
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -431,7 +431,7 @@ gulp.task('validateTelemetry', async () => {
 gulp.task('validatePackageLockJson', async () => {
     const fileName = path.join(__dirname, 'package-lock.json');
     const oldContents = fs.readFileSync(fileName).toString();
-    spawnSync('npm', ['install', '--build-from-source']);
+    spawnSync('npm', ['install', '--prefer-offline', '--build-from-source']);
     const newContents = fs.readFileSync(fileName).toString();
     if (oldContents.trim() !== newContents.trim()) {
         throw new Error('package-lock.json has changed after running `npm install`\n' + newContents);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -434,7 +434,10 @@ gulp.task('validatePackageLockJson', async () => {
     spawnSync('npm', ['install', '--prefer-offline', '--build-from-source']);
     const newContents = fs.readFileSync(fileName).toString();
     if (oldContents.trim() !== newContents.trim()) {
-        throw new Error('package-lock.json has changed after running `npm install`\n' + newContents);
+        console.error('old Content\n' + oldContents + '\n');
+        console.error('new Content\n' + newContents + '\n');
+
+        throw new Error('package-lock.json has changed after running `npm install`');
     }
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -431,13 +431,10 @@ gulp.task('validateTelemetry', async () => {
 gulp.task('validatePackageLockJson', async () => {
     const fileName = path.join(__dirname, 'package-lock.json');
     const oldContents = fs.readFileSync(fileName).toString();
-    spawnSync('npm', ['install', '--prefer-offline', '--build-from-source']);
+    spawnSync('npm', ['install', '--prefer-offline']);
     const newContents = fs.readFileSync(fileName).toString();
     if (oldContents.trim() !== newContents.trim()) {
-        console.error('old Content\n' + oldContents + '\n');
-        console.error('new Content\n' + newContents + '\n');
-
-        // throw new Error('package-lock.json has changed after running `npm install`');
+        throw new Error('package-lock.json has changed after running `npm install`');
     }
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -431,7 +431,7 @@ gulp.task('validateTelemetry', async () => {
 gulp.task('validatePackageLockJson', async () => {
     const fileName = path.join(__dirname, 'package-lock.json');
     const oldContents = fs.readFileSync(fileName).toString();
-    spawnSync('npm', ['install']);
+    spawnSync('npm', ['install', '--build-from-source']);
     const newContents = fs.readFileSync(fileName).toString();
     if (oldContents.trim() !== newContents.trim()) {
         throw new Error('package-lock.json has changed after running `npm install`');

--- a/package-lock.json
+++ b/package-lock.json
@@ -30650,7 +30650,8 @@
             }
         },
         "d3-color": {
-            "version": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
             "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
         },
         "d3-ease": {
@@ -30668,7 +30669,7 @@
             "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
             "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
             "requires": {
-                "d3-color": "1"
+                "d3-color": "3.1.0"
             }
         },
         "d3-timer": {
@@ -33597,7 +33598,7 @@
             "requires": {
                 "extend": "^3.0.0",
                 "glob": "^7.1.1",
-                "glob-parent": "^3.1.0",
+                "glob-parent": "5.1.2",
                 "is-negated-glob": "^1.0.0",
                 "ordered-read-streams": "^1.0.0",
                 "pumpify": "^1.3.5",
@@ -33608,7 +33609,8 @@
             },
             "dependencies": {
                 "glob-parent": {
-                    "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
                     "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
                     "dev": true,
                     "requires": {
@@ -33720,7 +33722,7 @@
                         "async-each": "^1.0.1",
                         "braces": "^2.3.2",
                         "fsevents": "^1.2.7",
-                        "glob-parent": "^3.1.0",
+                        "glob-parent": "5.1.2",
                         "inherits": "^2.0.3",
                         "is-binary-path": "^1.0.0",
                         "is-glob": "^4.0.0",
@@ -33763,7 +33765,8 @@
                     }
                 },
                 "glob-parent": {
-                    "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
                     "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
                     "dev": true,
                     "requires": {
@@ -34458,7 +34461,7 @@
                 "he": "^1.2.0",
                 "param-case": "^3.0.4",
                 "relateurl": "^0.2.7",
-                "terser": "^5.10.0"
+                "terser": "5.14.2"
             },
             "dependencies": {
                 "commander": {
@@ -36048,7 +36051,7 @@
             "requires": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
-                "json5": "^1.0.1"
+                "json5": "2.2.2"
             }
         },
         "locate-path": {
@@ -40364,7 +40367,7 @@
             "integrity": "sha512-DF7ePE5bwitJrRdJSNrV+qAnQsfds0GbRA02ywy6TQrQewkm9DSHGDUxJaoJk2WUMlyQ7Odrf2o1PCZM50BcSg==",
             "requires": {
                 "jquery": ">=1.8.0",
-                "jquery-ui": "1.13.2"
+                "jquery-ui": ">=1.8.0"
             }
         },
         "snapdragon": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
                 "vscode-languageserver-protocol": "3.17.2-next.6",
                 "vscode-tas-client": "^0.1.27",
                 "ws": "^6.2.2",
-                "zeromq": "^6.0.0-beta.6"
+                "zeromq": "^6.0.0-beta.12"
             },
             "devDependencies": {
                 "@actions/core": "^1.9.1",
@@ -341,6 +341,16 @@
             "dev": true,
             "dependencies": {
                 "tunnel": "0.0.6"
+            }
+        },
+        "node_modules/@aminya/node-gyp-build": {
+            "version": "4.5.0-aminya.4",
+            "resolved": "https://registry.npmjs.org/@aminya/node-gyp-build/-/node-gyp-build-4.5.0-aminya.4.tgz",
+            "integrity": "sha512-2c2+BqZOxfTz/m+1MNWncMyMgil2WOg8cHhKPf1qUo1t9ohOWOgSeb7TVVD4fnTxIcAcpWdmXBpFkjPRyBVS9g==",
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -13207,7 +13217,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
             "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.10"
             }
@@ -13764,8 +13773,7 @@
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "node_modules/isobject": {
             "version": "3.0.1",
@@ -16398,6 +16406,11 @@
                 "node": ">= 6.0"
             }
         },
+        "node_modules/node-addon-api": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+            "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
+        },
         "node_modules/node-fetch": {
             "version": "2.6.7",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -16440,6 +16453,7 @@
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
             "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+            "devOptional": true,
             "bin": {
                 "node-gyp-build": "bin.js",
                 "node-gyp-build-optional": "optional.js",
@@ -19283,7 +19297,6 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-            "dev": true,
             "dependencies": {
                 "resolve": "^1.1.6"
             },
@@ -20275,6 +20288,37 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/shelljs": {
+            "version": "0.8.5",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+            "dependencies": {
+                "glob": "^7.0.0",
+                "interpret": "^1.0.0",
+                "rechoir": "^0.6.2"
+            },
+            "bin": {
+                "shjs": "bin/shjs"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/shx": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+            "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+            "dependencies": {
+                "minimist": "^1.2.3",
+                "shelljs": "^0.8.5"
+            },
+            "bin": {
+                "shx": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/side-channel": {
@@ -24395,15 +24439,90 @@
             }
         },
         "node_modules/zeromq": {
-            "version": "6.0.0-beta.6",
-            "resolved": "https://registry.npmjs.org/zeromq/-/zeromq-6.0.0-beta.6.tgz",
-            "integrity": "sha512-wLf6M7pBHijl+BRltUL2VoDpgbQcOZetiX8UzycHL8CcYFxYnRrpoG5fi3UX3+Umavz1lk4/dGaQez8qiDgr/Q==",
+            "version": "6.0.0-beta.16",
+            "resolved": "https://registry.npmjs.org/zeromq/-/zeromq-6.0.0-beta.16.tgz",
+            "integrity": "sha512-taPr+V2synMrybR4H4YBJkjQ1tIi0CPuXsO6Jm2O1IbgnfJ0o3qYqi0QuhT9/oFwiTNr/yQiCze9OU2szGlp7w==",
             "hasInstallScript": true,
             "dependencies": {
-                "node-gyp-build": "^4.1.0"
+                "@aminya/node-gyp-build": "4.5.0-aminya.4",
+                "cross-env": "^7.0.3",
+                "node-addon-api": "^5.0.0",
+                "shelljs": "^0.8.5",
+                "shx": "^0.3.4"
             },
             "engines": {
                 "node": ">= 10.2"
+            }
+        },
+        "node_modules/zeromq/node_modules/cross-env": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "dependencies": {
+                "cross-spawn": "^7.0.1"
+            },
+            "bin": {
+                "cross-env": "src/bin/cross-env.js",
+                "cross-env-shell": "src/bin/cross-env-shell.js"
+            },
+            "engines": {
+                "node": ">=10.14",
+                "npm": ">=6",
+                "yarn": ">=1"
+            }
+        },
+        "node_modules/zeromq/node_modules/cross-spawn": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/zeromq/node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/zeromq/node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/zeromq/node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/zeromq/node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         }
     },
@@ -24465,6 +24584,11 @@
             "requires": {
                 "tunnel": "0.0.6"
             }
+        },
+        "@aminya/node-gyp-build": {
+            "version": "4.5.0-aminya.4",
+            "resolved": "https://registry.npmjs.org/@aminya/node-gyp-build/-/node-gyp-build-4.5.0-aminya.4.tgz",
+            "integrity": "sha512-2c2+BqZOxfTz/m+1MNWncMyMgil2WOg8cHhKPf1qUo1t9ohOWOgSeb7TVVD4fnTxIcAcpWdmXBpFkjPRyBVS9g=="
         },
         "@ampproject/remapping": {
             "version": "2.1.2",
@@ -30526,8 +30650,7 @@
             }
         },
         "d3-color": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "version": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
             "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
         },
         "d3-ease": {
@@ -30545,7 +30668,7 @@
             "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
             "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
             "requires": {
-                "d3-color": "3.1.0"
+                "d3-color": "1"
             }
         },
         "d3-timer": {
@@ -33474,7 +33597,7 @@
             "requires": {
                 "extend": "^3.0.0",
                 "glob": "^7.1.1",
-                "glob-parent": "5.1.2",
+                "glob-parent": "^3.1.0",
                 "is-negated-glob": "^1.0.0",
                 "ordered-read-streams": "^1.0.0",
                 "pumpify": "^1.3.5",
@@ -33485,8 +33608,7 @@
             },
             "dependencies": {
                 "glob-parent": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                    "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
                     "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
                     "dev": true,
                     "requires": {
@@ -33598,7 +33720,7 @@
                         "async-each": "^1.0.1",
                         "braces": "^2.3.2",
                         "fsevents": "^1.2.7",
-                        "glob-parent": "5.1.2",
+                        "glob-parent": "^3.1.0",
                         "inherits": "^2.0.3",
                         "is-binary-path": "^1.0.0",
                         "is-glob": "^4.0.0",
@@ -33641,8 +33763,7 @@
                     }
                 },
                 "glob-parent": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                    "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
                     "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
                     "dev": true,
                     "requires": {
@@ -34337,7 +34458,7 @@
                 "he": "^1.2.0",
                 "param-case": "^3.0.4",
                 "relateurl": "^0.2.7",
-                "terser": "5.14.2"
+                "terser": "^5.10.0"
             },
             "dependencies": {
                 "commander": {
@@ -34603,8 +34724,7 @@
         "interpret": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-            "dev": true
+            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
         },
         "inversify": {
             "version": "5.1.1",
@@ -35001,8 +35121,7 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isobject": {
             "version": "3.0.1",
@@ -35929,7 +36048,7 @@
             "requires": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
-                "json5": "2.2.2"
+                "json5": "^1.0.1"
             }
         },
         "locate-path": {
@@ -37082,6 +37201,11 @@
                 "semver": "^5.5.0"
             }
         },
+        "node-addon-api": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+            "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
+        },
         "node-fetch": {
             "version": "2.6.7",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -37114,7 +37238,8 @@
         "node-gyp-build": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-            "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ=="
+            "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+            "devOptional": true
         },
         "node-has-native-dependencies": {
             "version": "1.0.2",
@@ -39258,7 +39383,6 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-            "dev": true,
             "requires": {
                 "resolve": "^1.1.6"
             }
@@ -40071,6 +40195,25 @@
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
         },
+        "shelljs": {
+            "version": "0.8.5",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+            "requires": {
+                "glob": "^7.0.0",
+                "interpret": "^1.0.0",
+                "rechoir": "^0.6.2"
+            }
+        },
+        "shx": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+            "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+            "requires": {
+                "minimist": "^1.2.3",
+                "shelljs": "^0.8.5"
+            }
+        },
         "side-channel": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -40221,7 +40364,7 @@
             "integrity": "sha512-DF7ePE5bwitJrRdJSNrV+qAnQsfds0GbRA02ywy6TQrQewkm9DSHGDUxJaoJk2WUMlyQ7Odrf2o1PCZM50BcSg==",
             "requires": {
                 "jquery": ">=1.8.0",
-                "jquery-ui": ">=1.8.0"
+                "jquery-ui": "1.13.2"
             }
         },
         "snapdragon": {
@@ -43352,11 +43495,61 @@
             "dev": true
         },
         "zeromq": {
-            "version": "6.0.0-beta.6",
-            "resolved": "https://registry.npmjs.org/zeromq/-/zeromq-6.0.0-beta.6.tgz",
-            "integrity": "sha512-wLf6M7pBHijl+BRltUL2VoDpgbQcOZetiX8UzycHL8CcYFxYnRrpoG5fi3UX3+Umavz1lk4/dGaQez8qiDgr/Q==",
+            "version": "6.0.0-beta.16",
+            "resolved": "https://registry.npmjs.org/zeromq/-/zeromq-6.0.0-beta.16.tgz",
+            "integrity": "sha512-taPr+V2synMrybR4H4YBJkjQ1tIi0CPuXsO6Jm2O1IbgnfJ0o3qYqi0QuhT9/oFwiTNr/yQiCze9OU2szGlp7w==",
             "requires": {
-                "node-gyp-build": "^4.1.0"
+                "@aminya/node-gyp-build": "4.5.0-aminya.4",
+                "cross-env": "^7.0.3",
+                "node-addon-api": "^5.0.0",
+                "shelljs": "^0.8.5",
+                "shx": "^0.3.4"
+            },
+            "dependencies": {
+                "cross-env": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+                    "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+                    "requires": {
+                        "cross-spawn": "^7.0.1"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+                    "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+                    "requires": {
+                        "path-key": "^3.1.0",
+                        "shebang-command": "^2.0.0",
+                        "which": "^2.0.1"
+                    }
+                },
+                "path-key": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+                },
+                "shebang-command": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+                    "requires": {
+                        "shebang-regex": "^3.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
                 "vscode-languageserver-protocol": "3.17.2-next.6",
                 "vscode-tas-client": "^0.1.27",
                 "ws": "^6.2.2",
-                "zeromq": "^6.0.0-beta.12"
+                "zeromq": "^6.0.0-beta.16"
             },
             "devDependencies": {
                 "@actions/core": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -2177,7 +2177,7 @@
         "vscode-languageserver-protocol": "3.17.2-next.6",
         "vscode-tas-client": "^0.1.27",
         "ws": "^6.2.2",
-        "zeromq": "^6.0.0-beta.6"
+        "zeromq": "^6.0.0-beta.12"
     },
     "devDependencies": {
         "@actions/core": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -2177,7 +2177,7 @@
         "vscode-languageserver-protocol": "3.17.2-next.6",
         "vscode-tas-client": "^0.1.27",
         "ws": "^6.2.2",
-        "zeromq": "^6.0.0-beta.12"
+        "zeromq": "^6.0.0-beta.16"
     },
     "devDependencies": {
         "@actions/core": "^1.9.1",


### PR DESCRIPTION
Prepare for the upcoming 1.77 Insiders. 1.77 ships with Electron 22, which introduces v8 memory cage. Current zeromq will crash with Electron 22. The issue was already fixed in a newer version of zeromq https://github.com/zeromq/zeromq.js/issues/514 .

More details about the v8 memory cage https://github.com/electron/electron/pull/36624

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
