### PR TITLE
remove deprecated linting settings and use flake8, fix lint errors

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,6 @@
         "editorconfig.editorconfig",
         "esbenp.prettier-vscode",
         "hbenl.vscode-mocha-test-adapter",
-        "ms-python.flake8"
+        "ms-python.black"
     ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,7 @@
         "dbaeumer.vscode-eslint",
         "editorconfig.editorconfig",
         "esbenp.prettier-vscode",
-        "hbenl.vscode-mocha-test-adapter"
+        "hbenl.vscode-mocha-test-adapter",
+        "ms-python.flake8"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,7 +56,7 @@
         "source.fixAll.eslint": true,
         "source.fixAll.tslint": true
     },
-    "python.languageServer": "Jedi",
+    "python.languageServer": "Pylance",
     "python.analysis.logLevel": "Trace",
     "typescript.preferences.importModuleSpecifier": "relative",
     "mochaExplorer.files": "./out/test/**/*.unit.test.js",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,10 +38,12 @@
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
-    "git.branchProtection": ["main", "release*"],
+    "git.branchProtection": [
+        "main",
+        "release*"
+    ],
     "git.branchProtectionPrompt": "alwaysCommitToNewBranch",
     "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
-    "python.linting.enabled": false,
     "python.testing.promptToConfigure": false,
     "python.workspaceSymbols.enabled": false,
     "python.formatting.provider": "black",
@@ -54,17 +56,16 @@
         "source.fixAll.eslint": true,
         "source.fixAll.tslint": true
     },
-    "python.languageServer": "Pylance",
+    "python.languageServer": "Jedi",
     "python.analysis.logLevel": "Trace",
-    "python.linting.pylintEnabled": false,
-    "python.linting.flake8Enabled": true,
-    "python.linting.flake8Args": [
-        // Match what black does.
-        "--max-line-length=88"
-    ],
     "typescript.preferences.importModuleSpecifier": "relative",
     "mochaExplorer.files": "./out/test/**/*.unit.test.js",
     "mochaExplorer.configFile": "./build/.mocha.unittests.js.json",
     "mochaExplorer.ui": "tdd",
-    "mochaExplorer.nodeArgv": ["--enable-source-maps"]
+    "mochaExplorer.nodeArgv": [
+        "--enable-source-maps"
+    ],
+    "flake8.args": [
+        "--max-line-length=120"
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,7 +46,9 @@
     "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
     "python.testing.promptToConfigure": false,
     "python.workspaceSymbols.enabled": false,
-    "python.formatting.provider": "black",
+    "python.analysis.diagnosticSeverityOverrides": {
+        "reportMissingImports": "none",
+    },
     "typescript.preferences.quoteStyle": "single",
     "javascript.preferences.quoteStyle": "single",
     "typescriptHero.imports.stringQuoteStyle": "'",
@@ -64,8 +66,5 @@
     "mochaExplorer.ui": "tdd",
     "mochaExplorer.nodeArgv": [
         "--enable-source-maps"
-    ],
-    "flake8.args": [
-        "--max-line-length=120"
     ]
 }

--- a/pythonFiles/aggregateTestResults.py
+++ b/pythonFiles/aggregateTestResults.py
@@ -1,10 +1,11 @@
 # %%
 import io
+import os
 import json
 import sys
 import zipfile
-
 import requests
+from datetime import date, datetime, timedelta
 
 authtoken = sys.argv[1]
 print("Using authtoken with prefix: " + authtoken[:4])
@@ -142,7 +143,7 @@ def flattenTestResultsToFile(runResults, filename):
 
 
 # %%
-from datetime import date, datetime, timedelta
+
 
 inputDate = ""
 if len(sys.argv) > 2:
@@ -170,8 +171,6 @@ resultFile = f'AggTestResults-{collectionDate.strftime("%Y-%m-%d")}.json'
 allTests = flattenTestResultsToFile(runResults, resultFile)
 
 # %%
-import os
-
 file_size = os.path.getsize(resultFile)
 print(f"Wrote {file_size} bytes to {resultFile}")
 

--- a/pythonFiles/completion.py
+++ b/pythonFiles/completion.py
@@ -1,7 +1,6 @@
 import os
 import os.path
 import io
-import re
 import sys
 import json
 import traceback
@@ -105,7 +104,7 @@ class JediCompletion(object):
             call_signatures = script.call_signatures()
         except KeyError:
             call_signatures = []
