### PR TITLE
Fix reading `JUPYTER_RUNTIME_DIR` and `XDG_RUNTIME_DIR`

### DIFF
--- a/src/kernels/raw/finder/jupyterPaths.node.ts
+++ b/src/kernels/raw/finder/jupyterPaths.node.ts
@@ -133,7 +133,9 @@ export class JupyterPaths {
     private async getRuntimeDirImpl(): Promise<Uri | undefined> {
         let runtimeDir: Uri | undefined;
         const userHomeDir = this.platformService.homeDir;
-        if (userHomeDir) {
+        if (process.env['JUPYTER_RUNTIME_DIR']) {
+            runtimeDir = Uri.file(path.normalize(process.env['JUPYTER_RUNTIME_DIR']));
+        } else if (userHomeDir) {
             if (this.platformService.isWindows) {
                 // On windows the path is not correct if we combine those variables.
                 // It won't point to a path that you can actually read from.
@@ -141,8 +143,8 @@ export class JupyterPaths {
             } else if (this.platformService.isMac) {
                 runtimeDir = uriPath.joinPath(userHomeDir, macJupyterRuntimePath);
             } else {
-                runtimeDir = process.env['$XDG_RUNTIME_DIR']
-                    ? Uri.file(path.join(process.env['$XDG_RUNTIME_DIR'], 'jupyter', 'runtime'))
+                runtimeDir = process.env['XDG_RUNTIME_DIR']
+                    ? Uri.file(path.join(process.env['XDG_RUNTIME_DIR'], 'jupyter', 'runtime'))
                     : uriPath.joinPath(userHomeDir, '.local', 'share', 'jupyter', 'runtime');
             }
         }


### PR DESCRIPTION
Fixes #16450

Currently, we don't respect either `JUPYTER_RUNTIME_DIR` or `XDG_RUNTIME_DIR` when determining where to store our runtime files.

This PR simply fixes a typo that was preventing us from reading `XDG_RUNTIME_DIR` and also makes it so that we read `JUPYTER_RUNTIME_DIR` ([the official config for this in Jupyter itself](https://docs.jupyter.org/en/stable/use/jupyter-directories.html#runtime-files)) before falling back to `XDG_RUNTIME_DIR`.