### PR TITLE
Display kernels found in non-python conda envs

### DIFF
--- a/src/kernels/execution/helpers.ts
+++ b/src/kernels/execution/helpers.ts
@@ -734,7 +734,9 @@ export async function updateNotebookMetadata(
     const kernelSpecOrModel =
         kernelConnection && kernelConnectionMetadataHasKernelModel(kernelConnection)
             ? kernelConnection.kernelModel
-            : kernelConnection?.kernelSpec;
+            : kernelConnection && 'kernelSpec' in kernelConnection
+            ? kernelConnection.kernelSpec
+            : undefined;
     if (kernelConnection?.kind === 'startUsingPythonInterpreter') {
         // Store interpreter name, we expect the kernel finder will find the corresponding interpreter based on this name.
         const kernelSpec = kernelConnection.kernelSpec;

--- a/src/kernels/helpers.ts
+++ b/src/kernels/helpers.ts
@@ -277,18 +277,9 @@ export function getDisplayNameOrNameOfKernelConnection(kernelConnection: KernelC
                     return kernelConnection.kernelSpec.display_name;
                 }
                 // If this is a conda environment without Python, then don't display `Python` in it.
-                const isEmptyVersion =
-                    !kernelConnection.interpreter.version ||
-                    (!kernelConnection.interpreter.version.major &&
-                        !kernelConnection.interpreter.version.minor &&
-                        !kernelConnection.interpreter.version.patch &&
-                        !kernelConnection.interpreter.version.raw);
                 const isCondaEnvWithoutPython =
                     kernelConnection.interpreter.envType === EnvironmentType.Conda &&
-                    !kernelConnection.interpreter.sysPrefix &&
-                    isEmptyVersion &&
-                    (kernelConnection.interpreter.uri.path === '/python' ||
-                        kernelConnection.interpreter.uri.path === 'python');
+                    kernelConnection.interpreter.isCondaEnvWithoutPython === true;
                 const pythonDisplayName = pythonVersion.trim() ? `Python ${pythonVersion}` : 'Python';
                 const envName = getPythonEnvironmentName(kernelConnection.interpreter);
                 if (isCondaEnvWithoutPython && envName) {

--- a/src/kernels/raw/finder/interpreterKernelSpecFinderHelper.node.ts
+++ b/src/kernels/raw/finder/interpreterKernelSpecFinderHelper.node.ts
@@ -628,19 +628,22 @@ export async function listPythonAndRelatedNonPythonKernelSpecs(
     }
 
     await Promise.all(
-        filteredInterpreters.map(async (i) => {
-            // Update spec to have a default spec file
-            const spec = await createInterpreterKernelSpec(i, tempDirForKernelSpecs);
-            const result = PythonKernelConnectionMetadata.create({
-                kernelSpec: spec,
-                interpreter: i,
-                id: getKernelId(spec, i)
-            });
-            traceVerbose(`Kernel for interpreter ${i.id} is ${result.id}`);
-            if (!distinctKernelMetadata.has(result.id)) {
-                distinctKernelMetadata.set(result.id, result);
-            }
-        })
+        filteredInterpreters
+            // Exclude conda envs without Python.
+            .filter((i) => (i.isCondaEnvWithoutPython ? false : true))
+            .map(async (i) => {
+                // Update spec to have a default spec file
+                const spec = await createInterpreterKernelSpec(i, tempDirForKernelSpecs);
+                const result = PythonKernelConnectionMetadata.create({
+                    kernelSpec: spec,
+                    interpreter: i,
+                    id: getKernelId(spec, i)
+                });
+                traceVerbose(`Kernel for interpreter ${i.id} is ${result.id}`);
+                if (!distinctKernelMetadata.has(result.id)) {
+                    distinctKernelMetadata.set(result.id, result);
+                }
+            })
     );
     if (cancelToken.isCancellationRequested) {
         return [];

--- a/src/kernels/raw/finder/localKernelSpecFinderBase.node.ts
+++ b/src/kernels/raw/finder/localKernelSpecFinderBase.node.ts
@@ -387,7 +387,8 @@ export async function loadKernelSpec(
 
     // Possible user deleted the underlying interpreter.
     const interpreterPath = interpreter?.uri.fsPath || kernelJson?.metadata?.interpreter?.path;
-    if (interpreterPath && !(await fs.exists(Uri.file(interpreterPath)))) {
+    const isEmptyCondaEnv = interpreter?.isCondaEnvWithoutPython ? true : false;
+    if (interpreterPath && !isEmptyCondaEnv && !(await fs.exists(Uri.file(interpreterPath)))) {
         return;
     }
 

--- a/src/kernels/raw/launcher/kernelLauncher.node.ts
+++ b/src/kernels/raw/launcher/kernelLauncher.node.ts
@@ -40,6 +40,7 @@ import { getResourceType } from '../../../platform/common/utils';
 import { format } from '../../../platform/common/helpers';
 import { IPythonExecutionFactory } from '../../../platform/interpreter/types.node';
 import { UsedPorts } from '../../common/usedPorts';
+import { isPythonKernelConnection } from '../../helpers';
 
 const PortFormatString = `kernelLauncherPortStart_{0}.tmp`;
 // Launches and returns a kernel process given a resource or python interpreter.
@@ -143,7 +144,11 @@ export class KernelLauncher implements IKernelLauncher {
         token: CancellationToken
     ) {
         const interpreter = kernelConnectionMetadata.interpreter;
-        if (!isLocalConnection(kernelConnectionMetadata) || !interpreter) {
+        if (
+            !isLocalConnection(kernelConnectionMetadata) ||
+            !isPythonKernelConnection(kernelConnectionMetadata) ||
+            !interpreter
+        ) {
             return;
         }
         const service = await this.pythonExecFactory.createActivatedEnvironment({

--- a/src/platform/api/pythonApi.unit.test.ts
+++ b/src/platform/api/pythonApi.unit.test.ts
@@ -8,7 +8,7 @@ import { Disposable, EventEmitter, WorkspaceFoldersChangeEvent } from 'vscode';
 import { createEventHandler } from '../../test/common';
 import { IWorkspaceService } from '../common/application/types';
 import { disposeAllDisposables } from '../common/helpers';
-import { IDisposable, IExtensionContext } from '../common/types';
+import { IDisposable, IExtensionContext, IFeaturesManager, KernelPickerType } from '../common/types';
 import { IInterpreterService } from '../interpreter/contracts';
 import { InterpreterService } from './pythonApi';
 import {
@@ -19,77 +19,83 @@ import {
 } from './pythonApiTypes';
 import { IPythonApiProvider, IPythonExtensionChecker } from './types';
 
-suite('Interpreter Service', () => {
-    let clock: fakeTimers.InstalledClock;
-    let interpreterService: IInterpreterService;
-    let apiProvider: IPythonApiProvider;
-    let extensionChecker: IPythonExtensionChecker;
-    let workspace: IWorkspaceService;
-    let context: IExtensionContext;
-    const disposables: IDisposable[] = [];
-    let onDidActivatePythonExtension: EventEmitter<void>;
-    let onDidChangeWorkspaceFolders: EventEmitter<WorkspaceFoldersChangeEvent>;
-    let onDidChangeActiveEnvironmentPath: EventEmitter<ActiveEnvironmentPathChangeEvent>;
-    let onDidChangeEnvironments: EventEmitter<EnvironmentsChangeEvent>;
-    let onDidEnvironmentVariablesChange: EventEmitter<EnvironmentVariablesChangeEvent>;
-    let newPythonApi: ProposedExtensionAPI;
-    let environments: ProposedExtensionAPI['environments'];
-    setup(() => {
-        interpreterService = mock<IInterpreterService>();
-        apiProvider = mock<IPythonApiProvider>();
-        extensionChecker = mock<IPythonExtensionChecker>();
-        workspace = mock<IWorkspaceService>();
-        context = mock<IExtensionContext>();
-        onDidActivatePythonExtension = new EventEmitter<void>();
-        onDidChangeWorkspaceFolders = new EventEmitter<WorkspaceFoldersChangeEvent>();
-        onDidChangeActiveEnvironmentPath = new EventEmitter<ActiveEnvironmentPathChangeEvent>();
-        onDidChangeEnvironments = new EventEmitter<EnvironmentsChangeEvent>();
-        onDidEnvironmentVariablesChange = new EventEmitter<EnvironmentVariablesChangeEvent>();
-        disposables.push(onDidActivatePythonExtension);
-        disposables.push(onDidChangeWorkspaceFolders);
-        disposables.push(onDidChangeActiveEnvironmentPath);
-        disposables.push(onDidChangeEnvironments);
-        disposables.push(onDidEnvironmentVariablesChange);
+(['Insiders', 'Stable'] as KernelPickerType[]).forEach((kernelPickerType) => {
+    suite(`Interpreter Service for ${kernelPickerType}`, () => {
+        let clock: fakeTimers.InstalledClock;
+        let interpreterService: IInterpreterService;
+        let apiProvider: IPythonApiProvider;
+        let extensionChecker: IPythonExtensionChecker;
+        let workspace: IWorkspaceService;
+        let context: IExtensionContext;
+        const disposables: IDisposable[] = [];
+        let onDidActivatePythonExtension: EventEmitter<void>;
+        let onDidChangeWorkspaceFolders: EventEmitter<WorkspaceFoldersChangeEvent>;
+        let onDidChangeActiveEnvironmentPath: EventEmitter<ActiveEnvironmentPathChangeEvent>;
+        let onDidChangeEnvironments: EventEmitter<EnvironmentsChangeEvent>;
+        let onDidEnvironmentVariablesChange: EventEmitter<EnvironmentVariablesChangeEvent>;
+        let newPythonApi: ProposedExtensionAPI;
+        let environments: ProposedExtensionAPI['environments'];
+        let featureManager: IFeaturesManager;
+        setup(() => {
+            interpreterService = mock<IInterpreterService>();
+            apiProvider = mock<IPythonApiProvider>();
+            extensionChecker = mock<IPythonExtensionChecker>();
+            workspace = mock<IWorkspaceService>();
+            context = mock<IExtensionContext>();
+            featureManager = mock<IFeaturesManager>();
+            onDidActivatePythonExtension = new EventEmitter<void>();
+            onDidChangeWorkspaceFolders = new EventEmitter<WorkspaceFoldersChangeEvent>();
+            onDidChangeActiveEnvironmentPath = new EventEmitter<ActiveEnvironmentPathChangeEvent>();
+            onDidChangeEnvironments = new EventEmitter<EnvironmentsChangeEvent>();
+            onDidEnvironmentVariablesChange = new EventEmitter<EnvironmentVariablesChangeEvent>();
+            disposables.push(onDidActivatePythonExtension);
+            disposables.push(onDidChangeWorkspaceFolders);
+            disposables.push(onDidChangeActiveEnvironmentPath);
+            disposables.push(onDidChangeEnvironments);
+            disposables.push(onDidEnvironmentVariablesChange);
 
-        newPythonApi = mock<ProposedExtensionAPI>();
-        environments = mock<ProposedExtensionAPI['environments']>();
-        when(newPythonApi.environments).thenReturn(instance(environments));
-        when(environments.onDidChangeActiveEnvironmentPath).thenReturn(onDidChangeActiveEnvironmentPath.event);
-        when(environments.onDidChangeEnvironments).thenReturn(onDidChangeEnvironments.event);
-        when(environments.onDidEnvironmentVariablesChange).thenReturn(onDidEnvironmentVariablesChange.event);
-        when(environments.known).thenReturn([]);
-        when(environments.getActiveEnvironmentPath(anything())).thenReturn();
-        (instance(newPythonApi) as any).then = undefined;
-        when(apiProvider.getNewApi()).thenResolve(instance(newPythonApi));
-        when(apiProvider.onDidActivatePythonExtension).thenReturn(onDidActivatePythonExtension.event);
-        when(workspace.onDidChangeWorkspaceFolders).thenReturn(onDidChangeWorkspaceFolders.event);
-        when(extensionChecker.isPythonExtensionInstalled).thenReturn(true);
-        clock = fakeTimers.install();
-        disposables.push(new Disposable(() => clock.uninstall()));
-    });
-    teardown(() => disposeAllDisposables(disposables));
-    function createInterpreterService() {
-        interpreterService = new InterpreterService(
-            instance(apiProvider),
-            instance(extensionChecker),
-            disposables,
-            instance(workspace),
-            instance(context)
-        );
-    }
-    test('Progress status triggered upon refresh', async () => {
-        createInterpreterService();
+            newPythonApi = mock<ProposedExtensionAPI>();
+            environments = mock<ProposedExtensionAPI['environments']>();
+            when(featureManager.features).thenReturn({ kernelPickerType });
+            when(newPythonApi.environments).thenReturn(instance(environments));
+            when(environments.onDidChangeActiveEnvironmentPath).thenReturn(onDidChangeActiveEnvironmentPath.event);
+            when(environments.onDidChangeEnvironments).thenReturn(onDidChangeEnvironments.event);
+            when(environments.onDidEnvironmentVariablesChange).thenReturn(onDidEnvironmentVariablesChange.event);
+            when(environments.known).thenReturn([]);
+            when(environments.getActiveEnvironmentPath(anything())).thenReturn();
+            (instance(newPythonApi) as any).then = undefined;
+            when(apiProvider.getNewApi()).thenResolve(instance(newPythonApi));
+            when(apiProvider.onDidActivatePythonExtension).thenReturn(onDidActivatePythonExtension.event);
+            when(workspace.onDidChangeWorkspaceFolders).thenReturn(onDidChangeWorkspaceFolders.event);
+            when(extensionChecker.isPythonExtensionInstalled).thenReturn(true);
+            clock = fakeTimers.install();
+            disposables.push(new Disposable(() => clock.uninstall()));
+        });
+        teardown(() => disposeAllDisposables(disposables));
+        function createInterpreterService() {
+            interpreterService = new InterpreterService(
+                instance(apiProvider),
+                instance(extensionChecker),
+                disposables,
+                instance(workspace),
+                instance(context),
+                instance(featureManager)
+            );
+        }
+        test('Progress status triggered upon refresh', async () => {
+            createInterpreterService();
 
-        const statuses: typeof interpreterService.status[] = [];
-        interpreterService.onDidChangeStatus(() => statuses.push(interpreterService.status));
-        const progressEvent = createEventHandler(interpreterService, 'onDidChangeStatus', disposables);
-        // const deferred = createDeferred<void>();
-        when(environments.refreshEnvironments(anything())).thenReturn(Promise.resolve());
-        await interpreterService.refreshInterpreters();
-        await clock.runAllAsync();
+            const statuses: typeof interpreterService.status[] = [];
+            interpreterService.onDidChangeStatus(() => statuses.push(interpreterService.status));
+            const progressEvent = createEventHandler(interpreterService, 'onDidChangeStatus', disposables);
+            // const deferred = createDeferred<void>();
+            when(environments.refreshEnvironments(anything())).thenReturn(Promise.resolve());
+            await interpreterService.refreshInterpreters();
+            await clock.runAllAsync();
 
-        verify(environments.refreshEnvironments(anything())).once();
-        assert.isAtLeast(progressEvent.count, 2, 'Progress event not triggered at least 2 times');
-        assert.deepEqual(statuses, ['refreshing', 'idle']);
+            verify(environments.refreshEnvironments(anything())).once();
+            assert.isAtLeast(progressEvent.count, 2, 'Progress event not triggered at least 2 times');
+            assert.deepEqual(statuses, ['refreshing', 'idle']);
+        });
     });
 });

--- a/src/platform/api/types.ts
+++ b/src/platform/api/types.ts
@@ -12,6 +12,7 @@ export const IPythonApiProvider = Symbol('IPythonApi');
 export interface IPythonApiProvider {
     onDidActivatePythonExtension: Event<void>;
     pythonExtensionHooked: Promise<void>;
+    pythonExtensionVersion: SemVer | undefined;
     getApi(): Promise<PythonApi>;
     getNewApi(): Promise<ProposedExtensionAPI | undefined>;
     setApi(api: PythonApi): void;

--- a/src/platform/common/utils/localize.ts
+++ b/src/platform/common/utils/localize.ts
@@ -582,6 +582,7 @@ export namespace DataScience {
     export const kernelCategoryForRemoteJupyterKernel = (kernelSpecName: string) =>
         l10n.t('({0}) Jupyter Kernel', kernelSpecName);
     export const kernelCategoryForConda = l10n.t('Conda Env');
+    export const kernelCategoryForCondaWithoutPython = l10n.t('Conda Env Without Python');
     export const kernelCategoryForPoetry = l10n.t('Poetry Env');
     export const kernelCategoryForPipEnv = l10n.t('Pipenv Env');
     export const kernelCategoryForPyEnv = l10n.t('PyEnv Env');

--- a/src/platform/interpreter/contracts.ts
+++ b/src/platform/interpreter/contracts.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 import { Event, Uri, CancellationToken } from 'vscode';
-import { PythonEnvironmentV2 } from '../api/types';
 import { PythonEnvironment } from '../pythonEnvironments/info';
-
+import { PythonEnvironmentV2 } from '../api/types';
+type InterpreterId = string;
 export const IInterpreterService = Symbol('IInterpreterService');
 export interface IInterpreterService {
     readonly status: 'refreshing' | 'idle';
@@ -34,7 +34,8 @@ export interface IInterpreterService {
             | {
                   /** Environment Path */
                   path: string;
-              },
+              }
+            | InterpreterId,
         token?: CancellationToken
     ): Promise<undefined | PythonEnvironment>;
     getInterpreterHash(id: string): string | undefined;

--- a/src/platform/interpreter/installer/productInstaller.node.ts
+++ b/src/platform/interpreter/installer/productInstaller.node.ts
@@ -110,6 +110,9 @@ export class DataScienceInstaller {
         if (cancelTokenSource.token.isCancellationRequested) {
             return InstallerResponse.Cancelled;
         }
+        if (interpreter.isCondaEnvWithoutPython) {
+            interpreter.isCondaEnvWithoutPython = false;
+        }
         return this.isInstalled(product, interpreter).then((isInstalled) => {
             return isInstalled ? InstallerResponse.Installed : InstallerResponse.Ignore;
         });

--- a/src/platform/interpreter/interpreterPackages.node.ts
+++ b/src/platform/interpreter/interpreterPackages.node.ts
@@ -182,6 +182,9 @@ export class InterpreterPackages implements IInterpreterPackages {
         TraceOptions.BeforeCall | TraceOptions.Arguments
     )
     private async getPackageInformation({ interpreter }: { interpreter: PythonEnvironment }) {
+        if (interpreter.isCondaEnvWithoutPython) {
+            return;
+        }
         const service = await this.executionFactory.createActivatedEnvironment({
             interpreter
         });

--- a/src/platform/pythonEnvironments/info/index.ts
+++ b/src/platform/pythonEnvironments/info/index.ts
@@ -19,6 +19,7 @@ export enum EnvironmentType {
     VirtualEnvWrapper = 'VirtualEnvWrapper',
 }
 
+export type InterpreterId = string;
 /**
  * Details about a Python runtime.
  *
@@ -28,7 +29,7 @@ export enum EnvironmentType {
  * @prop sysPrefix - the environment's install root (`sys.prefix`)
  */
 export type InterpreterInformation = {
-    id: string;
+    id: InterpreterId;
     uri: Uri;
     version?: PythonVersion;
     sysVersion?: string;
@@ -52,4 +53,5 @@ export type PythonEnvironment = InterpreterInformation & {
      * Used for display purposes only (in kernel picker or other places).
      */
     displayPath?: Uri;
+    isCondaEnvWithoutPython?: boolean;
 };


### PR DESCRIPTION
Part 1 of #11855
This only focuses on displaying non-python kernels in Conda envs without Python,
Displaying python kernels for conda envs without python will be done in a separate PR.