### PR TITLE
Handle unexecuted precedent cells

### DIFF
--- a/src/test/datascience/widgets/standardWidgets.vscode.common.test.ts
+++ b/src/test/datascience/widgets/standardWidgets.vscode.common.test.ts
@@ -133,7 +133,7 @@ suite('Standard IPyWidget Tests @widgets', function () {
         // and the output is not visible, then it will not get rendered & the tests will fail. The tests inspect the rendered HTML.
         // Solution - maximize available real-estate by hiding the output panels & hiding the input cells.
         await commands.executeCommand('workbench.action.closePanel');
-        await commands.executeCommand('workbench.action.maximizeEditor');
+        await commands.executeCommand('workbench.action.maximizeEditorGroup');
         await commands.executeCommand('notebook.cell.collapseAllCellInputs');
         comms = await initializeWidgetComms(disposables);
 

--- a/src/test/datascience/widgets/thirdpartyWidgets.vscode.common.test.ts
+++ b/src/test/datascience/widgets/thirdpartyWidgets.vscode.common.test.ts
@@ -80,7 +80,7 @@ import { getTextOutputValue } from '../../../kernels/execution/helpers';
             // and the output is not visible, then it will not get rendered & the tests will fail. The tests inspect the rendered HTML.
             // Solution - maximize available real-estate by hiding the output panels & hiding the input cells.
             await commands.executeCommand('workbench.action.closePanel');
-            await commands.executeCommand('workbench.action.maximizeEditor');
+            await commands.executeCommand('workbench.action.maximizeEditorGroup');
             comms = await initializeWidgetComms(disposables);
 
             vscodeNotebook = api.serviceContainer.get<IVSCodeNotebook>(IVSCodeNotebook);


### PR DESCRIPTION
When precedent cells are not executed yet, ensure they are included in the precedent cell list.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
