### PR TITLE
only ask for summary on supported types

### DIFF
--- a/src/kernels/variables/JupyterVariablesProvider.ts
+++ b/src/kernels/variables/JupyterVariablesProvider.ts
@@ -139,7 +139,7 @@ export class JupyterVariablesProvider implements NotebookVariableProvider {
                 const executionCount = this.kernelProvider.getKernelExecution(kernel).executionCount;
                 let summary = this.variableSummaryCache.getResults(executionCount, cacheKey);
 
-                if (summary == undefined) {
+                if (summary == undefined && result.variable.type === 'pandas.core.frame.dataframe') {
                     summary = await this.variables.getVariableValueSummary(
                         {
                             name: result.variable.name,

--- a/src/kernels/variables/JupyterVariablesProvider.ts
+++ b/src/kernels/variables/JupyterVariablesProvider.ts
@@ -139,7 +139,7 @@ export class JupyterVariablesProvider implements NotebookVariableProvider {
                 const executionCount = this.kernelProvider.getKernelExecution(kernel).executionCount;
                 let summary = this.variableSummaryCache.getResults(executionCount, cacheKey);
 
-                if (summary == undefined && result.variable.type === 'pandas.core.frame.dataframe') {
+                if (summary == undefined && result.variable.type === 'pandas.core.frame.DataFrame') {
                     summary = await this.variables.getVariableValueSummary(
                         {
                             name: result.variable.name,
@@ -167,7 +167,7 @@ export class JupyterVariablesProvider implements NotebookVariableProvider {
                         expression: result.variable.expression,
                         type: result.variable.type,
                         language: result.variable.language,
-                        summary: summary
+                        summary: summary ?? ''
                     }
                 };
             }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/209663

only pandas dataframes will actually get anything for the summary, so don't spend time calling into the kernel for anything else.