### PR TITLE
refresh variable view for kernel crash/restarts

### DIFF
--- a/src/kernels/variables/JupyterVariableProvider.unit.test.ts
+++ b/src/kernels/variables/JupyterVariableProvider.unit.test.ts
@@ -3,7 +3,7 @@
 
 import { assert } from 'chai';
 import { JupyterVariablesProvider } from './JupyterVariablesProvider';
-import { NotebookDocument, CancellationTokenSource, VariablesResult, Variable } from 'vscode';
+import { NotebookDocument, CancellationTokenSource, VariablesResult, Variable, Uri } from 'vscode';
 import { mock, instance, when, anything, verify, objectContaining } from 'ts-mockito';
 import { IKernelProvider, IKernel } from '../types';
 import { IJupyterVariables, IVariableDescription } from './types';
@@ -15,7 +15,7 @@ suite('JupyterVariablesProvider', () => {
     const notebook = mock<NotebookDocument>();
     const cancellationToken = new CancellationTokenSource().token;
     const kernel = mock<IKernel>();
-    let kernelChangeHandler: (nb: NotebookDocument) => void;
+    let kernelChangeHandler: ({ kernel }: { kernel: IKernel }) => void;
 
     const objectVariable: IVariableDescription = {
         name: 'myObject',
@@ -268,6 +268,8 @@ suite('JupyterVariablesProvider', () => {
             variablesChangedForNotebooks.push(e.uri.toString());
         });
 
-        kernelChangeHandler({ uri: { toString: () => 'uri1' } } as NotebookDocument);
+        kernelChangeHandler({
+            kernel: { status: 'restarting', notebook: { uri: Uri.file('test.ipynb') } as NotebookDocument } as IKernel
+        });
     });
 });

--- a/src/kernels/variables/JupyterVariableProvider.unit.test.ts
+++ b/src/kernels/variables/JupyterVariableProvider.unit.test.ts
@@ -3,7 +3,7 @@
 
 import { assert } from 'chai';
 import { JupyterVariablesProvider } from './JupyterVariablesProvider';
-import { NotebookDocument, CancellationTokenSource, EventEmitter, VariablesResult, Variable, Uri } from 'vscode';
+import { NotebookDocument, CancellationTokenSource, EventEmitter, VariablesResult, Variable } from 'vscode';
 import { mock, instance, when, anything, verify, objectContaining } from 'ts-mockito';
 import { IKernelProvider, IKernel } from '../types';
 import { IJupyterVariables, IVariableDescription } from './types';
