### PR TITLE
fix: tag experimental settings with new system

### DIFF
--- a/package.json
+++ b/package.json
@@ -1708,7 +1708,7 @@
                     "default": false,
                     "description": "%jupyter.configuration.jupyter.interactiveWindowNotebookRepl.description%",
                     "tags": [
-                        "experimental"
+                        "experimental", "onExP"
                     ]
                 },
                 "jupyter.interactiveWindow.textEditor.cellFolding": {
@@ -1802,7 +1802,10 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Experimental feature to enable execution analysis in notebooks",
-                    "scope": "application"
+                    "scope": "application",
+                    "tags": [
+                        "experimental"
+                    ]
                 },
                 "jupyter.enableKernelCompletions": {
                     "type": "boolean",
@@ -1810,7 +1813,7 @@
                     "markdownDescription": "%jupyter.configuration.jupyter.enableKernelCompletions.markdownDescription%",
                     "scope": "application",
                     "tags": [
-                        "experimental"
+                        "onExP"
                     ]
                 },
                 "jupyter.formatStackTraces": {

--- a/package.json
+++ b/package.json
@@ -1708,7 +1708,8 @@
                     "default": false,
                     "description": "%jupyter.configuration.jupyter.interactiveWindowNotebookRepl.description%",
                     "tags": [
-                        "experimental", "onExP"
+                        "experimental",
+                        "onExP"
                     ]
                 },
                 "jupyter.interactiveWindow.textEditor.cellFolding": {
@@ -1811,10 +1812,7 @@
                     "type": "boolean",
                     "default": true,
                     "markdownDescription": "%jupyter.configuration.jupyter.enableKernelCompletions.markdownDescription%",
-                    "scope": "application",
-                    "tags": [
-                        "onExP"
-                    ]
+                    "scope": "application"
                 },
                 "jupyter.formatStackTraces": {
                     "type": "boolean",


### PR DESCRIPTION
I'm retagging some Jupyter extension settings as part of the experimental -> onExP rename where:
- experimental refers to a setting not being stable yet
- onExP refers to a setting that can be part of ExP A/B experiments