### PR TITLE
Correct initial value of IExportedKernelService.status

### DIFF
--- a/src/standalone/api/kernelApi.ts
+++ b/src/standalone/api/kernelApi.ts
@@ -116,6 +116,7 @@ class JupyterKernelService implements IExportedKernelService {
         @inject(IControllerRegistration) private readonly controllerRegistration: IControllerRegistration,
         @inject(IServiceContainer) private serviceContainer: IServiceContainer
     ) {
+        this._status = this.kernelFinder.status;
         this.kernelFinder.onDidChangeStatus(
             () => {
                 this._status = this.kernelFinder.status;


### PR DESCRIPTION
-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [ ] ~~Has telemetry for feature-requests.~~
-   [ ] ~~Unit tests & system/integration tests are added/updated.~~
-   [ ] ~~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~~
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
