### PR TITLE
Bump engine to 1.77

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -255,7 +255,7 @@
                 "yargs-parser": "^13.1.2"
             },
             "engines": {
-                "vscode": "^1.76.0"
+                "vscode": "^1.77.0"
             },
             "optionalDependencies": {
                 "canvas": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "theme": "light"
     },
     "engines": {
-        "vscode": "^1.76.0"
+        "vscode": "^1.77.0"
     },
     "l10n": "./l10n",
     "keywords": [


### PR DESCRIPTION
Bump the engine check to 1.77 to avoid releasing to current Stable (1.76) users.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
