### PR TITLE
Account for global window object in desktop extensions

### DIFF
--- a/build/esbuild/build.ts
+++ b/build/esbuild/build.ts
@@ -151,6 +151,7 @@ const jupyterLabServerConnectionPlugin: Plugin = {
         build.onResolve({ filter: /serverconnection$/ }, async (args) => {
             const absPath = `${path.join(args.resolveDir, args.path)}.js`;
             if (await fs.pathExists(absPath)) {
+                // For https://github.com/microsoft/vscode-jupyter/issues/16558
                 const contents = await fs
                     .readFile(absPath, 'utf8')
                     .then((data) =>


### PR DESCRIPTION
Implement a plugin to handle the `serverconnection` for desktop environments, ensuring compatibility with extensions that create a global `window` object. This change enhances the handling of WebSocket checks in the JupyterLab server connection.

For https://github.com/microsoft/vscode-jupyter/issues/16558