### PR TITLE
Experimental cell execution analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -775,6 +775,29 @@
                 "icon": "$(vm)",
                 "enablement": "true",
                 "category": "Jupyter"
+            },
+            {
+                "command": "jupyter.gatherCells",
+                "title": "Gather code",
+                "shortTitle": "Gather",
+                "icon": "$(gather)",
+                "enablement": "!jupyter.webExtension",
+                "category": "Jupyter"
+            },
+            {
+                "command": "jupyter.selectSuccessorCells",
+                "title": "Select Successors",
+                "shortTitle": "Select",
+                "icon": "$(arrow-down)",
+                "enablement": "!jupyter.webExtension",
+                "category": "Jupyter"
+            },
+            {
+                "command": "jupyter.debugCellSymbols",
+                "title": "Debug Cell Symbols",
+                "icon": "$(debug-alt-small)",
+                "enablement": "!jupyter.webExtension",
+                "category": "Jupyter"
             }
         ],
         "submenus": [
@@ -925,6 +948,16 @@
                     "command": "jupyter.runByLineStop",
                     "when": "notebookCellResource in jupyter.notebookeditor.runByLineCells && notebookCellToolbarLocation == right",
                     "group": "inline/cell@0"
+                },
+                {
+                    "command": "jupyter.gatherCells",
+                    "when": "notebookType == 'jupyter-notebook' && isWorkspaceTrusted && config.jupyter.executionAnalysis.enabled",
+                    "group": "executionAnalysis@0"
+                },
+                {
+                    "command": "jupyter.selectSuccessorCells",
+                    "when": "notebookType == 'jupyter-notebook' && isWorkspaceTrusted && config.jupyter.executionAnalysis.enabled",
+                    "group": "executionAnalysis@0"
                 }
             ],
             "notebook/cell/execute": [
@@ -1365,6 +1398,18 @@
                 {
                     "command": "jupyter.clearSavedJupyterUris",
                     "title": "%jupyter.command.jupyter.clearSavedJupyterUris.title%"
+                },
+                {
+                    "command": "jupyter.gatherCells",
+                    "when": "config.jupyter.executionAnalysis.enabled"
+                },
+                {
+                    "command": "jupyter.selectSuccessorCells",
+                    "when": "config.jupyter.executionAnalysis.enabled"
+                },
+                {
+                    "command": "jupyter.debugCellSymbols",
+                    "when": "config.jupyter.executionAnalysis.enabled"
                 }
             ],
             "debug/variables/context": [
@@ -1873,6 +1918,12 @@
                     "type": "boolean",
                     "default": false,
                     "markdownDescription": "%jupyter.configuration.jupyter.enableExtendedKernelCompletions.markdownDescription%",
+                    "scope": "application"
+                },
+                "jupyter.executionAnalysis.enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Experimental feature to enable execution analysis in notebooks",
                     "scope": "application"
                 }
             }

--- a/src/extension.node.ts
+++ b/src/extension.node.ts
@@ -92,6 +92,10 @@ import { IInterpreterPackages } from './platform/interpreter/types';
 import { homedir, platform, arch, userInfo } from 'os';
 import { getUserHomeDir } from './platform/common/utils/platform.node';
 import { homePath } from './platform/common/platform/fs-paths.node';
+import {
+    activate as activateExecutionAnalysis,
+    deactivate as deactivateExecutionAnalysis
+} from './standalone/executionAnalysis/extension';
 
 durations.codeLoadingTime = stopWatch.elapsedTime;
 
@@ -151,6 +155,8 @@ export function deactivate(): Thenable<void> {
         }
     }
 
+    deactivateExecutionAnalysis();
+
     return Promise.resolve();
 }
 
