### PR TITLE
Add support for DataFrames with to_pandas method

### DIFF
--- a/pythonFiles/vscode_datascience_helpers/dataframes/vscodeDataFrame.py
+++ b/pythonFiles/vscode_datascience_helpers/dataframes/vscodeDataFrame.py
@@ -100,6 +100,8 @@ def _VSCODE_getDataFrame(what_to_get, is_debugging, *args):
             df = _VSCODE_pd.Series.to_frame(df).iloc[start:end]
         elif _VSCODE_builtins.hasattr(df, "toPandas"):
             df = df.toPandas().iloc[start:end]
+        elif _VSCODE_builtins.hasattr(df, "to_pandas"):
+            df = df.to_pandas().iloc[start:end]
         elif (
             _VSCODE_builtins.hasattr(vartype, "__name__")
             and vartype.__name__ in _VSCODE_allowedTensorTypes

--- a/pythonFiles/vscode_datascience_helpers/getJupyterVariableDataFrameInfo.py
+++ b/pythonFiles/vscode_datascience_helpers/getJupyterVariableDataFrameInfo.py
@@ -58,6 +58,9 @@ else:
     elif hasattr(_VSCODE_df, "toPandas"):
         _VSCODE_df = _VSCODE_df.toPandas()
         _VSCODE_targetVariable["rowCount"] = _VSCODE_getRowCount(_VSCODE_df)
+    elif hasattr(_VSCODE_df, "to_pandas"):
+        _VSCODE_df = _VSCODE_df.to_pandas()
+        _VSCODE_targetVariable["rowCount"] = _VSCODE_getRowCount(_VSCODE_df)
 
     # If any rows, use pandas json to convert a single row to json. Extract
     # the column names and types from the json so we match what we'll fetch when

--- a/pythonFiles/vscode_datascience_helpers/getJupyterVariableDataFrameRows.py
+++ b/pythonFiles/vscode_datascience_helpers/getJupyterVariableDataFrameRows.py
@@ -30,6 +30,8 @@ elif _VSCODE_targetVariable["type"] == "ndarray":
     _VSCODE_df = _VSCODE_pd.DataFrame(_VSCODE_evalResult)
 elif hasattr(_VSCODE_df, "toPandas"):
     _VSCODE_df = _VSCODE_df.toPandas()
+elif hasattr(_VSCODE_df, "to_pandas"):
+    _VSCODE_df = _VSCODE_df.to_pandas()
 # If not a known type, then just let pandas handle it.
 elif not (hasattr(_VSCODE_df, "iloc")):
     _VSCODE_df = _VSCODE_pd.DataFrame(_VSCODE_evalResult)


### PR DESCRIPTION
Fixes #12519

This is a really simple change that would support DataFrame libraries (like Polars) that have a snake case name (to_pandas) instead of a camel case name (toPandas) to convert the data frame to pandas.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for feature-requests.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
