### PR TITLE
interactive.execute keyboard shortcut migrated to core, configure for jupyter IW users

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,11 +145,6 @@
                 "when": "editorTextFocus && !editorHasSelection && jupyter.hascodecells && !notebookEditorFocused"
             },
             {
-                "key": "shift+enter",
-                "when": "activeEditor == 'workbench.editor.interactive' && notebookKernel =~ /^ms-toolsai.jupyter\\// || activeEditor == 'workbench.editor.interactive' && !notebookKernel",
-                "command": "interactive.execute"
-            },
-            {
                 "key": "escape",
                 "when": "activeEditor == 'workbench.editor.interactive' && !editorHoverVisible && !suggestWidgetVisible && !isComposing && !inSnippetMode && !exceptionWidgetVisible && !selectionAnchorSet && !LinkedEditingInputVisible && !renameInputVisible && !editorHasSelection && !accessibilityHelpWidgetVisible && !breakpointWidgetVisible && !findWidgetVisible && !markersNavigationVisible && !parameterHintsVisible && !editorHasMultipleSelections && !notificationToastsVisible",
                 "command": "interactive.input.clear"

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -190,6 +190,7 @@ export class InteractiveWindow implements IInteractiveWindow {
     }
 
     public async ensureInitialized() {
+        await updateExecuteConfigSetting();
         if (!this.notebookDocument) {
             logger.debug(`Showing Interactive editor to initialize codeGenerator from notebook document`);
             await this.showInteractiveEditor();
@@ -627,5 +628,15 @@ export class InteractiveWindow implements IInteractiveWindow {
                 )
                 .then(noop, noop);
         }
+    }
+}
+
+async function updateExecuteConfigSetting() {
+    const config = workspace.getConfiguration('interactiveWindow');
+    const inspected = config.inspect<boolean>('executeWithShiftEnter');
+    if (!inspected?.workspaceValue && !inspected?.workspaceFolderValue && !inspected?.globalValue) {
+        // Update the setting to execute with shift+enter if the user has not set it explicitly
+        // This is to ensure that the behavior stays consistent, but we should only keep doing this for a single release cycle
+        await config.update('executeWithShiftEnter', true).then(noop, noop);
     }
 }

--- a/src/interactive-window/interactiveWindow.ts
+++ b/src/interactive-window/interactiveWindow.ts
@@ -190,7 +190,6 @@ export class InteractiveWindow implements IInteractiveWindow {
     }
 
     public async ensureInitialized() {
-        await updateExecuteConfigSetting();
         if (!this.notebookDocument) {
             logger.debug(`Showing Interactive editor to initialize codeGenerator from notebook document`);
             await this.showInteractiveEditor();
@@ -628,15 +627,5 @@ export class InteractiveWindow implements IInteractiveWindow {
                 )
                 .then(noop, noop);
         }
-    }
-}
-
-async function updateExecuteConfigSetting() {
-    const config = workspace.getConfiguration('interactiveWindow');
-    const inspected = config.inspect<boolean>('executeWithShiftEnter');
-    if (!inspected?.workspaceValue && !inspected?.workspaceFolderValue && !inspected?.globalValue) {
-        // Update the setting to execute with shift+enter if the user has not set it explicitly
-        // This is to ensure that the behavior stays consistent, but we should only keep doing this for a single release cycle
-        await config.update('executeWithShiftEnter', true).then(noop, noop);
     }
 }


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/212051

This will configure the keybinding to continue to be shift+enter for jupyter IW users when we switch the default to be `enter`.