### PR TITLE
prePublishNonBundleNLS became prePublishNonBundle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Run the `Compile`, `Compile Web Views`, and `Compile Web Extension` build Tasks 
 You can also compile from the command-line. For a full compile you can use:
 
 ```shell
-npx gulp prePublishNonBundleNLS
+npx gulp prePublishNonBundle
 ```
 
 For incremental builds you can use the following commands depending on your needs:


### PR DESCRIPTION
Fixes info in CONTRIBUTING

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] ~Appropriate comments and documentation strings in the code.~
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for feature-requests.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
