### PR TITLE
register watcher for new debugger type

### DIFF
--- a/src/notebooks/debugger/debuggerVariableRegistration.node.ts
+++ b/src/notebooks/debugger/debuggerVariableRegistration.node.ts
@@ -23,6 +23,7 @@ export class DebuggerVariableRegistration implements IExtensionSyncActivationSer
     ) {}
     public activate() {
         this.disposables.push(this.debugService.registerDebugAdapterTrackerFactory(PYTHON_LANGUAGE, this));
+        this.disposables.push(this.debugService.registerDebugAdapterTrackerFactory('debugpy', this));
         this.disposables.push(this.debugService.registerDebugAdapterTrackerFactory(pythonKernelDebugAdapter, this));
         this.disposables.push(this.debugService.registerDebugAdapterTrackerFactory(pythonIWKernelDebugAdapter, this));
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-jupyter/issues/15121

the newly split out python debugger extension uses the debug type `debugpy`, rather than `python` as it was previously