### PR TITLE
dedent code sent to IW from .py cells

### DIFF
--- a/src/interactive-window/editor-integration/codewatcher.ts
+++ b/src/interactive-window/editor-integration/codewatcher.ts
@@ -34,6 +34,7 @@ import { TraceOptions } from '../../platform/logging/types';
 import * as urlPath from '../../platform/vscode-path/resources';
 import { IDataScienceErrorHandler } from '../../kernels/errors/types';
 import { dispose } from '../../platform/common/utils/lifecycle';
+import { dedentCode } from '../../platform/common/helpers';
 
 function getIndex(index: number, length: number): number {
     // return index within the length range with negative indexing
@@ -1046,7 +1047,7 @@ export class CodeWatcher implements ICodeWatcher {
         const nextRunCellLens = this.getNextCellLens(range.start);
 
         if (currentRunCellLens && this.document) {
-            const code = this.document.getText(currentRunCellLens.range);
+            const code = dedentCode(this.document.getText(currentRunCellLens.range));
 
             // Move the next cell if allowed.
             if (advance) {

--- a/src/interactive-window/helpers.ts
+++ b/src/interactive-window/helpers.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { NotebookCell } from 'vscode';
-import { splitLines } from '../platform/common/helpers';
+import { dedentCode, splitLines } from '../platform/common/helpers';
 import { IJupyterSettings } from '../platform/common/types';
 import { appendLineFeed, removeLinesFromFrontAndBackNoConcat } from '../platform/common/utils';
 import { isUri } from '../platform/common/utils/misc';
@@ -36,7 +36,7 @@ export function generateInteractiveCode(code: string, settings: IJupyterSettings
         settings.magicCommandsAsComments ? uncommentMagicCommands : undefined
     );
 
-    return withMagicsAndLinefeeds.join('');
+    return dedentCode(withMagicsAndLinefeeds.join(''));
 }
 
 export function isInteractiveInputTab(tab: unknown): tab is InteractiveTab {

--- a/src/platform/common/helpers.ts
+++ b/src/platform/common/helpers.ts
@@ -90,3 +90,20 @@ export function stripCodicons(text: string | undefined) {
     }
     return text.replace(/\$\([a-z0-9\-]+?\)/gi, '').trim();
 }
+
+export function dedentCode(code: string) {
+    const lines = code.split('\n');
+    const firstNonEmptyLine = lines.find((line) => line.trim().length > 0 && !line.trim().startsWith('#'));
+    if (firstNonEmptyLine) {
+        const leadingSpaces = firstNonEmptyLine.match(/^\s*/)![0];
+        return lines
+            .map((line) => {
+                if (line.startsWith(leadingSpaces)) {
+                    return line.replace(leadingSpaces, '');
+                }
+                return line;
+            })
+            .join('\n');
+    }
+    return code;
+}

--- a/src/platform/terminals/codeExecution/codeExecutionHelper.ts
+++ b/src/platform/terminals/codeExecution/codeExecutionHelper.ts
@@ -6,6 +6,7 @@ import { Position, Range, TextEditor, Uri, window, workspace } from 'vscode';
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import { ICodeExecutionHelper } from '../types';
 import { noop } from '../../common/utils/misc';
+import { dedentCode } from '../../common/helpers';
 
 /**
  * Handles trimming code sent to a terminal so it actually runs.
@@ -49,7 +50,8 @@ export class CodeExecutionHelperBase implements ICodeExecutionHelper {
         } else {
             code = this.getMultiLineSelectionText(textEditor);
         }
-        return this.dedentCode(code.trimEnd());
+
+        return dedentCode(code.trimEnd());
     }
 
     public async saveFileIfDirty(file: Uri): Promise<void> {
@@ -57,23 +59,6 @@ export class CodeExecutionHelperBase implements ICodeExecutionHelper {
         if (docs.length === 1 && docs[0].isDirty) {
             await docs[0].save();
         }
-    }
-
-    private dedentCode(code: string) {
-        const lines = code.split('\n');
-        const firstNonEmptyLine = lines.find((line) => line.trim().length > 0);
-        if (firstNonEmptyLine) {
-            const leadingSpaces = firstNonEmptyLine.match(/^\s*/)![0];
-            return lines
-                .map((line) => {
-                    if (line.startsWith(leadingSpaces)) {
-                        return line.replace(leadingSpaces, '');
-                    }
-                    return line;
-                })
-                .join('\n');
-        }
-        return code;
     }
 
     private getSingleLineSelectionText(textEditor: TextEditor): string {

--- a/src/test/datascience/interactiveWindow.vscode.common.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.common.test.ts
@@ -240,7 +240,7 @@ suite(`Interactive window execution @iw`, async function () {
         );
     });
 
-    test('Leading and trailing empty lines in #%% cell are trimmed', async () => {
+    test.only('Leading and trailing empty lines in #%% cell are trimmed', async () => {
         const actualCode = `    print('foo')
 
 
@@ -255,7 +255,7 @@ print('bar')`;
 
 
 
-    ${actualCode}
+${actualCode}
 
 
 

--- a/src/test/datascience/interactiveWindow.vscode.common.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.common.test.ts
@@ -246,11 +246,16 @@ suite(`Interactive window execution @iw`, async function () {
 
 
     print('bar')`;
+    const dedentedCode = `print('foo')
+
+
+
+print('bar')`;
         const codeWithWhitespace = `    # %%
 
 
 
-${actualCode}
+    ${actualCode}
 
 
 
@@ -265,7 +270,7 @@ ${actualCode}
         traceInfoIfCI('After submitting');
         const lastCell = await waitForLastCellToComplete(interactiveWindow);
         const actualCellText = lastCell.document.getText();
-        assert.equal(actualCellText, actualCode);
+        assert.equal(actualCellText, dedentedCode);
     });
 
     test('Run current file in interactive window (with cells)', async () => {

--- a/src/test/datascience/interactiveWindow.vscode.common.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.common.test.ts
@@ -240,7 +240,7 @@ suite(`Interactive window execution @iw`, async function () {
         );
     });
 
-    test.only('Leading and trailing empty lines in #%% cell are trimmed', async () => {
+    test('Leading and trailing empty lines in #%% cell are trimmed', async () => {
         const actualCode = `    print('foo')
 
 

--- a/src/test/datascience/interactiveWindow.vscode.common.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.common.test.ts
@@ -246,7 +246,7 @@ suite(`Interactive window execution @iw`, async function () {
 
 
     print('bar')`;
-    const dedentedCode = `print('foo')
+        const dedentedCode = `print('foo')
 
 
 


### PR DESCRIPTION
Fixes #13065

dedent both the code sent to the kernel and the "original" code we store in the metadata since that would be preferrable in an exported python file.
