### PR TITLE
Add qsharp to the list of supported languages by ipykernel

### DIFF
--- a/src/platform/common/constants.ts
+++ b/src/platform/common/constants.ts
@@ -126,6 +126,7 @@ export const LanguagesSupportedByPythonkernel = [
     'ruby', // %%ruby
     'sql', // %%sql
     'perl', // %%perl
+    'qsharp', // %%qsharp
     'raw' // raw cells (no formatting)
 ];
 export const jupyterLanguageToMonacoLanguageMapping = new Map([


### PR DESCRIPTION
Q# support and the corresponding `%%qsharp` cell magic can be added through the `qsharp` Python package. See: https://learn.microsoft.com/en-us/azure/quantum/how-to-python-qdk-local#the-qsharp-magic-command

Related issue #4588 would generalize this to all languages with corresponding magics, but this change only aims to fix Q#.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for feature-requests.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
