### PR TITLE
Revert zmq to previous version

### DIFF
--- a/.github/actions/build-vsix/action.yml
+++ b/.github/actions/build-vsix/action.yml
@@ -10,8 +10,6 @@ runs:
   using: 'composite'
   steps:
     - run: npm ci --prefer-offline
-      env:
-        npm_config_build_from_source: true
       shell: bash
 
     - run: npm run package

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,11 +67,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install dependencies for native modules
-        run: |
-          sudo apt-get update
-          sudo apt-get install libpango1.0-dev libgif-dev
-
       - name: Use Node ${{env.NODE_VERSION}}
         uses: actions/setup-node@v3
         with:
@@ -117,11 +112,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install dependencies for native modules
-        run: |
-          sudo apt-get update
-          sudo apt-get install libpango1.0-dev libgif-dev
-
       - name: Use Node ${{env.NODE_VERSION}}
         uses: actions/setup-node@v3
         with:
@@ -143,9 +133,7 @@ jobs:
           key: ${{runner.os}}-${{env.CACHE_NPM_DEPS}}-${{hashFiles('package-lock.json')}}
 
       - name: Install dependencies (npm ci)
-        run: npm ci --foreground-scripts --prefer-offline
-        env:
-          npm_config_build_from_source: true
+        run: npm ci --prefer-offline
 
       - name: Verify Translation files
         run: npm run validateTranslationFiles
@@ -202,12 +190,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install dependencies for native modules
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install libpango1.0-dev libgif-dev
-
       - name: Use Node ${{env.NODE_VERSION}}
         uses: actions/setup-node@v3
         with:
@@ -249,9 +231,7 @@ jobs:
           key: ${{runner.os}}-${{env.CACHE_OUT_DIRECTORY}}-${{hashFiles('src/**')}}
 
       - name: Install dependencies (npm ci)
-        run: npm ci --foreground-scripts --prefer-offline
-        env:
-          npm_config_build_from_source: true
+        run: npm ci --prefer-offline
 
       - name: Compile if not cached
         run: npm run prePublishNonBundle
@@ -411,12 +391,6 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install -U pip
         if: matrix.python != 'conda' && matrix.python != 'noPython'
-
-      - name: Install dependencies for native modules
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install libpango1.0-dev libgif-dev
 
       - name: Use Node ${{env.NODE_VERSION}}
         uses: actions/setup-node@v3
@@ -579,9 +553,7 @@ jobs:
 
         # This step is slow.
       - name: Install dependencies (npm ci)
-        run: npm ci --foreground-scripts --prefer-offline
-        env:
-          npm_config_build_from_source: true
+        run: npm ci --prefer-offline
 
       - name: Install screen capture dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -812,22 +784,8 @@ jobs:
         with:
           name: 'ms-toolsai-jupyter-insiders.vsix'
 
-      - name: Install libsodium and gnutls
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew install libsodium gnutls
-        shell: bash
-
-      - name: Install dependencies for native modules
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install libpango1.0-dev libgif-dev
-
       - name: Install dependencies (npm ci)
-        run: npm ci --foreground-scripts --prefer-offline
-        env:
-          npm_config_build_from_source: true
+        run: npm ci --prefer-offline
 
       - name: pip install system test requirements
         run: |
@@ -884,10 +842,7 @@ jobs:
           node-version: ${{env.NODE_VERSION}}
 
       - name: Install dependencies (npm ci)
-        run: npm ci --foreground-scripts --prefer-offline
-        env:
-          npm_config_build_from_source: true
-
+        run: npm ci --prefer-offline
 
       - name: Cache compiled TS files
         id: out-cache

--- a/build/azure-pipeline.pre-release.yml
+++ b/build/azure-pipeline.pre-release.yml
@@ -24,18 +24,11 @@ extends:
   parameters:
     l10nSourcePaths: ./src
     buildSteps:
-      - script: |
-          sudo apt-get update
-          sudo apt-get install libpango1.0-dev libgif-dev
-        displayName: Install dependencies for zeromq.js
-
       - script: npm i -g npm@8.15.1
         displayName: Install npm 8.15.1
 
-      - script: npm ci --foreground-scripts
+      - script: npm ci
         displayName: Install dependencies
-        env:
-          npm_config_build_from_source: true
 
       - script: gulp clean
         displayName: Clean

--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -20,18 +20,11 @@ extends:
     publishExtension: true
     l10nSourcePaths: ./src
     buildSteps:
-      - script: |
-          sudo apt-get update
-          sudo apt-get install libpango1.0-dev libgif-dev
-        displayName: Install dependencies for zeromq.js
-
       - script: npm i -g npm@8.15.1
         displayName: Install npm 8.15.1
 
-      - script: npm ci --foreground-scripts
+      - script: npm ci
         displayName: Install dependencies
