### PR TITLE
only decorate cell tops for allCells decoration

### DIFF
--- a/src/interactive-window/editor-integration/decorator.ts
+++ b/src/interactive-window/editor-integration/decorator.ts
@@ -144,13 +144,16 @@ export class Decorator implements IExtensionSyncActivationService, IDisposable {
                     const currentRange = cells.map((c) => c.range).filter((r) => r.contains(editor.selection.anchor));
                     const rangeTop =
                         currentRange.length > 0 ? [new vscode.Range(currentRange[0].start, currentRange[0].start)] : [];
+                    // no need to decorate the bottom if we're decorating all cells
                     const rangeBottom =
-                        currentRange.length > 0 ? [new vscode.Range(currentRange[0].end, currentRange[0].end)] : [];
+                        settings.decorateCells !== 'allCells' && currentRange.length > 0
+                            ? [new vscode.Range(currentRange[0].end, currentRange[0].end)]
+                            : [];
                     const nonCurrentCells: vscode.Range[] = [];
                     if (settings.decorateCells === 'allCells')
                         cells.forEach((cell) => {
                             const cellTop = cell.range.start;
-                            if (cellTop !== currentRange[0].start && cellTop.line - 1 !== currentRange[0].end.line) {
+                            if (cellTop !== currentRange[0].start) {
                                 nonCurrentCells.push(new vscode.Range(cellTop, cellTop));
                             }
                         });


### PR DESCRIPTION
for https://github.com/microsoft/vscode-jupyter/issues/8368

With all cells decorated, we can just skip decorating the bottom of the current cell since the top of the next cell will denote the same thing.