### PR TITLE
Set env variable PYTHON_FROZEN_MODULES

### DIFF
--- a/src/platform/common/process/proc.node.ts
+++ b/src/platform/common/process/proc.node.ts
@@ -273,6 +273,11 @@ export class ProcessService implements IProcessService {
             defaultOptions.env.PYTHONIOENCODING = 'utf-8';
         }
 
+        // Always ensure we have unbuffered output.
+        if (!defaultOptions.env.PYTHON_FROZEN_MODULES) {
+            defaultOptions.env.PYTHON_FROZEN_MODULES = 'on';
+        }
+
         return defaultOptions;
     }
 }


### PR DESCRIPTION
Set the required env variable to hide the warning messages about frozen modules being sent in stdout of kernel process
See https://github.com/python/cpython/issues/111374 & https://discourse.jupyter.org/t/what-should-i-do-about-frozen-modules-warning/21528