-        except:
+        except Exception:
             call_signatures = []
         for signature in call_signatures:
             for pos, param in enumerate(signature.params):
@@ -230,7 +229,7 @@ class JediCompletion(object):
             completions = script.completions()
         except KeyError:
             completions = []
-        except:
+        except Exception:
             completions = []
         for completion in completions:
             try:
@@ -342,7 +341,7 @@ class JediCompletion(object):
                 "end_line": end_line,
                 "end_column": end_column,
             }
-        except Exception as e:
+        except Exception:
             return {
                 "start_line": definition.line - 1,
                 "start_column": definition.column,
@@ -419,7 +418,7 @@ class JediCompletion(object):
                     "signature": self._generate_signature(definition),
                 }
                 _definitions.append(_definition)
-            except Exception as e:
+            except Exception:
                 pass
         return _definitions
 
@@ -465,7 +464,7 @@ class JediCompletion(object):
                         "raw_docstring": rawdocstring,
                     }
                     _definitions.append(_definition)
-            except Exception as e:
+            except Exception:
                 pass
         return json.dumps({"id": identifier, "results": _definitions})
 
@@ -610,14 +609,14 @@ class JediCompletion(object):
                     defs = self._get_definitionsx(
                         script.goto_definitions(), request["id"], True
                     )
-                except:
+                except Exception:
                     pass
                 try:
                     if len(defs) == 0:
                         defs = self._get_definitionsx(
                             script.goto_assignments(), request["id"], True
                         )
-                except:
+                except Exception:
                     pass
                 return json.dumps({"id": request["id"], "results": defs})
             else:
@@ -625,7 +624,7 @@ class JediCompletion(object):
                     return self._serialize_tooltip(
                         script.goto_definitions(), request["id"]
                     )
-                except:
+                except Exception:
                     return json.dumps({"id": request["id"], "results": []})
         elif lookup == "arguments":
             return self._serialize_arguments(script, request["id"])

--- a/pythonFiles/get-pip.py
+++ b/pythonFiles/get-pip.py
@@ -21,6 +21,11 @@
 # `scripts/generate.py` in https://github.com/pypa/get-pip.
 
 import sys
+import os.path
+import pkgutil
+import shutil
+import tempfile
+from base64 import b85decode
 
 this_python = sys.version_info[:2]
 min_version = (3, 6)
@@ -34,13 +39,6 @@ if this_python < min_version:
     ]
     print("ERROR: " + " ".join(message_parts))
     sys.exit(1)
-
-
-import os.path
-import pkgutil
-import shutil
-import tempfile
-from base64 import b85decode
 
 
 def determine_pip_install_arguments():

--- a/pythonFiles/normalizeSelection.py
+++ b/pythonFiles/normalizeSelection.py
@@ -119,7 +119,7 @@ def normalize_lines(selection):
 
         # Insert a newline between each top-level statement, and append a newline to the selection.
         source = "\n".join(statements) + "\n"
-    except:
+    except Exception:
         # If there's a problem when parsing statements,
         # append a blank line to end the block and send it as-is.
         source = selection + "\n\n"

--- a/pythonFiles/printJupyWidgetEntryPoints.py
+++ b/pythonFiles/printJupyWidgetEntryPoints.py
@@ -6,6 +6,7 @@
 # ingore flake8 undefined variable errors since it doesn't like these temporary imports
 # flake8: noqa: F821
 
+
 def __vsc_print_nbextension_widgets():
     import os as __vscode_os
     import site as __vscode_site

--- a/pythonFiles/printJupyWidgetEntryPoints.py
+++ b/pythonFiles/printJupyWidgetEntryPoints.py
@@ -3,6 +3,8 @@
 
 # Source borrowed from site-packages/jupyter_core/paths.py
 
+# ingore flake8 undefined variable errors since it doesn't like these temporary imports
+# flake8: noqa: F821
 
 def __vsc_print_nbextension_widgets():
     import os as __vscode_os
@@ -192,11 +194,12 @@ def __vsc_print_nbextension_widgets():
                 __vscode_widget_folder = __vsc_file.replace(
                     __vsc_nbextension_Folder, ""
                 )
-                if not __vscode_widget_folder in __vsc_nbextension_widgets:
+                if __vscode_widget_folder not in __vsc_nbextension_widgets:
                     __vsc_nbextension_widgets.append(__vscode_widget_folder)
 
         print(__vsc_nbextension_widgets)
