### PR TITLE
Improvements to `write` references.

### DIFF
--- a/src/standalone/executionAnalysis/common.ts
+++ b/src/standalone/executionAnalysis/common.ts
@@ -92,6 +92,15 @@ export function findNotebookAndCell(
     return { notebook, cell: currentCell };
 }
 
+export function areRangesEqual(a: Range | vscode.Range, b: Range | vscode.Range) {
+    return (
+        a.start.line === b.start.line &&
+        a.start.character === b.start.character &&
+        a.end.line === b.end.line &&
+        a.end.character === b.end.character
+    );
+}
+
 // eslint-disable-next-line no-empty,@typescript-eslint/no-empty-function
 export function noop() {}
 

--- a/src/standalone/executionAnalysis/symbols.ts
+++ b/src/standalone/executionAnalysis/symbols.ts
@@ -249,26 +249,9 @@ export class NotebookDocumentSymbolTracker {
 
     async selectSuccessorCells(cell: vscode.NotebookCell) {
         await this.requestCellSymbolsSync();
-        const refs = this._cellRefs.get(cell.document.uri.fragment);
-        const cells = this._notebookEditor.notebook.getCells();
-        const indexes: number[] = [];
-        const currentCellIndex = cells.findIndex((c) => c.document.uri.toString() === cell.document.uri.toString());
-        if (currentCellIndex === -1) {
-            return;
-        }
-
-        refs?.forEach((ref) => {
-            const index = cells.findIndex((cell) => cell.document.uri.fragment === ref.uri.fragment);
-            if (index !== -1 && index !== currentCellIndex) {
-                indexes.push(index);
-            }
-        });
-
-        if (indexes.length === 0) {
-            return;
-        }
-
-        const cellRanges = cellIndexesToRanges(indexes);
+        const analysis = new CellAnalysis(this._cellExecution, this._cellRefs);
+        const successorCells = analysis.getSuccessorCells(cell) as vscode.NotebookCell[];
+        const cellRanges = cellIndexesToRanges(successorCells.map((cell) => cell.index));
         this._notebookEditor.selections = cellRanges;
     }
 


### PR DESCRIPTION
Re #14316

Improvements to the code execution analysis:

* Mark all symbol definition as write operation.
* Unify select dependent cells and run dependent cells commands.
* Better handling of `write` references.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
