### PR TITLE
Removal of builtin data viewer entry point.

### DIFF
--- a/src/platform/common/utils/localize.ts
+++ b/src/platform/common/utils/localize.ts
@@ -751,6 +751,7 @@ export namespace DataScience {
     export const dataViewerExtensionRequired = l10n.t(
         'A Data Viewer Extension is required to view data frames. Click Yes to see recommended extensions.'
     );
+    export const selectExternalDataViewer = l10n.t('Select DataFrame Viewer');
 }
 export namespace WebViews {
     export const collapseSingle = l10n.t('Collapse');

--- a/src/platform/common/utils/localize.ts
+++ b/src/platform/common/utils/localize.ts
@@ -748,6 +748,9 @@ export namespace DataScience {
         'The built-in data viewer will be deprecated soon. Please install other data viewing extensions to keep the ability to inspect data.'
     );
     export const dataViewerDeprecationRecommendationActionMessage = l10n.t('See Recommended Extensions');
+    export const dataViewerExtensionRequired = l10n.t(
+        'A Data Viewer Extension is required to view data frames. Click Yes to see recommended extensions.'
+    );
 }
 export namespace WebViews {
     export const collapseSingle = l10n.t('Collapse');

--- a/src/test/datascience/data-viewing/showInDataViewerPythonInterpreter.vscode.test.ts
+++ b/src/test/datascience/data-viewing/showInDataViewerPythonInterpreter.vscode.test.ts
@@ -17,7 +17,7 @@ import { dispose } from '../../../platform/common/utils/lifecycle';
 import { IShowDataViewerFromVariablePanel } from '../../../messageTypes';
 
 /* eslint-disable @typescript-eslint/no-explicit-any, no-invalid-this */
-suite('DataViewer @webview', function () {
+suite.skip('DataViewer @webview', function () {
     const disposables: IDisposable[] = [];
     const testPythonFile = path.join(
         EXTENSION_ROOT_DIR_FOR_TESTS,

--- a/src/test/datascience/variableView/variableView.vscode.test.ts
+++ b/src/test/datascience/variableView/variableView.vscode.test.ts
@@ -274,7 +274,7 @@ mySet = {1, 2, 3}
     });
 
     // Test opening data viewers while another dataviewer is open
-    test('Open dataviewer', async function () {
+    test.skip('Open dataviewer', async function () {
         // Send the command to open the view
         await commands.executeCommand(Commands.OpenVariableView);
 

--- a/src/webviews/extension-side/dataviewer/dataViewerCommandRegistry.ts
+++ b/src/webviews/extension-side/dataviewer/dataViewerCommandRegistry.ts
@@ -77,7 +77,7 @@ export class DataViewerCommandRegistry implements IExtensionSyncActivationServic
             return;
         }
         this.registerCommand(Commands.ShowDataViewer, this.delegateDataViewer);
-        this.registerCommand(Commands.ShowJupyterDataViewer, this.showJupyterVariableView);
+        this.registerCommand(Commands.ShowJupyterDataViewer, this.delegateDataViewer);
     }
     private registerCommand<
         E extends keyof ICommandNameArgumentTypeMapping,
@@ -106,6 +106,7 @@ export class DataViewerCommandRegistry implements IExtensionSyncActivationServic
         }
     }
 
+    // @ts-ignore: temporarily disable the warning and keep the code. Will be removed later.
     private async showJupyterVariableView(requestVariable: IJupyterVariable) {
         sendTelemetryEvent(EventName.OPEN_DATAVIEWER_FROM_VARIABLE_WINDOW_REQUEST);
 

--- a/src/webviews/extension-side/dataviewer/dataViewerDelegator.ts
+++ b/src/webviews/extension-side/dataviewer/dataViewerDelegator.ts
@@ -43,7 +43,7 @@ export class DataViewerDelegator {
                 }
                 // show quick pick
                 const quickPick = window.createQuickPick<QuickPickItem & { command: string }>();
-                quickPick.title = 'Select DataFrame Viewer';
+                quickPick.title = localize.DataScience.selectExternalDataViewer;
                 quickPick.items = variableViewers.map((d) => {
                     return {
                         label: d.jupyterVariableViewers.title,

--- a/src/webviews/extension-side/dataviewer/dataViewerDelegator.ts
+++ b/src/webviews/extension-side/dataviewer/dataViewerDelegator.ts
@@ -2,9 +2,8 @@
 // Licensed under the MIT License.
 
 import { commands, Extension, QuickPickItem, window, extensions } from 'vscode';
-import { Experiments, IExperimentService } from '../../../platform/common/types';
-import { Commands, JVSC_EXTENSION_ID, Telemetry } from '../../../platform/common/constants';
-import { inject, injectable } from 'inversify';
+import { JVSC_EXTENSION_ID, Telemetry } from '../../../platform/common/constants';
+import { injectable } from 'inversify';
 import { IJupyterVariable } from '../../../kernels/variables/types';
 import { IVariableViewer } from '../variablesView/types';
 import { noop } from '../../../platform/common/utils/misc';
@@ -14,46 +13,52 @@ import * as localize from '../../../platform/common/utils/localize';
 
 @injectable()
 export class DataViewerDelegator {
-    constructor(@inject(IExperimentService) private readonly experiments: IExperimentService) {}
-
     public async showContributedDataViewer(variable: IJupyterVariable) {
         try {
-            if (this.experiments.inExperiment(Experiments.DataViewerContribution)) {
-                // jupyterVariableViewers
-                const variableViewers = this.getMatchingVariableViewers(variable);
-                if (variableViewers.length === 0) {
-                    // No data frame viewer extensions, show notifications
-                    return commands.executeCommand('workbench.extensions.search', '@tag:jupyterVariableViewers');
-                } else if (variableViewers.length === 1) {
-                    const command = variableViewers[0].jupyterVariableViewers.command;
-                    return commands.executeCommand(command, variable);
-                } else {
-                    const thirdPartyViewers = variableViewers.filter((d) => d.extension.id !== JVSC_EXTENSION_ID);
-                    if (thirdPartyViewers.length === 1) {
-                        const command = thirdPartyViewers[0].jupyterVariableViewers.command;
-                        return commands.executeCommand(command, variable);
-                    }
-                    // show quick pick
-                    const quickPick = window.createQuickPick<QuickPickItem & { command: string }>();
-                    quickPick.title = 'Select DataFrame Viewer';
-                    quickPick.items = variableViewers.map((d) => {
-                        return {
-                            label: d.jupyterVariableViewers.title,
-                            detail: d.extension.packageJSON?.displayName ?? d.extension.id,
-                            command: d.jupyterVariableViewers.command
-                        };
-                    });
-                    quickPick.onDidAccept(async () => {
-                        const item = quickPick.selectedItems[0];
-                        if (item) {
-                            quickPick.hide();
-                            return commands.executeCommand(item.command, variable);
+            // jupyterVariableViewers
+            const variableViewers = this.getMatchingExternalVariableViewers(variable);
+            if (variableViewers.length === 0) {
+                // No data frame viewer extensions, show notifications
+                return window
+                    .showInformationMessage(
+                        localize.DataScience.dataViewerExtensionRequired,
+                        { modal: true },
+                        localize.Common.bannerLabelYes
+                    )
+                    .then((answer) => {
+                        if (answer === localize.Common.bannerLabelYes) {
+                            commands
+                                .executeCommand('workbench.extensions.search', '@tag:jupyterVariableViewers')
+                                .then(noop, noop);
                         }
                     });
-                    quickPick.show();
-                }
+            } else if (variableViewers.length === 1) {
+                const command = variableViewers[0].jupyterVariableViewers.command;
+                return commands.executeCommand(command, variable);
             } else {
-                return commands.executeCommand(Commands.ShowJupyterDataViewer, variable);
+                const thirdPartyViewers = variableViewers.filter((d) => d.extension.id !== JVSC_EXTENSION_ID);
+                if (thirdPartyViewers.length === 1) {
+                    const command = thirdPartyViewers[0].jupyterVariableViewers.command;
+                    return commands.executeCommand(command, variable);
+                }
+                // show quick pick
+                const quickPick = window.createQuickPick<QuickPickItem & { command: string }>();
+                quickPick.title = 'Select DataFrame Viewer';
+                quickPick.items = variableViewers.map((d) => {
+                    return {
+                        label: d.jupyterVariableViewers.title,
+                        detail: d.extension.packageJSON?.displayName ?? d.extension.id,
+                        command: d.jupyterVariableViewers.command
+                    };
+                });
+                quickPick.onDidAccept(async () => {
+                    const item = quickPick.selectedItems[0];
+                    if (item) {
+                        quickPick.hide();
+                        return commands.executeCommand(item.command, variable);
+                    }
+                });
+                quickPick.show();
             }
         } catch (e) {
             logger.error(e);
@@ -62,11 +67,13 @@ export class DataViewerDelegator {
         }
     }
 
-    private getMatchingVariableViewers(
+    private getMatchingExternalVariableViewers(
         variable: IJupyterVariable
     ): { extension: Extension<unknown>; jupyterVariableViewers: IVariableViewer }[] {
         const variableViewers = this.getVariableViewers();
-        return variableViewers.filter((d) => d.jupyterVariableViewers.dataTypes.includes(variable.type));
+        return variableViewers
+            .filter((d) => d.jupyterVariableViewers.dataTypes.includes(variable.type))
+            .filter((e) => e.extension.id !== JVSC_EXTENSION_ID);
     }
 
     public getVariableViewers(): { extension: Extension<unknown>; jupyterVariableViewers: IVariableViewer }[] {

--- a/src/webviews/extension-side/variablesView/variableView.ts
+++ b/src/webviews/extension-side/variablesView/variableView.ts
@@ -20,9 +20,7 @@ import {
     IConfigurationService,
     IDisposableRegistry,
     IDisposable,
-    IExtensionContext,
-    IExperimentService,
-    Experiments
+    IExtensionContext
 } from '../../../platform/common/types';
 import { WebviewViewHost } from '../../../platform/webviews/webviewViewHost';
 import { swallowExceptions } from '../../../platform/common/utils/decorators';
@@ -43,7 +41,6 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
         private readonly variables: IJupyterVariables,
         private readonly disposables: IDisposableRegistry,
         private readonly notebookWatcher: INotebookWatcher,
-        private readonly experiments: IExperimentService,
         private readonly dataViewerDelegator: DataViewerDelegator
     ) {
         const variableViewDir = joinPath(context.extensionUri, 'dist', 'webviews', 'webview-side', 'viewers');
@@ -142,11 +139,9 @@ export class VariableView extends WebviewViewHost<IVariableViewPanelMapping> imp
     private postProcessSupportsDataExplorer(response: IJupyterVariablesResponse) {
         const variableViewers = this.dataViewerDelegator.getVariableViewers();
         response.pageResponse.forEach((variable) => {
-            if (this.experiments.inExperiment(Experiments.DataViewerContribution)) {
-                variable.supportsDataExplorer = variableViewers.some((d) =>
-                    d.jupyterVariableViewers.dataTypes.includes(variable.type)
-                );
-            }
+            variable.supportsDataExplorer = variableViewers.some((d) =>
+                d.jupyterVariableViewers.dataTypes.includes(variable.type)
+            );
         });
 
         return response;

--- a/src/webviews/extension-side/variablesView/variableViewProvider.ts
+++ b/src/webviews/extension-side/variablesView/variableViewProvider.ts
@@ -6,12 +6,7 @@ import { CancellationToken, WebviewView, WebviewViewResolveContext } from 'vscod
 import { IJupyterVariables } from '../../../kernels/variables/types';
 import { IWebviewViewProvider } from '../../../platform/common/application/types';
 import { Identifiers, isTestExecution } from '../../../platform/common/constants';
-import {
-    IConfigurationService,
-    IDisposableRegistry,
-    IExperimentService,
-    IExtensionContext
-} from '../../../platform/common/types';
+import { IConfigurationService, IDisposableRegistry, IExtensionContext } from '../../../platform/common/types';
 import { createDeferred, Deferred } from '../../../platform/common/utils/async';
 import { INotebookWatcher, IVariableViewProvider } from './types';
 import { VariableView } from './variableView';
@@ -48,7 +43,6 @@ export class VariableViewProvider implements IVariableViewProvider {
         @inject(IJupyterVariables) @named(Identifiers.ALL_VARIABLES) private variables: IJupyterVariables,
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
         @inject(INotebookWatcher) private readonly notebookWatcher: INotebookWatcher,
-        @inject(IExperimentService) private readonly experiments: IExperimentService,
         @inject(DataViewerDelegator) private readonly dataViewerDelegator: DataViewerDelegator
     ) {}
 
@@ -67,7 +61,6 @@ export class VariableViewProvider implements IVariableViewProvider {
             this.variables,
             this.disposables,
             this.notebookWatcher,
-            this.experiments,
             this.dataViewerDelegator
         );
 


### PR DESCRIPTION
Users should now be directed to extension recommendations for data frame viewers instead of using the deprecated builtin one.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" or remove that:
-->

-   [ ] Ignore Proposed API verification.
