### PR TITLE
Allow custom data viewer for Insiders

### DIFF
--- a/src/platform/common/experiments/service.ts
+++ b/src/platform/common/experiments/service.ts
@@ -128,6 +128,12 @@ export class ExperimentService implements IExperimentService {
         ) {
             return true;
         }
+        if (
+            experiment === ExperimentGroups.DataViewerContribution &&
+            (getVSCodeChannel() === 'insiders' || isPreReleaseVersion())
+        ) {
+            return true;
+        }
 
         // If getTreatmentVariable returns undefined,
         // it means that the value for this experiment was not found on the server.


### PR DESCRIPTION
<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
