### PR TITLE
Revert "Temporarily disable APIScan"

### DIFF
--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -87,11 +87,7 @@ extends:
         serviceTreeID: '14f24efd-b502-422a-9f40-09ea7ce9cf14'
       enabled: true
 
-    # Temporarily disable APIScan until we have new zeromq-prebuilt symbols
-    skipAPIScan: true
-
-    # Add a dependency on zeromq-prebuilt
-    apiScanDependentPipelineId: '466'
+    apiScanDependentPipelineId: '466' # zeromq-prebuilt
     apiScanSoftwareVersion: '2024'
 
     # Exclude win32-arm64/*.* because APIScan cannot process them.


### PR DESCRIPTION
Reverts microsoft/vscode-jupyter#16479

We have new zeromq-prebuilt symbols now.
Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=336920&view=results