### PR TITLE
Add support for `Restart Kernel + Run up to Selected Cell` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -631,7 +631,7 @@
                 "title": "%jupyter.command.jupyter.restartkernelandrunuptoselectedcell.title%",
                 "shortTitle": "%jupyter.command.jupyter.restartkernelandrunuptoselectedcell.title%",
                 "category": "Jupyter",
-                "enablement": "isWorkspaceTrusted && (jupyter.interactive.canRestartNotebookKernel || (notebookKernel =~ /^ms-toolsai.jupyter\\// && jupyter.notebookeditor.canrestartNotebookkernel))"
+                "enablement": "isWorkspaceTrusted && (notebookKernel =~ /^ms-toolsai.jupyter\\// && jupyter.notebookeditor.canrestartNotebookkernel)"
             },
             {
                 "command": "jupyter.notebookeditor.addcellbelow",

--- a/package.json
+++ b/package.json
@@ -627,6 +627,13 @@
                 "enablement": "isWorkspaceTrusted && (jupyter.interactive.canRestartNotebookKernel || (notebookKernel =~ /^ms-toolsai.jupyter\\// && jupyter.notebookeditor.canrestartNotebookkernel))"
             },
             {
+                "command": "jupyter.restartkernelandrunuptoselectedcell",
+                "title": "%jupyter.command.jupyter.restartkernelandrunuptoselectedcell.title%",
+                "shortTitle": "%jupyter.command.jupyter.restartkernelandrunuptoselectedcell.title%",
+                "category": "Jupyter",
+                "enablement": "isWorkspaceTrusted && (jupyter.interactive.canRestartNotebookKernel || (notebookKernel =~ /^ms-toolsai.jupyter\\// && jupyter.notebookeditor.canrestartNotebookkernel))"
+            },
+            {
                 "command": "jupyter.notebookeditor.addcellbelow",
                 "title": "%jupyter.command.jupyter.notebookeditor.addcellbelow.title%",
                 "category": "Notebook",

--- a/package.nls.json
+++ b/package.nls.json
@@ -138,6 +138,7 @@
     "jupyter.command.jupyter.restartkernel.shorttitle": "Restart",
     "jupyter.command.jupyter.restartkernelandrunallcells.title": "Restart Kernel and Run All Cells",
     "jupyter.command.jupyter.restartkernelandrunallcells.shorttitle": "Restart and Run All",
+    "jupyter.command.jupyter.restartkernelandrunuptoselectedcell.title": "Restart Kernel and Run Up To Selected Cell",
     "jupyter.command.jupyter.expandallcells.title": "Expand All Interactive Cells",
     "jupyter.command.jupyter.collapseallcells.title": "Collapse All Interactive Cells",
     "jupyter.command.jupyter.expandallcells.shorttitle": "Expand",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -50,6 +50,7 @@ export interface ICommandNameArgumentTypeMapping {
     [DSCommands.InterruptKernel]: [{ notebookEditor: { notebookUri: Uri } } | undefined];
     [DSCommands.RestartKernel]: [{ notebookEditor: { notebookUri: Uri } } | undefined];
     [DSCommands.RestartKernelAndRunAllCells]: [{ notebookEditor: { notebookUri: Uri } } | undefined];
+    [DSCommands.RestartKernelAndRunUpToSelectedCell]: [{ notebookEditor: { notebookUri: Uri } } | undefined];
     [DSCommands.NotebookEditorRemoveAllCells]: [];
     [DSCommands.NotebookEditorRunAllCells]: [];
     [DSCommands.NotebookEditorAddCellBelow]: [];

--- a/src/notebooks/notebookCommandListener.ts
+++ b/src/notebooks/notebookCommandListener.ts
@@ -103,9 +103,9 @@ export class NotebookCommandListener implements IDataScienceCommandListener {
                 Commands.RestartKernelAndRunUpToSelectedCell,
                 (context?: { notebookEditor: { notebookUri: Uri } }) => {
                     if (context && 'notebookEditor' in context) {
-                        this.RestartKernelAndRunUpToSelectedCell(context?.notebookEditor?.notebookUri).catch(noop);
+                        this.restartKernelAndRunUpToSelectedCell(context?.notebookEditor?.notebookUri).catch(noop);
                     } else {
-                        this.RestartKernelAndRunUpToSelectedCell(context).catch(noop);
+                        this.restartKernelAndRunUpToSelectedCell(context).catch(noop);
                     }
                 }
             )
@@ -187,14 +187,14 @@ export class NotebookCommandListener implements IDataScienceCommandListener {
         this.runAllCells();
     }
 
-    private async RestartKernelAndRunUpToSelectedCell(notebookUri: Uri | undefined) {
-        const uri = notebookUri ?? this.notebookEditorProvider.activeNotebookEditor?.notebook.uri;
-
-        await this.restartKernel(uri);
-        if (this.notebooks.activeNotebookEditor) {
+    private async restartKernelAndRunUpToSelectedCell(notebookUri: Uri | undefined) {
+        const activeNBE = this.notebookEditorProvider.activeNotebookEditor;
+        if(activeNBE) {
+            const uri = notebookUri ?? activeNBE.notebook.uri;
+            await this.restartKernel(uri);
             this.commandManager
                 .executeCommand('notebook.cell.execute', {
-                    ranges: [{ start: 0, end: this.notebooks.activeNotebookEditor.selection.end }],
+                    ranges: [{ start: 0, end: activeNBE.selection.end }],
                     document: uri
                 })
                 .then(noop, noop);

--- a/src/notebooks/notebookCommandListener.ts
+++ b/src/notebooks/notebookCommandListener.ts
@@ -189,7 +189,7 @@ export class NotebookCommandListener implements IDataScienceCommandListener {
 
     private async restartKernelAndRunUpToSelectedCell(notebookUri: Uri | undefined) {
         const activeNBE = this.notebookEditorProvider.activeNotebookEditor;
-        if(activeNBE) {
+        if (activeNBE) {
             const uri = notebookUri ?? activeNBE.notebook.uri;
             await this.restartKernel(uri);
             this.commandManager

--- a/src/platform/common/constants.ts
+++ b/src/platform/common/constants.ts
@@ -188,6 +188,7 @@ export namespace Commands {
     export const InterruptKernel = 'jupyter.interruptkernel';
     export const RestartKernel = 'jupyter.restartkernel';
     export const RestartKernelAndRunAllCells = 'jupyter.restartkernelandrunallcells';
+    export const RestartKernelAndRunUpToSelectedCell = 'jupyter.restartkernelandrunuptoselectedcell';
     export const NotebookEditorRemoveAllCells = 'jupyter.notebookeditor.removeallcells';
     export const NotebookEditorRunAllCells = 'jupyter.notebookeditor.runallcells';
     export const NotebookEditorRunSelectedCell = 'jupyter.notebookeditor.runselectedcell';


### PR DESCRIPTION
Fixes #9242 

Only thought is a different enablement, taking into account `notebookEditorFocused` and/or `jupyter.hascodecells`? On the other hand, commands like `jupyter.runcurrentcell` only require `isWorkspaceTrusted` to be used. 


-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).

