### PR TITLE
ignore deprecation message causing exception

### DIFF
--- a/src/test/datascience/data-viewing/showInDataViewerPythonInterpreter.vscode.test.ts
+++ b/src/test/datascience/data-viewing/showInDataViewerPythonInterpreter.vscode.test.ts
@@ -58,7 +58,7 @@ suite('DataViewer @webview', function () {
         await vscode.commands.executeCommand('workbench.debug.viewlet.action.removeAllBreakpoints');
     });
     // Start debugging using the python extension
-    test.skip('Open from Python debug variables', async () => {
+    test('Open from Python debug variables', async () => {
         // First off, open up our python test file and make sure editor and groups are how we want them
         const textDocument = await openFile(testPythonFile);
 

--- a/src/test/datascience/plotViewer/plotViewer.vscode.test.ts
+++ b/src/test/datascience/plotViewer/plotViewer.vscode.test.ts
@@ -47,14 +47,17 @@ suite('VSCode Notebook PlotViewer integration - VSCode Notebook @webview', funct
         await insertCodeCell(
             `import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
-x = np.linspace(0, 20, 100)
+import matplotlib.pyplot as plt`,
+            { index: 1 }
+        );
+        await insertCodeCell(
+            `x = np.linspace(0, 20, 100)
 plt.plot(x, np.sin(x))
 plt.show()`,
-            { index: 0 }
+            { index: 1 }
         );
 
-        const plotCell = window.activeNotebookEditor?.notebook.cellAt(0)!;
+        const plotCell = window.activeNotebookEditor?.notebook.cellAt(1)!;
 
         await runAllCellsInActiveNotebook();
         await waitForExecutionCompletedSuccessfully(plotCell);

--- a/src/test/datascience/variableView/variableView.vscode.test.ts
+++ b/src/test/datascience/variableView/variableView.vscode.test.ts
@@ -272,7 +272,7 @@ mySet = {1, 2, 3}
     });
 
     // Test opening data viewers while another dataviewer is open
-    test.skip('Open dataviewer', async function () {
+    test('Open dataviewer', async function () {
         // Send the command to open the view
         await commands.executeCommand(Commands.OpenVariableView);
 

--- a/src/webviews/extension-side/dataviewer/dataViewerDependencyServiceInterpreter.node.unit.test.ts
+++ b/src/webviews/extension-side/dataviewer/dataViewerDependencyServiceInterpreter.node.unit.test.ts
@@ -16,6 +16,7 @@ import { pandasMinimumVersionSupportedByVariableViewer } from '../../../webviews
 import { PythonExecutionFactory } from '../../../platform/interpreter/pythonExecutionFactory.node';
 import { IPythonExecutionFactory, IPythonExecutionService } from '../../../platform/interpreter/types.node';
 import { mockedVSCodeNamespaces, resetVSCodeMocks } from '../../../test/vscode-mock';
+import { kernelGetPandasVersion } from './interpreterDataViewerDependencyImplementation.node';
 
 suite('DataViewerDependencyService (PythonEnvironment, Node)', () => {
     let dependencyService: DataViewerDependencyService;
@@ -56,27 +57,15 @@ suite('DataViewerDependencyService (PythonEnvironment, Node)', () => {
     });
     teardown(() => resetVSCodeMocks());
     test('All ok, if pandas is installed and version is > 1.20', async () => {
-        when(
-            pythonExecService.exec(
-                deepEqual([
-                    '-c',
-                    'import pandas;print(pandas.__version__);print("5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d")'
-                ]),
-                anything()
-            )
-        ).thenResolve({ stdout: '0.30.0\n5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d' });
+        when(pythonExecService.exec(deepEqual(['-c', kernelGetPandasVersion]), anything())).thenResolve({
+            stdout: '0.30.0\n5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d'
+        });
         await dependencyService.checkAndInstallMissingDependencies(interpreter);
     });
     test('Throw exception if pandas is installed and version is = 0.20', async () => {
-        when(
-            pythonExecService.exec(
-                deepEqual([
-                    '-c',
-                    'import pandas;print(pandas.__version__);print("5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d")'
-                ]),
-                anything()
-            )
-        ).thenResolve({ stdout: '0.20.0\n5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d' });
+        when(pythonExecService.exec(deepEqual(['-c', kernelGetPandasVersion]), anything())).thenResolve({
+            stdout: '0.20.0\n5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d'
+        });
 
         const promise = dependencyService.checkAndInstallMissingDependencies(interpreter);
 
@@ -86,15 +75,9 @@ suite('DataViewerDependencyService (PythonEnvironment, Node)', () => {
         );
     });
     test('Throw exception if pandas is installed and version is < 0.20', async () => {
-        when(
-            pythonExecService.exec(
-                deepEqual([
-                    '-c',
-                    'import pandas;print(pandas.__version__);print("5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d")'
-                ]),
-                anything()
-            )
-        ).thenResolve({ stdout: '0.10.0\n5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d' });
+        when(pythonExecService.exec(deepEqual(['-c', kernelGetPandasVersion]), anything())).thenResolve({
+            stdout: '0.10.0\n5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d'
+        });
 
         const promise = dependencyService.checkAndInstallMissingDependencies(interpreter);
 

--- a/src/webviews/extension-side/dataviewer/dataViewerDependencyServiceInterpreter.node.unit.test.ts
+++ b/src/webviews/extension-side/dataviewer/dataViewerDependencyServiceInterpreter.node.unit.test.ts
@@ -16,7 +16,7 @@ import { pandasMinimumVersionSupportedByVariableViewer } from '../../../webviews
 import { PythonExecutionFactory } from '../../../platform/interpreter/pythonExecutionFactory.node';
 import { IPythonExecutionFactory, IPythonExecutionService } from '../../../platform/interpreter/types.node';
 import { mockedVSCodeNamespaces, resetVSCodeMocks } from '../../../test/vscode-mock';
-import { kernelGetPandasVersion } from './interpreterDataViewerDependencyImplementation.node';
+import { interpreterGetPandasVersion } from './interpreterDataViewerDependencyImplementation.node';
 
 suite('DataViewerDependencyService (PythonEnvironment, Node)', () => {
     let dependencyService: DataViewerDependencyService;
@@ -57,13 +57,13 @@ suite('DataViewerDependencyService (PythonEnvironment, Node)', () => {
     });
     teardown(() => resetVSCodeMocks());
     test('All ok, if pandas is installed and version is > 1.20', async () => {
-        when(pythonExecService.exec(deepEqual(['-c', kernelGetPandasVersion]), anything())).thenResolve({
+        when(pythonExecService.exec(deepEqual(['-c', interpreterGetPandasVersion]), anything())).thenResolve({
             stdout: '0.30.0\n5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d'
         });
         await dependencyService.checkAndInstallMissingDependencies(interpreter);
     });
     test('Throw exception if pandas is installed and version is = 0.20', async () => {
-        when(pythonExecService.exec(deepEqual(['-c', kernelGetPandasVersion]), anything())).thenResolve({
+        when(pythonExecService.exec(deepEqual(['-c', interpreterGetPandasVersion]), anything())).thenResolve({
             stdout: '0.20.0\n5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d'
         });
 
@@ -75,7 +75,7 @@ suite('DataViewerDependencyService (PythonEnvironment, Node)', () => {
         );
     });
     test('Throw exception if pandas is installed and version is < 0.20', async () => {
-        when(pythonExecService.exec(deepEqual(['-c', kernelGetPandasVersion]), anything())).thenResolve({
+        when(pythonExecService.exec(deepEqual(['-c', interpreterGetPandasVersion]), anything())).thenResolve({
             stdout: '0.10.0\n5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d'
         });
 

--- a/src/webviews/extension-side/dataviewer/interpreterDataViewerDependencyImplementation.node.ts
+++ b/src/webviews/extension-side/dataviewer/interpreterDataViewerDependencyImplementation.node.ts
@@ -14,7 +14,7 @@ import { DataScience } from '../../../platform/common/utils/localize';
 import { splitLines } from '../../../platform/common/helpers';
 
 const separator = '5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d';
-export const kernelGetPandasVersion = `import pandas;print(pandas.__version__);print("${separator}")`;
+export const kernelGetPandasVersion = `import warnings as _VSCODE_warnings;_VSCODE_warnings.filterwarnings("ignore", category=DeprecationWarning);import pandas as _VSCODE_pandas;print(_VSCODE_pandas.__version__);print("${separator}"); del _VSCODE_pandas; del _VSCODE_warnings`;
 
 /**
  * Uses the Python interpreter to manage dependencies of a Data Viewer.

--- a/src/webviews/extension-side/dataviewer/interpreterDataViewerDependencyImplementation.node.ts
+++ b/src/webviews/extension-side/dataviewer/interpreterDataViewerDependencyImplementation.node.ts
@@ -14,7 +14,7 @@ import { DataScience } from '../../../platform/common/utils/localize';
 import { splitLines } from '../../../platform/common/helpers';
 
 const separator = '5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d';
-export const interpreterGetPandasVersion = `import warnings as _VSCODE_warnings;_VSCODE_warnings.filterwarnings("ignore", category=DeprecationWarning);import pandas as _VSCODE_pandas;print(_VSCODE_pandas.__version__);print("${separator}"); del _VSCODE_pandas; del _VSCODE_warnings`;
+export const interpreterGetPandasVersion = `import pandas;print(pandas.__version__);print("${separator}")`;
 
 /**
  * Uses the Python interpreter to manage dependencies of a Data Viewer.
@@ -37,7 +37,6 @@ export class InterpreterDataViewerDependencyImplementation extends BaseDataViewe
             interpreter
         });
         const result = await launcher.exec(['-c', interpreterGetPandasVersion], {
-            throwOnStdErr: true,
             token
         });
         const output = result.stdout;

--- a/src/webviews/extension-side/dataviewer/interpreterDataViewerDependencyImplementation.node.ts
+++ b/src/webviews/extension-side/dataviewer/interpreterDataViewerDependencyImplementation.node.ts
@@ -14,7 +14,7 @@ import { DataScience } from '../../../platform/common/utils/localize';
 import { splitLines } from '../../../platform/common/helpers';
 
 const separator = '5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d';
-export const kernelGetPandasVersion = `import warnings as _VSCODE_warnings;_VSCODE_warnings.filterwarnings("ignore", category=DeprecationWarning);import pandas as _VSCODE_pandas;print(_VSCODE_pandas.__version__);print("${separator}"); del _VSCODE_pandas; del _VSCODE_warnings`;
+export const interpreterGetPandasVersion = `import warnings as _VSCODE_warnings;_VSCODE_warnings.filterwarnings("ignore", category=DeprecationWarning);import pandas as _VSCODE_pandas;print(_VSCODE_pandas.__version__);print("${separator}"); del _VSCODE_pandas; del _VSCODE_warnings`;
 
 /**
  * Uses the Python interpreter to manage dependencies of a Data Viewer.
@@ -36,7 +36,7 @@ export class InterpreterDataViewerDependencyImplementation extends BaseDataViewe
             resource: undefined,
             interpreter
         });
-        const result = await launcher.exec(['-c', kernelGetPandasVersion], {
+        const result = await launcher.exec(['-c', interpreterGetPandasVersion], {
             throwOnStdErr: true,
             token
         });

--- a/src/webviews/extension-side/dataviewer/kernelDataViewerDependencyImplementation.ts
+++ b/src/webviews/extension-side/dataviewer/kernelDataViewerDependencyImplementation.ts
@@ -12,7 +12,7 @@ import { SessionDisposedError } from '../../../platform/errors/sessionDisposedEr
 import { splitLines } from '../../../platform/common/helpers';
 
 const separator = '5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d';
-export const kernelGetPandasVersion = `import warnings as _VSCODE_warnings;_VSCODE_warnings.filterwarnings("ignore", category=DeprecationWarning);import pandas as _VSCODE_pandas;print(_VSCODE_pandas.__version__);print("${separator}"); del _VSCODE_pandas; del _VSCODE_warnings`;
+export const kernelGetPandasVersion = `import pandas as _VSCODE_pandas;print(_VSCODE_pandas.__version__);print("${separator}"); del _VSCODE_pandas`;
 
 function kernelPackaging(kernel: IKernel): '%conda' | '%pip' {
     const envType = kernel.kernelConnectionMetadata.interpreter?.envType;

--- a/src/webviews/extension-side/dataviewer/kernelDataViewerDependencyImplementation.ts
+++ b/src/webviews/extension-side/dataviewer/kernelDataViewerDependencyImplementation.ts
@@ -12,7 +12,7 @@ import { SessionDisposedError } from '../../../platform/errors/sessionDisposedEr
 import { splitLines } from '../../../platform/common/helpers';
 
 const separator = '5dc3a68c-e34e-4080-9c3e-2a532b2ccb4d';
-export const kernelGetPandasVersion = `import pandas as _VSCODE_pandas;print(_VSCODE_pandas.__version__);print("${separator}"); del _VSCODE_pandas`;
+export const kernelGetPandasVersion = `import warnings as _VSCODE_warnings;_VSCODE_warnings.filterwarnings("ignore", category=DeprecationWarning);import pandas as _VSCODE_pandas;print(_VSCODE_pandas.__version__);print("${separator}"); del _VSCODE_pandas; del _VSCODE_warnings`;
 
 function kernelPackaging(kernel: IKernel): '%conda' | '%pip' {
     const envType = kernel.kernelConnectionMetadata.interpreter?.envType;


### PR DESCRIPTION
https://github.com/microsoft/vscode-jupyter/issues/15060

The latest pandas package throws a deprecation error every time the package is imported. This adds another error output to cells, confusing our assertions, and also causes the python executor just to fail so we fail to check which version of pandas the user has installed. https://github.com/pandas-dev/pandas/issues/54466

cc @DonJayamanne 
