### PR TITLE
Fix #14564. Hide run dependent cells commands in Command Palette when not enabled.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1428,6 +1428,14 @@
                     "when": "config.jupyter.executionAnalysis.enabled"
                 },
                 {
+                    "command": "jupyter.runPrecedentCells",
+                    "when": "config.jupyter.executionAnalysis.enabled"
+                },
+                {
+                    "command": "jupyter.runDependentCells",
+                    "when": "config.jupyter.executionAnalysis.enabled"
+                },
+                {
                     "command": "jupyter.debugCellSymbols",
                     "when": "config.jupyter.executionAnalysis.enabled"
                 }


### PR DESCRIPTION
Fixes #14564

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
