### PR TITLE
stop migrating jupyter users to shift+enter execute

### DIFF
--- a/src/interactive-window/interactiveWindowProvider.ts
+++ b/src/interactive-window/interactiveWindowProvider.ts
@@ -122,9 +122,6 @@ export class InteractiveWindowProvider implements IInteractiveWindowProvider, IE
                 Uri.parse(iw.inputBoxUriString)
             );
 
-            this.updateExecuteConfigSetting().catch((ex) =>
-                logger.warn('Failed to update executeWithShiftEnter setting', ex)
-            );
             result.notifyConnectionReset();
 
             this._windows.push(result);
@@ -170,35 +167,10 @@ export class InteractiveWindowProvider implements IInteractiveWindowProvider, IE
         }
 
         await result.ensureInitialized();
-        this.updateExecuteConfigSetting().catch((ex) =>
-            logger.warn('Failed to update executeWithShiftEnter setting', ex)
-        );
 
         return result;
     }
 
-    private async updateExecuteConfigSetting() {
-        const updatedExecuteConfigKey = 'updatedExecuteInteractiveConfig';
-        const updatedExecuteConfig = this.globalMemento.get<boolean>(updatedExecuteConfigKey);
-        if (updatedExecuteConfig) {
-            // We've already updated the setting, don't change it again if the user removed it
-            return;
-        }
-
-        const config = workspace.getConfiguration('interactiveWindow');
-        const inspected = config.inspect<boolean>('executeWithShiftEnter');
-
-        if (
-            inspected?.workspaceValue === undefined &&
-            inspected?.workspaceFolderValue === undefined &&
-            inspected?.globalValue === undefined
-        ) {
-            // Update the setting to execute with shift+enter if the user has not set it explicitly
-            // This is to ensure that the behavior stays consistent, but we should only keep doing this for a single release cycle
-            await config.update('executeWithShiftEnter', true, ConfigurationTarget.Global);
-            await this.globalMemento.update(updatedExecuteConfigKey, undefined);
-        }
-    }
 
     /**
      * Given a text document, return the associated interactive window if one exists.

--- a/src/interactive-window/interactiveWindowProvider.ts
+++ b/src/interactive-window/interactiveWindowProvider.ts
@@ -171,7 +171,6 @@ export class InteractiveWindowProvider implements IInteractiveWindowProvider, IE
         return result;
     }
 
-
     /**
      * Given a text document, return the associated interactive window if one exists.
      * @param owner The URI of a text document which may be associated with an interactive window.


### PR DESCRIPTION
follow up https://github.com/microsoft/vscode-jupyter/pull/15714

with https://github.com/microsoft/vscode/pull/216633, this should be a smoother switch and our plan was to only do this migration for a single release cycle

