### PR TITLE
Prevent 'Reconnecting to the kernel' notification from staying forever

### DIFF
--- a/src/kernels/kernelAutoReConnectMonitor.ts
+++ b/src/kernels/kernelAutoReConnectMonitor.ts
@@ -204,7 +204,7 @@ export class KernelAutoReconnectMonitor implements IExtensionSyncActivationServi
             await kernel.dispose();
         }
     }
-    
+
     private async handleRemoteServerReinitiate(
         kernel: IKernel,
         metadata: RemoteKernelConnectionMetadata

--- a/src/kernels/kernelAutoReConnectMonitor.ts
+++ b/src/kernels/kernelAutoReConnectMonitor.ts
@@ -117,11 +117,13 @@ export class KernelAutoReconnectMonitor implements IExtensionSyncActivationServi
         }
         switch (connectionStatus) {
             case 'connected': {
+                this.kernelReconnectProgress.get(kernel)?.dispose();
                 this.kernelReconnectProgress.delete(kernel);
                 return;
             }
             case 'disconnected': {
                 if (this.kernelReconnectProgress.has(kernel)) {
+                    this.kernelReconnectProgress.get(kernel)?.dispose();
                     this.kernelReconnectProgress.delete(kernel);
                     this.onKernelDisconnected(kernel)?.catch(noop);
                 }
@@ -202,6 +204,7 @@ export class KernelAutoReconnectMonitor implements IExtensionSyncActivationServi
             await kernel.dispose();
         }
     }
+    
     private async handleRemoteServerReinitiate(
         kernel: IKernel,
         metadata: RemoteKernelConnectionMetadata


### PR DESCRIPTION
Hi, I don't have a repro, but from the code I can see why this notification is never disappearing even though my Interactive is working with a new Python process.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