@@ -186,6 +192,10 @@ async function activateUnsafe(
 
         startupDurations.endActivateTime = startupStopWatch.elapsedTime;
         activationDeferred.resolve();
+
+        //===============================================
+        // dynamically load standalone plugins
+        activateExecutionAnalysis(context).then(noop, noop);
 
         const api = buildApi(activationPromise, serviceManager, serviceContainer, context);
         return [api, activationPromise, serviceContainer];

--- a/src/standalone/executionAnalysis/common.ts
+++ b/src/standalone/executionAnalysis/common.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as vscode from 'vscode';
+
+export interface Range {
+    /**
+     * The range's start position
+     */
+    start: Position;
+    /**
+     * The range's end position.
+     */
+    end: Position;
+}
+
+export interface Position {
+    /**
+     * Line position in a document (zero-based).
+     */
+    line: number;
+    /**
+     * Character offset on a line in a document (zero-based). Assuming that the line is
+     * represented as a string, the `character` value represents the gap between the
+     * `character` and `character + 1`.
+     *
+     * If the character value is greater than the line length it defaults back to the
+     * line length.
+     */
+    character: number;
+}
+
+export interface Location {
+    uri: string;
+    range: Range;
+}
+
+export interface LocationWithReferenceKind extends Location {
+    kind?: string;
+}
+
+export function cellIndexesToRanges(indexes: number[]): vscode.NotebookRange[] {
+    indexes.sort((a, b) => a - b);
+    const first = indexes.shift();
+
+    if (first === undefined) {
+        return [];
+    }
+
+    return indexes
+        .reduce(
+            function (ranges, num) {
+                if (num <= ranges[0][1]) {
+                    ranges[0][1] = num + 1;
+                } else {
+                    ranges.unshift([num, num + 1]);
+                }
+                return ranges;
+            },
+            [[first, first + 1]]
+        )
+        .reverse()
+        .map((val) => new vscode.NotebookRange(val[0], val[1]));
+}
+
+export function findNotebook(document: vscode.TextDocument): vscode.NotebookDocument | undefined {
+    return vscode.workspace.notebookDocuments.find(
+        (doc) => doc.uri.authority === document.uri.authority && doc.uri.path === document.uri.path
+    );
+}
+
+// eslint-disable-next-line no-empty,@typescript-eslint/no-empty-function
+export function noop() {}
+
+export const PylanceExtension = 'ms-python.vscode-pylance';

--- a/src/standalone/executionAnalysis/extension.ts
+++ b/src/standalone/executionAnalysis/extension.ts
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as vscode from 'vscode';
+import { activatePylance } from './pylance';
+import { findNotebook, noop } from './common';
+import { SymbolsTracker } from './symbols';
+
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    const optInto = vscode.workspace.getConfiguration('jupyter').get<boolean>('executionAnalysis.enabled');
+    if (!optInto) {
+        return;
+    }
+
+    const referencesProvider = await activatePylance();
+    if (!referencesProvider) {
+        vscode.window
+            .showErrorMessage('Could not get references provider from language server, Pylance prerelease required.')
+            .then(noop, noop);
+        return;
+    }
+
+    const symbolsManager = new SymbolsTracker(referencesProvider);
+    context.subscriptions.push(symbolsManager);
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'jupyter.selectSuccessorCells',
+            async (cell: vscode.NotebookCell | undefined) => {
+                const doc =
+                    vscode.workspace.textDocuments.find(
+                        (doc) => doc.uri.toString() === cell?.document.uri.toString()
+                    ) ?? vscode.window.activeTextEditor?.document;
+                if (!doc) {
+                    return;
+                }
+
+                const notebook = findNotebook(doc);
+                if (!notebook) {
+                    return;
+                }
+                const cells = notebook.getCells();
+                const currentCell = cells.find((cell) => cell.document.uri.toString() === doc.uri.toString());
+                if (!currentCell) {
+                    return;
+                }
+
+                await symbolsManager.selectSuccessorCells(notebook, currentCell);
+            }
+        )
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('jupyter.gatherCells', async (cell: vscode.NotebookCell | undefined) => {
+            const doc =
+                vscode.workspace.textDocuments.find((doc) => doc.uri.toString() === cell?.document.uri.toString()) ??
+                vscode.window.activeTextEditor?.document;
+            if (!doc) {
+                return;
+            }
+
+            const notebook = findNotebook(doc);
+            if (!notebook) {
+                return;
+            }
+            const cells = notebook.getCells();
+            const currentCell = cells.find((cell) => cell.document.uri.toString() === doc.uri.toString());
+            if (!currentCell) {
+                return;
+            }
+
+            const gatheredCells = (await symbolsManager.gatherCells(notebook, currentCell)) as vscode.NotebookCell[];
+            if (gatheredCells) {
+                // console.log(gatheredCells?.map(cell => `${cell.index}:\n ${cell.document.getText()}\n`));
+
+                const nbCells = gatheredCells.map((cell) => {
+                    return new vscode.NotebookCellData(
+                        vscode.NotebookCellKind.Code,
+                        cell.document.getText(),
+                        cell.document.languageId
+                    );
+                });
+                const doc = await vscode.workspace.openNotebookDocument(
+                    'jupyter-notebook',
+                    new vscode.NotebookData(nbCells)
+                );
+                await vscode.window.showNotebookDocument(doc, {
+                    viewColumn: 1,
+                    preserveFocus: true
+                });
+            }
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('jupyter.debugCellSymbols', async () => {
+            const notebookEditor = vscode.window.activeNotebookEditor;
+            if (notebookEditor) {
+                await symbolsManager.debugSymbols(notebookEditor.notebook);
+            }
+        })
+    );
+}
+
+// This method is called when your extension is deactivated
+export function deactivate() {
+    noop();
+}

