### PR TITLE
chore: bump vscode/zeromq

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -140,7 +140,7 @@
                 "@vscode/test-cli": "^0.0.8",
                 "@vscode/test-electron": "^2.3.9",
                 "@vscode/test-web": "^0.0.61",
-                "@vscode/zeromq": "^0.2.4",
+                "@vscode/zeromq": "^0.2.5",
                 "acorn": "^8.9.0",
                 "babel-polyfill": "^6.26.0",
                 "buffer": "^6.0.3",
@@ -4598,9 +4598,9 @@
             }
         },
         "node_modules/@vscode/zeromq": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/@vscode/zeromq/-/zeromq-0.2.4.tgz",
-            "integrity": "sha512-uPSjhcB935sw85Pj9mW78YTNWF1BXYH8sWHkAqDlOM3nvUYaG3uLLBdxca9yilfEyyArKu4oL57VJ76xeGkFNA==",
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/@vscode/zeromq/-/zeromq-0.2.5.tgz",
+            "integrity": "sha512-JG/ExFIW7Beko5lhv+TDTM14zxFiXn7bgoYo3BLAA2KndRNZc8QKfRzIN3uq9YQUMMosKUYwXjsrVy15sQEJog==",
             "dev": true,
             "license": "MIT"
         },
@@ -23267,9 +23267,9 @@
             }
         },
         "@vscode/zeromq": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/@vscode/zeromq/-/zeromq-0.2.4.tgz",
-            "integrity": "sha512-uPSjhcB935sw85Pj9mW78YTNWF1BXYH8sWHkAqDlOM3nvUYaG3uLLBdxca9yilfEyyArKu4oL57VJ76xeGkFNA==",
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/@vscode/zeromq/-/zeromq-0.2.5.tgz",
+            "integrity": "sha512-JG/ExFIW7Beko5lhv+TDTM14zxFiXn7bgoYo3BLAA2KndRNZc8QKfRzIN3uq9YQUMMosKUYwXjsrVy15sQEJog==",
             "dev": true
         },
         "@webassemblyjs/ast": {

--- a/package.json
+++ b/package.json
@@ -2257,7 +2257,7 @@
         "@vscode/test-cli": "^0.0.8",
         "@vscode/test-electron": "^2.3.9",
         "@vscode/test-web": "^0.0.61",
-        "@vscode/zeromq": "^0.2.4",
+        "@vscode/zeromq": "^0.2.5",
         "acorn": "^8.9.0",
         "babel-polyfill": "^6.26.0",
         "buffer": "^6.0.3",


### PR DESCRIPTION
This PR bumps vscode/zeromq to allow the pipeline to fetch the proper symbols for APIScan. The previous version of vscode/zeromq did not have that associated pipeline infrastructure in place.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=307228&view=results