### PR TITLE
Temporarily disable APIScan

### DIFF
--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -87,7 +87,11 @@ extends:
         serviceTreeID: '14f24efd-b502-422a-9f40-09ea7ce9cf14'
       enabled: true
 
-    apiScanDependentPipelineId: '466' # zeromq-prebuilt
+    # Temporarily disable APIScan until we have new zeromq-prebuilt symbols
+    skipAPIScan: true
+
+    # Add a dependency on zeromq-prebuilt
+    apiScanDependentPipelineId: '466'
     apiScanSoftwareVersion: '2024'
 
     # Exclude win32-arm64/*.* because APIScan cannot process them.


### PR DESCRIPTION
This PR temporarily disables APIScan until we have new zeromq-prebuilt symbols.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=323512&view=results
The verification build is already good to go because it does not contain the APIScan stage.

CC @DonJayamanne 