### PR TITLE
Simple, fast way to select kernel in smoke tests

### DIFF
--- a/src/test/smoke/datascience.smoke.test.ts
+++ b/src/test/smoke/datascience.smoke.test.ts
@@ -3,17 +3,21 @@
 
 import { assert } from 'chai';
 /* eslint-disable , no-invalid-this, @typescript-eslint/no-explicit-any */
-import * as os from 'os';
 import * as fs from 'fs-extra';
 import * as path from '../../platform/vscode-path/path';
 import * as vscode from 'vscode';
-import { traceInfo, traceVerbose } from '../../platform/logging';
+import { traceInfo } from '../../platform/logging';
 import { PYTHON_PATH, setAutoSaveDelayInWorkspaceRoot, waitForCondition } from '../common.node';
-import { EXTENSION_ROOT_DIR_FOR_TESTS, IS_SMOKE_TEST } from '../constants.node';
+import { EXTENSION_ROOT_DIR_FOR_TESTS, IS_SMOKE_TEST, JVSC_EXTENSION_ID_FOR_TESTS } from '../constants.node';
 import { sleep } from '../core';
 import { closeActiveWindows, initialize, initializeTest } from '../initialize.node';
 import { captureScreenShot } from '../common';
 import { getCachedEnvironments } from '../../platform/interpreter/helpers';
+import { PythonExtension, type EnvironmentPath } from '@vscode/python-extension';
+
+type JupyterApi = {
+    openNotebook(uri: vscode.Uri, env: EnvironmentPath): Promise<void>;
+};
 
 const timeoutForCellToRun = 3 * 60 * 1_000;
 suite('Smoke Tests', function () {
@@ -86,33 +90,25 @@ suite('Smoke Tests', function () {
             await fs.unlink(outputFile);
         }
         traceInfo(`Opening notebook file ${file}`);
-        await vscode.commands.executeCommand('vscode.openWith', vscode.Uri.file(file), 'jupyter-notebook');
+        const notebook = await vscode.workspace.openNotebookDocument(vscode.Uri.file(file));
+        await vscode.window.showNotebookDocument(notebook);
 
-        // Wait for 15 seconds for notebook to launch.
-        // Unfortunately there's no way to know for sure it has completely loaded.
-        await sleep(60_000);
-
-        let controllerId = '';
         let pythonPath = PYTHON_PATH;
-        let hash = await getInterpreterHash(vscode.Uri.file(pythonPath));
-        traceInfo(`Hash of old path ${pythonPath} is ${hash}`);
-        if (os.platform() === 'darwin' || os.platform() === 'linux') {
-            if (pythonPath.endsWith('/bin/python')) {
-                // have a look at the code in getNormalizedInterpreterPath
-                pythonPath = pythonPath.replace('/bin/python', '/python');
-            }
-        } else {
-            pythonPath = `${PYTHON_PATH.substring(0, 1).toLowerCase()}${PYTHON_PATH.substring(1)}`;
+        const nb = vscode.window.activeNotebookEditor?.notebook;
+        if (!nb) {
+            throw new Error('No active notebook');
         }
-        hash = await getInterpreterHash(vscode.Uri.file(pythonPath));
-        controllerId = `.jvsc74a57bd0${hash}.${pythonPath}.${pythonPath}.-m#ipykernel_launcher`;
-        traceVerbose(`Before selected kernel ${controllerId}`);
-        await vscode.commands.executeCommand('notebook.selectKernel', {
-            id: controllerId,
-            extension: 'ms-toolsai.jupyter'
-        });
+        const pythonEnv = await PythonExtension.api().then((api) => api.environments.resolveEnvironment(pythonPath));
+        if (!pythonEnv) {
+            throw new Error(`Python environment not found ${pythonPath}`);
+        }
+        const jupyterExt = vscode.extensions.getExtension<JupyterApi>(JVSC_EXTENSION_ID_FOR_TESTS);
+        if (!jupyterExt) {
+            throw new Error('Jupyter extension not found');
+        }
+        await jupyterExt?.activate();
+        await jupyterExt.exports.openNotebook(nb.uri, pythonEnv);
 
-        traceVerbose(`Selected kernel ${controllerId}`);
         await vscode.commands.executeCommand<void>('notebook.execute');
         const checkIfFileHasBeenCreated = () => fs.pathExists(outputFile);
         await waitForCondition(checkIfFileHasBeenCreated, timeoutForCellToRun, `"${outputFile}" file not created`);
@@ -153,63 +149,4 @@ suite('Smoke Tests', function () {
         //     'Interactive window not created with newly selected interpreter'
         // );
     });
-    async function computeHash(data: string, algorithm: 'SHA-512' | 'SHA-256' | 'SHA-1'): Promise<string> {
-        const inputBuffer = new TextEncoder().encode(data);
-        const hashBuffer = await require('node:crypto').webcrypto.subtle.digest({ name: algorithm }, inputBuffer);
-
-        // Turn into hash string (got this logic from https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest)
-        const hashArray = Array.from(new Uint8Array(hashBuffer));
-        return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
-    }
-
-    function getInterpreterHash(uri: vscode.Uri) {
-        const interpreterPath = getNormalizedInterpreterPath(uri);
-        return computeHash(interpreterPath.path, 'SHA-256');
-    }
-    /**
-     * Sometimes on CI, we have paths such as (this could happen on user machines as well)
-     *  - /opt/hostedtoolcache/Python/3.8.11/x64/python
-     *  - /opt/hostedtoolcache/Python/3.8.11/x64/bin/python
-     *  They are both the same.
-     * This function will take that into account.
-     */
-    function getNormalizedInterpreterPath(path: vscode.Uri, forceLowerCase: boolean = false) {
-        let fsPath = getFilePath(path);
-        if (forceLowerCase) {
-            fsPath = fsPath.toLowerCase();
-        }
-
-        // No need to generate hashes, its unnecessarily slow.
-        if (!fsPath.endsWith('/bin/python')) {
-            return vscode.Uri.file(fsPath);
-        }
-        // Sometimes on CI, we have paths such as (this could happen on user machines as well)
-        // - /opt/hostedtoolcache/Python/3.8.11/x64/python
-        // - /opt/hostedtoolcache/Python/3.8.11/x64/bin/python
-        // They are both the same.
-        // To ensure we treat them as the same, lets drop the `bin` on unix.
-        const isWindows = /^win/.test(process.platform);
-        if (!isWindows) {
-            // We need to exclude paths such as `/usr/bin/python`
-            return fsPath.endsWith('/bin/python') && fsPath.split('/').length > 4
-                ? vscode.Uri.file(fsPath.replace('/bin/python', '/python'))
-                : vscode.Uri.file(fsPath);
-        }
-        return vscode.Uri.file(fsPath);
-    }
-    function getFilePath(file: vscode.Uri | undefined) {
-        const isWindows = /^win/.test(process.platform);
-        if (file) {
-            const fsPath = file.path;
-
-            // Remove separator on the front if not a network drive.
-            // Example, if you create a URI with Uri.file('hello world'), the fsPath will come out as '\Hello World' on windows. We don't want that
-            // However if you create a URI from a network drive, like '\\mydrive\foo\bar\python.exe', we want to keep the \\ on the front.
-            if (fsPath && fsPath.startsWith(path.sep) && fsPath.length > 1 && fsPath[1] !== path.sep && isWindows) {
-                return fsPath.slice(1);
-            }
-            return fsPath || '';
-        }
-        return '';
-    }
 });


### PR DESCRIPTION
Halves the total time spent running the smoke tests, primarily by removing the 60s wait.