--- a/src/standalone/executionAnalysis/pylance.ts
+++ b/src/standalone/executionAnalysis/pylance.ts
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as vscode from 'vscode';
+import { BaseLanguageClient } from 'vscode-languageclient';
+import { LocationWithReferenceKind, PylanceExtension, noop } from './common';
+
+export interface ILanguageServerFolder {
+    path: string;
+    version: string; // SemVer, in string form to avoid cross-extension type issues.
+}
+
+export interface INotebookLanguageClient {
+    registerJupyterPythonPathFunction(func: (uri: vscode.Uri) => Promise<string | undefined>): void;
+    registerGetNotebookUriForTextDocumentUriFunction(
+        func: (textDocumentUri: vscode.Uri) => vscode.Uri | undefined
+    ): void;
+    getCompletionItems(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        context: vscode.CompletionContext,
+        token: vscode.CancellationToken
+    ): Promise<vscode.CompletionItem[] | vscode.CompletionList | undefined>;
+    getReferences(
+        textDocument: vscode.TextDocument,
+        position: vscode.Position,
+        options: {
+            includeDeclaration: boolean;
+        },
+        token: vscode.CancellationToken
+    ): Promise<LocationWithReferenceKind[] | null | undefined>;
+}
+
+export interface LSExtensionApi {
+    languageServerFolder?(): Promise<ILanguageServerFolder>;
+    client?: {
+        isEnabled(): boolean;
+        start(): Promise<void>;
+        stop(): Promise<void>;
+    };
+    notebook?: INotebookLanguageClient;
+}
+
+export interface PythonApi {
+    readonly pylance?: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        createClient(...args: any[]): BaseLanguageClient;
+        start(client: BaseLanguageClient): Promise<void>;
+        stop(client: BaseLanguageClient): Promise<void>;
+    };
+}
+
+export async function runPylance(pylanceExtension: vscode.Extension<LSExtensionApi>) {
+    const pylanceApi = await pylanceExtension.activate();
+    return pylanceApi;
+}
+
+let _client: INotebookLanguageClient | undefined;
+export async function activatePylance(): Promise<INotebookLanguageClient | undefined> {
+    const pylanceExtension = vscode.extensions.getExtension(PylanceExtension);
+    if (!pylanceExtension) {
+        return undefined;
+    }
+
+    if (_client) {
+        return _client;
+    }
+
+    return new Promise((resolve, reject) => {
+        runPylance(pylanceExtension)
+            .then(async (client) => {
+                if (!client) {
+                    vscode.window.showErrorMessage('Could not start Pylance').then(noop, noop);
+                    reject();
+                    return;
+                }
+
+                if (client.client) {
+                    await client.client.start();
+                }
+
+                _client = client.notebook;
+                resolve(client.notebook);
+            })
+            .then(noop, noop);
+    });
+}

