### PR TITLE
Fix PDF export file path handling

### DIFF
--- a/src/notebooks/export/exportBase.node.ts
+++ b/src/notebooks/export/exportBase.node.ts
@@ -108,8 +108,12 @@ export class ExportBase implements IExportBase {
             return;
         }
         try {
-            if ((await this.fs.stat(Uri.file(tempTarget.filePath))).size > 1) {
-                await this.fs.copy(Uri.file(tempTarget.filePath), target);
+            let pdfFilePath = tempTarget.filePath;
+            if (!pdfFilePath.endsWith('.pdf') && (await this.fs.exists(Uri.file(pdfFilePath + '.pdf')))) {
+                pdfFilePath = pdfFilePath + '.pdf';
+            }
+            if ((await this.fs.stat(Uri.file(pdfFilePath))).size > 1) {
+                await this.fs.copy(Uri.file(pdfFilePath), target);
             } else {
                 throw new Error('File size is zero during conversion. Outputting error.');
             }


### PR DESCRIPTION
Fixes #16590

Fixes the long-standing bug where exporting a Jupyter notebook to PDF via the VS Code Jupyter extension fails, even though the PDF is correctly generated in the temp directory. The extension was looking for the wrong filename (missing or duplicating the `.pdf` extension), resulting in a file-not-found error and failed export.

## Background and Motivation

- As detailed in [issue #16590](https://github.com/microsoft/vscode-jupyter/issues/16590), exporting to PDF from the VS Code extension has been broken for years (at least since 2020).
- The bug is not present in the web interface or command-line tools (`nbconvert`), only in the VS Code extension.
- Many users believe Jupyter's export is convenient, but in practice, exporting to PDF from VS Code is unreliable and cumbersome. But if this commit is merged,  exporting to PDF from VS Code would be much easier, especially for begginners.

## Root Cause

- The extension generates a PDF file in the temp directory (e.g., `tmp-xxxx.pdf`), but then tries to access or copy a file with an incorrect name (e.g., `tmp-xxxx.pdf.pdf` or missing `.pdf`).
- This is due to incorrect filename/path handling in the export logic, specifically in `src/notebooks/export/exportBase.node.ts`:
    ```js
    if ((await this.fs.stat(Uri.file(tempTarget.filePath))).size > 1) {
        await this.fs.copy(Uri.file(tempTarget.filePath), target);
    }
    ```

## What has been changed
- The filename and path handling logic is corrected to ensure the extension always looks for the actual generated PDF file.

## Additional context
- Thanks to the community for detailed analysis and temporary workarounds.
- My implementation might not be robust for non-Windows environment. Please follow the post if there is any problem. 👍 

---

Closes #16590