-        env:
-          npm_config_build_from_source: true
 
       - script: gulp clean
         displayName: Clean

--- a/build/ci/postInstall.js
+++ b/build/ci/postInstall.js
@@ -7,7 +7,7 @@ const colors = require('colors/safe');
 const fs = require('fs-extra');
 const path = require('path');
 const constants = require('../constants');
-const { downloadZMQ } = require('@vscode/zeromq');
+
 /**
  * In order to get raw kernels working, we reuse the default kernel that jupyterlab ships.
  * However it expects to be talking to a websocket which is serializing the messages to strings.
@@ -206,6 +206,3 @@ createJupyterKernelWithoutSerialization();
 updateJSDomTypeDefinition();
 fixStripComments();
 verifyMomentIsOnlyUsedByJupyterLabCoreUtils();
-downloadZMQ()
-    .then(() => process.exit(0))
-    .catch((ex) => console.error('Failed to download ZMQ', ex));

--- a/build/webpack/webpack.extension.node.config.js
+++ b/build/webpack/webpack.extension.node.config.js
@@ -128,7 +128,7 @@ const config = {
         new copyWebpackPlugin({ patterns: [{ from: './node_modules/zeromq/**/*.js' }] }),
         new copyWebpackPlugin({ patterns: [{ from: './node_modules/zeromq/**/*.node' }] }),
         new copyWebpackPlugin({ patterns: [{ from: './node_modules/zeromq/**/*.json' }] }),
-        new copyWebpackPlugin({ patterns: [{ from: './node_modules/@aminya/node-gyp-build/**/*' }] }),
+        new copyWebpackPlugin({ patterns: [{ from: './node_modules/node-gyp-build/**/*' }] }),
         new webpack.DefinePlugin({
             IS_PRE_RELEASE_VERSION_OF_JUPYTER_EXTENSION: JSON.stringify(
                 typeof process.env.IS_PRE_RELEASE_VERSION_OF_JUPYTER_EXTENSION === 'string'

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
                 "vscode-languageserver-protocol": "3.17.2-next.6",
                 "vscode-tas-client": "^0.1.27",
                 "ws": "^6.2.2",
-                "zeromq": "^6.0.0-beta.16"
+                "zeromq": "^6.0.0-beta.6"
             },
             "devDependencies": {
                 "@actions/core": "^1.9.1",
@@ -155,7 +155,6 @@
                 "@typescript-eslint/parser": "^5.47.0",
                 "@vscode/test-electron": "^2.2.0",
                 "@vscode/test-web": "^0.0.29",
-                "@vscode/zeromq": "^0.0.6",
                 "acorn": "^6.4.1",
                 "babel-polyfill": "^6.26.0",
                 "bufferutil": "^4.0.6",
@@ -167,7 +166,7 @@
                 "codecov": "^3.7.1",
                 "colors": "^1.2.1",
                 "copy-webpack-plugin": "^10.2.4",
-                "cross-env": "^7.0.3",
+                "cross-env": "^6.0.3",
                 "cross-spawn": "^6.0.5",
                 "css-loader": "^6.6.0",
                 "dedent": "^0.7.0",
@@ -215,6 +214,7 @@
                 "mocha-junit-reporter": "^2.0.2",
                 "mocha-multi-reporters": "^1.1.7",
                 "nock": "^10.0.6",
+                "node-gyp-build": "^4.2.3",
                 "node-has-native-dependencies": "^1.0.2",
                 "nyc": "^15.0.0",
                 "path-browserify": "^1.0.1",
@@ -322,16 +322,6 @@
             "dev": true,
             "dependencies": {
                 "tunnel": "0.0.6"
-            }
-        },
-        "node_modules/@aminya/node-gyp-build": {
-            "version": "4.5.0-aminya.4",
-            "resolved": "https://registry.npmjs.org/@aminya/node-gyp-build/-/node-gyp-build-4.5.0-aminya.4.tgz",
-            "integrity": "sha512-2c2+BqZOxfTz/m+1MNWncMyMgil2WOg8cHhKPf1qUo1t9ohOWOgSeb7TVVD4fnTxIcAcpWdmXBpFkjPRyBVS9g==",
-            "bin": {
-                "node-gyp-build": "bin.js",
-                "node-gyp-build-optional": "optional.js",
-                "node-gyp-build-test": "build-test.js"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -4693,16 +4683,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/@vscode/zeromq": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/zeromq/-/zeromq-0.0.6.tgz",
-            "integrity": "sha512-hQoUWAauqLCVCkXxZgrZfPDZjQ41xY7jWUwM/2n3E+3PAKOjwTn8JOG3i3GcXDzknarvJw27GTHkjz9Q74UwZA==",
-            "dev": true,
-            "dependencies": {
-                "https-proxy-agent": "^5.0.1",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -7582,26 +7562,26 @@
             }
         },
         "node_modules/cross-env": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
+            "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
+            "dev": true,
             "dependencies": {
-                "cross-spawn": "^7.0.1"
+                "cross-spawn": "^7.0.0"
             },
             "bin": {
                 "cross-env": "src/bin/cross-env.js",
                 "cross-env-shell": "src/bin/cross-env-shell.js"
             },
             "engines": {
-                "node": ">=10.14",
-                "npm": ">=6",
-                "yarn": ">=1"
+                "node": ">=8.0"
             }
         },
         "node_modules/cross-env/node_modules/cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
             "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dev": true,
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -7615,6 +7595,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -7623,6 +7604,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -7634,6 +7616,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -7642,6 +7625,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -12950,6 +12934,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
             "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.10"
             }
@@ -13497,7 +13482,8 @@
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
         },
         "node_modules/isobject": {
             "version": "3.0.1",
@@ -16105,11 +16091,6 @@
                 "node": ">= 6.0"
             }
         },
