### PR TITLE
prompt to change back to previous IW execute keybinding

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,11 +145,6 @@
                 "when": "editorTextFocus && !editorHasSelection && jupyter.hascodecells && !notebookEditorFocused"
             },
             {
-                "key": "shift+enter",
-                "when": "activeEditor == 'workbench.editor.interactive' && notebookKernel =~ /^ms-toolsai.jupyter\\// || activeEditor == 'workbench.editor.interactive' && !notebookKernel",
-                "command": "interactive.execute"
-            },
-            {
                 "key": "escape",
                 "when": "activeEditor == 'workbench.editor.interactive' && !editorHoverVisible && !suggestWidgetVisible && !isComposing && !inSnippetMode && !exceptionWidgetVisible && !selectionAnchorSet && !LinkedEditingInputVisible && !renameInputVisible && !editorHasSelection && !accessibilityHelpWidgetVisible && !breakpointWidgetVisible && !findWidgetVisible && !markersNavigationVisible && !parameterHintsVisible && !editorHasMultipleSelections && !notificationToastsVisible",
                 "command": "interactive.input.clear"

--- a/src/notebooks/controllers/InteractiveExecutionPrompt.ts
+++ b/src/notebooks/controllers/InteractiveExecutionPrompt.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ConfigurationTarget, NotebookCell, window, workspace } from 'vscode';
+import { IConfigurationService } from '../../platform/common/types';
+
+export class InteractiveExecutionPrompt {
+    private disabled = false;
+
+    constructor(private readonly configurationService: IConfigurationService) {}
+
+    public async checkToPrompt(cell: NotebookCell) {
+        if (this.disabled) {
+            return;
+        }
+        if (cell.notebook.notebookType === 'interactive' && !cell.metadata.interactive) {
+            const settings = this.configurationService.getSettings(cell.document.uri);
+            const config = workspace.getConfiguration('interactiveWindow');
+
+            // can we check if the keybinding for interactive.execute is set to 'enter'?
+            if (!settings.promptToChangeInteractiveExecute || config.get('interactiveShiftEnter')) {
+                return;
+            }
+
+            const response = await window.showInformationMessage(
+                'Would you like to have `shift+enter` execute input and `enter` create a new line? (previous behavior)',
+                'shift+enter to execute',
+                'enter to execute'
+            );
+            switch (response) {
+                case 'shift+enter to execute': {
+                    await config.update('executeWithShiftEnter', true, ConfigurationTarget.Global);
+                    await this.configurationService.updateSetting('promptToChangeInteractiveExecute', false);
+                    break;
+                }
+                case 'enter to execute': {
+                    await this.configurationService.updateSetting('promptToChangeInteractiveExecute', false);
+                    break;
+                }
+                default:
+                    {
+                    }
+
+                    this.disabled = true;
+            }
+        }
+    }
+}

--- a/src/notebooks/controllers/InteractiveExecutionPrompt.ts
+++ b/src/notebooks/controllers/InteractiveExecutionPrompt.ts
@@ -16,14 +16,15 @@ export class InteractiveExecutionPrompt {
         if (cell.notebook.notebookType === 'interactive' && !cell.metadata.interactive) {
             const settings = this.configurationService.getSettings(cell.document.uri);
             const config = workspace.getConfiguration('interactiveWindow');
+            const setting = config.get('executeWithShiftEnter');
 
             // can we check if the keybinding for interactive.execute is set to 'enter'?
-            if (!settings.promptToChangeInteractiveExecute || config.get('interactiveShiftEnter')) {
+            if (!settings.promptToChangeInteractiveExecute || setting === undefined || setting === true) {
                 return;
             }
 
             const response = await window.showInformationMessage(
-                'Would you like to have `shift+enter` execute input and `enter` create a new line? (previous behavior)',
+                'Change execute keyboard shortcut to shift+enter? (previous behavior)',
                 'shift+enter to execute',
                 'enter to execute'
             );

--- a/src/platform/common/configSettings.ts
+++ b/src/platform/common/configSettings.ts
@@ -88,6 +88,7 @@ export class JupyterSettings implements IWatchableJupyterSettings {
     public excludeUserSitePackages: boolean = false;
     public enableExtendedPythonKernelCompletions: boolean = false;
     public formatStackTraces: boolean = false;
+    public promptToChangeInteractiveExecute: boolean = true;
     // Privates should start with _ so that they are not read from the settings.json
     private _changeEmitter = new EventEmitter<void>();
     private _workspaceRoot: Resource;

--- a/src/platform/common/types.ts
+++ b/src/platform/common/types.ts
@@ -93,6 +93,7 @@ export interface IJupyterSettings {
     readonly excludeUserSitePackages: boolean;
     readonly enableExtendedPythonKernelCompletions: boolean;
     readonly formatStackTraces: boolean;
+    readonly promptToChangeInteractiveExecute: boolean;
     /**
      * Trigger characters for Jupyter completion, per language.
      * This excludes the trigger characters for python.


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/212051

After changing the default keybinding to execute the IW input box, we should have an easy way to change it back to the previous behavior to try and reduce the disruption.