### PR TITLE
stop uploading test coverage reports

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -40,7 +40,6 @@ env:
   VSC_JUPYTER_CI_RUN_NON_PYTHON_NB_TEST: 'true'
   # Key for the cache created at the end of the the 'Cache ./pythonFiles/lib/python' step.
   CACHE_PYTHONFILES: cache-pvsc-pythonFiles
-  COVERAGE_REPORTS: tests-coverage-reports
   TEST_RESULTS_DIRECTORY: .
   TEST_RESULTS_GLOB: '**/test-results*.xml'
   IPYWIDGET_SCREENSHOT_PATH: '*-screenshot.png'
@@ -252,18 +251,6 @@ jobs:
 
       - name: Verify there are no unhandled errors
         run: npm run verifyUnhandledErrors
-
-      - name: Create coverage folder (if not created)
-        run: npm run createNycFolder
-
-      # Upload unit test coverage reports for later use in the "reports" job.
-      - name: Upload unit test coverage reports
-        uses: actions/upload-artifact@v3
-        if: "(success() || failure()) && !contains(github.ref, 'refs/heads/release') && github.event_name != 'pull_request'"
-        with:
-          name: ${{env.COVERAGE_REPORTS}}-${{runner.os}}
-          path: .nyc_output
-          retention-days: 1
 
   vscodeTests:
     name: Tests # These tests run with Python extension & real Jupyter
@@ -760,18 +747,6 @@ jobs:
         id: test_notebookWithoutPythonExt_vscode
         if: matrix.python == 'noPython' && matrix.os != 'windows-latest'
 
-      - name: Create coverage folder (if not created)
-        run: npm run createNycFolder
-
-      # Upload unit test coverage reports for later use in the "reports" job.
-      - name: Upload unit test coverage reports
-        uses: actions/upload-artifact@v3
-        if: "(success() || failure()) && !contains(github.ref, 'refs/heads/release') && github.event_name != 'pull_request'"
-        with:
-          name: ${{env.COVERAGE_REPORTS}}-${{runner.os}}
-          path: .nyc_output
-          retention-days: 1
-
       - name: Upload VS code logs
         uses: actions/upload-artifact@v3
         if: failure()
@@ -865,70 +840,3 @@ jobs:
         uses: GabrielBB/xvfb-action@v1.4
         with:
           run: npm run testSmokeLogged
-
-  coverage:
-    name: Coverage reports upload
-    runs-on: ubuntu-latest
-    if: "(success() || failure()) && !contains(github.ref, 'refs/heads/release') && github.event_name != 'pull_request'"
-    needs: [ts_tests, vscodeTests]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{env.NODE_VERSION}}
-
-      - name: npm ci
-        uses: ./.github/actions/npm-ci
-
-      - name: Cache compiled TS files
-        id: out-cache
-        uses: actions/cache@v4
-        with:
-          path: ./out
-          key: ${{runner.os}}-${{env.CACHE_OUT_DIRECTORY}}-${{hashFiles('src/**')}}
-
-      - name: Compile if not cached
-        run: npm run prePublishNonBundle
-        if: steps.out-cache.outputs.cache-hit != 'true'
-
-      # It isn't possible to specify a regex for artifact names, so we have to download each artifact manually.
-      # The name pattern is ${{env.COVERAGE_REPORTS}}-${{runner.os}}, and possible values for runner.os are `Linux`, `Windows`, or `macOS`.
-      # See https://help.github.com/en/actions/reference/contexts-and-expression-syntax-for-github-actions#runner-context
-      - name: Download Ubuntu test coverage artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{env.COVERAGE_REPORTS}}-${{runner.os}}
-          path: ${{env.COVERAGE_REPORTS}}-${{runner.os}}
-
-      - name: Extract Ubuntu coverage artifacts to ./nyc_output
-        run: |
-          pwd
-          mkdir .nyc_output
-          mv ${{env.COVERAGE_REPORTS}}-${{runner.os}}/* .nyc_output
-          rm -r ${{env.COVERAGE_REPORTS}}-${{runner.os}}
-
-      - name: Merge coverage reports
-        run: |
-          pwd
-          npx nyc merge ./.nyc_output
-          rm -r .nyc_output
-          mkdir .nyc_output
-          mv coverage.json ./.nyc_output
-        continue-on-error: true
-
-      - name: Generate coverage reports
-        run: npm run test:cover:report
-        continue-on-error: true
-
-      - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage/cobertura-coverage.xml
-          path_to_write_report: ./coverage/codecov_report.txt
-      # Alternative method for uploading
-      # - name: Upload coverage to codecov
-      #  run: bash <(curl -s https://codecov.io/bash) -f ./coverage/cobertura-coverage.xml -v


### PR DESCRIPTION
The job has been failing, but we haven't been using these reports so we can just remove it.