--- a/src/standalone/executionAnalysis/symbols.ts
+++ b/src/standalone/executionAnalysis/symbols.ts
@@ -1,0 +1,475 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as vscode from 'vscode';
+import { INotebookLanguageClient } from './pylance';
+import { cellIndexesToRanges, LocationWithReferenceKind, noop, Range } from './common';
+
+const writeDecorationType = vscode.window.createTextEditorDecorationType({
+    after: {
+        contentText: 'write',
+        margin: '0 0 0 1em',
+        backgroundColor: 'red'
+    }
+});
+
+const readDecorationType = vscode.window.createTextEditorDecorationType({
+    after: {
+        contentText: 'read',
+        margin: '0 0 0 1em',
+        backgroundColor: 'green'
+    }
+});
+
+export interface IDocument {
+    uri: vscode.Uri;
+}
+
+export interface INotebookCell {
+    readonly document: IDocument;
+}
+
+export interface ILocationWithReferenceKind {
+    uri: vscode.Uri;
+    range: Range;
+    kind?: string;
+    symbolKind?: vscode.SymbolKind;
+}
+
+/**
+ * A defines symbol X
+ * B modifies symbol X
+ * C uses symbol X
+ *
+ * Fist step is the B and C uses symbol X so they depend on A, so to get the state of C, we need to run A -> output A and C
+ * Second step is since B modifies symbol X, we need to run both A and B to get the state of C. -> output A, B and C
+ */
+export class CellAnalysis {
+    constructor(
+        private readonly _cellExecution: ICellExecution[],
+        private readonly _cellRefs: Map<string, ILocationWithReferenceKind[]>
+    ) {}
+
+    /**
+     * Get predecessor cells
+     */
+    getPredecessorCells(cell: INotebookCell): INotebookCell[] {
+        // find last execution item index from this._cellExecution whose cell property matches cell
+        var i;
+        for (
+            i = this._cellExecution.length - 1;
+            i >= 0 && this._cellExecution[i].cell.document.uri.toString() !== cell.document.uri.toString();
+            i--
+        ) {
+            // no-op
+        }
+
+        if (i === -1) {
+            return [];
+        }
+
+        const lastExecutionIndex = i;
+        const slicedCellExecution = this._cellExecution.slice(0, lastExecutionIndex + 1);
+        const cellBitmap: boolean[] = new Array(slicedCellExecution.length).fill(false);
+        cellBitmap[lastExecutionIndex] = true;
+
+        const reversedCellRefs = new Map<string, string[]>(); // key: cell uri fragment, value: cell uri fragment[]
+        for (const [key, dependents] of this._cellRefs.entries()) {
+            dependents.forEach((dependent) => {
+                const fragment = dependent.uri.fragment;
+
+                if (reversedCellRefs.has(fragment)) {
+                    reversedCellRefs.get(fragment)?.push(key);
+                } else {
+                    reversedCellRefs.set(fragment, [key]);
+                }
+            });
+        }
+
+        const cellFragment = cell.document.uri.fragment;
+        this._resolveDependencies(
+            reversedCellRefs,
+            cellBitmap,
+            cellFragment,
+            slicedCellExecution.map((item) => item.cell)
+        );
+
+        const cellData: INotebookCell[] = [];
+        for (let i = 0; i < cellBitmap.length; i++) {
+            if (cellBitmap[i]) {
+                cellData.push(slicedCellExecution[i].cell);
+            }
+        }
+
+        return cellData;
+    }
+
+    /**
+     * @todo
+     * cell might not have symbols, but it can have references of other cells' symbols
+     * if the reference to the symbol is a write operation, then the following cells that use the symbol will depend on this cell
+     */
+    getSuccessorCells(cell: INotebookCell): INotebookCell[] {
+        const cellIndex = this._cellExecution.findIndex(
+            (item) => item.cell.document.uri.fragment === cell.document.uri.fragment
+        );
+        if (cellIndex === -1) {
+            return [];
+        }
+
+        const cellBitmap: boolean[] = new Array(this._cellExecution.length).fill(false);
+        cellBitmap[cellIndex] = true;
+
+        // a symbol is a definition so modifying it is always a `write` operation
+
+        for (let i = cellIndex; i < this._cellExecution.length; i++) {
+            if (cellBitmap[i]) {
+                const deps = this._cellRefs.get(this._cellExecution[i].cell.document.uri.fragment);
+                deps?.forEach((dep) => {
+                    const index = this._cellExecution.findIndex(
+                        (item) => item.cell.document.uri.fragment === dep.uri.fragment
+                    );
+                    // @todo what if index < cellIndex?
+                    if (index !== -1 && index >= cellIndex) {
+                        cellBitmap[index] = true;
+                    }
+                });
+
+                // check if this cell contains `write` references
+            }
+        }
+
+        const cellData: INotebookCell[] = [];
+        for (let i = 0; i < cellBitmap.length; i++) {
+            if (cellBitmap[i]) {
+                cellData.push(this._cellExecution[i].cell);
+            }
+        }
+
+        return cellData;
+    }
+
+    private _resolveDependencies(
+        reversedCellRefs: Map<string, string[]>,
+        cellBitmap: boolean[],
+        cellFragment: string,
+        cellExecution: INotebookCell[]
+    ) {
+        if (reversedCellRefs.has(cellFragment)) {
+            for (const dependency of reversedCellRefs.get(cellFragment)!) {
+                const index = cellExecution.findIndex((cell) => cell.document.uri.fragment === dependency);
+
+                if (index === -1) {
+                    throw new Error(`Dependency ${dependency} is not in the execution list.`);
+                }
+                if (!cellBitmap[index]) {
+                    cellBitmap[index] = true;
+                    this._resolveDependencies(reversedCellRefs, cellBitmap, dependency, cellExecution);
+                }
+            }
+        }
+    }
+}
+
+export interface ICellExecution {
+    cell: INotebookCell;
+    executionCount: number;
+}
+
+export class NotebookDocumentSymbolTracker {
+    private _pendingRequests: Map<string, vscode.CancellationTokenSource> = new Map();
+    private _cellRefs: Map<string, ILocationWithReferenceKind[]> = new Map();
+    private _cellExecution: ICellExecution[] = [];
+    private _disposables: vscode.Disposable[] = [];
+    constructor(
+        private readonly _notebookEditor: vscode.NotebookEditor,
+        private readonly _client: INotebookLanguageClient
+    ) {
+        this._notebookEditor.notebook.getCells().forEach((cell) => {
+            this._requestCellSymbols(cell, false).then(noop, noop);
+        });
+
+        this._disposables.push(
+            vscode.workspace.onDidChangeNotebookDocument((e) => {
+                if (e.notebook === this._notebookEditor.notebook) {
+                    e.contentChanges.forEach((change) => {
+                        change.removedCells.forEach((cell) => {
+                            this._pendingRequests.delete(cell.document.uri.fragment);
+                            this._cellRefs.delete(cell.document.uri.fragment);
+                        });
+
+                        change.addedCells.forEach((cell) => {
+                            this._requestCellSymbols(cell, false).then(noop, noop);
+                        });
+                    });
+
+                    e.cellChanges.forEach((change) => {
+                        this._requestCellSymbols(change.cell, false).then(noop, noop);
+                    });
+                }
+            })
+        );
+
+        this._disposables.push(
+            vscode.notebooks.onDidChangeNotebookCellExecutionState((e) => {
+                if (e.state === vscode.NotebookCellExecutionState.Idle && e.cell.document.languageId === 'python') {
+                    // just finished execution
+                    this._cellExecution.push({
+                        cell: e.cell,
+                        executionCount: e.cell.executionSummary?.executionOrder ?? 0
+                    });
+                }
+            })
+        );
+    }
+
+    async requestCellSymbolsSync() {
+        const _pendingRequestsKeys = [...this._pendingRequests.keys()];
+        this._pendingRequests.forEach((r) => r.cancel());
+        this._pendingRequests.clear();
+        // force request cell symbols synchronously
+        for (const key of _pendingRequestsKeys) {
+            const cell = this._notebookEditor.notebook.getCells().find((cell) => cell.document.uri.fragment === key);
+            if (cell) {
+                await this._requestCellSymbols(cell, true);
+            }
+        }
+    }
+
+    async gather(cell: vscode.NotebookCell) {
+        await this.requestCellSymbolsSync();
+        const analysis = new CellAnalysis(this._cellExecution, this._cellRefs);
+        return analysis.getPredecessorCells(cell);
+    }
+
+    async selectSuccessorCells(cell: vscode.NotebookCell) {
+        await this.requestCellSymbolsSync();
+        const tokenSource = new vscode.CancellationTokenSource();
+        const refs = this._cellRefs.get(cell.document.uri.fragment);
+        const cells = this._notebookEditor.notebook.getCells();
+        const indexes: number[] = [];
+        const currentCellIndex = cells.findIndex((c) => c.document.uri.toString() === cell.document.uri.toString());
+        if (currentCellIndex === -1) {
+            return;
+        }
+
+        refs?.forEach((ref) => {
+            const index = cells.findIndex((cell) => cell.document.uri.fragment === ref.uri.fragment);
+            if (index !== -1 && index !== currentCellIndex) {
+                indexes.push(index);
+            }
+        });
+
+        if (indexes.length === 0) {
+            return;
+        }
+
+        const cellRanges = cellIndexesToRanges(indexes);
+        this._notebookEditor.selections = cellRanges;
+
+        tokenSource.dispose();
+    }
+
+    async debugSymbols() {
+        const locations: ILocationWithReferenceKind[] = [];
+        await this.requestCellSymbolsSync();
+
+        console.log(JSON.stringify(Array.from(this._cellRefs.entries())));
+
+        for (const editor of vscode.window.visibleTextEditors) {
+            const document = editor.document;
+            if (
+                document.uri.scheme === 'vscode-notebook-cell' &&
+                document.uri.path === this._notebookEditor.notebook.uri.path
+            ) {
+                const refs = this._cellRefs.get(document.uri.fragment);
+                if (refs) {
+                    locations.push(...refs);
+                }
+            }
+        }
+
+        // group locations by uri
+        const locationsByUriFragment = new Map<string, ILocationWithReferenceKind[]>();
+        locations.forEach((loc) => {
+            const fragment = loc.uri.fragment;
+            if (!locationsByUriFragment.has(fragment)) {
+                locationsByUriFragment.set(fragment, []);
+            }
+            locationsByUriFragment.get(fragment)?.push(loc);
+        });
+
+        locationsByUriFragment.forEach((locations, fragment) => {
+            const matcheEditor = vscode.window.visibleTextEditors.find(
+                (editor) =>
+                    editor.document.uri.path === this._notebookEditor.notebook.uri.path &&
+                    editor.document.uri.fragment === fragment
+            );
+            if (matcheEditor) {
+                const writeRanges: vscode.Range[] = [];
+                const readRanges: vscode.Range[] = [];
+                locations.forEach((loc) => {
+                    const position = new vscode.Position(loc.range.end.line, loc.range.end.character);
+                    const range = new vscode.Range(position, position);
+
+                    if (loc.kind === 'write') {
+                        writeRanges.push(range);
+                    } else if (loc.kind === 'read') {
+                        readRanges.push(range);
+                    }
+                });
+
+                matcheEditor.setDecorations(writeDecorationType, writeRanges);
+                matcheEditor.setDecorations(readDecorationType, readRanges);
+            }
+        });
+    }
+
+    private async _requestCellSymbols(cell: vscode.NotebookCell, synchronous: boolean) {
+        // request cell symbols in a debounced fashion
+        const existing = this._pendingRequests.get(cell.document.uri.fragment);
+        if (existing) {
+            existing.cancel();
+        }
+
+        if (synchronous) {
+            const cancellationTokenSource = new vscode.CancellationTokenSource();
+            await this._doRequestCellSymbols(cell, cancellationTokenSource.token);
+            cancellationTokenSource.dispose();
+            return;
+        }
+
+        const request = new vscode.CancellationTokenSource();
+        this._pendingRequests.set(cell.document.uri.fragment, request);
+
+        // set timeout for 500ms, after which we will send the request
+        setTimeout(() => {
+            if (this._pendingRequests.get(cell.document.uri.fragment) !== request) {
+                return;
+            }
+
+            this._pendingRequests.delete(cell.document.uri.fragment);
+            if (request.token.isCancellationRequested) {
+                return;
+            }
+
+            this._doRequestCellSymbols(cell, request.token).then(noop, noop);
+        }, 500);
+    }
+
+    private async _getDocumentSymbols(cell: vscode.NotebookCell) {
+        return vscode.commands.executeCommand<(vscode.SymbolInformation & vscode.DocumentSymbol)[] | undefined>(
+            'vscode.executeDocumentSymbolProvider',
+            cell.document.uri
+        );
+    }
+
+    private async _doRequestCellSymbols(cell: vscode.NotebookCell, token: vscode.CancellationToken) {
+        const symbols = await this._getDocumentSymbols(cell);
+        if (!symbols) {
+            return;
+        }
+
+        const references: (LocationWithReferenceKind & { symbolKind?: vscode.SymbolKind })[] = [];
+        for (const symbol of symbols) {
+            const symbolReferences = await this._client.getReferences(
+                cell.document,
+                symbol.selectionRange.start,
+                { includeDeclaration: true },
+                token
+            );
+            if (symbolReferences) {
+                references.push(
+                    ...symbolReferences.map((ref) => ({
+                        ...ref,
+                        symbolKind: symbol.kind
+                    }))
+                );
+            }
+        }
+
+        if (references.length) {
+            // save refs for the cell
+            this._cellRefs.set(
+                cell.document.uri.fragment,
+                references.map((ref) => ({
+                    range: ref.range,
+                    uri: vscode.Uri.parse(ref.uri),
+                    // @todo: should we support other symbol types?
+                    kind: ref.symbolKind === vscode.SymbolKind.Function ? 'write' : ref.kind,
+                    symbolKind: ref.symbolKind
+                }))
+            );
+        }
+    }
+
+    dispose() {
+        // clear all pending requests
+        this._pendingRequests.forEach((r) => r.cancel());
+        this._pendingRequests.clear();
+        this._disposables.forEach((d) => d.dispose());
+        this._disposables = [];
+    }
+}
+
+export class SymbolsTracker {
+    private _disposables: vscode.Disposable[] = [];
+    private _notebookDocumentSymbolTrackers: Map<string, NotebookDocumentSymbolTracker> = new Map();
+    constructor(private readonly _client: INotebookLanguageClient) {
+        vscode.window.visibleNotebookEditors.forEach((editor) => {
+            this._notebookDocumentSymbolTrackers.set(
+                editor.notebook.uri.toString(),
+                new NotebookDocumentSymbolTracker(editor, this._client)
+            );
+        });
+
+        this._disposables.push(
+            vscode.window.onDidChangeVisibleNotebookEditors((e) => {
+                e.forEach((editor) => {
+                    if (!this._notebookDocumentSymbolTrackers.has(editor.notebook.uri.toString())) {
+                        this._notebookDocumentSymbolTrackers.set(
+                            editor.notebook.uri.toString(),
+                            new NotebookDocumentSymbolTracker(editor, this._client)
+                        );
+                    }
+                });
+
+                // remove trackers for closed editors
+                this._notebookDocumentSymbolTrackers.forEach((tracker, uri) => {
+                    if (
+                        !vscode.window.visibleNotebookEditors.find((editor) => editor.notebook.uri.toString() === uri)
+                    ) {
+                        tracker.dispose();
+                        this._notebookDocumentSymbolTrackers.delete(uri);
+                    }
+                });
+            })
+        );
+    }
+
+    async debugSymbols(notebookDocument: vscode.NotebookDocument) {
+        const tracker = this._notebookDocumentSymbolTrackers.get(notebookDocument.uri.toString());
+        if (tracker) {
+            await tracker.debugSymbols();
+        }
+    }
+
+    async selectSuccessorCells(notebookDocument: vscode.NotebookDocument, cell: vscode.NotebookCell) {
+        const tracker = this._notebookDocumentSymbolTrackers.get(notebookDocument.uri.toString());
+        if (tracker) {
+            await tracker.selectSuccessorCells(cell);
+        }
+    }
+
+    async gatherCells(notebookDocument: vscode.NotebookDocument, cell: vscode.NotebookCell) {
+        const tracker = this._notebookDocumentSymbolTrackers.get(notebookDocument.uri.toString());
+        if (tracker) {
+            return await tracker.gather(cell);
+        }
+    }
+
+    dispose() {
+        this._disposables.forEach((d) => d.dispose());
+        this._disposables = [];
+    }
+}


### PR DESCRIPTION
Re #14316.

This PR adds experiments for running code analysis upon cell execution, on top of which we can offer features like Gather Cells or Select/Run Dependent Cells. This requires the latest prerelease of Pylance extension for now.

The changes are contributed in `standalone` component and written in the same fashion as a standalone extension.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
