### PR TITLE
Show kernel detection progress when connecting to 3rd party server providers

### DIFF
--- a/src/notebooks/controllers/kernelSource/remoteNotebookKernelSourceSelector.ts
+++ b/src/notebooks/controllers/kernelSource/remoteNotebookKernelSourceSelector.ts
@@ -11,7 +11,8 @@ import {
     QuickPick,
     QuickPickItem,
     QuickPickItemKind,
-    ThemeIcon
+    ThemeIcon,
+    notebooks
 } from 'vscode';
 import { ContributedKernelFinderKind, IContributedKernelFinder } from '../../../kernels/internalTypes';
 import { computeServerId, generateUriFromRemoteProvider } from '../../../kernels/jupyter/jupyterUtils';
@@ -233,6 +234,7 @@ export class RemoteNotebookKernelSourceSelector implements IRemoteNotebookKernel
                 case KernelFinderEntityQuickPickType.KernelFinder:
                     return this.selectKernelFromKernelFinder.bind(this, selectedSource.kernelFinderInfo, token);
                 case KernelFinderEntityQuickPickType.UriProviderQuickPick:
+                    const taskNb = notebooks.createNotebookControllerDetectionTask(JupyterNotebookView);
                     try {
                         if (lazyQuickPick) {
                             lazyQuickPick.busy = true;
@@ -248,6 +250,8 @@ export class RemoteNotebookKernelSourceSelector implements IRemoteNotebookKernel
                         } else {
                             throw ex;
                         }
+                    } finally {
+                        taskNb.dispose();
                     }
                 default:
                     break;


### PR DESCRIPTION
We want to show the kernel detection progress when users are trying to connect to another remote jupyter server.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