-    except:
+
+    except Exception:
         pass
 
     # We need to ensure these variables don't interfere with the variable viewer, hence delete them after use.

--- a/pythonFiles/runJediLanguageServer.py
+++ b/pythonFiles/runJediLanguageServer.py
@@ -1,12 +1,11 @@
-import re
 import sys
 import os
+from jedi_language_server.cli import cli
 
 # Add the lib path to our sys path so jedi_language_server can find its references
 EXTENSION_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.join(EXTENSION_ROOT, "pythonFiles", "lib", "python"))
 
-from jedi_language_server.cli import cli
 
 # Trick language server into thinking it started from 'jedi-language-server.exe'
 sys.argv[0] = "jedi-language-server.exe"

--- a/pythonFiles/runJediLanguageServer.py
+++ b/pythonFiles/runJediLanguageServer.py
@@ -1,11 +1,11 @@
 import sys
 import os
-from jedi_language_server.cli import cli
 
 # Add the lib path to our sys path so jedi_language_server can find its references
 EXTENSION_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.join(EXTENSION_ROOT, "pythonFiles", "lib", "python"))
 
+from jedi_language_server.cli import cli
 
 # Trick language server into thinking it started from 'jedi-language-server.exe'
 sys.argv[0] = "jedi-language-server.exe"

--- a/pythonFiles/shell_exec.py
+++ b/pythonFiles/shell_exec.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import os
 import sys
 import subprocess
 

--- a/pythonFiles/symbolProvider.py
+++ b/pythonFiles/symbolProvider.py
@@ -26,12 +26,10 @@ class Visitor(ast.NodeVisitor):
                 pass
 
     def visitDef(self, node, namespace=""):
-        end_position = self.getEndPosition(node)
         symbol = "functions" if namespace == "" else "methods"
         self.symbols[symbol].append(self.getDataObject(node, namespace))
 
     def visitClassDef(self, node, namespace=""):
-        end_position = self.getEndPosition(node)
         self.symbols["classes"].append(self.getDataObject(node, namespace))
 
         if len(namespace) > 0:

--- a/pythonFiles/visualstudio_py_testlauncher.py
+++ b/pythonFiles/visualstudio_py_testlauncher.py
@@ -23,12 +23,11 @@ import json
 import unittest
 import socket
 import traceback
-from types import CodeType, FunctionType
 import signal
 
 try:
     import thread
-except:
+except Exception:
     import _thread as thread
 
 
@@ -116,7 +115,7 @@ class _IpcChannel(object):
 
     def readSocket(self):
         try:
-            data = self.socket.recv(1024)
+            self.socket.recv(1024)
             self.callback()
         except OSError:
             if not self._closed:
@@ -191,10 +190,10 @@ class VsTestResult(unittest.TextTestResult):
 def stopTests():
     try:
         os.kill(os.getpid(), signal.SIGUSR1)
-    except:
+    except Exception:
         try:
             os.kill(os.getpid(), signal.SIGTERM)
-        except:
+        except Exception:
             pass
 
 
@@ -272,10 +271,10 @@ def main():
     if opts.result_port:
         try:
             signal.signal(signal.SIGUSR1, signal_handler)
-        except:
+        except Exception:
             try:
                 signal.signal(signal.SIGTERM, signal_handler)
-            except:
+            except Exception:
                 pass
         _channel = _IpcChannel(
             socket.create_connection(("127.0.0.1", opts.result_port)), stopTests
@@ -312,7 +311,7 @@ def main():
                 cov = coverage.coverage(opts.coverage)
                 cov.load()
                 cov.start()
-            except:
+            except Exception:
                 pass
         if opts.tests is None and opts.testFile is None:
             if opts.us is None:
@@ -343,8 +342,7 @@ def main():
                                 if testId == opts.tests[0]:
                                     tests = unittest.TestSuite([m])
                                     break
-                        except Exception as err:
-                            errorMessage = traceback.format_exception()
+                        except Exception:
                             pass
                 if tests is None:
                     tests = suite
@@ -381,11 +379,11 @@ def main():
         # prevent generation of the error 'Error in sys.exitfunc:'
         try:
             sys.stdout.close()
-        except:
+        except Exception:
             pass
         try:
             sys.stderr.close()
-        except:
+        except Exception:
             pass
 
 


### PR DESCRIPTION
python.linting settings are deprecated and we're getting a warning notification about it.

Add flake8 as our recommended linting extension and fix the associated linting errors.