-        "node_modules/node-addon-api": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-            "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
-        },
         "node_modules/node-fetch": {
             "version": "2.6.7",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -16152,7 +16133,6 @@
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
             "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
-            "devOptional": true,
             "bin": {
                 "node-gyp-build": "bin.js",
                 "node-gyp-build-optional": "optional.js",
@@ -18472,12 +18452,6 @@
                 "node >= 0.8.1"
             ]
         },
-        "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "dev": true
-        },
         "node_modules/prr": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -18950,6 +18924,7 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+            "dev": true,
             "dependencies": {
                 "resolve": "^1.1.6"
             },
@@ -19869,37 +19844,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/shelljs": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-            "dependencies": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            },
-            "bin": {
-                "shjs": "bin/shjs"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/shx": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
-            "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
-            "dependencies": {
-                "minimist": "^1.2.3",
-                "shelljs": "^0.8.5"
-            },
-            "bin": {
-                "shx": "lib/cli.js"
-            },
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/side-channel": {
@@ -23947,16 +23891,12 @@
             }
         },
         "node_modules/zeromq": {
-            "version": "6.0.0-beta.16",
-            "resolved": "https://registry.npmjs.org/zeromq/-/zeromq-6.0.0-beta.16.tgz",
-            "integrity": "sha512-taPr+V2synMrybR4H4YBJkjQ1tIi0CPuXsO6Jm2O1IbgnfJ0o3qYqi0QuhT9/oFwiTNr/yQiCze9OU2szGlp7w==",
+            "version": "6.0.0-beta.6",
+            "resolved": "https://registry.npmjs.org/zeromq/-/zeromq-6.0.0-beta.6.tgz",
+            "integrity": "sha512-wLf6M7pBHijl+BRltUL2VoDpgbQcOZetiX8UzycHL8CcYFxYnRrpoG5fi3UX3+Umavz1lk4/dGaQez8qiDgr/Q==",
             "hasInstallScript": true,
             "dependencies": {
-                "@aminya/node-gyp-build": "4.5.0-aminya.4",
-                "cross-env": "^7.0.3",
-                "node-addon-api": "^5.0.0",
-                "shelljs": "^0.8.5",
-                "shx": "^0.3.4"
+                "node-gyp-build": "^4.1.0"
             },
             "engines": {
                 "node": ">= 10.2"
@@ -24021,11 +23961,6 @@
             "requires": {
                 "tunnel": "0.0.6"
             }
-        },
-        "@aminya/node-gyp-build": {
-            "version": "4.5.0-aminya.4",
-            "resolved": "https://registry.npmjs.org/@aminya/node-gyp-build/-/node-gyp-build-4.5.0-aminya.4.tgz",
-            "integrity": "sha512-2c2+BqZOxfTz/m+1MNWncMyMgil2WOg8cHhKPf1qUo1t9ohOWOgSeb7TVVD4fnTxIcAcpWdmXBpFkjPRyBVS9g=="
         },
         "@ampproject/remapping": {
             "version": "2.1.2",
@@ -27447,16 +27382,6 @@
                 }
             }
         },
-        "@vscode/zeromq": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/@vscode/zeromq/-/zeromq-0.0.6.tgz",
-            "integrity": "sha512-hQoUWAauqLCVCkXxZgrZfPDZjQ41xY7jWUwM/2n3E+3PAKOjwTn8JOG3i3GcXDzknarvJw27GTHkjz9Q74UwZA==",
-            "dev": true,
-            "requires": {
-                "https-proxy-agent": "^5.0.1",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
         "@webassemblyjs/ast": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -29759,17 +29684,19 @@
             }
         },
         "cross-env": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
