### PR TITLE
make feature experimental

### DIFF
--- a/package.json
+++ b/package.json
@@ -1979,7 +1979,10 @@
                     "type": "boolean",
                     "default": true,
                     "markdownDescription": "%jupyter.configuration.jupyter.enableKernelCompletions.markdownDescription%",
-                    "scope": "application"
+                    "scope": "application",
+                    "tags": [
+                        "experimental"
+                    ]
                 },
                 "jupyter.formatStackTraces": {
                     "type": "boolean",


### PR DESCRIPTION
Marking the `enablekernelcompletion` feature experimental to enable proper propagation in the exp platform. See [experiment](https://github.com/microsoft/devdiv-exp-reviews/issues/202) and [control tower](https://exp.microsoft.com/a/feature/a19e6113-1b2b-46f4-8efa-f3b2b680ee5e?workspaceId=0d334e33-be60-4f17-8171-a61b38d64de6&group=/vscodeexp) for reference.