### PR TITLE
remove unimplemented command

### DIFF
--- a/package.json
+++ b/package.json
@@ -584,18 +584,6 @@
                 "enablement": "isWorkspaceTrusted && !jupyter.webExtension"
             },
             {
-                "command": "jupyter.notebookeditor.undocells",
-                "title": "%jupyter.command.jupyter.undocells.title%",
-                "category": "Notebook",
-                "enablement": "!jupyter.webExtension"
-            },
-            {
-                "command": "jupyter.notebookeditor.redocells",
-                "title": "%jupyter.command.jupyter.redocells.title%",
-                "category": "Notebook",
-                "enablement": "!jupyter.webExtension"
-            },
-            {
                 "command": "jupyter.interruptkernel",
                 "title": "%jupyter.command.jupyter.interruptkernel.title%",
                 "shortTitle": "%jupyter.command.jupyter.interruptkernel.shorttitle%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -117,8 +117,6 @@
             "{Locked='Notebook'}"
         ]
     },
-    "jupyter.command.jupyter.undocells.title": "Undo Last Interactive Action",
-    "jupyter.command.jupyter.redocells.title": "Redo Last Interactive Action",
     "jupyter.command.jupyter.notebookeditor.removeallcells.title": {
         "message": "Delete All Notebook Editor Cells",
         "comment": [


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/186323

These commands always result in 'command not found' because they aren't actually implemented anywhere. Must have been missed during a previous cleanup