@@ -72,7 +72,7 @@ suite('JupyterVariablesProvider', () => {
         kernelProvider = mock<IKernelProvider>();
         when(kernelProvider.onKernelStatusChanged).thenReturn(kernelEventEmitter.event);
         when(kernelProvider.get(anything())).thenReturn(instance(kernel));
-        provider = new JupyterVariablesProvider(instance(variables), instance(kernelProvider), []);
+        provider = new JupyterVariablesProvider(instance(variables), instance(kernelProvider), '123', []);
     });
 
     test('provideVariables without parent should yield variables', async () => {
@@ -266,7 +266,7 @@ suite('JupyterVariablesProvider', () => {
             kernel: {
                 id: notebook,
                 status: status,
-                notebook: { uri: Uri.file(notebook) } as NotebookDocument
+                notebook: { uri: { toString: () => notebook } } as NotebookDocument
             } as IKernel
         });
     }

--- a/src/kernels/variables/JupyterVariableProvider.unit.test.ts
+++ b/src/kernels/variables/JupyterVariableProvider.unit.test.ts
@@ -8,7 +8,7 @@ import { mock, instance, when, anything, verify, objectContaining } from 'ts-moc
 import { IKernelProvider, IKernel } from '../types';
 import { IJupyterVariables, IVariableDescription } from './types';
 
-suite.only('JupyterVariablesProvider', () => {
+suite('JupyterVariablesProvider', () => {
     let variables: IJupyterVariables;
     let kernelProvider: IKernelProvider;
     let kernelEventEmitter = new EventEmitter<{ status: any; kernel: IKernel }>();

--- a/src/kernels/variables/JupyterVariablesProvider.ts
+++ b/src/kernels/variables/JupyterVariablesProvider.ts
@@ -36,9 +36,6 @@ export class JupyterVariablesProvider implements NotebookVariableProvider {
         } else if (kernel.status !== 'busy' && this.wasIdle) {
             this.wasIdle = false;
             this._onDidChangeVariables.fire(kernel.notebook);
-        } else {
-            // kernel is busy or unchanged, so don't fire the event
-            this.wasIdle = false;
         }
     }
 

--- a/src/kernels/variables/JupyterVariablesProvider.ts
+++ b/src/kernels/variables/JupyterVariablesProvider.ts
@@ -25,17 +25,22 @@ export class JupyterVariablesProvider implements NotebookVariableProvider {
     constructor(
         private readonly variables: IJupyterVariables,
         private readonly kernelProvider: IKernelProvider,
+        private readonly controllerId: string,
         disposables: IDisposable[]
     ) {
         disposables.push(this.kernelProvider.onKernelStatusChanged(this.onKernelStatusChanged, this));
     }
 
     private onKernelStatusChanged({ kernel }: { kernel: IKernel }) {
-        const kernelWasRunning = this.runningKernels.has(kernel.id);
+        if (kernel.controller.id !== this.controllerId) {
+            return;
+        }
+
+        const kernelWasRunning = this.runningKernels.has(kernel.notebook.uri.toString());
         if (kernel.status === 'idle' && !kernelWasRunning) {
-            this.runningKernels.add(kernel.id);
+            this.runningKernels.add(kernel.notebook.uri.toString());
         } else if (kernel.status !== 'busy' && kernel.status !== 'idle' && kernelWasRunning) {
-            this.runningKernels.delete(kernel.id);
+            this.runningKernels.delete(kernel.notebook.uri.toString());
             this._onDidChangeVariables.fire(kernel.notebook);
         }
     }

--- a/src/notebooks/controllers/vscodeNotebookController.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.ts
@@ -217,6 +217,7 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
             this.controller.variableProvider = new JupyterVariablesProvider(
                 jupyterVariables,
                 this.kernelProvider,
+                this.controller.id,
                 this.disposables
             );
         }

--- a/src/notebooks/controllers/vscodeNotebookController.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.ts
@@ -214,8 +214,11 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
         this.controller.supportsExecutionOrder = true;
         this.controller.supportedLanguages = this.languageService.getSupportedLanguages(kernelConnection);
         if (this.controller.supportedLanguages.includes('python')) {
-
-            this.controller.variableProvider = new JupyterVariablesProvider(jupyterVariables, this.kernelProvider, this.disposables);
+            this.controller.variableProvider = new JupyterVariablesProvider(
+                jupyterVariables,
+                this.kernelProvider,
+                this.disposables
+            );
         }
         // Hook up to see when this NotebookController is selected by the UI
         this.controller.onDidChangeSelectedNotebooks(this.onDidChangeSelectedNotebooks, this, this.disposables);

--- a/src/notebooks/controllers/vscodeNotebookController.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.ts
@@ -214,7 +214,8 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
         this.controller.supportsExecutionOrder = true;
         this.controller.supportedLanguages = this.languageService.getSupportedLanguages(kernelConnection);
         if (this.controller.supportedLanguages.includes('python')) {
-            this.controller.variableProvider = new JupyterVariablesProvider(jupyterVariables, this.kernelProvider);
+
+            this.controller.variableProvider = new JupyterVariablesProvider(jupyterVariables, this.kernelProvider, this.disposables);
         }
         // Hook up to see when this NotebookController is selected by the UI
         this.controller.onDidChangeSelectedNotebooks(this.onDidChangeSelectedNotebooks, this, this.disposables);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-jupyter/issues/15344

A cell finishing execution is already handled in core, so we just need to listen for kernel based events - restarting/crashing.
