### PR TITLE
just strip out the ascii formatting first

### DIFF
--- a/src/kernels/execution/helpers.ts
+++ b/src/kernels/execution/helpers.ts
@@ -779,13 +779,13 @@ export async function endCellAndDisplayErrorsInCell(
 }
 
 export function findErrorLocation(traceback: string[], cell: NotebookCell) {
-    const cellRegex = /Cell\s+(?:\u001b\[.+?m)?In\s*\[(?<executionCount>\d+)\],\s*line (?<lineNumber>\d+).*/;
+    const cellRegex = /Cell\s+In\s*\[(?<executionCount>\d+)\],\s*line (?<lineNumber>\d+).*/;
     // older versions of IPython ~8.3.0
-    const inputRegex =
-        /Input\s+?(?:\u001b\[.+?m)?In\s*\[(?<executionCount>\d+)\][^<]*<cell line:\s?(?<lineNumber>\d+)>.*/;
+    const inputRegex = /Input\s+?In\s*\[(?<executionCount>\d+)\][^<]*<cell line:\s?(?<lineNumber>\d+)>.*/;
     let lineNumber: number | undefined = undefined;
     for (const line of traceback) {
-        const lineMatch = cellRegex.exec(line) ?? inputRegex.exec(line);
+        const cleanLine = line.replace(/(?:\u001b\[.+?m)/g, '');
+        const lineMatch = cellRegex.exec(cleanLine) ?? inputRegex.exec(cleanLine);
         if (lineMatch && lineMatch.groups) {
             lineNumber = parseInt(lineMatch.groups['lineNumber']);
             break;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-jupyter/issues/16493

IPython 9 added a lot more formatting characters (`\u001b[39m`) into the stack traces, so just strip them all out first and then test the regex against it to protect against this kind of change.