### PR TITLE
workaround to make cell update

### DIFF
--- a/src/interactive-window/systemInfoCell.ts
+++ b/src/interactive-window/systemInfoCell.ts
@@ -82,6 +82,12 @@ export class SystemInfoCell {
             if (cell.index >= 0) {
                 if (!this.isDeleted && isSysInfoCell(cell)) {
                     edit.replace(cell.document.uri, new Range(0, 0, cell.document.lineCount, 0), newMessage);
+
+                    edit.set(this.notebookDocument!.uri, [
+                        NotebookEdit.updateCellMetadata(cell.index, {
+                            custom: { metadata: { isInteractiveWindowMessageCell: true } }
+                        })
+                    ]);
                     return;
                 }
             }


### PR DESCRIPTION
https://github.com/microsoft/vscode-jupyter/issues/13889

this is a workaround, as it looks like there is a bug in the `WorkspaceEdit.replace` API call: the edit only takes effect if it's editing text in the last cell of the notebook or if another edit is made afterward, as this PR does. 