### PR TITLE
bump release version to avoid conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "jupyter",
-    "version": "2024.9.0",
+    "version": "2024.9.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "jupyter",
-            "version": "2024.9.0",
+            "version": "2024.9.1",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "jupyter",
     "displayName": "Jupyter",
-    "version": "2024.9.0",
+    "version": "2024.9.1",
     "description": "Jupyter notebook support, interactive programming and computing that supports Intellisense, debugging and more.",
     "publisher": "ms-toolsai",
     "author": {


### PR DESCRIPTION
a version was pushed out early, so we need to bump