### PR TITLE
chore: bump vscode/zeromq to 0.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -140,7 +140,7 @@
                 "@vscode/test-cli": "^0.0.8",
                 "@vscode/test-electron": "^2.3.9",
                 "@vscode/test-web": "^0.0.61",
-                "@vscode/zeromq": "^0.2.3",
+                "@vscode/zeromq": "^0.2.4",
                 "acorn": "^8.9.0",
                 "babel-polyfill": "^6.26.0",
                 "buffer": "^6.0.3",
@@ -4599,10 +4599,11 @@
             }
         },
         "node_modules/@vscode/zeromq": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/@vscode/zeromq/-/zeromq-0.2.3.tgz",
-            "integrity": "sha512-2GXVM7PUJNVYE5f9+HfSuWez6rjt/GJdCP6WQy7qQDEqbGIW+g5sDzfEn7oqLGcIqCmvJLyqNssAzImBITQP5g==",
-            "dev": true
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@vscode/zeromq/-/zeromq-0.2.4.tgz",
+            "integrity": "sha512-uPSjhcB935sw85Pj9mW78YTNWF1BXYH8sWHkAqDlOM3nvUYaG3uLLBdxca9yilfEyyArKu4oL57VJ76xeGkFNA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.12.1",
@@ -23264,9 +23265,9 @@
             }
         },
         "@vscode/zeromq": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/@vscode/zeromq/-/zeromq-0.2.3.tgz",
-            "integrity": "sha512-2GXVM7PUJNVYE5f9+HfSuWez6rjt/GJdCP6WQy7qQDEqbGIW+g5sDzfEn7oqLGcIqCmvJLyqNssAzImBITQP5g==",
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@vscode/zeromq/-/zeromq-0.2.4.tgz",
+            "integrity": "sha512-uPSjhcB935sw85Pj9mW78YTNWF1BXYH8sWHkAqDlOM3nvUYaG3uLLBdxca9yilfEyyArKu4oL57VJ76xeGkFNA==",
             "dev": true
         },
         "@webassemblyjs/ast": {

--- a/package.json
+++ b/package.json
@@ -2257,7 +2257,7 @@
         "@vscode/test-cli": "^0.0.8",
         "@vscode/test-electron": "^2.3.9",
         "@vscode/test-web": "^0.0.61",
-        "@vscode/zeromq": "^0.2.3",
+        "@vscode/zeromq": "^0.2.4",
         "acorn": "^8.9.0",
         "babel-polyfill": "^6.26.0",
         "buffer": "^6.0.3",


### PR DESCRIPTION
Brings in the latest first-party prebuilt zeromq binaries, which are built on a newer environment and node version.