+            "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
+            "dev": true,
             "requires": {
-                "cross-spawn": "^7.0.1"
+                "cross-spawn": "^7.0.0"
             },
             "dependencies": {
                 "cross-spawn": {
                     "version": "7.0.3",
                     "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
                     "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+                    "dev": true,
                     "requires": {
                         "path-key": "^3.1.0",
                         "shebang-command": "^2.0.0",
@@ -29779,12 +29706,14 @@
                 "path-key": {
                     "version": "3.1.1",
                     "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+                    "dev": true
                 },
                 "shebang-command": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
                     "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+                    "dev": true,
                     "requires": {
                         "shebang-regex": "^3.0.0"
                     }
@@ -29792,12 +29721,14 @@
                 "shebang-regex": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+                    "dev": true
                 },
                 "which": {
                     "version": "2.0.2",
                     "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
                     "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
                     "requires": {
                         "isexe": "^2.0.0"
                     }
@@ -33943,7 +33874,8 @@
         "interpret": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+            "dev": true
         },
         "inversify": {
             "version": "6.0.1",
@@ -34334,7 +34266,8 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
         },
         "isobject": {
             "version": "3.0.1",
@@ -36398,11 +36331,6 @@
                 "semver": "^5.5.0"
             }
         },
-        "node-addon-api": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-            "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
-        },
         "node-fetch": {
             "version": "2.6.7",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -36435,8 +36363,7 @@
         "node-gyp-build": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-            "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
-            "devOptional": true
+            "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ=="
         },
         "node-has-native-dependencies": {
             "version": "1.0.2",
@@ -38149,12 +38076,6 @@
             "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
             "dev": true
         },
-        "proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "dev": true
-        },
         "prr": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -38543,6 +38464,7 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+            "dev": true,
             "requires": {
                 "resolve": "^1.1.6"
             }
@@ -39284,25 +39206,6 @@
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
-        },
-        "shelljs": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-            "requires": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            }
-        },
-        "shx": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
-            "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
-            "requires": {
-                "minimist": "^1.2.3",
-                "shelljs": "^0.8.5"
-            }
         },
         "side-channel": {
             "version": "1.0.4",
@@ -42528,15 +42431,11 @@
             "dev": true
         },
         "zeromq": {
-            "version": "6.0.0-beta.16",
-            "resolved": "https://registry.npmjs.org/zeromq/-/zeromq-6.0.0-beta.16.tgz",
-            "integrity": "sha512-taPr+V2synMrybR4H4YBJkjQ1tIi0CPuXsO6Jm2O1IbgnfJ0o3qYqi0QuhT9/oFwiTNr/yQiCze9OU2szGlp7w==",
+            "version": "6.0.0-beta.6",
+            "resolved": "https://registry.npmjs.org/zeromq/-/zeromq-6.0.0-beta.6.tgz",
+            "integrity": "sha512-wLf6M7pBHijl+BRltUL2VoDpgbQcOZetiX8UzycHL8CcYFxYnRrpoG5fi3UX3+Umavz1lk4/dGaQez8qiDgr/Q==",
             "requires": {
-                "@aminya/node-gyp-build": "4.5.0-aminya.4",
-                "cross-env": "^7.0.3",
-                "node-addon-api": "^5.0.0",
-                "shelljs": "^0.8.5",
-                "shx": "^0.3.4"
+                "node-gyp-build": "^4.1.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -2178,7 +2178,7 @@
         "vscode-languageserver-protocol": "3.17.2-next.6",
         "vscode-tas-client": "^0.1.27",
         "ws": "^6.2.2",
-        "zeromq": "^6.0.0-beta.16"
+        "zeromq": "^6.0.0-beta.6"
     },
     "devDependencies": {
         "@actions/core": "^1.9.1",
@@ -2250,7 +2250,6 @@
         "@typescript-eslint/parser": "^5.47.0",
         "@vscode/test-electron": "^2.2.0",
         "@vscode/test-web": "^0.0.29",
-        "@vscode/zeromq": "^0.0.6",
         "acorn": "^6.4.1",
         "babel-polyfill": "^6.26.0",
         "bufferutil": "^4.0.6",
@@ -2262,7 +2261,7 @@
         "codecov": "^3.7.1",
         "colors": "^1.2.1",
         "copy-webpack-plugin": "^10.2.4",
-        "cross-env": "^7.0.3",
+        "cross-env": "^6.0.3",
         "cross-spawn": "^6.0.5",
         "css-loader": "^6.6.0",
         "dedent": "^0.7.0",
@@ -2310,6 +2309,7 @@
         "mocha-junit-reporter": "^2.0.2",
         "mocha-multi-reporters": "^1.1.7",
         "nock": "^10.0.6",
+        "node-gyp-build": "^4.2.3",
         "node-has-native-dependencies": "^1.0.2",
         "nyc": "^15.0.0",
         "path-browserify": "^1.0.1",


### PR DESCRIPTION
Reverting this as we cannot even fallback to older binaries, as the zeromq js code has changed as well, hence dropin replacements of the binaries is not possible