### PR TITLE
Variables Viewer data types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2029,7 +2029,17 @@
         "jupyterVariableViewers": [
             {
                 "command": "jupyter.showDataViewer",
-                "title": "%jupyter.command.jupyter.showDataViewer.title%"
+                "title": "%jupyter.command.jupyter.showDataViewer.title%",
+                "dataTypes": [
+                    "DataFrame",
+                    "list",
+                    "dict",
+                    "ndarray",
+                    "Series",
+                    "Tensor",
+                    "EagerTensor",
+                    "DataArray"
+                ]
             }
         ]
     },

--- a/src/webviews/extension-side/variablesView/types.ts
+++ b/src/webviews/extension-side/variablesView/types.ts
@@ -45,3 +45,9 @@ export interface INotebookWatcher {
 
 export const IVariableViewProvider = Symbol('IVariableViewProvider');
 export interface IVariableViewProvider extends IVSCWebviewViewProvider {}
+
+export interface IVariableViewer {
+    command: string;
+    title: string;
+    dataTypes: string[];
+}

--- a/src/webviews/extension-side/variablesView/variableView.ts
+++ b/src/webviews/extension-side/variablesView/variableView.ts
@@ -212,11 +212,13 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
 
     private getMatchingVariableViewers(
         variable: IJupyterVariable
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ): { extension: Extension<any>; jupyterVariableViewers: IVariableViewer }[] {
         const variableViewers = this.getVariableViewers();
         return variableViewers.filter((d) => d.jupyterVariableViewers.dataTypes.includes(variable.type));
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private getVariableViewers(): { extension: Extension<any>; jupyterVariableViewers: IVariableViewer }[] {
         const extensions = this.extensions.all
             .filter(

--- a/src/webviews/extension-side/variablesView/variableView.ts
+++ b/src/webviews/extension-side/variablesView/variableView.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { QuickPickItem, Uri, WebviewView as vscodeWebviewView } from 'vscode';
+import { Extension, QuickPickItem, Uri, WebviewView as vscodeWebviewView } from 'vscode';
 import { joinPath } from '../../../platform/vscode-path/resources';
 import { capturePerfTelemetry, sendTelemetryEvent, Telemetry } from '../../../telemetry';
-import { INotebookWatcher, IVariableViewPanelMapping } from './types';
+import { INotebookWatcher, IVariableViewPanelMapping, IVariableViewer } from './types';
 import { VariableViewMessageListener } from './variableViewMessageListener';
 import { InteractiveWindowMessages, IShowDataViewer } from '../../../messageTypes';
 import {
+    IJupyterVariable,
     IJupyterVariables,
     IJupyterVariablesRequest,
     IJupyterVariablesResponse
@@ -155,29 +156,7 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
         try {
             if (this.experiments.inExperiment(Experiments.DataViewerContribution)) {
                 // jupyterVariableViewers
-                const extensions = this.extensions.all
-                    .filter(
-                        (e) =>
-                            e.packageJSON?.contributes?.jupyterVariableViewers &&
-                            e.packageJSON?.contributes?.jupyterVariableViewers.length
-                    )
-                    .filter((e) => e.id !== JVSC_EXTENSION_ID);
-
-                const variableViewers = extensions
-                    .map((e) => {
-                        const contributes = e.packageJSON?.contributes;
-                        if (contributes?.jupyterVariableViewers) {
-                            return contributes.jupyterVariableViewers.map(
-                                (jupyterVariableViewers: { command: string; title: string }[]) => ({
-                                    extension: e,
-                                    jupyterVariableViewers
-                                })
-                            );
-                        }
-                        return [];
-                    })
-                    .flat();
-
+                const variableViewers = this.getMatchingVariableViewers(request.variable);
                 if (variableViewers.length === 0) {
                     // No data frame viewer extensions, show notifications
                     await this.commandManager.executeCommand(
@@ -187,7 +166,8 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
                     return;
                 } else if (variableViewers.length === 1) {
                     const command = variableViewers[0].jupyterVariableViewers.command;
-                    return this.commandManager.executeCommand(command, {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    return this.commandManager.executeCommand(command as any, {
                         container: {},
                         variable: request.variable
                     });
@@ -230,6 +210,51 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
         }
     }
 
+    private getMatchingVariableViewers(
+        variable: IJupyterVariable
+    ): { extension: Extension<any>; jupyterVariableViewers: IVariableViewer }[] {
+        const variableViewers = this.getVariableViewers();
+        return variableViewers.filter((d) => d.jupyterVariableViewers.dataTypes.includes(variable.type));
+    }
+
+    private getVariableViewers(): { extension: Extension<any>; jupyterVariableViewers: IVariableViewer }[] {
+        const extensions = this.extensions.all
+            .filter(
+                (e) =>
+                    e.packageJSON?.contributes?.jupyterVariableViewers &&
+                    e.packageJSON?.contributes?.jupyterVariableViewers.length
+            )
+            .filter((e) => e.id !== JVSC_EXTENSION_ID);
+
+        const variableViewers = extensions
+            .map((e) => {
+                const contributes = e.packageJSON?.contributes;
+                if (contributes?.jupyterVariableViewers) {
+                    return contributes.jupyterVariableViewers.map((jupyterVariableViewers: IVariableViewer) => ({
+                        extension: e,
+                        jupyterVariableViewers
+                    }));
+                }
+                return [];
+            })
+            .flat();
+
+        return variableViewers;
+    }
+
+    private postProcessSupportsDataExplorer(response: IJupyterVariablesResponse) {
+        const variableViewers = this.getVariableViewers();
+        response.pageResponse.forEach((variable) => {
+            if (this.experiments.inExperiment(Experiments.DataViewerContribution)) {
+                variable.supportsDataExplorer = variableViewers.some((d) =>
+                    d.jupyterVariableViewers.dataTypes.includes(variable.type)
+                );
+            }
+        });
+
+        return response;
+    }
+
     // Variables for the current active editor are being requested, check that we have a valid active notebook
     // and use the variables interface to fetch them and pass them to the variable view UI
     @swallowExceptions()
@@ -238,7 +263,10 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
         if (activeNotebook) {
             const response = await this.variables.getVariables(args, activeNotebook);
 
-            this.postMessage(InteractiveWindowMessages.GetVariablesResponse, response).catch(noop);
+            this.postMessage(
+                InteractiveWindowMessages.GetVariablesResponse,
+                this.postProcessSupportsDataExplorer(response)
+            ).catch(noop);
             sendTelemetryEvent(Telemetry.VariableExplorerVariableCount, {
                 variableCount: response.totalCount
             });


### PR DESCRIPTION
Re #14315. Support specifying data types supported by a variable viewer.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
