### PR TITLE
change Restart Kernel ordering value to align with updates in core

### DIFF
--- a/package.json
+++ b/package.json
@@ -871,7 +871,7 @@
             "notebook/toolbar": [
                 {
                     "command": "jupyter.restartkernel",
-                    "group": "navigation/execute@1",
+                    "group": "navigation/execute@5",
                     "when": "notebookKernel =~ /^ms-toolsai.jupyter\\// && notebookType == 'jupyter-notebook' && isWorkspaceTrusted && jupyter.kernel.isjupyter"
                 },
                 {


### PR DESCRIPTION
re: [#185923](https://github.com/microsoft/vscode/pull/185923)

Toolbar ordering values are now as follows:
-  Run All // Restart // Clear Outputs // Go To
-  -1 // 5 // 10 // 20