### PR TITLE
Decouple Variable View and Data Viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1965,7 +1965,7 @@
                 "label": "%jupyter.debuggers.interactive%"
             }
         ],
-        "dataframeViewer": [
+        "jupyterVariableViewers": [
             {
                 "command": "jupyter.showDataViewer",
                 "title": "%jupyter.command.jupyter.showDataViewer.title%"

--- a/package.json
+++ b/package.json
@@ -1964,6 +1964,12 @@
                 "type": "Python Interactive Window Debug Adapter",
                 "label": "%jupyter.debuggers.interactive%"
             }
+        ],
+        "dataframeViewer": [
+            {
+                "command": "jupyter.showDataViewer",
+                "title": "%jupyter.command.jupyter.showDataViewer.title%"
+            }
         ]
     },
     "enabledApiProposals": [

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -39,6 +39,7 @@ export interface ICommandNameArgumentTypeMapping {
     ['workbench.action.debug.stop']: [];
     ['workbench.action.reloadWindow']: [];
     ['workbench.action.closeActiveEditor']: [];
+    ['workbench.extensions.search']: [string];
     ['editor.action.formatDocument']: [];
     ['editor.action.rename']: [];
     ['jupyter.selectJupyterInterpreter']: [];

--- a/src/platform/common/types.ts
+++ b/src/platform/common/types.ts
@@ -294,7 +294,8 @@ export interface IAsyncDisposableRegistry extends IAsyncDisposable {
 }
 
 export enum Experiments {
-    NewJupyterSession = 'NewJupyterSession'
+    NewJupyterSession = 'NewJupyterSession',
+    DataViewerContribution = 'DataViewerContribution'
 }
 
 /**

--- a/src/webviews/extension-side/variablesView/variableView.ts
+++ b/src/webviews/extension-side/variablesView/variableView.ts
@@ -167,10 +167,12 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
                     .map((e) => {
                         const contributes = e.packageJSON?.contributes;
                         if (contributes?.dataframeViewer) {
-                            return contributes.dataframeViewer.map((dataframeViewer: any) => ({
-                                extension: e,
-                                dataframeViewer
-                            }));
+                            return contributes.dataframeViewer.map(
+                                (dataframeViewer: { command: string; title: string }[]) => ({
+                                    extension: e,
+                                    dataframeViewer
+                                })
+                            );
                         }
                         return [];
                     })
@@ -201,6 +203,7 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
                         const item = quickPick.selectedItems[0];
                         if (item) {
                             quickPick.hide();
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
                             this.commandManager.executeCommand(item.command as any, {
                                 container: {},
                                 variable: request.variable

--- a/src/webviews/extension-side/variablesView/variableView.ts
+++ b/src/webviews/extension-side/variablesView/variableView.ts
@@ -204,10 +204,12 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
                         if (item) {
                             quickPick.hide();
                             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                            this.commandManager.executeCommand(item.command as any, {
-                                container: {},
-                                variable: request.variable
-                            });
+                            this.commandManager
+                                .executeCommand(item.command as any, {
+                                    container: {},
+                                    variable: request.variable
+                                })
+                                .then(noop, noop);
                         }
                     });
                     quickPick.show();

--- a/src/webviews/extension-side/variablesView/variableView.ts
+++ b/src/webviews/extension-side/variablesView/variableView.ts
@@ -203,8 +203,8 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
                         const item = quickPick.selectedItems[0];
                         if (item) {
                             quickPick.hide();
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
                             this.commandManager
+                                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                                 .executeCommand(item.command as any, {
                                     container: {},
                                     variable: request.variable

--- a/src/webviews/extension-side/variablesView/variableView.ts
+++ b/src/webviews/extension-side/variablesView/variableView.ts
@@ -154,23 +154,23 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
     public async showDataViewer(request: IShowDataViewer) {
         try {
             if (this.experiments.inExperiment(Experiments.DataViewerContribution)) {
-                // dataframeViewer
+                // jupyterVariableViewers
                 const extensions = this.extensions.all
                     .filter(
                         (e) =>
-                            e.packageJSON?.contributes?.dataframeViewer &&
-                            e.packageJSON?.contributes?.dataframeViewer.length
+                            e.packageJSON?.contributes?.jupyterVariableViewers &&
+                            e.packageJSON?.contributes?.jupyterVariableViewers.length
                     )
                     .filter((e) => e.id !== JVSC_EXTENSION_ID);
 
-                const dataframeViewers = extensions
+                const variableViewers = extensions
                     .map((e) => {
                         const contributes = e.packageJSON?.contributes;
-                        if (contributes?.dataframeViewer) {
-                            return contributes.dataframeViewer.map(
-                                (dataframeViewer: { command: string; title: string }[]) => ({
+                        if (contributes?.jupyterVariableViewers) {
+                            return contributes.jupyterVariableViewers.map(
+                                (jupyterVariableViewers: { command: string; title: string }[]) => ({
                                     extension: e,
-                                    dataframeViewer
+                                    jupyterVariableViewers
                                 })
                             );
                         }
@@ -178,12 +178,15 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
                     })
                     .flat();
 
-                if (dataframeViewers.length === 0) {
+                if (variableViewers.length === 0) {
                     // No data frame viewer extensions, show notifications
-                    await this.commandManager.executeCommand('workbench.extensions.search', '@tag:datascience');
+                    await this.commandManager.executeCommand(
+                        'workbench.extensions.search',
+                        '@tag:jupyterVariableViewers'
+                    );
                     return;
-                } else if (dataframeViewers.length === 1) {
-                    const command = dataframeViewers[0].dataframeViewer.command;
+                } else if (variableViewers.length === 1) {
+                    const command = variableViewers[0].jupyterVariableViewers.command;
                     return this.commandManager.executeCommand(command, {
                         container: {},
                         variable: request.variable
@@ -192,11 +195,11 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
                     // show quick pick
                     const quickPick = this.appShell.createQuickPick<QuickPickItem & { command: string }>();
                     quickPick.title = 'Select DataFrame Viewer';
-                    quickPick.items = dataframeViewers.map((d) => {
+                    quickPick.items = variableViewers.map((d) => {
                         return {
-                            label: d.dataframeViewer.title,
+                            label: d.jupyterVariableViewers.title,
                             detail: d.extension.packageJSON?.displayName ?? d.extension.id,
-                            command: d.dataframeViewer.command
+                            command: d.jupyterVariableViewers.command
                         };
                     });
                     quickPick.onDidAccept(() => {

--- a/src/webviews/extension-side/variablesView/variableView.ts
+++ b/src/webviews/extension-side/variablesView/variableView.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Uri, WebviewView as vscodeWebviewView } from 'vscode';
+import { QuickPickItem, Uri, WebviewView as vscodeWebviewView } from 'vscode';
 import { joinPath } from '../../../platform/vscode-path/resources';
 import { capturePerfTelemetry, sendTelemetryEvent, Telemetry } from '../../../telemetry';
 import { INotebookWatcher, IVariableViewPanelMapping } from './types';
@@ -26,20 +26,21 @@ import {
     IConfigurationService,
     IDisposableRegistry,
     IDisposable,
-    IExtensionContext
+    IExtensionContext,
+    IExtensions,
+    IExperimentService,
+    Experiments
 } from '../../../platform/common/types';
 import * as localize from '../../../platform/common/utils/localize';
-import { DataViewerChecker } from '../dataviewer/dataViewerChecker';
-import { IJupyterVariableDataProviderFactory, IDataViewerFactory, IDataViewer } from '../dataviewer/types';
 import { WebviewViewHost } from '../../../platform/webviews/webviewViewHost';
 import { swallowExceptions } from '../../../platform/common/utils/decorators';
 import { noop } from '../../../platform/common/utils/misc';
+import { Commands, JVSC_EXTENSION_ID } from '../../../platform/common/constants';
 
 // This is the client side host for the native notebook variable view webview
 // It handles passing messages to and from the react view as well as the connection
 // to execution and changing of the active notebook
 export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> implements IDisposable {
-    private dataViewerChecker: DataViewerChecker;
     protected get owningResource(): Resource {
         return undefined;
     }
@@ -51,11 +52,11 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
         private readonly variables: IJupyterVariables,
         private readonly disposables: IDisposableRegistry,
         private readonly appShell: IApplicationShell,
-        private readonly jupyterVariableDataProviderFactory: IJupyterVariableDataProviderFactory,
-        private readonly dataViewerFactory: IDataViewerFactory,
         private readonly notebookWatcher: INotebookWatcher,
         private readonly commandManager: ICommandManager,
-        private readonly documentManager: IDocumentManager
+        private readonly documentManager: IDocumentManager,
+        private readonly extensions: IExtensions,
+        private readonly experiments: IExperimentService
     ) {
         const variableViewDir = joinPath(context.extensionUri, 'out', 'webviews', 'webview-side', 'viewers');
         super(
@@ -73,8 +74,6 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
         this.notebookWatcher.onDidRestartActiveNotebook(this.activeNotebookRestarted, this, this.disposables);
         this.variables.refreshRequired(this.sendRefreshMessage, this, this.disposables);
         this.documentManager.onDidChangeActiveTextEditor(this.activeTextEditorChanged, this, this.disposables);
-
-        this.dataViewerChecker = new DataViewerChecker(configuration, appShell);
     }
 
     @capturePerfTelemetry(Telemetry.NativeVariableViewLoaded)
@@ -152,19 +151,69 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
 
     // Handle a request from the react UI to show our data viewer. Public for testing
     @swallowExceptions()
-    public async showDataViewer(request: IShowDataViewer): Promise<IDataViewer | undefined> {
+    public async showDataViewer(request: IShowDataViewer) {
         try {
-            if (
-                this.notebookWatcher.activeKernel &&
-                (await this.dataViewerChecker.isRequestedColumnSizeAllowed(request.columnSize, this.owningResource))
-            ) {
-                // Create a variable data provider and pass it to the data viewer factory to create the data viewer
-                const jupyterVariableDataProvider = await this.jupyterVariableDataProviderFactory.create(
-                    request.variable,
-                    this.notebookWatcher.activeKernel
-                );
-                const title: string = `${localize.DataScience.dataExplorerTitle} - ${request.variable.name}`;
-                return await this.dataViewerFactory.create(jupyterVariableDataProvider, title);
+            if (this.experiments.inExperiment(Experiments.DataViewerContribution)) {
+                // dataframeViewer
+                const extensions = this.extensions.all
+                    .filter(
+                        (e) =>
+                            e.packageJSON?.contributes?.dataframeViewer &&
+                            e.packageJSON?.contributes?.dataframeViewer.length
+                    )
+                    .filter((e) => e.id !== JVSC_EXTENSION_ID);
+
+                const dataframeViewers = extensions
+                    .map((e) => {
+                        const contributes = e.packageJSON?.contributes;
+                        if (contributes?.dataframeViewer) {
+                            return contributes.dataframeViewer.map((dataframeViewer: any) => ({
+                                extension: e,
+                                dataframeViewer
+                            }));
+                        }
+                        return [];
+                    })
+                    .flat();
+
+                if (dataframeViewers.length === 0) {
+                    // No data frame viewer extensions, show notifications
+                    await this.commandManager.executeCommand('workbench.extensions.search', '@tag:datascience');
+                    return;
+                } else if (dataframeViewers.length === 1) {
+                    const command = dataframeViewers[0].dataframeViewer.command;
+                    return this.commandManager.executeCommand(command, {
+                        container: {},
+                        variable: request.variable
+                    });
+                } else {
+                    // show quick pick
+                    const quickPick = this.appShell.createQuickPick<QuickPickItem & { command: string }>();
+                    quickPick.title = 'Select DataFrame Viewer';
+                    quickPick.items = dataframeViewers.map((d) => {
+                        return {
+                            label: d.dataframeViewer.title,
+                            detail: d.extension.packageJSON?.displayName ?? d.extension.id,
+                            command: d.dataframeViewer.command
+                        };
+                    });
+                    quickPick.onDidAccept(() => {
+                        const item = quickPick.selectedItems[0];
+                        if (item) {
+                            quickPick.hide();
+                            this.commandManager.executeCommand(item.command as any, {
+                                container: {},
+                                variable: request.variable
+                            });
+                        }
+                    });
+                    quickPick.show();
+                }
+            } else {
+                return this.commandManager.executeCommand(Commands.ShowDataViewer, {
+                    container: {},
+                    variable: request.variable
+                });
             }
         } catch (e) {
             traceError(e);

--- a/src/webviews/extension-side/variablesView/variableViewProvider.ts
+++ b/src/webviews/extension-side/variablesView/variableViewProvider.ts
@@ -12,9 +12,14 @@ import {
     IDocumentManager
 } from '../../../platform/common/application/types';
 import { Identifiers, isTestExecution } from '../../../platform/common/constants';
-import { IConfigurationService, IDisposableRegistry, IExtensionContext } from '../../../platform/common/types';
+import {
+    IConfigurationService,
+    IDisposableRegistry,
+    IExperimentService,
+    IExtensionContext,
+    IExtensions
+} from '../../../platform/common/types';
 import { createDeferred, Deferred } from '../../../platform/common/utils/async';
-import { IJupyterVariableDataProviderFactory, IDataViewerFactory } from '../dataviewer/types';
 import { INotebookWatcher, IVariableViewProvider } from './types';
 import { VariableView } from './variableView';
 
@@ -50,12 +55,11 @@ export class VariableViewProvider implements IVariableViewProvider {
         @inject(IJupyterVariables) @named(Identifiers.ALL_VARIABLES) private variables: IJupyterVariables,
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
-        @inject(IJupyterVariableDataProviderFactory)
-        private readonly jupyterVariableDataProviderFactory: IJupyterVariableDataProviderFactory,
-        @inject(IDataViewerFactory) private readonly dataViewerFactory: IDataViewerFactory,
         @inject(INotebookWatcher) private readonly notebookWatcher: INotebookWatcher,
         @inject(ICommandManager) private readonly commandManager: ICommandManager,
-        @inject(IDocumentManager) private readonly documentManager: IDocumentManager
+        @inject(IDocumentManager) private readonly documentManager: IDocumentManager,
+        @inject(IExtensions) private readonly extensions: IExtensions,
+        @inject(IExperimentService) private readonly experiments: IExperimentService
     ) {}
 
     public async resolveWebviewView(
@@ -74,11 +78,11 @@ export class VariableViewProvider implements IVariableViewProvider {
             this.variables,
             this.disposables,
             this.appShell,
-            this.jupyterVariableDataProviderFactory,
-            this.dataViewerFactory,
             this.notebookWatcher,
             this.commandManager,
-            this.documentManager
+            this.documentManager,
+            this.extensions,
+            this.experiments
         );
 
         // If someone is waiting for the variable view resolve that here


### PR DESCRIPTION
Re #14315.

The main change in this PR is decoupling data viewer and variable view. Data Viewer contributes a command for opening data frame and Variable View invokes that command other than directly depending on the data viewer component. So for users there should be no UI/UX change at this moment. 

We also added an experiment, which once is turned on, it will then look at all data viewer contributions in the extensions installed locally, and use the contributed command to open the data frame or supported variable. This experiment is now fully turned off.

An example of how an extension can contribute a data viewer for Jupyter https://github.com/rebornix/vscode-data-grid-example

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
