### PR TITLE
attach a basic variable provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -2193,7 +2193,8 @@
         "notebookKernelSource",
         "interactiveWindow",
         "quickPickItemTooltip",
-        "notebookExecution"
+        "notebookExecution",
+        "notebookVariableProvider"
     ],
     "scripts": {
         "package": "gulp clean && gulp prePublishBundle && vsce package -o ms-toolsai-jupyter-insiders.vsix",

--- a/pythonFiles/vscode_datascience_helpers/getVariableInfo/vscodeGetVariableInfo.py
+++ b/pythonFiles/vscode_datascience_helpers/getVariableInfo/vscodeGetVariableInfo.py
@@ -76,7 +76,12 @@ def _VSCODE_getVariable(what_to_get, is_debugging, *args):
     ### Get info on variables at the root level
     def _VSCODE_getAllVariableDescriptions(varNames):
         variables = [
-            {"name": varName, **getVariableDescription(globals()[varName])}
+            {
+                "name": varName,
+                **getVariableDescription(globals()[varName]),
+                "root": varName,
+                "propertyChain": [],
+            }
             for varName in varNames
             if varName in globals()
         ]

--- a/pythonFiles/vscode_datascience_helpers/getVariableInfo/vscodeGetVariableInfo.py
+++ b/pythonFiles/vscode_datascience_helpers/getVariableInfo/vscodeGetVariableInfo.py
@@ -49,8 +49,8 @@ def _VSCODE_getVariable(what_to_get, is_debugging, *args):
             result["count"] = _VSCODE_builtins.len(variable)
         if _VSCODE_builtins.hasattr(variable, "__dict__"):
             result["properties"] = getPropertyNames(variable)
-        elif _VSCODE_builtins.type(variable) == dict:
-            result["properties"] = list(variable.keys())
+        elif _VSCODE_builtins.type(variable) == _VSCODE_builtins.dict:
+            result["properties"] = _VSCODE_builtins.list(variable.keys())
 
         result["value"] = getValue(variable)
         return result
@@ -58,16 +58,19 @@ def _VSCODE_getVariable(what_to_get, is_debugging, *args):
     def getChildProperty(root, propertyChain):
         variable = root
         for property in propertyChain:
-            if _VSCODE_builtins.type(property) == int:
+            if _VSCODE_builtins.type(property) == _VSCODE_builtins.int:
                 if _VSCODE_builtins.hasattr(variable, "__getitem__"):
                     variable = variable[property]
-                elif _VSCODE_builtins.type(variable) == set:
-                    variable = list(variable)[property]
+                elif _VSCODE_builtins.type(variable) == _VSCODE_builtins.set:
+                    variable = _VSCODE_builtins.list(variable)[property]
                 else:
                     return None
             elif _VSCODE_builtins.hasattr(variable, property):
                 variable = getattr(variable, property)
-            elif _VSCODE_builtins.type(variable) == dict and property in variable:
+            elif (
+                _VSCODE_builtins.type(variable) == _VSCODE_builtins.dict
+                and property in variable
+            ):
                 variable = variable[property]
             else:
                 return None

--- a/src/kernels/variables/JupyterVariablesProvider.ts
+++ b/src/kernels/variables/JupyterVariablesProvider.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+    CancellationToken,
+    Event,
+    NotebookDocument,
+    NotebookVariableProvider,
+    Variable,
+    VariablesRequestKind,
+    VariablesResult
+} from 'vscode';
+import { IJupyterVariables, IJupyterVariablesRequest } from './types';
+import { IKernelProvider } from '../types';
+
+export class JupyterVariablesProvider implements NotebookVariableProvider {
+    constructor(
+        private readonly jupyterVariables: IJupyterVariables,
+        private readonly kernelProvider: IKernelProvider
+    ) {}
+
+    onDidChangeVariables: Event<void>;
+
+    async *provideVariables(
+        notebook: NotebookDocument,
+        _parent: Variable | undefined,
+        _kind: VariablesRequestKind,
+        start: number,
+        _token: CancellationToken
+    ): AsyncIterable<VariablesResult> {
+        const kernel = this.kernelProvider.get(notebook);
+        if (!kernel) {
+            return;
+        }
+
+        const execution = this.kernelProvider.getKernelExecution(kernel);
+        const request: IJupyterVariablesRequest = {
+            executionCount: execution.executionCount,
+            sortAscending: true,
+            sortColumn: 'name',
+            pageSize: 10,
+            refreshCount: 0,
+            startIndex: start
+        };
+        const response = this.jupyterVariables.getVariables(request, kernel);
+
+        const variables = await response;
+
+        for (const variable of variables.pageResponse) {
+            const result = { name: variable.name, value: variable.value ?? '' };
+            yield {
+                variable: result,
+                namedChildrenCount: 0,
+                indexedChildrenCount: 0
+            };
+        }
+    }
+}

