### PR TITLE
Rename types and classes

### DIFF
--- a/src/interactive-window/debugger/jupyter/kernelDebugAdapter.ts
+++ b/src/interactive-window/debugger/jupyter/kernelDebugAdapter.ts
@@ -4,7 +4,7 @@
 import { DebugAdapterTracker, DebugSession, NotebookDocument, Uri } from 'vscode';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { getInteractiveCellMetadata } from '../../../interactive-window/helpers';
-import { IKernel, IKernelConnectionSession } from '../../../kernels/types';
+import { IKernel, IKernelSession } from '../../../kernels/types';
 import { IDebugLocationTrackerFactory, IDumpCellResponse } from '../../../notebooks/debugger/debuggingTypes';
 import { KernelDebugAdapterBase } from '../../../notebooks/debugger/kernelDebugAdapterBase';
 import { IDebugService } from '../../../platform/common/application/types';
@@ -29,7 +29,7 @@ export class KernelDebugAdapter extends KernelDebugAdapterBase {
     constructor(
         session: DebugSession,
         notebookDocument: NotebookDocument,
-        jupyterSession: IKernelConnectionSession,
+        jupyterSession: IKernelSession,
         kernel: IKernel | undefined,
         platformService: IPlatformService,
         debugService: IDebugService,

--- a/src/kernels/common/baseJupyterSession.ts
+++ b/src/kernels/common/baseJupyterSession.ts
@@ -28,11 +28,11 @@ import { JupyterWaitForIdleError } from '../errors/jupyterWaitForIdleError';
 import { KernelInterruptTimeoutError } from '../errors/kernelInterruptTimeoutError';
 import { SessionDisposedError } from '../../platform/errors/sessionDisposedError';
 import {
-    IJupyterKernelConnectionSession,
+    IJupyterKernelSession,
     ISessionWithSocket,
     KernelConnectionMetadata,
     KernelSocketInformation,
-    IBaseKernelConnectionSession
+    IBaseKernelSession
 } from '../types';
 import { ChainingExecuteRequester } from './chainingExecuteRequester';
 import { getResourceType } from '../../platform/common/utils';
@@ -86,7 +86,9 @@ export class JupyterSessionStartError extends WrappedError {
 /**
  * Common code for a Jupyterlabs IKernelConnection. Raw and Jupyter both inherit from this.
  */
-export abstract class BaseJupyterSession implements IBaseKernelConnectionSession {
+export abstract class BaseJupyterSession<T extends 'remoteJupyter' | 'localJupyter' | 'localRaw'>
+    implements IBaseKernelSession<T>
+{
     /**
      * Keep a single instance of KernelConnectionWrapper.
      * This way when sessions change, we still have a single Kernel.IKernelConnection proxy (wrapper),
@@ -149,6 +151,7 @@ export abstract class BaseJupyterSession implements IBaseKernelConnectionSession
     private previousAnyMessageHandler?: IDisposable;
 
     constructor(
+        public readonly kind: T,
         protected resource: Resource,
         protected readonly kernelConnectionMetadata: KernelConnectionMetadata,
         public workingDirectory: Uri,
@@ -159,7 +162,7 @@ export abstract class BaseJupyterSession implements IBaseKernelConnectionSession
             traceWarning(`Unhandled message found: ${m.header.msg_type}`);
         };
     }
-    public isServerSession(): this is IJupyterKernelConnectionSession {
+    public isServerSession(): this is IJupyterKernelSession {
         return false;
     }
     public async dispose(): Promise<void> {

--- a/src/kernels/common/kernelSessionFactory.unit.test.ts
+++ b/src/kernels/common/kernelSessionFactory.unit.test.ts
@@ -12,11 +12,11 @@ import { disposeAllDisposables } from '../../platform/common/helpers';
 import { IAsyncDisposableRegistry } from '../../platform/common/types';
 import { DisplayOptions } from '../displayOptions';
 import { JupyterConnection } from '../jupyter/connection/jupyterConnection';
-import { JupyterKernelConnectionSessionCreator } from '../jupyter/session/jupyterKernelConnectionSessionCreator';
+import { JupyterKernelConnectionSessionCreator } from '../jupyter/session/jupyterKernelSessionFactory';
 import { IJupyterServerProvider, IJupyterSessionManagerFactory } from '../jupyter/types';
-import { IRawKernelConnectionSessionCreator } from '../raw/types';
-import { IJupyterKernelConnectionSession, KernelConnectionMetadata } from '../types';
-import { KernelConnectionSessionCreator } from './kernelConnectionSessionCreator';
+import { IRawKernelSessionFactory } from '../raw/types';
+import { IJupyterKernelSession, KernelConnectionMetadata } from '../types';
+import { KernelSessionFactory } from './kernelSessionFactory';
 
 function Uri(filename: string): vscode.Uri {
     return vscode.Uri.file(filename);
@@ -24,16 +24,16 @@ function Uri(filename: string): vscode.Uri {
 
 /* eslint-disable  */
 suite('NotebookProvider', () => {
-    let kernelConnectionSessionCreator: KernelConnectionSessionCreator;
+    let kernelConnectionSessionCreator: KernelSessionFactory;
     let jupyterNotebookProvider: IJupyterServerProvider;
-    let rawKernelSessionCreator: IRawKernelConnectionSessionCreator;
+    let rawKernelSessionCreator: IRawKernelSessionFactory;
     let cancelToken: vscode.CancellationTokenSource;
     const disposables: IDisposable[] = [];
     let asyncDisposables: IAsyncDisposableRegistry;
     let onDidShutdown: EventEmitter<void>;
     setup(() => {
         jupyterNotebookProvider = mock<IJupyterServerProvider>();
-        rawKernelSessionCreator = mock<IRawKernelConnectionSessionCreator>();
+        rawKernelSessionCreator = mock<IRawKernelSessionFactory>();
         cancelToken = new vscode.CancellationTokenSource();
         disposables.push(cancelToken);
         when(rawKernelSessionCreator.isSupported).thenReturn(false);
@@ -50,12 +50,12 @@ suite('NotebookProvider', () => {
             localLaunch: true,
             baseUrl: 'http://localhost:8888'
         } as any);
-        const mockSession = mock<IJupyterKernelConnectionSession>();
+        const mockSession = mock<IJupyterKernelSession>();
         when(mockSession.onDidShutdown).thenReturn(onDidShutdown.event);
         instance(mockSession as any).then = undefined;
         when(jupyterSessionCreator.create(anything())).thenResolve(instance(mockSession));
         asyncDisposables = new AsyncDisposableRegistry();
-        kernelConnectionSessionCreator = new KernelConnectionSessionCreator(
+        kernelConnectionSessionCreator = new KernelSessionFactory(
             instance(rawKernelSessionCreator),
             instance(jupyterNotebookProvider),
             instance(sessionManagerFactory),

--- a/src/kernels/execution/cellExecution.ts
+++ b/src/kernels/execution/cellExecution.ts
@@ -26,12 +26,7 @@ import { getDisplayNameOrNameOfKernelConnection } from '../../kernels/helpers';
 import { isCancellationError } from '../../platform/common/cancellation';
 import { activeNotebookCellExecution, CellExecutionMessageHandler } from './cellExecutionMessageHandler';
 import { CellExecutionMessageHandlerService } from './cellExecutionMessageHandlerService';
-import {
-    IKernelConnectionSession,
-    IKernelController,
-    KernelConnectionMetadata,
-    NotebookCellRunState
-} from '../../kernels/types';
+import { IKernelSession, IKernelController, KernelConnectionMetadata, NotebookCellRunState } from '../../kernels/types';
 import { NotebookCellStateTracker, traceCellMessage } from './helpers';
 import { getDisplayPath } from '../../platform/common/platform/fs-paths';
 import { SessionDisposedError } from '../../platform/errors/sessionDisposedError';
@@ -85,7 +80,7 @@ export class CellExecution implements IDisposable {
     private readonly disposables: IDisposable[] = [];
     private _preExecuteEmitter = new EventEmitter<NotebookCell>();
     private cellExecutionHandler?: CellExecutionMessageHandler;
-    private session?: IKernelConnectionSession;
+    private session?: IKernelSession;
     private constructor(
         public readonly cell: NotebookCell,
         private readonly codeOverride: string | undefined,
@@ -141,7 +136,7 @@ export class CellExecution implements IDisposable {
     ) {
         return new CellExecution(cell, code, metadata, controller, requestListener);
     }
-    public async start(session: IKernelConnectionSession) {
+    public async start(session: IKernelSession) {
         this.session = session;
         if (this.cancelHandled) {
             traceCellMessage(this.cell, 'Not starting as it was cancelled');
@@ -329,12 +324,12 @@ export class CellExecution implements IDisposable {
         return !this.cell.document.isClosed;
     }
 
-    private async execute(code: string, session: IKernelConnectionSession) {
+    private async execute(code: string, session: IKernelSession) {
         traceCellMessage(this.cell, 'Send code for execution');
         await this.executeCodeCell(code, session);
     }
 
-    private async executeCodeCell(code: string, session: IKernelConnectionSession) {
+    private async executeCodeCell(code: string, session: IKernelSession) {
         // Skip if no code to execute
         if (code.trim().length === 0 || this.cell.document.isClosed) {
             traceCellMessage(this.cell, 'Empty cell execution');

--- a/src/kernels/execution/cellExecutionQueue.ts
+++ b/src/kernels/execution/cellExecutionQueue.ts
@@ -6,7 +6,7 @@ import { traceError, traceVerbose, traceWarning } from '../../platform/logging';
 import { noop } from '../../platform/common/utils/misc';
 import { traceCellMessage } from './helpers';
 import { CellExecution, CellExecutionFactory } from './cellExecution';
-import { IKernelConnectionSession, KernelConnectionMetadata, NotebookCellRunState } from '../../kernels/types';
+import { IKernelSession, KernelConnectionMetadata, NotebookCellRunState } from '../../kernels/types';
 import { Resource } from '../../platform/common/types';
 
 /**
@@ -39,7 +39,7 @@ export class CellExecutionQueue implements Disposable {
         return this.queueOfCellsToExecute.map((cell) => cell.cell);
     }
     constructor(
-        private readonly session: Promise<IKernelConnectionSession>,
+        private readonly session: Promise<IKernelSession>,
         private readonly executionFactory: CellExecutionFactory,
         readonly metadata: Readonly<KernelConnectionMetadata>,
         readonly resourceUri: Resource

--- a/src/kernels/execution/kernelCompletionPreWarmer.ts
+++ b/src/kernels/execution/kernelCompletionPreWarmer.ts
@@ -6,7 +6,7 @@ import { IExtensionSyncActivationService } from '../../platform/activation/types
 import { IDisposableRegistry } from '../../platform/common/types';
 import { noop } from '../../platform/common/utils/misc';
 import { isPythonKernelConnection } from '../helpers';
-import { IKernelConnectionSession, IKernelProvider } from '../types';
+import { IKernelSession, IKernelProvider } from '../types';
 
 @injectable()
 export class KernelCompletionsPreWarmer implements IExtensionSyncActivationService {
@@ -31,7 +31,7 @@ export class KernelCompletionsPreWarmer implements IExtensionSyncActivationServi
      * Hence we end up waiting indefinitely.
      * https://github.com/microsoft/vscode-jupyter/issues/9014
      */
-    private requestEmptyCompletions(session: IKernelConnectionSession) {
+    private requestEmptyCompletions(session: IKernelSession) {
         session
             ?.requestComplete({
                 code: '__file__.',

--- a/src/kernels/helpers.node.ts
+++ b/src/kernels/helpers.node.ts
@@ -3,7 +3,7 @@
 
 import * as path from '../platform/vscode-path/path';
 import * as nbformat from '@jupyterlab/nbformat';
-import { IJupyterKernelSpec, IKernelConnectionSession, isLocalConnection, KernelConnectionMetadata } from './types';
+import { IJupyterKernelSpec, IKernelSession, isLocalConnection, KernelConnectionMetadata } from './types';
 import { Uri } from 'vscode';
 import { traceError, traceVerbose } from '../platform/logging';
 import { Resource } from '../platform/common/types';
@@ -14,7 +14,7 @@ import { executeSilently, isPythonKernelConnection } from './helpers';
 import { PYTHON_LANGUAGE } from '../platform/common/constants';
 
 export async function sendTelemetryForPythonKernelExecutable(
-    session: IKernelConnectionSession,
+    session: IKernelSession,
     resource: Resource,
     kernelConnection: KernelConnectionMetadata
 ) {

--- a/src/kernels/helpers.ts
+++ b/src/kernels/helpers.ts
@@ -18,7 +18,7 @@ import {
     LiveRemoteKernelConnectionMetadata,
     PythonKernelConnectionMetadata,
     IJupyterKernelSpec,
-    IKernelConnectionSession
+    IKernelSession
 } from './types';
 import { Uri } from 'vscode';
 import { IWorkspaceService } from '../platform/common/application/types';
@@ -577,7 +577,7 @@ export type SilentExecutionErrorOptions = {
 };
 
 export async function executeSilently(
-    session: IKernelConnectionSession | Kernel.IKernelConnection,
+    session: IKernelSession | Kernel.IKernelConnection,
     code: string,
     errorOptions?: SilentExecutionErrorOptions
 ): Promise<nbformat.IOutput[]> {

--- a/src/kernels/jupyter/launcher/jupyterServerConnector.ts
+++ b/src/kernels/jupyter/launcher/jupyterServerConnector.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { inject, injectable, optional } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { IPythonExtensionChecker } from '../../../platform/api/types';
 import { ConnectNotebookProviderOptions, IJupyterConnection, IJupyterServerConnector } from '../../types';
 import { DisplayOptions } from '../../displayOptions';
-import { IRawKernelConnectionSessionCreator } from '../../raw/types';
 import { IJupyterServerProvider } from '../types';
 import { PythonExtensionNotInstalledError } from '../../../platform/errors/pythonExtNotInstalledError';
 
@@ -13,9 +12,6 @@ import { PythonExtensionNotInstalledError } from '../../../platform/errors/pytho
 export class JupyterServerConnector implements IJupyterServerConnector {
     private readonly startupUi = new DisplayOptions(true);
     constructor(
-        @inject(IRawKernelConnectionSessionCreator)
-        @optional()
-        private readonly rawSessionCreator: IRawKernelConnectionSessionCreator | undefined,
         @inject(IJupyterServerProvider)
         private readonly jupyterNotebookProvider: IJupyterServerProvider,
         @inject(IPythonExtensionChecker) private readonly extensionChecker: IPythonExtensionChecker
@@ -32,9 +28,7 @@ export class JupyterServerConnector implements IJupyterServerConnector {
             }
         });
         options.ui = this.startupUi;
-        if (this.rawSessionCreator?.isSupported) {
-            throw new Error('Connect method should not be invoked for local Connections when Raw is supported');
-        } else if (this.extensionChecker.isPythonExtensionInstalled) {
+        if (this.extensionChecker.isPythonExtensionInstalled) {
             return this.jupyterNotebookProvider.getOrCreateServer(options).finally(() => handler.dispose());
         } else {
             handler.dispose();

--- a/src/kernels/jupyter/serviceRegistry.node.ts
+++ b/src/kernels/jupyter/serviceRegistry.node.ts
@@ -5,7 +5,7 @@ import { IExtensionSyncActivationService } from '../../platform/activation/types
 import { IServiceManager } from '../../platform/ioc/types';
 import { DataScienceErrorHandlerNode } from '../errors/kernelErrorHandler.node';
 import { IDataScienceErrorHandler } from '../errors/types';
-import { IKernelConnectionSessionCreator, IJupyterServerConnector } from '../types';
+import { IKernelSessionFactory, IJupyterServerConnector } from '../types';
 import { JupyterCommandFactory } from './interpreter/jupyterCommand.node';
 import { JupyterInterpreterDependencyService } from './interpreter/jupyterInterpreterDependencyService.node';
 import { JupyterInterpreterOldCacheStateStore } from './interpreter/jupyterInterpreterOldCacheStateStore.node';
@@ -57,8 +57,8 @@ import {
 } from './types';
 import { IJupyterCommandFactory, IJupyterSubCommandExecutionService } from './types.node';
 import { RemoteKernelFinderController } from './finder/remoteKernelFinderController';
-import { KernelConnectionSessionCreator } from '../common/kernelConnectionSessionCreator';
-import { JupyterKernelConnectionSessionCreator } from './session/jupyterKernelConnectionSessionCreator';
+import { KernelSessionFactory } from '../common/kernelSessionFactory';
+import { JupyterKernelConnectionSessionCreator } from './session/jupyterKernelSessionFactory';
 
 export function registerTypes(serviceManager: IServiceManager, _isDevMode: boolean) {
     serviceManager.add<IJupyterCommandFactory>(IJupyterCommandFactory, JupyterCommandFactory);
@@ -117,10 +117,7 @@ export function registerTypes(serviceManager: IServiceManager, _isDevMode: boole
     serviceManager.addSingleton<IJupyterServerUriStorage>(IJupyterServerUriStorage, JupyterServerUriStorage);
     serviceManager.addSingleton<INotebookStarter>(INotebookStarter, NotebookStarter);
     serviceManager.addSingleton<IJupyterServerConnector>(IJupyterServerConnector, JupyterServerConnector);
-    serviceManager.addSingleton<IKernelConnectionSessionCreator>(
-        IKernelConnectionSessionCreator,
-        KernelConnectionSessionCreator
-    );
+    serviceManager.addSingleton<IKernelSessionFactory>(IKernelSessionFactory, KernelSessionFactory);
     serviceManager.addSingleton<JupyterKernelConnectionSessionCreator>(
         JupyterKernelConnectionSessionCreator,
         JupyterKernelConnectionSessionCreator

--- a/src/kernels/jupyter/serviceRegistry.web.ts
+++ b/src/kernels/jupyter/serviceRegistry.web.ts
@@ -5,7 +5,7 @@ import { IExtensionSyncActivationService } from '../../platform/activation/types
 import { IServiceManager } from '../../platform/ioc/types';
 import { DataScienceErrorHandlerWeb } from '../errors/kernelErrorHandler.web';
 import { IDataScienceErrorHandler } from '../errors/types';
-import { IKernelConnectionSessionCreator, IJupyterServerConnector } from '../types';
+import { IKernelSessionFactory, IJupyterServerConnector } from '../types';
 import { JupyterConnection } from './connection/jupyterConnection';
 import { JupyterKernelService } from './session/jupyterKernelService.web';
 import { JupyterRemoteCachedKernelValidator } from './connection/jupyterRemoteCachedKernelValidator';
@@ -35,8 +35,8 @@ import {
     IJupyterRemoteCachedKernelValidator
 } from './types';
 import { RemoteKernelFinderController } from './finder/remoteKernelFinderController';
-import { KernelConnectionSessionCreator } from '../common/kernelConnectionSessionCreator';
-import { JupyterKernelConnectionSessionCreator } from './session/jupyterKernelConnectionSessionCreator';
+import { KernelSessionFactory } from '../common/kernelSessionFactory';
+import { JupyterKernelConnectionSessionCreator } from './session/jupyterKernelSessionFactory';
 
 export function registerTypes(serviceManager: IServiceManager, _isDevMode: boolean) {
     serviceManager.addSingleton<IJupyterExecution>(IJupyterExecution, HostJupyterExecution);
@@ -53,10 +53,7 @@ export function registerTypes(serviceManager: IServiceManager, _isDevMode: boole
     );
     serviceManager.addSingleton<IJupyterServerUriStorage>(IJupyterServerUriStorage, JupyterServerUriStorage);
     serviceManager.addSingleton<IJupyterServerConnector>(IJupyterServerConnector, JupyterServerConnector);
-    serviceManager.addSingleton<IKernelConnectionSessionCreator>(
-        IKernelConnectionSessionCreator,
-        KernelConnectionSessionCreator
-    );
+    serviceManager.addSingleton<IKernelSessionFactory>(IKernelSessionFactory, KernelSessionFactory);
     serviceManager.addSingleton<JupyterKernelConnectionSessionCreator>(
         JupyterKernelConnectionSessionCreator,
         JupyterKernelConnectionSessionCreator

--- a/src/kernels/jupyter/session/jupyterKernelSessionFactory.ts
+++ b/src/kernels/jupyter/session/jupyterKernelSessionFactory.ts
@@ -4,8 +4,8 @@
 import { Uri } from 'vscode';
 import { Cancellation } from '../../../platform/common/cancellation';
 import {
-    IJupyterKernelConnectionSession,
-    KernelConnectionSessionCreationOptions,
+    IJupyterKernelSession,
+    KernelSessionCreationOptions,
     isLocalConnection,
     isRemoteConnection
 } from '../../types';
@@ -17,16 +17,14 @@ import { noop } from '../../../platform/common/utils/misc';
 import { SessionDisposedError } from '../../../platform/errors/sessionDisposedError';
 import { RemoteJupyterServerConnectionError } from '../../../platform/errors/remoteJupyterServerConnectionError';
 
-export type JupyterKernelConnectionSessionCreationOptions = KernelConnectionSessionCreationOptions & {
+export type JupyterKernelSessionCreationOptions = KernelSessionCreationOptions & {
     sessionManager: IJupyterSessionManager;
 };
 
 @injectable()
 export class JupyterKernelConnectionSessionCreator {
     constructor(@inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService) {}
-    public async create(
-        options: JupyterKernelConnectionSessionCreationOptions
-    ): Promise<IJupyterKernelConnectionSession> {
+    public async create(options: JupyterKernelSessionCreationOptions): Promise<IJupyterKernelSession> {
         if (options.sessionManager.isDisposed) {
             throw new SessionDisposedError();
         }

--- a/src/kernels/jupyter/session/jupyterSession.ts
+++ b/src/kernels/jupyter/session/jupyterSession.ts
@@ -21,7 +21,7 @@ import {
     IJupyterConnection,
     ISessionWithSocket,
     KernelActionSource,
-    IJupyterKernelConnectionSession,
+    IJupyterKernelSession,
     isRemoteConnection
 } from '../../types';
 import { DisplayOptions } from '../../displayOptions';
@@ -31,9 +31,10 @@ import { generateBackingIPyNbFileName } from './backingFileCreator.base';
 import { noop } from '../../../platform/common/utils/misc';
 
 // function is
-export class JupyterSession extends BaseJupyterSession implements IJupyterKernelConnectionSession {
-    public readonly kind: 'remoteJupyter' | 'localJupyter';
-
+export class JupyterSession
+    extends BaseJupyterSession<'localJupyter' | 'remoteJupyter'>
+    implements IJupyterKernelSession
+{
     constructor(
         resource: Resource,
         private connInfo: IJupyterConnection,
@@ -50,11 +51,16 @@ export class JupyterSession extends BaseJupyterSession implements IJupyterKernel
         private readonly requestCreator: IJupyterRequestCreator,
         private readonly sessionCreator: KernelActionSource
     ) {
-        super(resource, kernelConnectionMetadata, workingDirectory, interruptTimeout);
-        this.kind = connInfo.localLaunch ? 'localJupyter' : 'remoteJupyter';
+        super(
+            connInfo.localLaunch ? 'localJupyter' : 'remoteJupyter',
+            resource,
+            kernelConnectionMetadata,
+            workingDirectory,
+            interruptTimeout
+        );
     }
 
-    public override isServerSession(): this is IJupyterKernelConnectionSession {
+    public override isServerSession(): this is IJupyterKernelSession {
         return true;
     }
 

--- a/src/kernels/jupyter/types.ts
+++ b/src/kernels/jupyter/types.ts
@@ -15,7 +15,7 @@ import { PythonEnvironment } from '../../platform/pythonEnvironments/info';
 import {
     KernelConnectionMetadata,
     IJupyterConnection,
-    IJupyterKernelConnectionSession,
+    IJupyterKernelSession,
     IJupyterKernelSpec,
     GetServerOptions,
     IKernelSocket,
@@ -79,7 +79,7 @@ export interface IJupyterSessionManager extends IAsyncDisposable {
         ui: IDisplayOptions,
         cancelToken: CancellationToken,
         creator: KernelActionSource
-    ): Promise<IJupyterKernelConnectionSession>;
+    ): Promise<IJupyterKernelSession>;
     getKernelSpecs(): Promise<IJupyterKernelSpec[]>;
     getRunningKernels(): Promise<IJupyterKernel[]>;
     getRunningSessions(): Promise<Session.IModel[]>;

--- a/src/kernels/kernel.ts
+++ b/src/kernels/kernel.ts
@@ -43,7 +43,7 @@ import { Telemetry } from '../telemetry';
 import { executeSilently, getDisplayNameOrNameOfKernelConnection, isPythonKernelConnection } from './helpers';
 import {
     IKernel,
-    IKernelConnectionSession,
+    IKernelSession,
     InterruptResult,
     IStartupCodeProvider,
     KernelConnectionMetadata,
@@ -54,7 +54,7 @@ import {
     IKernelSettings,
     IKernelController,
     IThirdPartyKernel,
-    IKernelConnectionSessionCreator
+    IKernelSessionFactory
 } from './types';
 import { Cancellation, isCancellationError } from '../platform/common/cancellation';
 import { KernelProgressReporter } from '../platform/progress/kernelProgressReporter';
@@ -92,7 +92,7 @@ export function isKernelDead(k: IBaseKernel) {
     );
 }
 
-export function isKernelSessionDead(k: IKernelConnectionSession) {
+export function isKernelSessionDead(k: IKernelSession) {
     return (
         k.status === 'dead' ||
         (k.status === 'terminating' && !k.disposed) ||
@@ -155,7 +155,7 @@ abstract class BaseKernel implements IBaseKernel {
     get kernelSocket(): Observable<KernelSocketInformation | undefined> {
         return this._kernelSocket.asObservable();
     }
-    private _session?: IKernelConnectionSession;
+    private _session?: IKernelSession;
     /**
      * If the session died, then ensure the status is set to `dead`.
      * We need to provide an accurate status.
@@ -163,7 +163,7 @@ abstract class BaseKernel implements IBaseKernel {
      * If a jupyter kernel dies after it has started, then status is set to `dead`.
      */
     private isKernelDead?: boolean;
-    public get session(): IKernelConnectionSession | undefined {
+    public get session(): IKernelSession | undefined {
         return this._session;
     }
     private _disposed?: boolean;
@@ -174,8 +174,8 @@ abstract class BaseKernel implements IBaseKernel {
     private readonly _onRestarted = new EventEmitter<void>();
     private readonly _onStarted = new EventEmitter<void>();
     private readonly _onDisposed = new EventEmitter<void>();
-    private _jupyterSessionPromise?: Promise<IKernelConnectionSession>;
-    private readonly hookedSessionForEvents = new WeakSet<IKernelConnectionSession>();
+    private _jupyterSessionPromise?: Promise<IKernelSession>;
+    private readonly hookedSessionForEvents = new WeakSet<IKernelSession>();
     private hooks = new Map<KernelHooks, Set<Hook>>();
     private startCancellation = new CancellationTokenSource();
     private startupUI = new DisplayOptions(true);
@@ -190,7 +190,7 @@ abstract class BaseKernel implements IBaseKernel {
         public readonly uri: Uri,
         public readonly resourceUri: Resource,
         public readonly kernelConnectionMetadata: Readonly<KernelConnectionMetadata>,
-        private readonly sessionCreator: IKernelConnectionSessionCreator,
+        private readonly sessionCreator: IKernelSessionFactory,
         protected readonly kernelSettings: IKernelSettings,
         protected readonly appShell: IApplicationShell,
         protected readonly startupCodeProviders: IStartupCodeProvider[],
@@ -238,7 +238,7 @@ abstract class BaseKernel implements IBaseKernel {
         }
         return disposable;
     }
-    public async start(options?: IDisplayOptions): Promise<IKernelConnectionSession> {
+    public async start(options?: IDisplayOptions): Promise<IKernelSession> {
         // Possible this cancellation was cancelled previously.
         if (this.startCancellation.token.isCancellationRequested) {
             this.startCancellation.dispose();
@@ -407,9 +407,7 @@ abstract class BaseKernel implements IBaseKernel {
             Promise.all(Array.from(this.hooks.get('restartCompleted') || new Set<Hook>()).map((h) => h())).catch(noop);
         }
     }
-    protected async startJupyterSession(
-        options: IDisplayOptions = new DisplayOptions(false)
-    ): Promise<IKernelConnectionSession> {
+    protected async startJupyterSession(options: IDisplayOptions = new DisplayOptions(false)): Promise<IKernelSession> {
         this._startedAtLeastOnce = true;
         if (!options.disableUI) {
             this.startupUI.disableUI = false;
@@ -470,7 +468,7 @@ abstract class BaseKernel implements IBaseKernel {
     }
 
     private async interruptExecution(
-        session: IKernelConnectionSession,
+        session: IKernelSession,
         pendingExecutions: Promise<unknown>
     ): Promise<InterruptResult> {
         const restarted = createDeferred<boolean>();
@@ -547,7 +545,7 @@ abstract class BaseKernel implements IBaseKernel {
         });
     }
 
-    private async createJupyterSession(): Promise<IKernelConnectionSession> {
+    private async createJupyterSession(): Promise<IKernelSession> {
         let disposables: Disposable[] = [];
         try {
             // No need to block kernel startup on UI updates.
@@ -666,7 +664,7 @@ abstract class BaseKernel implements IBaseKernel {
         }
     }
 
-    protected async initializeAfterStart(session: IKernelConnectionSession | undefined) {
+    protected async initializeAfterStart(session: IKernelSession | undefined) {
         await Promise.all(Array.from(this.hooks.get('didStart') || new Set<Hook>()).map((h) => h()));
         traceVerbose(`Started running kernel initialization for ${getDisplayPath(this.uri)}`);
         if (!session) {
@@ -805,7 +803,7 @@ abstract class BaseKernel implements IBaseKernel {
      * For non-python kernels, we assume the version of IPyWidgets is 7.
      * For Python we just run a block of Python code to determine the version.
      */
-    private async determineVersionOfIPyWidgets(session: IKernelConnectionSession) {
+    private async determineVersionOfIPyWidgets(session: IKernelSession) {
         if (!isPythonKernelConnection(this.kernelConnectionMetadata)) {
             // For all other kernels, assume we are using the older version of IPyWidgets.
             // There are very few kernels that support IPyWidgets, however IPyWidgets 8 is very new
@@ -969,7 +967,7 @@ abstract class BaseKernel implements IBaseKernel {
     }
 
     protected async executeSilently(
-        session: IKernelConnectionSession,
+        session: IKernelSession,
         code: string[],
         errorOptions?: SilentExecutionErrorOptions
     ) {
@@ -992,7 +990,7 @@ export class ThirdPartyKernel extends BaseKernel implements IThirdPartyKernel {
         uri: Uri,
         resourceUri: Resource,
         kernelConnectionMetadata: Readonly<KernelConnectionMetadata>,
-        sessionCreator: IKernelConnectionSessionCreator,
+        sessionCreator: IKernelSessionFactory,
         appShell: IApplicationShell,
         kernelSettings: IKernelSettings,
         startupCodeProviders: IStartupCodeProvider[],
@@ -1025,7 +1023,7 @@ export class Kernel extends BaseKernel implements IKernel {
         resourceUri: Resource,
         public readonly notebook: NotebookDocument,
         kernelConnectionMetadata: Readonly<KernelConnectionMetadata>,
-        sessionCreator: IKernelConnectionSessionCreator,
+        sessionCreator: IKernelSessionFactory,
         kernelSettings: IKernelSettings,
         appShell: IApplicationShell,
         public readonly controller: IKernelController,

--- a/src/kernels/kernelAutoReConnectMonitor.unit.test.ts
+++ b/src/kernels/kernelAutoReConnectMonitor.unit.test.ts
@@ -9,7 +9,7 @@ import { disposeAllDisposables } from '../platform/common/helpers';
 import { IApplicationShell } from '../platform/common/application/types';
 import {
     IKernel,
-    IKernelConnectionSession,
+    IKernelSession,
     IKernelProvider,
     INotebookKernelExecution,
     RemoteKernelSpecConnectionMetadata
@@ -82,7 +82,7 @@ suite('Kernel ReConnect Progress Message', () => {
         const onPreExecute = new EventEmitter<NotebookCell>();
         disposables.push(onPreExecute);
         disposables.push(onRestarted);
-        const session = mock<IKernelConnectionSession>();
+        const session = mock<IKernelSession>();
         const kernelConnection = mock<Kernel.IKernelConnection>();
         const kernelConnectionStatusSignal = new Signal<Kernel.IKernelConnection, Kernel.ConnectionStatus>(
             instance(kernelConnection)
@@ -201,7 +201,7 @@ suite('Kernel ReConnect Failed Monitor', () => {
         const onRestarted = new EventEmitter<void>();
         disposables.push(onPreExecute);
         disposables.push(onRestarted);
-        const session = mock<IKernelConnectionSession>();
+        const session = mock<IKernelSession>();
         const kernelConnection = mock<Kernel.IKernelConnection>();
         const kernelConnectionStatusSignal = new Signal<Kernel.IKernelConnection, Kernel.ConnectionStatus>(
             instance(kernelConnection)

--- a/src/kernels/kernelAutoRestartMonitor.unit.test.ts
+++ b/src/kernels/kernelAutoRestartMonitor.unit.test.ts
@@ -6,7 +6,7 @@ import { instance, mock, verify, when } from 'ts-mockito';
 import { assert } from 'chai';
 import { EventEmitter } from 'vscode';
 import { KernelAutoRestartMonitor } from './kernelAutoRestartMonitor.node';
-import { IKernel, IKernelConnectionSession, IKernelProvider, LocalKernelSpecConnectionMetadata } from './types';
+import { IKernel, IKernelSession, IKernelProvider, LocalKernelSpecConnectionMetadata } from './types';
 import { disposeAllDisposables } from '../platform/common/helpers';
 import { IDisposable } from '../platform/common/types';
 import { KernelProgressReporter } from '../platform/progress/kernelProgressReporter';
@@ -58,7 +58,7 @@ suite('Jupyter Execution', async () => {
         restartMonitor.activate();
 
         const kernel = mock<IKernel>();
-        const session = mock<IKernelConnectionSession>();
+        const session = mock<IKernelSession>();
         const disposable = mock<IDisposable>();
         when(kernel.kernelConnectionMetadata).thenReturn(connectionMetadata);
         when(kernel.session).thenReturn(instance(session));

--- a/src/kernels/kernelCrashMonitor.unit.test.ts
+++ b/src/kernels/kernelCrashMonitor.unit.test.ts
@@ -12,7 +12,7 @@ import { createKernelController, TestNotebookDocument } from '../test/datascienc
 import { KernelCrashMonitor } from './kernelCrashMonitor';
 import {
     IKernel,
-    IKernelConnectionSession,
+    IKernelSession,
     IKernelController,
     IKernelProvider,
     INotebookKernelExecution,
@@ -38,7 +38,7 @@ suite('Kernel Crash Monitor', () => {
     let kernelExecution: INotebookKernelExecution;
     let onPreExecute: EventEmitter<NotebookCell>;
     let cell: NotebookCell;
-    let kernelSession: IKernelConnectionSession;
+    let kernelSession: IKernelSession;
     let notebook: TestNotebookDocument;
     let controller: IKernelController;
     let clock: fakeTimers.InstalledClock;
@@ -67,7 +67,7 @@ suite('Kernel Crash Monitor', () => {
         kernel = mock<IKernel>();
         appShell = mock<IApplicationShell>();
         kernelExecution = mock<INotebookKernelExecution>();
-        kernelSession = mock<IKernelConnectionSession>();
+        kernelSession = mock<IKernelSession>();
         onKernelStatusChanged = new EventEmitter<{
             status: KernelMessage.Status;
             kernel: IKernel;

--- a/src/kernels/kernelExecution.ts
+++ b/src/kernels/kernelExecution.ts
@@ -17,13 +17,7 @@ import { traceCellMessage } from './execution/helpers';
 import { executeSilently } from './helpers';
 import { initializeInteractiveOrNotebookTelemetryBasedOnUserAction } from './telemetry/helper';
 import { sendKernelTelemetryEvent } from './telemetry/sendKernelTelemetryEvent';
-import {
-    IKernel,
-    IKernelConnectionSession,
-    INotebookKernelExecution,
-    ITracebackFormatter,
-    NotebookCellRunState
-} from './types';
+import { IKernel, IKernelSession, INotebookKernelExecution, ITracebackFormatter, NotebookCellRunState } from './types';
 
 /**
  * Everything in this classes gets disposed via the `onWillCancel` hook.
@@ -134,7 +128,7 @@ export class NotebookKernelExecution implements INotebookKernelExecution {
      * Restarts the kernel
      * If we don't have a kernel (Jupyter Session) available, then just abort all of the cell executions.
      */
-    private async onWillRestart(sessionPromise?: Promise<IKernelConnectionSession>) {
+    private async onWillRestart(sessionPromise?: Promise<IKernelSession>) {
         const executionQueue = this.documentExecutions.get(this.notebook);
         // Possible we don't have a notebook.
         const session = sessionPromise ? await sessionPromise.catch(() => undefined) : undefined;
@@ -151,10 +145,7 @@ export class NotebookKernelExecution implements INotebookKernelExecution {
             await pendingCells;
         }
     }
-    private getOrCreateCellExecutionQueue(
-        document: NotebookDocument,
-        sessionPromise: Promise<IKernelConnectionSession>
-    ) {
+    private getOrCreateCellExecutionQueue(document: NotebookDocument, sessionPromise: Promise<IKernelSession>) {
         const existingExecutionQueue = this.documentExecutions.get(document);
         // Re-use the existing Queue if it can be used.
         if (existingExecutionQueue && !existingExecutionQueue.isEmpty && !existingExecutionQueue.failed) {

--- a/src/kernels/kernelProvider.node.ts
+++ b/src/kernels/kernelProvider.node.ts
@@ -22,7 +22,7 @@ import {
     KernelOptions,
     ThirdPartyKernelOptions,
     IStartupCodeProviders,
-    IKernelConnectionSessionCreator
+    IKernelSessionFactory
 } from './types';
 import { IJupyterServerUriStorage } from './jupyter/types';
 import { createKernelSettings } from './kernelSettings';
@@ -36,7 +36,7 @@ export class KernelProvider extends BaseCoreKernelProvider {
     constructor(
         @inject(IAsyncDisposableRegistry) asyncDisposables: IAsyncDisposableRegistry,
         @inject(IDisposableRegistry) disposables: IDisposableRegistry,
-        @inject(IKernelConnectionSessionCreator) private sessionCreator: IKernelConnectionSessionCreator,
+        @inject(IKernelSessionFactory) private sessionCreator: IKernelSessionFactory,
         @inject(IConfigurationService) private configService: IConfigurationService,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(IVSCodeNotebook) notebook: IVSCodeNotebook,
@@ -107,7 +107,7 @@ export class ThirdPartyKernelProvider extends BaseThirdPartyKernelProvider {
     constructor(
         @inject(IAsyncDisposableRegistry) asyncDisposables: IAsyncDisposableRegistry,
         @inject(IDisposableRegistry) disposables: IDisposableRegistry,
-        @inject(IKernelConnectionSessionCreator) private sessionCreator: IKernelConnectionSessionCreator,
+        @inject(IKernelSessionFactory) private sessionCreator: IKernelSessionFactory,
         @inject(IConfigurationService) private configService: IConfigurationService,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(IVSCodeNotebook) notebook: IVSCodeNotebook,

--- a/src/kernels/kernelProvider.node.unit.test.ts
+++ b/src/kernels/kernelProvider.node.unit.test.ts
@@ -26,7 +26,7 @@ import { IJupyterServerUriStorage } from './jupyter/types';
 import { KernelProvider, ThirdPartyKernelProvider } from './kernelProvider.node';
 import { Kernel, ThirdPartyKernel } from './kernel';
 import {
-    IKernelConnectionSessionCreator,
+    IKernelSessionFactory,
     IKernelController,
     IKernelProvider,
     IStartupCodeProviders,
@@ -44,7 +44,7 @@ import { CellOutputDisplayIdTracker } from './execution/cellDisplayIdTracker';
 suite('Node Kernel Provider', function () {
     const disposables: IDisposable[] = [];
     const asyncDisposables: { dispose: () => Promise<unknown> }[] = [];
-    let sessionCreator: IKernelConnectionSessionCreator;
+    let sessionCreator: IKernelSessionFactory;
     let configService: IConfigurationService;
     let appShell: IApplicationShell;
     let vscNotebook: IVSCodeNotebook;
@@ -54,7 +54,7 @@ suite('Node Kernel Provider', function () {
     let controller: IKernelController;
     let workspaceMemento: Memento;
     setup(() => {
-        sessionCreator = mock<IKernelConnectionSessionCreator>();
+        sessionCreator = mock<IKernelSessionFactory>();
         configService = mock<IConfigurationService>();
         appShell = mock<IApplicationShell>();
         vscNotebook = mock<IVSCodeNotebook>();
@@ -170,7 +170,7 @@ suite('KernelProvider Node', () => {
     let asyncDisposables: AsyncDisposableRegistry;
     let kernelProvider: IKernelProvider;
     let thirdPartyKernelProvider: IThirdPartyKernelProvider;
-    let sessionCreator: IKernelConnectionSessionCreator;
+    let sessionCreator: IKernelSessionFactory;
     let configService: IConfigurationService;
     let appShell: IApplicationShell;
     let vscNotebook: IVSCodeNotebook;
@@ -202,7 +202,7 @@ suite('KernelProvider Node', () => {
         onDidCloseNotebookDocument = new EventEmitter<NotebookDocument>();
         disposables.push(onDidCloseNotebookDocument);
         asyncDisposables = new AsyncDisposableRegistry();
-        sessionCreator = mock<IKernelConnectionSessionCreator>();
+        sessionCreator = mock<IKernelSessionFactory>();
         configService = mock<IConfigurationService>();
         appShell = mock<IApplicationShell>();
         vscNotebook = mock<IVSCodeNotebook>();

--- a/src/kernels/kernelProvider.web.ts
+++ b/src/kernels/kernelProvider.web.ts
@@ -22,7 +22,7 @@ import {
     KernelOptions,
     ThirdPartyKernelOptions,
     IStartupCodeProviders,
-    IKernelConnectionSessionCreator
+    IKernelSessionFactory
 } from './types';
 import { IJupyterServerUriStorage } from './jupyter/types';
 import { createKernelSettings } from './kernelSettings';
@@ -36,7 +36,7 @@ export class KernelProvider extends BaseCoreKernelProvider {
     constructor(
         @inject(IAsyncDisposableRegistry) asyncDisposables: IAsyncDisposableRegistry,
         @inject(IDisposableRegistry) disposables: IDisposableRegistry,
-        @inject(IKernelConnectionSessionCreator) private sessionCreator: IKernelConnectionSessionCreator,
+        @inject(IKernelSessionFactory) private sessionCreator: IKernelSessionFactory,
         @inject(IConfigurationService) private configService: IConfigurationService,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(IVSCodeNotebook) notebook: IVSCodeNotebook,
@@ -99,7 +99,7 @@ export class ThirdPartyKernelProvider extends BaseThirdPartyKernelProvider {
     constructor(
         @inject(IAsyncDisposableRegistry) asyncDisposables: IAsyncDisposableRegistry,
         @inject(IDisposableRegistry) disposables: IDisposableRegistry,
-        @inject(IKernelConnectionSessionCreator) private sessionCreator: IKernelConnectionSessionCreator,
+        @inject(IKernelSessionFactory) private sessionCreator: IKernelSessionFactory,
         @inject(IConfigurationService) private configService: IConfigurationService,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(IVSCodeNotebook) notebook: IVSCodeNotebook,

--- a/src/kernels/kernelProvider.web.unit.test.ts
+++ b/src/kernels/kernelProvider.web.unit.test.ts
@@ -13,12 +13,7 @@ import { createKernelController, TestNotebookDocument } from '../test/datascienc
 import { IJupyterServerUriStorage } from './jupyter/types';
 import { KernelProvider } from './kernelProvider.web';
 import { Kernel, ThirdPartyKernel } from './kernel';
-import {
-    IKernelConnectionSessionCreator,
-    IKernelController,
-    IStartupCodeProviders,
-    KernelConnectionMetadata
-} from './types';
+import { IKernelSessionFactory, IKernelController, IStartupCodeProviders, KernelConnectionMetadata } from './types';
 import { ThirdPartyKernelProvider } from './kernelProvider.node';
 import { disposeAllDisposables } from '../platform/common/helpers';
 import { noop } from '../test/core';
@@ -26,7 +21,7 @@ import { noop } from '../test/core';
 suite('Web Kernel Provider', function () {
     const disposables: IDisposable[] = [];
     const asyncDisposables: { dispose: () => Promise<unknown> }[] = [];
-    let sessionCreator: IKernelConnectionSessionCreator;
+    let sessionCreator: IKernelSessionFactory;
     let configService: IConfigurationService;
     let appShell: IApplicationShell;
     let vscNotebook: IVSCodeNotebook;
@@ -36,7 +31,7 @@ suite('Web Kernel Provider', function () {
     let controller: IKernelController;
     let workspaceMemento: Memento;
     setup(() => {
-        sessionCreator = mock<IKernelConnectionSessionCreator>();
+        sessionCreator = mock<IKernelSessionFactory>();
         configService = mock<IConfigurationService>();
         appShell = mock<IApplicationShell>();
         vscNotebook = mock<IVSCodeNotebook>();

--- a/src/kernels/raw/session/rawJupyterSession.node.ts
+++ b/src/kernels/raw/session/rawJupyterSession.node.ts
@@ -20,7 +20,7 @@ import { sendKernelTelemetryEvent } from '../../telemetry/sendKernelTelemetryEve
 import { trackKernelResourceInformation } from '../../telemetry/helper';
 import { Telemetry } from '../../../telemetry';
 import { getDisplayNameOrNameOfKernelConnection } from '../../../kernels/helpers';
-import { IRawKernelConnectionSession, ISessionWithSocket, KernelConnectionMetadata } from '../../../kernels/types';
+import { IRawKernelSession, ISessionWithSocket, KernelConnectionMetadata } from '../../../kernels/types';
 import { BaseJupyterSession } from '../../common/baseJupyterSession';
 import { IKernelLauncher, IKernelProcess } from '../types';
 import { RawSession } from './rawSession.node';
@@ -35,8 +35,7 @@ through ZMQ.
 It's responsible for translating our IJupyterKernelConnectionSession interface into the
 jupyterlabs interface as well as starting up and connecting to a raw session
 */
-export class RawJupyterSession extends BaseJupyterSession implements IRawKernelConnectionSession {
-    public readonly kind = 'localRaw';
+export class RawJupyterSession extends BaseJupyterSession<'localRaw'> implements IRawKernelSession {
     private processExitHandler = new WeakMap<RawSession, IDisposable>();
     private terminatingStatus?: KernelMessage.Status;
     public get atleastOneCellExecutedSuccessfully() {
@@ -59,7 +58,7 @@ export class RawJupyterSession extends BaseJupyterSession implements IRawKernelC
         kernelConnection: KernelConnectionMetadata,
         private readonly launchTimeout: number
     ) {
-        super(resource, kernelConnection, workingDirectory, interruptTimeout);
+        super('localRaw', resource, kernelConnection, workingDirectory, interruptTimeout);
     }
 
     public async waitForIdle(timeout: number, token: CancellationToken): Promise<void> {

--- a/src/kernels/raw/types.ts
+++ b/src/kernels/raw/types.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 import { CancellationToken, Event } from 'vscode';
-import { IAsyncDisposable, IDisplayOptions, Resource } from '../../platform/common/types';
+import { IAsyncDisposable, Resource } from '../../platform/common/types';
 import {
-    IRawKernelConnectionSession,
-    KernelConnectionMetadata,
+    IRawKernelSession,
+    KernelSessionCreationOptions,
     LocalKernelSpecConnectionMetadata,
     PythonKernelConnectionMetadata
 } from '../types';
@@ -61,13 +61,8 @@ export interface IRawNotebookSupportedService {
 }
 
 // Provides notebooks that talk directly to kernels as opposed to a jupyter server
-export const IRawKernelConnectionSessionCreator = Symbol('IRawKernelConnectionSessionCreator');
-export interface IRawKernelConnectionSessionCreator extends IAsyncDisposable {
+export const IRawKernelSessionFactory = Symbol('IRawKernelSessionFactory');
+export interface IRawKernelSessionFactory extends IAsyncDisposable {
     isSupported: boolean;
-    create(
-        resource: Resource,
-        kernelConnection: KernelConnectionMetadata,
-        ui: IDisplayOptions,
-        cancelToken: CancellationToken
-    ): Promise<IRawKernelConnectionSession>;
+    create(options: KernelSessionCreationOptions): Promise<IRawKernelSession>;
 }

--- a/src/kernels/serviceRegistry.node.ts
+++ b/src/kernels/serviceRegistry.node.ts
@@ -34,9 +34,9 @@ import { TrustedKernelPaths } from './raw/finder/trustedKernelPaths.node';
 import { ITrustedKernelPaths } from './raw/finder/types';
 import { KernelEnvironmentVariablesService } from './raw/launcher/kernelEnvVarsService.node';
 import { KernelLauncher } from './raw/launcher/kernelLauncher.node';
-import { RawKernelConnectionSessionCreator } from './raw/session/rawKernelConnectionSessionCreator.node';
+import { RawKernelSessionFactory } from './raw/session/rawKernelSessionFactory.node';
 import { RawNotebookSupportedService } from './raw/session/rawNotebookSupportedService.node';
-import { IKernelLauncher, IRawKernelConnectionSessionCreator, IRawNotebookSupportedService } from './raw/types';
+import { IKernelLauncher, IRawKernelSessionFactory, IRawNotebookSupportedService } from './raw/types';
 import {
     IKernelDependencyService,
     IKernelFinder,
@@ -65,10 +65,7 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
         PreferredRemoteKernelIdProvider,
         PreferredRemoteKernelIdProvider
     );
-    serviceManager.addSingleton<IRawKernelConnectionSessionCreator>(
-        IRawKernelConnectionSessionCreator,
-        RawKernelConnectionSessionCreator
-    );
+    serviceManager.addSingleton<IRawKernelSessionFactory>(IRawKernelSessionFactory, RawKernelSessionFactory);
     serviceManager.addSingleton<IKernelLauncher>(IKernelLauncher, KernelLauncher);
     serviceManager.addSingleton<KernelEnvironmentVariablesService>(
         KernelEnvironmentVariablesService,

--- a/src/kernels/variables/kernelVariables.ts
+++ b/src/kernels/variables/kernelVariables.ts
@@ -9,7 +9,7 @@ import { IConfigurationService, IDisposableRegistry } from '../../platform/commo
 import { createDeferred } from '../../platform/common/utils/async';
 import { stripAnsi } from '../../platform/common/utils/regexp';
 import { getKernelConnectionLanguage, isPythonKernelConnection } from '../helpers';
-import { IKernel, IKernelConnectionSession, IKernelProvider } from '../types';
+import { IKernel, IKernelSession, IKernelProvider } from '../types';
 import {
     IJupyterVariable,
     IJupyterVariables,
@@ -294,7 +294,7 @@ export class KernelVariables implements IJupyterVariables {
     }
 
     private inspect(
-        session: IKernelConnectionSession,
+        session: IKernelSession,
         code: string,
         offsetInCode = 0,
         cancelToken?: CancellationToken

--- a/src/notebooks/controllers/kernelConnector.ts
+++ b/src/notebooks/controllers/kernelConnector.ts
@@ -30,7 +30,7 @@ import { selectKernel } from './kernelSelector';
 import { KernelDeadError } from '../../kernels/errors/kernelDeadError';
 import { IDataScienceErrorHandler } from '../../kernels/errors/types';
 import { noop } from '../../platform/common/utils/misc';
-import { IRawKernelConnectionSessionCreator } from '../../kernels/raw/types';
+import { IRawKernelSessionFactory } from '../../kernels/raw/types';
 import { IControllerRegistration, IVSCodeNotebookController } from './types';
 import { getDisplayNameOrNameOfKernelConnection } from '../../kernels/helpers';
 import { isCancellationError } from '../../platform/common/cancellation';
@@ -127,9 +127,7 @@ export class KernelConnector {
         const isLocal = isLocalConnection(metadata);
 
         // Raw notebook provider is not available in web
-        const rawNotebookProvider = serviceContainer.tryGet<IRawKernelConnectionSessionCreator>(
-            IRawKernelConnectionSessionCreator
-        );
+        const rawNotebookProvider = serviceContainer.tryGet<IRawKernelSessionFactory>(IRawKernelSessionFactory);
         const rawLocalKernel = rawNotebookProvider?.isSupported && isLocal;
         if (rawLocalKernel && errorContext === 'start') {
             sendKernelTelemetryEvent(resource, Telemetry.RawKernelSessionStartNoIpykernel, {

--- a/src/notebooks/controllers/kernelConnector.unit.test.ts
+++ b/src/notebooks/controllers/kernelConnector.unit.test.ts
@@ -11,7 +11,7 @@ import { getDisplayNameOrNameOfKernelConnection } from '../../kernels/helpers';
 import { ITrustedKernelPaths } from '../../kernels/raw/finder/types';
 import {
     IKernel,
-    IKernelConnectionSession,
+    IKernelSession,
     IKernelController,
     IKernelProvider,
     KernelInterpreterDependencyResponse,
@@ -49,7 +49,7 @@ suite('Kernel Connector', () => {
     let controller: IKernelController;
     let kernel: IKernel;
     let errorHandler: IDataScienceErrorHandler;
-    let kernelSession: IKernelConnectionSession;
+    let kernelSession: IKernelSession;
     let appShell: IApplicationShell;
     let commandManager: ICommandManager;
     let pythonKernelSpec = PythonKernelConnectionMetadata.create({
@@ -71,7 +71,7 @@ suite('Kernel Connector', () => {
         kernelProvider = mock<IKernelProvider>();
         trustedKernels = mock<ITrustedKernelPaths>();
         errorHandler = mock<IDataScienceErrorHandler>();
-        kernelSession = mock<IKernelConnectionSession>();
+        kernelSession = mock<IKernelSession>();
         appShell = mock<IApplicationShell>();
         commandManager = mock<ICommandManager>();
         kernel = mock<IKernel>();

--- a/src/notebooks/debugger/kernelDebugAdapterBase.ts
+++ b/src/notebooks/debugger/kernelDebugAdapterBase.ts
@@ -21,7 +21,7 @@ import {
 } from 'vscode';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { executeSilently } from '../../kernels/helpers';
-import { IKernel, IKernelConnectionSession } from '../../kernels/types';
+import { IKernel, IKernelSession } from '../../kernels/types';
 import { IDebugService } from '../../platform/common/application/types';
 import { IPlatformService } from '../../platform/common/platform/types';
 import { IDisposable } from '../../platform/common/types';
@@ -63,7 +63,7 @@ export abstract class KernelDebugAdapterBase implements DebugAdapter, IKernelDeb
     constructor(
         protected session: DebugSession,
         protected notebookDocument: NotebookDocument,
-        protected readonly jupyterSession: IKernelConnectionSession,
+        protected readonly jupyterSession: IKernelSession,
         private readonly kernel: IKernel | undefined,
         private readonly platformService: IPlatformService,
         private readonly debugService: IDebugService

--- a/src/standalone/intellisense/pythonKernelCompletionProvider.ts
+++ b/src/standalone/intellisense/pythonKernelCompletionProvider.ts
@@ -20,7 +20,7 @@ import { IConfigurationService, IDisposableRegistry } from '../../platform/commo
 import { waitForPromise } from '../../platform/common/utils/async';
 import { isNotebookCell } from '../../platform/common/utils/misc';
 import { StopWatch } from '../../platform/common/utils/stopWatch';
-import { IKernelConnectionSession, IKernelProvider } from '../../kernels/types';
+import { IKernelSession, IKernelProvider } from '../../kernels/types';
 import { INotebookCompletionProvider, INotebookEditorProvider } from '../../notebooks/types';
 import { mapJupyterKind } from './conversion';
 import { isTestExecution, Settings } from '../../platform/common/constants';
@@ -156,7 +156,7 @@ export class PythonKernelCompletionProvider implements CompletionItemProvider {
         );
     }
     public async getJupyterCompletion(
-        session: IKernelConnectionSession,
+        session: IKernelSession,
         cellCode: string,
         offsetInCode: number,
         cancelToken?: CancellationToken

--- a/src/webviews/extension-side/dataviewer/kernelDataViewerDependencyImplementation.ts
+++ b/src/webviews/extension-side/dataviewer/kernelDataViewerDependencyImplementation.ts
@@ -6,7 +6,7 @@ import { DataScience } from '../../../platform/common/utils/localize';
 import { EnvironmentType } from '../../../platform/pythonEnvironments/info';
 import { sendTelemetryEvent, Telemetry } from '../../../telemetry';
 import { executeSilently } from '../../../kernels/helpers';
-import { IKernel, IKernelConnectionSession } from '../../../kernels/types';
+import { IKernel, IKernelSession } from '../../../kernels/types';
 import { BaseDataViewerDependencyImplementation } from './baseDataViewerDependencyImplementation';
 
 export const kernelGetPandasVersion =
@@ -19,7 +19,7 @@ function kernelPackaging(kernel: IKernel): '%conda' | '%pip' {
     return isConda ? '%conda' : '%pip';
 }
 
-type IKernelWithSession = IKernel & { session: IKernelConnectionSession };
+type IKernelWithSession = IKernel & { session: IKernelSession };
 
 // TypeScript will narrow the type to PythonEnvironment in any block guarded by a call to isPythonEnvironment
 function kernelHasSession(kernel: IKernel): kernel is IKernelWithSession {


### PR DESCRIPTION
Rename `IKernelConnectionSessionCreator` to `IKernelSessionFactory`
Rename `IJupyterKernelConnectionSession` to `IJupyterKernelSession`
Rename `IRawKernelConnectionSession` to `IRawKernelSession`
Rename `KernelConnectionSessionCreationOptions` to `KernelSessionCreationOptions`