### PR TITLE
skip adding diagnostic info for IW, guard against bad regex results

### DIFF
--- a/src/kernels/execution/cellExecutionMessageHandler.ts
+++ b/src/kernels/execution/cellExecutionMessageHandler.ts
@@ -1074,14 +1074,16 @@ export class CellExecutionMessageHandler implements IDisposable {
             traceback
         };
 
-        const cellExecution = CellExecutionCreator.get(this.cell);
-        if (cellExecution && msg.content.ename !== 'KeyboardInterrupt') {
-            cellExecution.errorInfo = {
-                message: `${msg.content.ename}: ${msg.content.evalue}`,
-                location: this.failureDiagostics.parseStackTrace(traceback, this.cell).range,
-                uri: this.cell.document.uri,
-                stack: msg.content.traceback.join('\n')
-            };
+        if (this.cell.notebook.notebookType !== 'interactive') {
+            const cellExecution = CellExecutionCreator.get(this.cell);
+            if (cellExecution && msg.content.ename !== 'KeyboardInterrupt') {
+                cellExecution.errorInfo = {
+                    message: `${msg.content.ename}: ${msg.content.evalue}`,
+                    location: this.failureDiagostics.parseStackTrace(msg.content.traceback, this.cell).range,
+                    uri: this.cell.document.uri,
+                    stack: msg.content.traceback.join('\n')
+                };
+            }
         }
 
         this.addToCellData(output, msg);

--- a/src/kernels/execution/cellFailureDiagnostics.ts
+++ b/src/kernels/execution/cellFailureDiagnostics.ts
@@ -83,7 +83,7 @@ export class CellFailureDiagnostics {
         }
 
         let range: Range | undefined = undefined;
-        if (lineNumber) {
+        if (lineNumber && lineNumber > 0 && lineNumber <= cell.document.lineCount) {
             const line = cell.document.lineAt(lineNumber - 1);
             const end = line.text.split('#')[0].trimEnd().length;
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-jupyter/issues/15438

There is a mismatch between the cell contents sent to the kernel and what we add to the cell document when sending a `# %%` cell to the interactive window because of the `# %%` line.
We're not using the diagnostics for IW at this point anyway, so we can just skip this for interactive notebooks.
Also added a guard against bad line numbers from the regex, since that should not break the rest of the error rendering.