--- a/src/kernels/variables/jupyterVariables.ts
+++ b/src/kernels/variables/jupyterVariables.ts
@@ -44,10 +44,9 @@ export class JupyterVariables implements IJupyterVariables {
         kernel: IKernel,
         parent: IVariableDescription | undefined,
         token?: CancellationToken
-    ): Promise<IVariableDescription[]>{
+    ): Promise<IVariableDescription[]> {
         return this.variableHandler.getAllVariableDiscriptions(kernel, parent, token);
     }
-
 
     @capturePerfTelemetry(Telemetry.VariableExplorerFetchTime)
     public async getVariables(request: IJupyterVariablesRequest, kernel?: IKernel): Promise<IJupyterVariablesResponse> {

--- a/src/kernels/variables/jupyterVariables.ts
+++ b/src/kernels/variables/jupyterVariables.ts
@@ -13,7 +13,8 @@ import {
     IConditionalJupyterVariables,
     IJupyterVariablesRequest,
     IJupyterVariablesResponse,
-    IJupyterVariable
+    IJupyterVariable,
+    IVariableDescription
 } from './types';
 
 /**
@@ -39,6 +40,15 @@ export class JupyterVariables implements IJupyterVariables {
     }
 
     // IJupyterVariables implementation
+    getAllVariableDiscriptions(
+        kernel: IKernel,
+        parent: IVariableDescription | undefined,
+        token?: CancellationToken
+    ): Promise<IVariableDescription[]>{
+        return this.variableHandler.getAllVariableDiscriptions(kernel, parent, token);
+    }
+
+
     @capturePerfTelemetry(Telemetry.VariableExplorerFetchTime)
     public async getVariables(request: IJupyterVariablesRequest, kernel?: IKernel): Promise<IJupyterVariablesResponse> {
         return this.variableHandler.getVariables(request, kernel);

--- a/src/kernels/variables/kernelVariables.ts
+++ b/src/kernels/variables/kernelVariables.ts
@@ -15,7 +15,8 @@ import {
     IJupyterVariables,
     IJupyterVariablesRequest,
     IJupyterVariablesResponse,
-    IKernelVariableRequester
+    IKernelVariableRequester,
+    IVariableDescription
 } from './types';
 import type { Kernel } from '@jupyterlab/services';
 
@@ -71,6 +72,19 @@ export class KernelVariables implements IJupyterVariables {
     }
 
     // IJupyterVariables implementation
+    public async getAllVariableDiscriptions(
+        kernel: IKernel,
+        parent: IVariableDescription | undefined,
+        token?: CancellationToken
+    ): Promise<IVariableDescription[]> {
+        const languageId = getKernelConnectionLanguage(kernel.kernelConnectionMetadata) || PYTHON_LANGUAGE;
+        const variableRequester = this.variableRequesters.get(languageId);
+        if (variableRequester) {
+            return variableRequester.getAllVariableDiscriptions(kernel, parent, token);
+        }
+        return [];
+    }
+
     public async getVariables(request: IJupyterVariablesRequest, kernel: IKernel): Promise<IJupyterVariablesResponse> {
         // Run the language appropriate variable fetch
         return this.getVariablesBasedOnKernel(kernel, request);

--- a/src/kernels/variables/types.ts
+++ b/src/kernels/variables/types.ts
@@ -29,6 +29,11 @@ export interface IJupyterVariable {
 export const IJupyterVariables = Symbol('IJupyterVariables');
 export interface IJupyterVariables {
     readonly refreshRequired: Event<void>;
+    getAllVariableDiscriptions(
+        kernel: IKernel,
+        parent: IVariableDescription | undefined,
+        token?: CancellationToken
+    ): Promise<IVariableDescription[]>;
     getVariables(request: IJupyterVariablesRequest, kernel?: IKernel): Promise<IJupyterVariablesResponse>;
     getFullVariable(
         variable: IJupyterVariable,

--- a/src/kernels/variables/types.ts
+++ b/src/kernels/variables/types.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { CancellationToken, Event, Uri } from 'vscode';
+import { CancellationToken, Event, Uri, Variable } from 'vscode';
 import { IKernel } from '../types';
 import type { JSONObject } from '@lumino/coreutils';
 
@@ -80,9 +80,23 @@ export interface IJupyterVariablesResponse {
     refreshCount: number;
 }
 
+export interface IVariableDescription extends Variable {
+    // The name of the variable at the root scope
+    root: string;
+    // How to look up the specific property of the root variable
+    propertyChain: (string | number)[];
+    count?: number;
+    properties?: string[];
+}
+
 export const IKernelVariableRequester = Symbol('IKernelVariableRequester');
 
 export interface IKernelVariableRequester {
+    getAllVariableDiscriptions(
+        kernel: IKernel,
+        parent: IVariableDescription | undefined,
+        token?: CancellationToken
+    ): Promise<IVariableDescription[]>;
     getVariableNamesAndTypesFromKernel(kernel: IKernel, token?: CancellationToken): Promise<IJupyterVariable[]>;
     getFullVariable(
         targetVariable: IJupyterVariable,

--- a/src/kernels/variables/types.ts
+++ b/src/kernels/variables/types.ts
@@ -86,11 +86,13 @@ export interface IJupyterVariablesResponse {
 }
 
 export interface IVariableDescription extends Variable {
-    // The name of the variable at the root scope
+    /** The name of the variable at the root scope */
     root: string;
-    // How to look up the specific property of the root variable
+    /** How to look up the specific property of the root variable */
     propertyChain: (string | number)[];
+    /** The number of children for collection types */
     count?: number;
+    /** names of children */
     properties?: string[];
 }
 

