### PR TITLE
only handle reading outputs in one place

### DIFF
--- a/src/standalone/api/kernels/backgroundExecution.ts
+++ b/src/standalone/api/kernels/backgroundExecution.ts
@@ -133,5 +133,5 @@ del __jupyter_exec_background__
         return;
     }
 
-    await promise;
+    return promise;
 }


### PR DESCRIPTION
remove some duplicated code.

From what I can tell, we only need the API listener to determine when we have the final output that we are looking for.
Without this, an error can be thrown in both promises, leaving one rejected promise orphaned which adds another error to the log.