### PR TITLE
Scan first-party prebuilt binary again

### DIFF
--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -89,9 +89,6 @@ extends:
 
     apiScanSoftwareVersion: '2024'
 
-    # Exclude win32-x64/node.napi.glibc.node, which is already scanned
-    # by the zeromq-prebuilt pipeline, until we have symbol publishing.
     # Exclude win32-arm64/*.* because APIScan cannot process them.
     apiScanExcludes: |
-      extension/dist/node_modules/zeromq/prebuilds/win32-x64/node.napi.glibc.node
       extension/dist/node_modules/zeromq/prebuilds/win32-arm64/*.*


### PR DESCRIPTION
Enables scanning the first-party zeromq-prebuilt binary now that we have SymWeb publishing set up for the zeromq-prebuilt pipeline.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=303258&view=results