### PR TITLE
Fix to the typo in 'codeLes' setting name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1746,7 +1746,7 @@
                     "deprecationMessage": "%jupyter.configuration.jupyter.debugCodeLenses.deprecationMessage%",
                     "scope": "resource"
                 },
-                "jupyter.interactiveWindow.codeLes.debugCommands": {
+                "jupyter.interactiveWindow.codeLens.debugCommands": {
                     "type": "string",
                     "default": "jupyter.debugcontinue, jupyter.debugstop, jupyter.debugstepover",
                     "description": "%jupyter.configuration.jupyter.debugCodeLenses.description%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -186,7 +186,7 @@
     "jupyter.configuration.jupyter.codeLenses.description": "Set of commands to put as code lens above a cell.",
     "jupyter.configuration.jupyter.codeLenses.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.codeLens.commands.",
     "jupyter.configuration.jupyter.debugCodeLenses.description": "Set of debug commands to put as code lens above a cell while debugging.",
-    "jupyter.configuration.jupyter.debugCodeLenses.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.codeLes.debugCommands.",
+    "jupyter.configuration.jupyter.debugCodeLenses.deprecationMessage": "This setting has been deprecated in favor of jupyter.interactiveWindow.codeLens.debugCommands.",
     "jupyter.configuration.jupyter.debugpyDistPath.description": "Path to debugpy bits for debugging cells.",
     "jupyter.configuration.jupyter.stopOnFirstLineWhileDebugging.description": "When debugging a cell, stop on the first line.",
     "jupyter.configuration.jupyter.remoteDebuggerPort.description": "When debugging a cell, open this port on the remote box. If -1 is specified, a random port between 8889 and 9000 will be attempted.",

--- a/src/platform/common/configMigration.ts
+++ b/src/platform/common/configMigration.ts
@@ -22,7 +22,7 @@ export class ConfigMigration {
         enableCellCodeLens: 'interactiveWindow.codeLens.enable',
         addGotoCodeLenses: 'interactiveWindow.codeLens.enableGotoCell',
         codeLenses: 'interactiveWindow.codeLens.commands',
-        debugCodeLenses: 'interactiveWindow.codeLes.debugCommands',
+        debugCodeLenses: 'interactiveWindow.codeLens.debugCommands',
 
         codeRegularExpression: 'interactiveWindow.cellMarker.codeRegex',
         markdownRegularExpression: 'interactiveWindow.cellMarker.markdownRegex',


### PR DESCRIPTION
Fixes #

The `jupyter.interactiveWindow.codeLes.debugCommands` setting name seems to have a typo in the `codeLes` part, which is fixed by this PR.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] Has telemetry for feature-requests.
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
