### PR TITLE
Revert "Unify variable viewer data types (#15038)"

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -11,10 +11,10 @@ import {
     Uri,
     ViewColumn
 } from 'vscode';
+import { IShowDataViewerFromVariablePanel } from './messageTypes';
 import { Commands as DSCommands, CommandSource } from './platform/common/constants';
 import { PythonEnvironment } from './platform/pythonEnvironments/info';
 import { Channel } from './platform/common/application/types';
-import { IJupyterVariable } from './kernels/variables/types';
 
 export type CommandIds = keyof ICommandNameArgumentTypeMapping;
 
@@ -178,7 +178,7 @@ export interface ICommandNameArgumentTypeMapping {
     [DSCommands.EnableLoadingWidgetsFrom3rdPartySource]: [];
     [DSCommands.NotebookEditorExpandAllCells]: [];
     [DSCommands.NotebookEditorCollapseAllCells]: [];
-    [DSCommands.ShowDataViewer]: [IJupyterVariable];
+    [DSCommands.ShowDataViewer]: [IShowDataViewerFromVariablePanel];
     [DSCommands.RefreshDataViewer]: [];
     [DSCommands.ClearSavedJupyterUris]: [];
     [DSCommands.RunByLine]: [NotebookCell];

--- a/src/test/datascience/data-viewing/showInDataViewerPythonInterpreter.vscode.test.ts
+++ b/src/test/datascience/data-viewing/showInDataViewerPythonInterpreter.vscode.test.ts
@@ -14,6 +14,7 @@ import { waitForCondition } from '../../common.node';
 import { defaultNotebookTestTimeout } from '../notebook/helper';
 import { createDeferred } from '../../../platform/common/utils/async';
 import { dispose } from '../../../platform/common/utils/lifecycle';
+import { IShowDataViewerFromVariablePanel } from '../../../messageTypes';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, no-invalid-this */
 suite('DataViewer @webview', function () {
@@ -105,12 +106,14 @@ suite('DataViewer @webview', function () {
         await stoppedDef.promise;
 
         // Properties that we want to show the data viewer with
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const props: any = {
-            evaluateName: 'my_list',
-            name: 'my_list',
-            value: '[1, 2, 3]',
-            variablesReference
+        const props: IShowDataViewerFromVariablePanel = {
+            container: {},
+            variable: {
+                evaluateName: 'my_list',
+                name: 'my_list',
+                value: '[1, 2, 3]',
+                variablesReference
+            }
         };
 
         // Run our command to actually open the variable view

--- a/src/test/datascience/data-viewing/showInDataViewerPythonInterpreter.vscode.test.ts
+++ b/src/test/datascience/data-viewing/showInDataViewerPythonInterpreter.vscode.test.ts
@@ -58,7 +58,7 @@ suite('DataViewer @webview', function () {
         await vscode.commands.executeCommand('workbench.debug.viewlet.action.removeAllBreakpoints');
     });
     // Start debugging using the python extension
-    test.skip('Open from Python debug variables', async () => {
+    test('Open from Python debug variables', async () => {
         // First off, open up our python test file and make sure editor and groups are how we want them
         const textDocument = await openFile(testPythonFile);
 

--- a/src/test/datascience/variableView/variableView.vscode.test.ts
+++ b/src/test/datascience/variableView/variableView.vscode.test.ts
@@ -272,7 +272,7 @@ mySet = {1, 2, 3}
     });
 
     // Test opening data viewers while another dataviewer is open
-    test.skip('Open dataviewer', async function () {
+    test('Open dataviewer', async function () {
         // Send the command to open the view
         await commands.executeCommand(Commands.OpenVariableView);
 

--- a/src/webviews/extension-side/variablesView/variableView.ts
+++ b/src/webviews/extension-side/variablesView/variableView.ts
@@ -148,14 +148,11 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
                 } else if (variableViewers.length === 1) {
                     const command = variableViewers[0].jupyterVariableViewers.command;
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    return commands.executeCommand(command as any, request.variable);
+                    return commands.executeCommand(command as any, {
+                        container: {},
+                        variable: request.variable
+                    });
                 } else {
-                    const thirdPartyViewers = variableViewers.filter((d) => d.extension.id !== JVSC_EXTENSION_ID);
-                    if (thirdPartyViewers.length === 1) {
-                        const command = thirdPartyViewers[0].jupyterVariableViewers.command;
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        return commands.executeCommand(command as any, request.variable);
-                    }
                     // show quick pick
                     const quickPick = window.createQuickPick<QuickPickItem & { command: string }>();
                     quickPick.title = 'Select DataFrame Viewer';
@@ -172,14 +169,20 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
                             quickPick.hide();
                             commands
                                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                .executeCommand(item.command as any, request.variable)
+                                .executeCommand(item.command as any, {
+                                    container: {},
+                                    variable: request.variable
+                                })
                                 .then(noop, noop);
                         }
                     });
                     quickPick.show();
                 }
             } else {
-                return commands.executeCommand(Commands.ShowDataViewer, request.variable);
+                return commands.executeCommand(Commands.ShowDataViewer, {
+                    container: {},
+                    variable: request.variable
+                });
             }
         } catch (e) {
             traceError(e);
@@ -204,6 +207,7 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
                     e.packageJSON?.contributes?.jupyterVariableViewers &&
                     e.packageJSON?.contributes?.jupyterVariableViewers.length
             )
+            .filter((e) => e.id !== JVSC_EXTENSION_ID)
             .map((e) => {
                 const contributes = e.packageJSON?.contributes;
                 if (contributes?.jupyterVariableViewers) {


### PR DESCRIPTION
This reverts commit 14fc23d695bbabc4bf851815537c31e031ab3304.

Fixes #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
