### PR TITLE
Update VSCode commands to maximize real-estate by

### DIFF
--- a/src/test/datascience/widgets/standardWidgets.vscode.common.test.ts
+++ b/src/test/datascience/widgets/standardWidgets.vscode.common.test.ts
@@ -133,7 +133,7 @@ suite('Standard IPyWidget Tests @widgets', function () {
         // and the output is not visible, then it will not get rendered & the tests will fail. The tests inspect the rendered HTML.
         // Solution - maximize available real-estate by hiding the output panels & hiding the input cells.
         await commands.executeCommand('workbench.action.closePanel');
-        await commands.executeCommand('workbench.action.maximizeEditorGroup');
+        await commands.executeCommand('workbench.action.closeSidebar');
         await commands.executeCommand('notebook.cell.collapseAllCellInputs');
         comms = await initializeWidgetComms(disposables);
 

--- a/src/test/datascience/widgets/standardWidgets.vscode.common.test.ts
+++ b/src/test/datascience/widgets/standardWidgets.vscode.common.test.ts
@@ -39,7 +39,6 @@ import { initializeWidgetComms, Utils } from './commUtils';
 import { WidgetRenderingTimeoutForTests } from './constants';
 import { getTextOutputValue } from '../../../kernels/execution/helpers';
 import { isWeb } from '../../../platform/common/utils/misc';
-import { noop } from '../../core';
 
 const templateRootPath: Uri =
     workspace.workspaceFolders && workspace.workspaceFolders.length > 0

--- a/src/test/datascience/widgets/standardWidgets.vscode.common.test.ts
+++ b/src/test/datascience/widgets/standardWidgets.vscode.common.test.ts
@@ -133,7 +133,7 @@ suite('Standard IPyWidget Tests @widgets', function () {
         // and the output is not visible, then it will not get rendered & the tests will fail. The tests inspect the rendered HTML.
         // Solution - maximize available real-estate by hiding the output panels & hiding the input cells.
         await commands.executeCommand('workbench.action.closePanel');
-        await commands.executeCommand('workbench.action.closeSidebar');
+        await commands.executeCommand('workbench.action.maximizeEditorHideSidebar');
         await commands.executeCommand('notebook.cell.collapseAllCellInputs');
         comms = await initializeWidgetComms(disposables);
 

--- a/src/test/datascience/widgets/thirdpartyWidgets.vscode.common.test.ts
+++ b/src/test/datascience/widgets/thirdpartyWidgets.vscode.common.test.ts
@@ -80,7 +80,7 @@ import { getTextOutputValue } from '../../../kernels/execution/helpers';
             // and the output is not visible, then it will not get rendered & the tests will fail. The tests inspect the rendered HTML.
             // Solution - maximize available real-estate by hiding the output panels & hiding the input cells.
             await commands.executeCommand('workbench.action.closePanel');
-            await commands.executeCommand('workbench.action.closeSidebar');
+            await commands.executeCommand('workbench.action.maximizeEditorHideSidebar');
             comms = await initializeWidgetComms(disposables);
 
             vscodeNotebook = api.serviceContainer.get<IVSCodeNotebook>(IVSCodeNotebook);

--- a/src/test/datascience/widgets/thirdpartyWidgets.vscode.common.test.ts
+++ b/src/test/datascience/widgets/thirdpartyWidgets.vscode.common.test.ts
@@ -80,7 +80,7 @@ import { getTextOutputValue } from '../../../kernels/execution/helpers';
             // and the output is not visible, then it will not get rendered & the tests will fail. The tests inspect the rendered HTML.
             // Solution - maximize available real-estate by hiding the output panels & hiding the input cells.
             await commands.executeCommand('workbench.action.closePanel');
-            await commands.executeCommand('workbench.action.maximizeEditorGroup');
+            await commands.executeCommand('workbench.action.closeSidebar');
             comms = await initializeWidgetComms(disposables);
 
             vscodeNotebook = api.serviceContainer.get<IVSCodeNotebook>(IVSCodeNotebook);


### PR DESCRIPTION
closing sidebar

Looks like the `workbench.action.maximizedEditorGroup` command was removed from VS Code