### PR TITLE
try delegating even if we cannot get the full info

### DIFF
--- a/src/kernels/variables/helpers.ts
+++ b/src/kernels/variables/helpers.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { DebugProtocol } from 'vscode-debugprotocol';
+import { IJupyterVariable } from './types';
 
 export const DataViewableTypes: Set<string> = new Set<string>([
     'DataFrame',
@@ -14,7 +15,7 @@ export const DataViewableTypes: Set<string> = new Set<string>([
     'DataArray'
 ]);
 
-export function convertDebugProtocolVariableToIJupyterVariable(variable: DebugProtocol.Variable) {
+export function convertDebugProtocolVariableToIJupyterVariable(variable: DebugProtocol.Variable): IJupyterVariable {
     return {
         // If `evaluateName` is available use that. That is the name that we can eval in the debugger
         // but it's an optional property so fallback to `variable.name`

--- a/src/kernels/variables/types.ts
+++ b/src/kernels/variables/types.ts
@@ -25,6 +25,7 @@ export interface IJupyterVariable {
     indexColumn?: string;
     maximumRowChunkSize?: number;
     fileName?: Uri;
+    frameId?: number;
 }
 
 export const IJupyterVariables = Symbol('IJupyterVariables');

--- a/src/webviews/extension-side/dataviewer/dataViewerCommandRegistry.ts
+++ b/src/webviews/extension-side/dataviewer/dataViewerCommandRegistry.ts
@@ -90,7 +90,7 @@ export class DataViewerCommandRegistry implements IExtensionSyncActivationServic
     private async delegateDataViewer(request: IJupyterVariable | IShowDataViewerFromVariablePanel) {
         const variable = 'variable' in request ? await this.getVariableFromRequest(request) : request;
         if (!variable) {
-            logger.error('Full variable info could not be retreived');
+            logger.error('Variable info could not be retreived');
             sendTelemetryEvent(Telemetry.FailedShowDataViewer, undefined, {
                 reason: 'no variable info',
                 fromVariableView: false
@@ -106,7 +106,13 @@ export class DataViewerCommandRegistry implements IExtensionSyncActivationServic
             const variable = convertDebugProtocolVariableToIJupyterVariable(
                 request.variable as unknown as DebugProtocol.Variable
             );
-            return this.variableProvider.getFullVariable(variable);
+            try {
+                const result = await this.variableProvider.getFullVariable(variable);
+                return result;
+            } catch (e) {
+                logger.error('Full variable info could not be retreived, will attempt with partial info.', e);
+                return variable;
+            }
         }
     }
 

--- a/src/webviews/extension-side/dataviewer/dataViewerCommandRegistry.ts
+++ b/src/webviews/extension-side/dataviewer/dataViewerCommandRegistry.ts
@@ -110,7 +110,7 @@ export class DataViewerCommandRegistry implements IExtensionSyncActivationServic
                 const result = await this.variableProvider.getFullVariable(variable);
                 return result;
             } catch (e) {
-                logger.error('Full variable info could not be retreived, will attempt with partial info.', e);
+                logger.warn('Full variable info could not be retreived, will attempt with partial info.', e);
                 return variable;
             }
         }

--- a/src/webviews/extension-side/dataviewer/dataViewerDelegator.ts
+++ b/src/webviews/extension-side/dataviewer/dataViewerDelegator.ts
@@ -90,7 +90,7 @@ export class DataViewerDelegator {
     ): { extension: Extension<unknown>; jupyterVariableViewers: IVariableViewer }[] {
         const variableViewers = this.getVariableViewers();
         return variableViewers
-            .filter((d) => d.jupyterVariableViewers.dataTypes.includes(variable.type))
+            .filter((d) => !variable.type || d.jupyterVariableViewers.dataTypes.includes(variable.type))
             .filter((e) => e.extension.id !== JVSC_EXTENSION_ID);
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-jupyter/issues/16026

We add the context menu command only if we decide that the variable can support a Data viewer, so it seems pretty safe to try and delegate the Data viewer command out even if we can't get the type info at that moment.
