### PR TITLE
Improve initialization of IW controller

### DIFF
--- a/src/interactive-window/InteractiveWindowController.ts
+++ b/src/interactive-window/InteractiveWindowController.ts
@@ -20,7 +20,6 @@ export class InteractiveWindowController {
     public kernel: Deferred<IKernel> | undefined;
     public controller: NotebookController | undefined;
     public metadata: KernelConnectionMetadata | undefined;
-    private autoStart = false;
     private disposables: Disposable[] = [];
     private systemInfoCell: SystemInfoCell | undefined;
     private fileInKernel: Uri | undefined;
@@ -44,10 +43,6 @@ export class InteractiveWindowController {
 
     public updateOwners(file: Uri) {
         this.owner = file;
-    }
-
-    public enableAutoStart() {
-        this.autoStart = true;
     }
 
     public async startKernel(): Promise<IKernel> {
@@ -185,11 +180,7 @@ export class InteractiveWindowController {
                     this.disconnect();
                     this.controller = e.controller.controller;
                     this.metadata = e.controller.connection;
-
-                    // don't start the kernel if the IW has only been restored from a previous session
-                    if (this.autoStart) {
-                        this.startKernel().catch(noop);
-                    }
+                    this.startKernel().catch(noop);
                 }
             },
             this

--- a/src/interactive-window/InteractiveWindowController.ts
+++ b/src/interactive-window/InteractiveWindowController.ts
@@ -50,7 +50,7 @@ export class InteractiveWindowController {
             return this.kernel.promise;
         }
         if (!this.controller || !this.metadata) {
-            throw new Error('Controller not selected');
+            throw new Error('Interactive Window kernel not selected');
         }
 
         this.setInfoMessage(this.metadata, SysInfoReason.Start);

--- a/src/interactive-window/InteractiveWindowController.ts
+++ b/src/interactive-window/InteractiveWindowController.ts
@@ -20,7 +20,6 @@ export class InteractiveWindowController {
     public kernel: Deferred<IKernel> | undefined;
     public controller: NotebookController | undefined;
     public metadata: KernelConnectionMetadata | undefined;
-    private notebook: NotebookDocument | undefined;
     private autoStart = false;
     private disposables: Disposable[] = [];
     private systemInfoCell: SystemInfoCell | undefined;
@@ -29,10 +28,15 @@ export class InteractiveWindowController {
     constructor(
         private readonly controllerService: IInteractiveControllerHelper,
         private mode: InteractiveWindowMode,
+        private readonly notebook: NotebookDocument,
         private readonly errorHandler: IDataScienceErrorHandler,
         private readonly kernelProvider: IKernelProvider,
-        private owner: Resource
-    ) {}
+        private owner: Resource,
+        controller: IVSCodeNotebookController | undefined
+    ) {
+        this.controller = controller?.controller;
+        this.metadata = controller?.connection;
+    }
 
     public updateMode(mode: InteractiveWindowMode) {
         this.mode = mode;
@@ -42,21 +46,8 @@ export class InteractiveWindowController {
         this.owner = file;
     }
 
-    public get kernelDisposables() {
-        return this.disposables;
-    }
-
     public enableAutoStart() {
         this.autoStart = true;
-    }
-
-    public setController(notebook: NotebookDocument) {
-        if (!this.controller || !this.metadata) {
-            this.notebook = notebook;
-            const selected = this.controllerService.getSelectedController(notebook);
-            this.controller = selected?.controller;
-            this.metadata = selected?.connection;
-        }
     }
 
     public async startKernel(): Promise<IKernel> {
@@ -67,18 +58,18 @@ export class InteractiveWindowController {
             throw new Error('Controller not selected');
         }
 
-        this.setInfoMessageCell(this.metadata, SysInfoReason.Start);
+        this.setInfoMessage(this.metadata, SysInfoReason.Start);
         try {
             const kernel = await this.createKernel();
             const kernelEventHookForRestart = async () => {
                 if (this.notebook && this.metadata) {
                     this.systemInfoCell = undefined;
                     // If we're about to restart, insert a 'restarting' message as it happens
-                    this.setInfoMessageCell(this.metadata, SysInfoReason.Restart);
+                    this.setInfoMessage(this.metadata, SysInfoReason.Restart);
                 }
             };
             // Hook pre interrupt so we can stick in a message
-            this.kernelDisposables.push(kernel.addHook('willRestart', kernelEventHookForRestart));
+            this.disposables.push(kernel.addHook('willRestart', kernelEventHookForRestart));
             // When restart finishes, rerun our initialization code
             kernel.onRestarted(
                 async () => {
@@ -93,7 +84,7 @@ export class InteractiveWindowController {
                     }
                 },
                 this,
-                this.kernelDisposables
+                this.disposables
             );
             this.fileInKernel = undefined;
             await this.setFileInKernel(kernel);
@@ -132,12 +123,12 @@ export class InteractiveWindowController {
                 this.controller,
                 this.owner,
                 this.notebook!,
-                this.kernelDisposables
+                this.disposables
             );
             this.metadata = kernel.kernelConnectionMetadata;
             this.controller = actualController;
 
-            this.kernelDisposables.push(kernel);
+            this.disposables.push(kernel);
             kernelPromise.resolve(kernel);
             return kernel;
         } catch (ex) {
@@ -205,18 +196,24 @@ export class InteractiveWindowController {
         );
     }
 
-    private setInfoMessageCell(metadata: KernelConnectionMetadata, reason: SysInfoReason) {
+    public setInfoMessageCell(message: string) {
         if (!this.notebook) {
             return;
         }
-        const message = getSysInfoMessage(metadata, reason);
         if (!this.systemInfoCell) {
             this.systemInfoCell = new SystemInfoCell(this.notebook, message);
         } else {
             this.systemInfoCell
                 .updateMessage(message)
-                .catch((error) => traceWarning(`could not update kernel ${reason} info message: ${error}`));
+                .catch((error) =>
+                    traceWarning(`could not update info cell with message: "${message}", error: ${error}`)
+                );
         }
+    }
+
+    private setInfoMessage(metadata: KernelConnectionMetadata, reason: SysInfoReason) {
+        const message = getSysInfoMessage(metadata, reason);
+        this.setInfoMessageCell(message);
     }
 
     private finishSysInfoMessage(kernel: IKernel, reason: SysInfoReason) {
@@ -259,10 +256,30 @@ export class InteractiveWindowController {
 export class InteractiveControllerFactory {
     constructor(
         private readonly controllerService: IInteractiveControllerHelper,
-        private readonly mode: InteractiveWindowMode
+        private readonly mode: InteractiveWindowMode,
+        private readonly initialController?: IVSCodeNotebookController
     ) {}
 
-    public create(errorHandler: IDataScienceErrorHandler, kernelProvider: IKernelProvider, owner: Resource) {
-        return new InteractiveWindowController(this.controllerService, this.mode, errorHandler, kernelProvider, owner);
+    public create(
+        notebook: NotebookDocument,
+        errorHandler: IDataScienceErrorHandler,
+        kernelProvider: IKernelProvider,
+        owner: Resource
+    ) {
+        let controller = this.initialController;
+        const selected = this.controllerService.getSelectedController(notebook);
+        if (selected) {
+            controller = selected;
+        }
+
+        return new InteractiveWindowController(
+            this.controllerService,
+            this.mode,
+            notebook,
+            errorHandler,
+            kernelProvider,
+            owner,
+            controller
+        );
     }
 }

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -191,7 +191,6 @@ export class InteractiveWindow implements IInteractiveWindow {
         this.internalDisposables.push(this.controller.listenForControllerSelection());
 
         if (this.controller.controller) {
-            this.controller.enableAutoStart();
             this.startKernel().catch(noop);
         } else {
             traceInfo('No controller selected for Interactive Window initilization');

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -182,24 +182,22 @@ export class InteractiveWindow implements IInteractiveWindow {
             this.codeGeneratorFactory.getOrCreate(this.notebookDocument);
         }
 
-        this.controller = this.controllerFactory.create(
-            this.notebookDocument,
-            this.errorHandler,
-            this.kernelProvider,
-            this._owner
-        );
-        this.internalDisposables.push(this.controller.listenForControllerSelection());
+        if (!this.controller) {
+            this.controller = this.controllerFactory.create(
+                this.notebookDocument,
+                this.errorHandler,
+                this.kernelProvider,
+                this._owner
+            );
+            this.internalDisposables.push(this.controller.listenForControllerSelection());
+        }
 
         if (this.controller.controller) {
-            this.startKernel().catch(noop);
+            this.controller.startKernel().catch(noop);
         } else {
             traceInfo('No controller selected for Interactive Window initilization');
             this.controller.setInfoMessageCell(DataScience.selectKernelForEditor);
         }
-    }
-
-    public async startKernel(): Promise<IKernel> {
-        return this.controller.startKernel();
     }
 
     /**
@@ -393,7 +391,7 @@ export class InteractiveWindow implements IInteractiveWindow {
     private async createExecutionPromise(notebookCellPromise: Promise<NotebookCell>, isDebug: boolean) {
         traceInfoIfCI('InteractiveWindow.ts.createExecutionPromise.start');
         // Kick of starting kernels early.
-        const kernelPromise = this.startKernel();
+        const kernelPromise = this.controller.startKernel();
         const cell = await notebookCellPromise;
 
         let success = true;
@@ -579,7 +577,7 @@ export class InteractiveWindow implements IInteractiveWindow {
     }
 
     public async exportAs() {
-        const kernel = await this.startKernel();
+        const kernel = await this.controller.startKernel();
 
         // Pull out the metadata from our active notebook
         const metadata: nbformat.INotebookMetadata = { orig_nbformat: defaultNotebookFormat.major };

--- a/src/interactive-window/interactiveWindowProvider.ts
+++ b/src/interactive-window/interactiveWindowProvider.ts
@@ -215,7 +215,7 @@ export class InteractiveWindowProvider
             const result = new InteractiveWindow(
                 this.serviceContainer,
                 resource,
-                new InteractiveControllerFactory(this.controllerHelper, mode),
+                new InteractiveControllerFactory(this.controllerHelper, mode, initialController),
                 editor,
                 inputUri
             );


### PR DESCRIPTION
- Use the controller info that we already calculated in case the notebookDocument isn't ready to tell us which one is actually selected
- Simplify the controller object by only creating it once we have all the dependencies