### PR TITLE
Remove win32-ia32 from build configurations (#14606)

### DIFF
--- a/.github/endgame_plan.md
+++ b/.github/endgame_plan.md
@@ -26,7 +26,6 @@
   Tip: You can use the dev containers in the this repo for testing against linux (just open the repo and use thd command `Dev Containers: Reopen in Container`)
   - [ ] Windows
     - [ ] win32-x64
-    - [ ] win32-ia32
     - [ ] win32-arm64
   - [ ] macOS
     - [ ] darwin-x64
@@ -64,7 +63,7 @@
   Tip: You can use the dev containers in the this repo for testing against linux (just open the repo and use thd command `Dev Containers: Reopen in Container`)
   - [ ] Windows
     - [ ] win32-x64
-    - [ ] win32-ia32
+    - [ ]
     - [ ] win32-arm64
   - [ ] macOS
     - [ ] darwin-x64

--- a/build/azure-pipeline.pre-release.yml
+++ b/build/azure-pipeline.pre-release.yml
@@ -53,9 +53,6 @@ extends:
         packageArch: x64
         vsceTarget: darwin-x64
       - name: Windows
-        packageArch: ia32
-        vsceTarget: win32-ia32
-      - name: Windows
         packageArch: x64
         vsceTarget: win32-x64
       - name: Windows

--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -48,9 +48,6 @@ extends:
         packageArch: x64
         vsceTarget: darwin-x64
       - name: Windows
-        packageArch: ia32
-        vsceTarget: win32-ia32
-      - name: Windows
         packageArch: x64
         vsceTarget: win32-x64
       - name: Windows

--- a/build/webpack/common.js
+++ b/build/webpack/common.js
@@ -75,14 +75,12 @@ function getZeroMQPreBuildsFoldersToKeep() {
     } else if (vsceTarget === 'web') {
         throw new Error('Not supported when targeting the Web');
     } else if (vsceTarget.includes('win32')) {
-        if (vsceTarget.includes('ia32')) {
-            return ['win32-ia32'];
-        } else if (vsceTarget.includes('x64')) {
+        if (vsceTarget.includes('x64')) {
             return ['win32-x64'];
         } else if (vsceTarget.includes('arm64')) {
             return ['win32-arm64'];
         } else {
-            return ['win32-ia32', 'win32-x64', 'win32-arm64'];
+            return ['win32-x64', 'win32-arm64'];
         }
     } else if (vsceTarget.includes('linux')) {
         if (vsceTarget.includes('arm64')) {


### PR DESCRIPTION
* Remove win32-ia32 from build configurations

* Remove empty checkbox for win32-x64 in
endgame_plan.md
