### PR TITLE
populate notebook filepath from notebookwatcher if needed

### DIFF
--- a/src/webviews/extension-side/variablesView/variableView.ts
+++ b/src/webviews/extension-side/variablesView/variableView.ts
@@ -137,6 +137,7 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
     // Handle a request from the react UI to show our data viewer. Public for testing
     @swallowExceptions()
     public async showDataViewer(request: IShowDataViewer) {
+        request.variable.fileName = request.variable.fileName ?? this.notebookWatcher.activeKernel?.notebook.uri;
         try {
             if (this.experiments.inExperiment(Experiments.DataViewerContribution)) {
                 // jupyterVariableViewers


### PR DESCRIPTION
We weren't populating the filename for debug scenarios, but DW would like that info to be able to recover from the kernel after the debug session ends
