### PR TITLE
option to disable stack trace formatting

### DIFF
--- a/src/notebooks/outputs/tracebackFormatter.unit.test.ts
+++ b/src/notebooks/outputs/tracebackFormatter.unit.test.ts
@@ -6,13 +6,16 @@ import { instance, mock, when } from 'ts-mockito';
 import { NotebookCell, NotebookDocument, TextDocument, Uri } from 'vscode';
 import { JupyterNotebookView } from '../../platform/common/constants';
 import { NotebookTracebackFormatter } from './tracebackFormatter';
+import { IConfigurationService } from '../../platform/common/types';
 
 suite(`Notebook trace formatter`, function () {
     let notebook: NotebookDocument;
     let cell: NotebookCell;
     let document: TextDocument;
+    let config: IConfigurationService;
 
     setup(() => {
+        config = mock<IConfigurationService>();
         notebook = mock<NotebookDocument>();
         when(notebook.notebookType).thenReturn(JupyterNotebookView);
         cell = mock<NotebookCell>();
@@ -25,7 +28,7 @@ suite(`Notebook trace formatter`, function () {
     });
 
     test('ipython: 8.3.0, ipykernel: 6.13.0', function () {
-        const formatter = new NotebookTracebackFormatter();
+        const formatter = new NotebookTracebackFormatter(config);
         /**
          * To generate the traceback, install a specific version of ipykernel and ipython.
          * Then run following code in a cell:
@@ -54,7 +57,7 @@ suite(`Notebook trace formatter`, function () {
     });
 
     test('ipython 8.5.0, ipykernel 6.16.0', function () {
-        const formatter = new NotebookTracebackFormatter();
+        const formatter = new NotebookTracebackFormatter(config);
         const traceback = [
             '[0;31m---------------------------------------------------------------------------[0m',
             '[0;31mNameError[0m                                 Traceback (most recent call last)',

--- a/src/platform/common/configSettings.ts
+++ b/src/platform/common/configSettings.ts
@@ -99,6 +99,7 @@ export class JupyterSettings implements IWatchableJupyterSettings {
     public excludeUserSitePackages: boolean = false;
     public enableExtendedKernelCompletions: boolean = false;
     public useOldKernelResolve: boolean = false;
+    public formatStackTraces: boolean = false;
 
     public variableTooltipFields: IVariableTooltipFields = {
         python: {

--- a/src/platform/common/types.ts
+++ b/src/platform/common/types.ts
@@ -108,6 +108,7 @@ export interface IJupyterSettings {
      * Added as a fallback in case the new approach of resolving Python env variables for Kernels fails or does not work as expected.
      */
     readonly useOldKernelResolve: boolean;
+    readonly formatStackTraces: boolean;
 }
 
 export interface IVariableTooltipFields {


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/195576

helpful for using/testing https://github.com/microsoft/vscode/pull/195743

We can ramp this setting up through an experiment to expose the core stack trace rendering.

Does not affect IW since we still want to translate cells from .py files to the relevant filepath.
