### PR TITLE
do not support variable view if were unsure how to retrieve the variable

### DIFF
--- a/src/notebooks/debugger/debuggerVariables.ts
+++ b/src/notebooks/debugger/debuggerVariables.ts
@@ -396,7 +396,7 @@ export class DebuggerVariables
 
     private monkeyPatchDataViewableVariables(variablesResponse: DebugProtocol.VariablesResponse) {
         variablesResponse.body.variables.forEach((v) => {
-            if (v.type && DataViewableTypes.has(v.type)) {
+            if (v.type && DataViewableTypes.has(v.type) && v.evaluateName) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 (v as any).__vscodeVariableMenuContext = 'viewableInDataViewer';
             }


### PR DESCRIPTION
If the debugger doesn't tell us how to get the variable (evaluateName), then DW won't know how to actually get that variable to open the Data viewer for it.

https://github.com/microsoft/vscode-data-wrangler/issues/285
