### PR TITLE
Fix notebookUri/tab.uri comparison to handle leading slash differences

### DIFF
--- a/src/standalone/intellisense/notebookPythonPathService.node.ts
+++ b/src/standalone/intellisense/notebookPythonPathService.node.ts
@@ -155,7 +155,7 @@ export class NotebookPythonPathService implements IExtensionSingleActivationServ
                 if (isInteractiveInputTab(tab)) {
                     const tabUri = tab.input.uri.toString();
                     // the interactive resource URI was altered to start with `/`, this will account for both URI formats
-                    if (tab.input.uri.toString().endsWith(notebookUri.toString())) {
+                    if (tab.input.uri.toString().endsWith(notebookUri.path)) {
                         result = tabUri;
                     }
                 }


### PR DESCRIPTION
Fixes #13018

Fixed bug in `_getNotebookUriForTextDocumentUri` logic to handle VS Code adding a `/` at the start of notebook URI paths. This was probably what was originally intended rather than checking `endsWith` on the whole URI.

-   [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [X] Title summarizes what is changing.
-   [X] Appropriate comments and documentation strings in the code.
-   [X] Has sufficient logging.
-   [X] Has telemetry for feature-requests.
-   [X] ~Unit tests & system/integration tests are added/updated.~
-   [X] ~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [X] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
