### PR TITLE
Adopt new document symbol api

### DIFF
--- a/src/standalone/executionAnalysis/pylance.ts
+++ b/src/standalone/executionAnalysis/pylance.ts
@@ -29,6 +29,10 @@ export interface INotebookLanguageClient {
         },
         token: vscode.CancellationToken
     ): Promise<LocationWithReferenceKind[] | null | undefined>;
+    getDocumentSymbols(
+        document: vscode.TextDocument,
+        token: vscode.CancellationToken
+    ): Promise<vscode.DocumentSymbol[] | undefined>;
 }
 
 export interface LSExtensionApi {

--- a/src/standalone/executionAnalysis/pylance.ts
+++ b/src/standalone/executionAnalysis/pylance.ts
@@ -29,7 +29,7 @@ export interface INotebookLanguageClient {
         },
         token: vscode.CancellationToken
     ): Promise<LocationWithReferenceKind[] | null | undefined>;
-    getDocumentSymbols(
+    getDocumentSymbols?(
         document: vscode.TextDocument,
         token: vscode.CancellationToken
     ): Promise<vscode.DocumentSymbol[] | undefined>;

--- a/src/standalone/executionAnalysis/symbols.ts
+++ b/src/standalone/executionAnalysis/symbols.ts
@@ -462,7 +462,7 @@ export class NotebookDocumentSymbolTracker {
 
     private async _getDocumentSymbols(cell: vscode.NotebookCell) {
         const tokenSource = new vscode.CancellationTokenSource();
-        return this._client.getDocumentSymbols(cell.document, tokenSource.token)
+        return this._client.getDocumentSymbols(cell.document, tokenSource.token);
     }
 
     private async _doRequestCellSymbols(cell: vscode.NotebookCell, token: vscode.CancellationToken) {

--- a/src/standalone/executionAnalysis/symbols.ts
+++ b/src/standalone/executionAnalysis/symbols.ts
@@ -461,8 +461,15 @@ export class NotebookDocumentSymbolTracker {
     }
 
     private async _getDocumentSymbols(cell: vscode.NotebookCell) {
-        const tokenSource = new vscode.CancellationTokenSource();
-        return this._client.getDocumentSymbols(cell.document, tokenSource.token);
+        if (this._client.getDocumentSymbols) {
+            const tokenSource = new vscode.CancellationTokenSource();
+            return this._client.getDocumentSymbols(cell.document, tokenSource.token);
+        } else {
+            return vscode.commands.executeCommand<(vscode.SymbolInformation & vscode.DocumentSymbol)[] | undefined>(
+                'vscode.executeDocumentSymbolProvider',
+                cell.document.uri
+            );
+        }
     }
 
     private async _doRequestCellSymbols(cell: vscode.NotebookCell, token: vscode.CancellationToken) {

--- a/src/standalone/executionAnalysis/symbols.ts
+++ b/src/standalone/executionAnalysis/symbols.ts
@@ -27,7 +27,7 @@ export interface ILocationWithReferenceKind {
     kind?: string;
 }
 
-type ISymbol = vscode.SymbolInformation & vscode.DocumentSymbol;
+type ISymbol = vscode.DocumentSymbol;
 
 export interface ILocationWithReferenceKindAndSymbol extends ILocationWithReferenceKind {
     associatedSymbol?: ISymbol;
@@ -461,10 +461,8 @@ export class NotebookDocumentSymbolTracker {
     }
 
     private async _getDocumentSymbols(cell: vscode.NotebookCell) {
-        return vscode.commands.executeCommand<(vscode.SymbolInformation & vscode.DocumentSymbol)[] | undefined>(
-            'vscode.executeDocumentSymbolProvider',
-            cell.document.uri
-        );
+        const tokenSource = new vscode.CancellationTokenSource();
+        return this._client.getDocumentSymbols(cell.document, tokenSource.token)
     }
 
     private async _doRequestCellSymbols(cell: vscode.NotebookCell, token: vscode.CancellationToken) {


### PR DESCRIPTION
New document symbol api for fetching symbols which include module alias

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for feature-requests.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
