### PR TITLE
chore: move up UsePythonVersion

### DIFF
--- a/build/azure-pipeline.pre-release.yml
+++ b/build/azure-pipeline.pre-release.yml
@@ -68,6 +68,12 @@ extends:
       - script: npm i -g npm@9.5.0
         displayName: npm 9.5.0
 
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.8'
+          addToPath: true
+          architecture: 'x64'
+
       - script: npm ci --foreground-scripts
         displayName: npm ci
         env:
@@ -76,12 +82,6 @@ extends:
 
       - script: npm run clean
         displayName: Clean
-
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '3.8'
-          addToPath: true
-          architecture: 'x64'
 
       - script: python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r ./requirements.txt
         displayName: Install Python libs

--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -63,6 +63,12 @@ extends:
       - script: npm i -g npm@9.5.0
         displayName: npm 9.5.0
 
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.8'
+          addToPath: true
+          architecture: 'x64'
+
       - script: npm ci --foreground-scripts
         displayName: npm ci
         env:
@@ -71,12 +77,6 @@ extends:
 
       - script: npm run clean
         displayName: Clean
-
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '3.8'
-          addToPath: true
-          architecture: 'x64'
 
       - script: python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r ./requirements.txt
         displayName: Install Python libs


### PR DESCRIPTION
This pull request moves up the UsePythonVersion task in the build pipeline to try and provide node-gyp with distutils.