### PR TITLE
fix: Kubeflow Authentication

### DIFF
--- a/src/standalone/userJupyterServer/jupyterPasswordConnect.ts
+++ b/src/standalone/userJupyterServer/jupyterPasswordConnect.ts
@@ -202,7 +202,7 @@ export class JupyterPasswordConnect {
         let tokenUrl = new URL('login?', addTrailingSlash(url)).toString();
 
         if (sessionCookie != '') {
-            tokenUrl = new URL('tree', addTrailingSlash(url)).toString();
+            tokenUrl = new URL('lab', addTrailingSlash(url)).toString();
             headers = {
                 Connection: 'keep-alive',
                 Cookie: sessionCookie


### PR DESCRIPTION
Fixes #15659

Use a Jupyter URL that does not return 404 with Jupyter 4.x and thus breaks the authentication. 