### PR TITLE
Update pre-release helper to fix boolean checks

### DIFF
--- a/src/kernels/serviceRegistry.node.ts
+++ b/src/kernels/serviceRegistry.node.ts
@@ -132,7 +132,7 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
 
     // Subdirectories
     registerJupyterTypes(serviceManager, isDevMode);
-    setSharedProperty('isInsiderExtension', isPreReleaseVersion());
+    setSharedProperty('isInsiderExtension', isPreReleaseVersion() ? 'true' : 'false');
 
     const isPythonExtensionInstalled = serviceManager.get<IPythonExtensionChecker>(IPythonExtensionChecker);
     setSharedProperty(

--- a/src/kernels/serviceRegistry.web.ts
+++ b/src/kernels/serviceRegistry.web.ts
@@ -48,7 +48,7 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
         IRawNotebookSupportedService,
         RawNotebookSupportedService
     );
-    setSharedProperty('isInsiderExtension', isPreReleaseVersion());
+    setSharedProperty('isInsiderExtension', isPreReleaseVersion() ? 'true' : 'false');
 
     const isPythonExtensionInstalled = serviceManager.get<IPythonExtensionChecker>(IPythonExtensionChecker);
     setSharedProperty(

--- a/src/platform/constants.ts
+++ b/src/platform/constants.ts
@@ -5,14 +5,12 @@ export const HiddenFileFormatString = '_HiddenFile_{0}.py';
 
 export const MillisecondsInADay = 24 * 60 * 60 * 1_000;
 
-export function isPreReleaseVersion() {
+export function isPreReleaseVersion(): boolean {
     try {
-        return require('vscode-jupyter-release-version').isPreRelesVersionOfJupyterExtension === true
-            ? 'true'
-            : 'false';
+        return require('vscode-jupyter-release-version').isPreRelesVersionOfJupyterExtension === true;
     } catch {
         // Dev version is treated as pre-release.
-        return 'true';
+        return true;
     }
 }
 


### PR DESCRIPTION
To enable some experiments only in pre-release versions, the truthiness of `isPreReleaseVersion()` is tested. But the function currently returns a string type, so the value is always truthy.

This PR updates the helper to return a more intuitive boolean type, and places where it is needs to be a string (i.e. telemetry) to determine the string based on the boolean value.


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] ~Has sufficient logging.~
-   [ ] ~Has telemetry for feature-requests.~
-   [ ] ~Unit tests & system/integration tests are added/updated.~
-   [ ] ~[Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [ ] ~[`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
