### PR TITLE
chore: exclude ARM64 binaries from APIScan

### DIFF
--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -89,4 +89,4 @@ extends:
 
     apiScanSoftwareVersion: '2024'
     apiScanExcludes: |
-        extension/dist/node_modules/zeromq/prebuilds/win32-arm64/*.dll
+        extension/dist/node_modules/zeromq/prebuilds/win32-arm64/*.*

--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -88,5 +88,4 @@ extends:
       enabled: true
 
     apiScanSoftwareVersion: '2024'
-    apiScanExcludes: |
-        extension/dist/node_modules/zeromq/prebuilds/win32-arm64/*.*
+    apiScanExcludes: 'extension/dist/node_modules/zeromq/prebuilds/win32-arm64/*.*'

--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -88,3 +88,5 @@ extends:
       enabled: true
 
     apiScanSoftwareVersion: '2024'
+    apiScanExcludes: |
+        extension/dist/node_modules/zeromq/prebuilds/win32-arm64/*.dll


### PR DESCRIPTION
Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=270625&view=results

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] Has telemetry for feature-requests.
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] [Test plan](https://github.com/Microsoft/vscode-jupyter/blob/main/.github/test_plan.md) is updated as appropriate.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-jupyter/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
