### PR TITLE
Log errors from WebSockets

### DIFF
--- a/src/kernels/common/kernelSocketWrapper.ts
+++ b/src/kernels/common/kernelSocketWrapper.ts
@@ -110,6 +110,9 @@ export function KernelSocketWrapper<T extends ClassType<IWebSocketLike>>(SuperCl
         }
 
         public override emit(event: string | symbol, ...args: any[]): boolean {
+            if (event === 'unexpected-response' || event === 'error') {
+                logger.error(`Error in websocket: ${JSON.stringify(args)}`);
+            }
             return this.handleEvent((ev, ...args) => super.emit(ev, ...args), event, ...args);
         }
 


### PR DESCRIPTION
Errors from websockets are swallowed by Jupyter Lab library.
Was difficult to identify root cause of issue in #15852 without the errors