--- a/src/notebooks/controllers/controllerRegistration.ts
+++ b/src/notebooks/controllers/controllerRegistration.ts
@@ -9,7 +9,7 @@ import { IKernelFinder, IKernelProvider, isRemoteConnection, KernelConnectionMet
 import { IExtensionSyncActivationService } from '../../platform/activation/types';
 import { IPythonExtensionChecker } from '../../platform/api/types';
 import { isCancellationError } from '../../platform/common/cancellation';
-import { isCI, JupyterNotebookView, InteractiveWindowView } from '../../platform/common/constants';
+import { isCI, JupyterNotebookView, InteractiveWindowView, Identifiers } from '../../platform/common/constants';
 import {
     IDisposableRegistry,
     IConfigurationService,
@@ -30,6 +30,7 @@ import {
     IVSCodeNotebookControllerUpdateEvent
 } from './types';
 import { VSCodeNotebookController } from './vscodeNotebookController';
+import { IJupyterVariables } from '../../kernels/variables/types';
 
 /**
  * Keeps track of registered controllers and available KernelConnectionMetadatas.
@@ -358,7 +359,8 @@ export class ControllerRegistration implements IControllerRegistration, IExtensi
                         this.serviceContainer.get<IConfigurationService>(IConfigurationService),
                         this.extensionChecker,
                         this.serviceContainer,
-                        this.serviceContainer.get<IConnectionDisplayDataProvider>(IConnectionDisplayDataProvider)
+                        this.serviceContainer.get<IConnectionDisplayDataProvider>(IConnectionDisplayDataProvider),
+                        this.serviceContainer.get<IJupyterVariables>(IJupyterVariables, Identifiers.KERNEL_VARIABLES)
                     );
                     // Hook up to if this NotebookController is selected or de-selected
                     const controllerDisposables: IDisposable[] = [];

--- a/src/notebooks/controllers/vscodeNotebookController.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.ts
@@ -83,6 +83,8 @@ import { getParentHeaderMsgId } from '../../kernels/execution/cellExecutionMessa
 import { DisposableStore } from '../../platform/common/utils/lifecycle';
 import { openInBrowser } from '../../platform/common/net/browser';
 import { KernelError } from '../../kernels/errors/kernelError';
+import { JupyterVariablesProvider } from '../../kernels/variables/JupyterVariablesProvider';
+import { IJupyterVariables } from '../../kernels/variables/types';
 
 /**
  * Our implementation of the VSCode Notebook Controller. Called by VS code to execute cells in a notebook. Also displayed
@@ -157,7 +159,8 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
         configuration: IConfigurationService,
         extensionChecker: IPythonExtensionChecker,
         serviceContainer: IServiceContainer,
-        displayDataProvider: IConnectionDisplayDataProvider
+        displayDataProvider: IConnectionDisplayDataProvider,
+        jupyterVariables: IJupyterVariables
     ): IVSCodeNotebookController {
         return new VSCodeNotebookController(
             kernelConnection,
@@ -170,7 +173,8 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
             configuration,
             extensionChecker,
             serviceContainer,
-            displayDataProvider
+            displayDataProvider,
+            jupyterVariables
         );
     }
     constructor(
@@ -184,7 +188,8 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
         private readonly configuration: IConfigurationService,
         private readonly extensionChecker: IPythonExtensionChecker,
         private serviceContainer: IServiceContainer,
-        private readonly displayDataProvider: IConnectionDisplayDataProvider
+        private readonly displayDataProvider: IConnectionDisplayDataProvider,
+        jupyterVariables: IJupyterVariables
     ) {
         disposableRegistry.push(this);
         this._onNotebookControllerSelected = new EventEmitter<{
@@ -207,6 +212,7 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
         this.controller.interruptHandler = this.handleInterrupt.bind(this);
         this.controller.supportsExecutionOrder = true;
         this.controller.supportedLanguages = this.languageService.getSupportedLanguages(kernelConnection);
+        this.controller.variableProvider = new JupyterVariablesProvider(jupyterVariables, this.kernelProvider);
         // Hook up to see when this NotebookController is selected by the UI
         this.controller.onDidChangeSelectedNotebooks(this.onDidChangeSelectedNotebooks, this, this.disposables);
         workspace.onDidCloseNotebookDocument(

--- a/src/notebooks/controllers/vscodeNotebookController.unit.test.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.unit.test.ts
@@ -32,6 +32,7 @@ import { PythonEnvironment } from '../../platform/pythonEnvironments/info';
 import { IConnectionDisplayDataProvider } from './types';
 import { ConnectionDisplayDataProvider } from './connectionDisplayData.node';
 import { mockedVSCodeNamespaces, resetVSCodeMocks } from '../../test/vscode-mock';
+import { IJupyterVariables } from '../../kernels/variables/types';
 
 suite(`Notebook Controller`, function () {
     let controller: NotebookController;
@@ -57,6 +58,7 @@ suite(`Notebook Controller`, function () {
     let trustedPaths: ITrustedKernelPaths;
     let displayDataProvider: IConnectionDisplayDataProvider;
     let interpreterService: IInterpreterService;
+    let jupyterVariables: IJupyterVariables;
     setup(async function () {
         resetVSCodeMocks();
         disposables.push(new Disposable(() => resetVSCodeMocks()));
@@ -71,6 +73,7 @@ suite(`Notebook Controller`, function () {
         extensionChecker = mock<IPythonExtensionChecker>();
         controller = mock<NotebookController>();
         kernel = mock<IKernel>();
+        jupyterVariables = mock<IJupyterVariables>();
         onDidChangeSelectedNotebooks = new EventEmitter<{
             readonly notebook: NotebookDocument;
             readonly selected: boolean;
@@ -142,7 +145,8 @@ suite(`Notebook Controller`, function () {
             instance(configService),
             instance(extensionChecker),
             instance(serviceContainer),
-            displayDataProvider
+            displayDataProvider,
+            jupyterVariables
         );
         notebook = new TestNotebookDocument(undefined, viewType);
     }

--- a/src/notebooks/debugger/debuggerVariables.ts
+++ b/src/notebooks/debugger/debuggerVariables.ts
@@ -14,7 +14,8 @@ import {
     IConditionalJupyterVariables,
     IJupyterVariable,
     IJupyterVariablesRequest,
-    IJupyterVariablesResponse
+    IJupyterVariablesResponse,
+    IVariableDescription
 } from '../../kernels/variables/types';
 import { IDebugService } from '../../platform/common/application/types';
 import { Identifiers } from '../../platform/common/constants';
@@ -74,6 +75,10 @@ export class DebuggerVariables
     }
 
     // IJupyterVariables implementation
+    getAllVariableDiscriptions(): Promise<IVariableDescription[]> {
+        throw new Error('Method not implemented.');
+    }
+
     public async getVariables(request: IJupyterVariablesRequest, kernel?: IKernel): Promise<IJupyterVariablesResponse> {
         // Listen to notebook events if we haven't already
         if (kernel) {

--- a/src/platform/common/types.ts
+++ b/src/platform/common/types.ts
@@ -310,6 +310,10 @@ export interface IVariableScriptGenerator {
         stringifiedAttributeNameList: string;
     }): Promise<ScriptCode>;
     generateCodeToGetVariableTypes(options: { isDebugging: boolean }): Promise<ScriptCode>;
+    generateCodeToGetAllVariableDescriptions(options: {
+        isDebugging: boolean;
+        parent: { root: string; propertyChain: (string | number)[] } | undefined;
+    }): Promise<ScriptCode>;
 }
 export const IDataFrameScriptGenerator = Symbol('IDataFrameScriptGenerator');
 export interface IDataFrameScriptGenerator {

--- a/src/platform/interpreter/variableScriptGenerator.ts
+++ b/src/platform/interpreter/variableScriptGenerator.ts
@@ -70,7 +70,7 @@ export class VariableScriptGenerator implements IVariableScriptGenerator {
     }) {
         const scriptCode = await this.getContentsOfScript();
         const isDebugging = options.isDebugging ? 'True' : 'False';
-        const initializeCode = parent ? scriptCode : `${scriptCode}\n\n_VSCODE_rwho_ls = %who_ls\n`;
+        const initializeCode = options.parent ? scriptCode : `${scriptCode}\n\n_VSCODE_rwho_ls = %who_ls\n`;
         const cleanupWhoLsCode = dedent`
         try:
             del _VSCODE_rwho_ls
@@ -87,7 +87,7 @@ export class VariableScriptGenerator implements IVariableScriptGenerator {
             return {
                 initializeCode,
                 code,
-                cleanupCode: parent ? cleanupCode : `${cleanupCode}\n${cleanupWhoLsCode}`
+                cleanupCode: options.parent ? cleanupCode : `${cleanupCode}\n${cleanupWhoLsCode}`
             };
         } else {
             return {

--- a/src/platform/interpreter/variableScriptGenerator.ts
+++ b/src/platform/interpreter/variableScriptGenerator.ts
@@ -64,6 +64,30 @@ export class VariableScriptGenerator implements IVariableScriptGenerator {
             };
         }
     }
+    async generateCodeToGetAllVariableDescriptions(options: {
+        isDebugging: boolean;
+        parent: { root: string; propertyChain: string[] } | undefined;
+    }) {
+        const initializeCode = await this.getContentsOfScript();
+        const isDebugging = options.isDebugging ? 'True' : 'False';
+
+        const code = options.parent
+            ? `${VariableFunc}("AllChildrenDescriptions", ${isDebugging}, ${options.parent.root}, ${JSON.stringify(
+                  options.parent.propertyChain
+              )}`
+            : `${VariableFunc}("AllVariableDescriptions", ${isDebugging})`;
+        if (options.isDebugging) {
+            return {
+                initializeCode,
+                code,
+                cleanupCode
+            };
+        } else {
+            return {
+                code: `${initializeCode}\n\n${code}\n\n${cleanupCode}`
+            };
+        }
+    }
     async generateCodeToGetVariableTypes(options: { isDebugging: boolean }) {
         const scriptCode = await this.getContentsOfScript();
         const initializeCode = `${scriptCode}\n\n_VSCODE_rwho_ls = %who_ls\n`;

--- a/src/platform/interpreter/variableScriptGenerator.ts
+++ b/src/platform/interpreter/variableScriptGenerator.ts
@@ -79,9 +79,9 @@ export class VariableScriptGenerator implements IVariableScriptGenerator {
         `;
 
         const code = options.parent
-            ? `${VariableFunc}("AllChildrenDescriptions", ${isDebugging}, ${options.parent.root}, ${JSON.stringify(
+            ? `${VariableFunc}("AllChildrenDescriptions", ${isDebugging}, "${options.parent.root}", ${JSON.stringify(
                   options.parent.propertyChain
-              )}`
+              )})`
             : `${VariableFunc}("AllVariableDescriptions", ${isDebugging}, _VSCODE_rwho_ls)`;
         if (options.isDebugging) {
             return {

--- a/src/test/datascience/notebook/kernelCrashes.vscode.test.ts
+++ b/src/test/datascience/notebook/kernelCrashes.vscode.test.ts
@@ -53,6 +53,7 @@ import { instance, mock, when } from 'ts-mockito';
 import { IPlatformService } from '../../../platform/common/platform/types';
 import { IInterpreterService } from '../../../platform/interpreter/contracts';
 import { ConnectionDisplayDataProvider } from '../../../notebooks/controllers/connectionDisplayData.node';
+import { IJupyterVariables } from '../../../kernels/variables/types';
 
 const codeToKillKernel = dedent`
 import IPython
@@ -95,6 +96,7 @@ suite('VSCode Notebook Kernel Error Handling - @kernelCore', function () {
                 api.serviceContainer.get<IJupyterServerProviderRegistry>(IJupyterServerProviderRegistry);
             const platform = api.serviceContainer.get<IPlatformService>(IPlatformService);
             const interpreters = api.serviceContainer.get<IInterpreterService>(IInterpreterService);
+            const jupyterVariables = api.serviceContainer.get<IJupyterVariables>(IJupyterVariables);
             kernelConnectionMetadata = await getDefaultKernelConnection();
             const displayDataProvider = new ConnectionDisplayDataProvider(
                 platform,
@@ -140,7 +142,8 @@ suite('VSCode Notebook Kernel Error Handling - @kernelCore', function () {
                 configuration,
                 extensionChecker,
                 api.serviceContainer,
-                displayDataProvider
+                displayDataProvider,
+                jupyterVariables
             );
             disposables.push(interpreterController);
 

--- a/src/test/datascience/notebook/kernelCrashes.vscode.test.ts
+++ b/src/test/datascience/notebook/kernelCrashes.vscode.test.ts
@@ -96,7 +96,7 @@ suite('VSCode Notebook Kernel Error Handling - @kernelCore', function () {
                 api.serviceContainer.get<IJupyterServerProviderRegistry>(IJupyterServerProviderRegistry);
             const platform = api.serviceContainer.get<IPlatformService>(IPlatformService);
             const interpreters = api.serviceContainer.get<IInterpreterService>(IInterpreterService);
-            const jupyterVariables = api.serviceContainer.get<IJupyterVariables>(IJupyterVariables);
+            const jupyterVariables = mock<IJupyterVariables>();
             kernelConnectionMetadata = await getDefaultKernelConnection();
             const displayDataProvider = new ConnectionDisplayDataProvider(
                 platform,


### PR DESCRIPTION
#14821

- initial implementation for a variable provider
- only makes one python call per request (all variables at that level)
  - No `inspect` requests to the kernel as those were significantly slower than just calling python code
- values are very simple at this point
  - raw types are displayed as is
  - collections are displayed as `[...]`, objects as `{...}`
- The data pipe is separate from the jupyter variable viewer since the types didn't mesh, and this way they can be removed cleanly when we get around to fully replacing the current view.
- No caching yet, but can be implemented for the execution count
- Also missing logic around paging/limiting number of children returned
