### PR TITLE
migrate interrupt to core

### DIFF
--- a/package.json
+++ b/package.json
@@ -938,11 +938,6 @@
                     "when": "isWorkspaceTrusted && notebookKernel =~ /^ms-toolsai.jupyter\\// || isWorkspaceTrusted && !notebookKernel"
                 },
                 {
-                    "command": "jupyter.interruptkernel",
-                    "group": "navigation@2",
-                    "when": "isWorkspaceTrusted && notebookKernel =~ /^ms-toolsai.jupyter\\// || isWorkspaceTrusted && !notebookKernel"
-                },
-                {
                     "command": "jupyter.openVariableView",
                     "group": "navigation@3",
                     "when": "isWorkspaceTrusted && notebookKernel =~ /^ms-toolsai.jupyter\\// || isWorkspaceTrusted && !notebookKernel"
@@ -1198,12 +1193,6 @@
                     "title": "%jupyter.command.jupyter.exportfileandoutputasnotebook.title%",
                     "category": "Jupyter",
                     "when": "jupyter.hascodecells && jupyter.ispythonorinteractiveeactive && !notebookEditorFocused && isWorkspaceTrusted"
-                },
-                {
-                    "command": "jupyter.interruptkernel",
-                    "title": "%jupyter.command.jupyter.interruptkernel.title%",
-                    "category": "Jupyter",
-                    "when": "jupyter.ispythonorinteractiveeactive && isWorkspaceTrusted"
                 },
                 {
                     "command": "jupyter.restartkernel",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-jupyter/issues/7661

The command is still used to handle interruption events from the controller for both notebooks and IW, but this will make them use the same core command from the toolbar/palette