### PR TITLE
Unify variable viewer data types

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -11,10 +11,10 @@ import {
     Uri,
     ViewColumn
 } from 'vscode';
-import { IShowDataViewerFromVariablePanel } from './messageTypes';
 import { Commands as DSCommands, CommandSource } from './platform/common/constants';
 import { PythonEnvironment } from './platform/pythonEnvironments/info';
 import { Channel } from './platform/common/application/types';
+import { IJupyterVariable } from './kernels/variables/types';
 
 export type CommandIds = keyof ICommandNameArgumentTypeMapping;
 
@@ -178,7 +178,7 @@ export interface ICommandNameArgumentTypeMapping {
     [DSCommands.EnableLoadingWidgetsFrom3rdPartySource]: [];
     [DSCommands.NotebookEditorExpandAllCells]: [];
     [DSCommands.NotebookEditorCollapseAllCells]: [];
-    [DSCommands.ShowDataViewer]: [IShowDataViewerFromVariablePanel];
+    [DSCommands.ShowDataViewer]: [IJupyterVariable];
     [DSCommands.RefreshDataViewer]: [];
     [DSCommands.ClearSavedJupyterUris]: [];
     [DSCommands.RunByLine]: [NotebookCell];

--- a/src/webviews/extension-side/dataviewer/dataViewerCommandRegistry.ts
+++ b/src/webviews/extension-side/dataviewer/dataViewerCommandRegistry.ts
@@ -5,7 +5,7 @@ import { inject, injectable, named, optional } from 'inversify';
 import { DebugConfiguration, Uri, commands, window, workspace } from 'vscode';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { convertDebugProtocolVariableToIJupyterVariable } from '../../../kernels/variables/helpers';
-import { IJupyterVariables } from '../../../kernels/variables/types';
+import { IJupyterVariable, IJupyterVariables } from '../../../kernels/variables/types';
 import { IExtensionSyncActivationService } from '../../../platform/activation/types';
 import { ICommandNameArgumentTypeMapping } from '../../../commands';
 import { IDebugService } from '../../../platform/common/application/types';
@@ -17,7 +17,6 @@ import { noop } from '../../../platform/common/utils/misc';
 import { untildify } from '../../../platform/common/utils/platform';
 import { IInterpreterService } from '../../../platform/interpreter/contracts';
 import { traceError, traceInfo } from '../../../platform/logging';
-import { IShowDataViewerFromVariablePanel } from '../../../messageTypes';
 import { sendTelemetryEvent } from '../../../telemetry';
 import { EventName } from '../../../platform/telemetry/constants';
 import { IDataScienceErrorHandler } from '../../../kernels/errors/types';
@@ -73,7 +72,7 @@ export class DataViewerCommandRegistry implements IExtensionSyncActivationServic
         const disposable = commands.registerCommand(command, callback, this);
         this.disposables.push(disposable);
     }
-    private async onVariablePanelShowDataViewerRequest(request: IShowDataViewerFromVariablePanel) {
+    private async onVariablePanelShowDataViewerRequest(request: IJupyterVariable) {
         sendTelemetryEvent(EventName.OPEN_DATAVIEWER_FROM_VARIABLE_WINDOW_REQUEST);
         if (
             this.debugService?.activeDebugSession &&
@@ -97,7 +96,7 @@ export class DataViewerCommandRegistry implements IExtensionSyncActivationServic
                 }
 
                 const variable = convertDebugProtocolVariableToIJupyterVariable(
-                    request.variable as DebugProtocol.Variable
+                    request as unknown as DebugProtocol.Variable
                 );
                 const jupyterVariable = await this.variableProvider.getFullVariable(variable);
                 const jupyterVariableDataProvider = await this.jupyterVariableDataProviderFactory.create(
@@ -123,11 +122,11 @@ export class DataViewerCommandRegistry implements IExtensionSyncActivationServic
                 if (activeKernel && this.jupyterVariableDataProviderFactory && this.dataViewerFactory) {
                     // Create a variable data provider and pass it to the data viewer factory to create the data viewer
                     const jupyterVariableDataProvider = await this.jupyterVariableDataProviderFactory.create(
-                        request.variable,
+                        request,
                         activeKernel
                     );
 
-                    const title: string = `${DataScience.dataExplorerTitle} - ${request.variable.name}`;
+                    const title: string = `${DataScience.dataExplorerTitle} - ${request.name}`;
                     return await this.dataViewerFactory.create(jupyterVariableDataProvider, title);
                 }
             } catch (e) {

--- a/src/webviews/extension-side/variablesView/variableView.ts
+++ b/src/webviews/extension-side/variablesView/variableView.ts
@@ -148,11 +148,14 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
                 } else if (variableViewers.length === 1) {
                     const command = variableViewers[0].jupyterVariableViewers.command;
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    return commands.executeCommand(command as any, {
-                        container: {},
-                        variable: request.variable
-                    });
+                    return commands.executeCommand(command as any, request.variable);
                 } else {
+                    const thirdPartyViewers = variableViewers.filter((d) => d.extension.id !== JVSC_EXTENSION_ID);
+                    if (thirdPartyViewers.length === 1) {
+                        const command = thirdPartyViewers[0].jupyterVariableViewers.command;
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        return commands.executeCommand(command as any, request.variable);
+                    }
                     // show quick pick
                     const quickPick = window.createQuickPick<QuickPickItem & { command: string }>();
                     quickPick.title = 'Select DataFrame Viewer';
@@ -169,20 +172,14 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
                             quickPick.hide();
                             commands
                                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                .executeCommand(item.command as any, {
-                                    container: {},
-                                    variable: request.variable
-                                })
+                                .executeCommand(item.command as any, request.variable)
                                 .then(noop, noop);
                         }
                     });
                     quickPick.show();
                 }
             } else {
-                return commands.executeCommand(Commands.ShowDataViewer, {
-                    container: {},
-                    variable: request.variable
-                });
+                return commands.executeCommand(Commands.ShowDataViewer, request.variable);
             }
         } catch (e) {
             traceError(e);
@@ -207,7 +204,6 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
                     e.packageJSON?.contributes?.jupyterVariableViewers &&
                     e.packageJSON?.contributes?.jupyterVariableViewers.length
             )
-            .filter((e) => e.id !== JVSC_EXTENSION_ID)
             .map((e) => {
                 const contributes = e.packageJSON?.contributes;
                 if (contributes?.jupyterVariableViewers) {


### PR DESCRIPTION
The variable data type shoud be aligned for both the old and new native variable view.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
