### PR TITLE
put sysinfo metadata into the property that we serialize

### DIFF
--- a/src/interactive-window/editor-integration/cellFactory.ts
+++ b/src/interactive-window/editor-integration/cellFactory.ts
@@ -9,6 +9,7 @@ import { noop } from '../../platform/common/utils/misc';
 import { createJupyterCellFromVSCNotebookCell } from '../../kernels/execution/helpers';
 import { appendLineFeed, parseForComments, generateMarkdownFromCodeLines } from '../../platform/common/utils';
 import { splitLines } from '../../platform/common/helpers';
+import { isSysInfoCell } from '../systemInfoCell';
 
 export function createCodeCell(): nbformat.ICodeCell;
 // eslint-disable-next-line @typescript-eslint/unified-signatures
@@ -175,7 +176,7 @@ export function generateCellsFromNotebookDocument(
 ): ICell[] {
     return notebookDocument
         .getCells()
-        .filter((cell) => !cell.metadata.isInteractiveWindowMessageCell)
+        .filter((cell) => !isSysInfoCell(cell))
         .map((cell) => {
             // Reinstate cell structure + comments from cell metadata
             let code = splitLines(cell.document.getText(), { trim: false, removeEmptyEntries: false });

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -270,7 +270,7 @@ export class InteractiveWindow implements IInteractiveWindow {
             return;
         }
         const markdownCell = new NotebookCellData(NotebookCellKind.Markup, message, MARKDOWN_LANGUAGE);
-        markdownCell.metadata = { isInteractiveWindowMessageCell: true };
+        markdownCell.metadata = { custom: { metadata: { isInteractiveWindowMessageCell: true } } };
         const insertionIndex =
             notebookCell && notebookCell.index >= 0 ? notebookCell.index : this.notebookDocument.cellCount;
         // If possible display the error message in the cell.

--- a/src/notebooks/export/exportToPythonPlain.ts
+++ b/src/notebooks/export/exportToPythonPlain.ts
@@ -40,7 +40,7 @@ export class ExportToPythonPlain implements IExport {
     private exportDocument(document: NotebookDocument): string {
         return document
             .getCells()
-            .filter((cell) => !cell.metadata.isInteractiveWindowMessageCell) // We don't want interactive window sys info cells
+            .filter((cell) => !cell.metadata.custom?.metadata?.isInteractiveWindowMessageCell) // We don't want interactive window sys info cells
             .reduce((previousValue, currentValue) => previousValue + this.exportCell(currentValue), '');
     }
 

--- a/src/test/datascience/interactiveWindow.vscode.common.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.common.test.ts
@@ -54,6 +54,7 @@ import { IControllerRegistration } from '../../notebooks/controllers/types';
 import { format } from 'util';
 import { InteractiveWindow } from '../../interactive-window/interactiveWindow';
 import { getNotebookUriFromInputBoxUri } from '../../standalone/intellisense/notebookPythonPathService.node';
+import { isSysInfoCell } from '../../interactive-window/systemInfoCell';
 
 suite(`Interactive window execution @iw`, async function () {
     this.timeout(120_000);
@@ -117,7 +118,7 @@ suite(`Interactive window execution @iw`, async function () {
         async function verifyCells() {
             // Verify sys info cell
             const firstCell = notebookDocument.cellAt(0);
-            assert.ok(firstCell?.metadata.isInteractiveWindowMessageCell, 'First cell should be sys info cell');
+            assert.ok(isSysInfoCell(firstCell), 'First cell should be sys info cell');
             assert.equal(firstCell?.kind, vscode.NotebookCellKind.Markup, 'First cell should be markdown cell');
 
             // Verify executed cell input and output
@@ -375,7 +376,8 @@ ${actualCode}
 
         // Verify sys info cell
         const firstCell = notebookDocument?.cellAt(0);
-        assert.ok(firstCell?.metadata.isInteractiveWindowMessageCell, 'First cell should be sys info cell');
+        assert.ok(firstCell, 'cell not added');
+        assert.ok(isSysInfoCell(firstCell!), 'First cell should be sys info cell');
         assert.equal(firstCell?.kind, vscode.NotebookCellKind.Markup, 'First cell should be markdown cell');
 
         // Verify executed cell input and output


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-jupyter/issues/13871

the cell metadata that is serialized for backup is in the custom property. Move the info there so that it persists through a window reload.