### PR TITLE
Make `jupyter.runStartupCommands` show in the workspace settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1740,7 +1740,7 @@
                     "type": "array",
                     "default": "",
                     "description": "%jupyter.configuration.jupyter.runStartupCommands.description%",
-                    "scope": "application"
+                    "scope": "machine-overridable"
                 },
                 "jupyter.debugJustMyCode": {
                     "type": "boolean",


### PR DESCRIPTION
Fixes #15626 

Just a small change to make `jupyter.runStartupCommands` not only show in the User settings.

Built the extension and confirmed that it now auto-completes in a `.vscode/settings.json` file (which it wasn't doing before):

![image](https://github.com/user-attachments/assets/0f1bfdf8-50de-4309-a54e-18a77b695624)

And that it shows in the Workspace tab in the Settings:

![image](https://github.com/user-attachments/assets/31c024f8-52b1-4ad5-b8bb-edd6f0fd460d)

Thanks for all the effort in maintaining this!