### PR TITLE
Bump vscode/zeromq from 0.2.3 to 0.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4838,9 +4838,9 @@
             }
         },
         "node_modules/@vscode/zeromq": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/@vscode/zeromq/-/zeromq-0.2.3.tgz",
-            "integrity": "sha512-2GXVM7PUJNVYE5f9+HfSuWez6rjt/GJdCP6WQy7qQDEqbGIW+g5sDzfEn7oqLGcIqCmvJLyqNssAzImBITQP5g==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/@vscode/zeromq/-/zeromq-0.2.7.tgz",
+            "integrity": "sha512-lbnfCMoVe6O7aHL0TkQJSU+yd5Hs1A6mpr/zG/C+ibFXlhGq7rUEIHt4krf6P9gn0rgoAYJceJkvLHnvDWk5/A==",
             "dev": true,
             "license": "MIT"
         },
@@ -23740,9 +23740,9 @@
             }
         },
         "@vscode/zeromq": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/@vscode/zeromq/-/zeromq-0.2.3.tgz",
-            "integrity": "sha512-2GXVM7PUJNVYE5f9+HfSuWez6rjt/GJdCP6WQy7qQDEqbGIW+g5sDzfEn7oqLGcIqCmvJLyqNssAzImBITQP5g==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/@vscode/zeromq/-/zeromq-0.2.7.tgz",
+            "integrity": "sha512-lbnfCMoVe6O7aHL0TkQJSU+yd5Hs1A6mpr/zG/C+ibFXlhGq7rUEIHt4krf6P9gn0rgoAYJceJkvLHnvDWk5/A==",
             "dev": true
         },
         "@webassemblyjs/ast": {


### PR DESCRIPTION
The newer vscode/zeromq includes compliance fixes and zeromq prebuilds that were built on newer build agents. The prebuilds also use static linking on Windows to avoid https://github.com/microsoft/vscode-jupyter/issues/16378.