### PR TITLE
Re #16648. Ensure nb editor is open before kernel activation.

### DIFF
--- a/src/standalone/chat/installPackageTool.ts
+++ b/src/standalone/chat/installPackageTool.ts
@@ -43,6 +43,10 @@ export class InstallPackagesTool implements vscode.LanguageModelTool<IInstallPac
             }
         }
 
+        if (!vscode.window.visibleNotebookEditors.some((e) => e.notebook.uri.toString() === notebook.uri.toString())) {
+            await vscode.window.showNotebookDocument(notebook);
+        }
+
         const kernel = await ensureKernelSelectedAndStarted(
             notebook,
             this.controllerRegistration,


### PR DESCRIPTION
The editor should be open before we start kernels. Opening notebook document itself is not sufficient.