### PR TITLE
Call restart kernel tool from install package tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -2205,13 +2205,17 @@
                         "filePath": {
                             "description": "The absolute path of the notebook with the active kernel.",
                             "type": "string"
+                        },
+                        "reason": {
+                            "description": "The reason for restarting the kernel.",
+                            "type": "string"
                         }
                     },
                     "required": [
                         "filePath"
                     ]
                 },
-                "when": "workspacePlatform != webworker"
+                "when": "false"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -2188,9 +2188,8 @@
             },
             {
                 "name": "restart_notebook_kernel",
-                "displayName": "%jupyter.languageModelTools.restart_notebook_kernel.displayName%",
+                "displayName": "Restart Notebook",
                 "modelDescription": "Tool used to restart a Notebook kernel. Some packages require a restart of the kernel after being installed. Use this if after installing a package if you know the package requires a restart, or if still getting an error about a missing package after installing.",
-                "userDescription": "%jupyter.languageModelTools.restart_notebook_kernel.userDescription%",
                 "toolReferenceName": "restartNotebookKernel",
                 "tags": [
                     "extension_installed_by_tool",

--- a/package.json
+++ b/package.json
@@ -2197,7 +2197,6 @@
                     "notebooks"
                 ],
                 "icon": "$(notebook)",
-                "canBeReferencedInPrompt": true,
                 "inputSchema": {
                     "type": "object",
                     "properties": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -246,7 +246,5 @@
     "DataScience.installPythonExtensionViaKernelPickerTitle": "Install Python Extension",
     "DataScience.switchToRemoteKernelsTitle": "Connect to a Jupyter Server",
     "jupyter.languageModelTools.configure_notebook.displayName": "Configure Jupyter Notebook",
-    "jupyter.languageModelTools.configure_notebook.userDescription": "Configures notebooks by selecting a relevant Kernel.",
-    "jupyter.languageModelTools.restart_notebook_kernel.displayName": "Restart Notebook Kernel",
-    "jupyter.languageModelTools.restart_notebook_kernel.userDescription": "Restarts the kernel for the Jupyter Notebook."
+    "jupyter.languageModelTools.configure_notebook.userDescription": "Configures notebooks by selecting a relevant Kernel."
 }

--- a/src/standalone/chat/installPackageTool.node.ts
+++ b/src/standalone/chat/installPackageTool.node.ts
@@ -89,7 +89,11 @@ export class InstallPackagesTool implements vscode.LanguageModelTool<IInstallPac
             await vscode.lm.invokeTool(RestartKernelTool.toolName, restartOptions);
         } catch (ex) {
             return new vscode.LanguageModelToolResult([
-                new vscode.LanguageModelTextPart(`Installation finished, but the kernel was not restarted because ${ex.name === 'Canceled' ? 'the user chose not to' : `an error occurred: ${ex.message}`}.`)
+                new vscode.LanguageModelTextPart(
+                    `Installation finished, but the kernel was not restarted because ${
+                        ex.name === 'Canceled' ? 'the user chose not to' : `an error occurred: ${ex.message}`
+                    }.`
+                )
             ]);
         }
 

--- a/src/standalone/chat/installPackageTool.node.ts
+++ b/src/standalone/chat/installPackageTool.node.ts
@@ -13,7 +13,6 @@ import { IControllerRegistration } from '../../notebooks/controllers/types';
 import { IInstallationChannelManager } from '../../platform/interpreter/installer/types';
 import { isPythonKernelConnection } from '../../kernels/helpers';
 import { RestartKernelTool } from './restartKernelTool.node';
-import { logger } from '../../platform/logging';
 
 export class InstallPackagesTool implements vscode.LanguageModelTool<IInstallPackageParams> {
     public static toolName = 'notebook_install_packages';

--- a/src/standalone/chat/installPackageTool.node.ts
+++ b/src/standalone/chat/installPackageTool.node.ts
@@ -12,6 +12,8 @@ import {
 import { IControllerRegistration } from '../../notebooks/controllers/types';
 import { IInstallationChannelManager } from '../../platform/interpreter/installer/types';
 import { isPythonKernelConnection } from '../../kernels/helpers';
+import { RestartKernelTool } from './restartKernelTool.node';
+import { logger } from '../../platform/logging';
 
 export class InstallPackagesTool implements vscode.LanguageModelTool<IInstallPackageParams> {
     public static toolName = 'notebook_install_packages';
@@ -78,6 +80,17 @@ export class InstallPackagesTool implements vscode.LanguageModelTool<IInstallPac
         if (!success) {
             const message = `Failed to install one or more packages: ${packageList.join(', ')}.`;
             return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(message)]);
+        }
+
+        const restartOptionsInput = { ...options.input, reason: 'Packages installed' };
+        const restartOptions = { ...options, input: restartOptionsInput };
+
+        try {
+            await vscode.lm.invokeTool(RestartKernelTool.toolName, restartOptions);
+        } catch (ex) {
+            return new vscode.LanguageModelToolResult([
+                new vscode.LanguageModelTextPart(`Installation finished, but the kernel was not restarted because ${ex.name === 'Canceled' ? 'the user chose not to' : `an error occurred: ${ex.message}`}.`)
+            ]);
         }
 
         return new vscode.LanguageModelToolResult([

--- a/src/standalone/chat/restartKernelTool.node.ts
+++ b/src/standalone/chat/restartKernelTool.node.ts
@@ -6,7 +6,11 @@ import { IKernelProvider } from '../../kernels/types';
 import { IBaseToolParams, resolveNotebookFromFilePath } from './helper.node';
 import { IControllerRegistration } from '../../notebooks/controllers/types';
 
-export class RestartKernelTool implements vscode.LanguageModelTool<IBaseToolParams> {
+interface RestartKernelToolParams extends IBaseToolParams {
+    reason?: string;
+}
+
+export class RestartKernelTool implements vscode.LanguageModelTool<RestartKernelToolParams> {
     public static toolName = 'restart_notebook_kernel';
 
     public get name() {
@@ -22,7 +26,7 @@ export class RestartKernelTool implements vscode.LanguageModelTool<IBaseToolPara
     ) {}
 
     async invoke(
-        options: vscode.LanguageModelToolInvocationOptions<IBaseToolParams>,
+        options: vscode.LanguageModelToolInvocationOptions<RestartKernelToolParams>,
         _token: vscode.CancellationToken
     ) {
         await vscode.commands.executeCommand('jupyter.restartkernel', vscode.Uri.file(options.input.filePath));
@@ -31,7 +35,7 @@ export class RestartKernelTool implements vscode.LanguageModelTool<IBaseToolPara
     }
 
     async prepareInvocation(
-        options: vscode.LanguageModelToolInvocationPrepareOptions<IBaseToolParams>,
+        options: vscode.LanguageModelToolInvocationPrepareOptions<RestartKernelToolParams>,
         _token: vscode.CancellationToken
     ): Promise<vscode.PreparedToolInvocation> {
         const notebook = await resolveNotebookFromFilePath(options.input.filePath);
@@ -47,7 +51,7 @@ export class RestartKernelTool implements vscode.LanguageModelTool<IBaseToolPara
         return {
             confirmationMessages: {
                 title: vscode.l10n.t(`Restart Kernel`),
-                message: vscode.l10n.t('Restart the notebook kernel?')
+                message: options.input.reason ?? vscode.l10n.t('Restart the notebook kernel?')
             },
             invocationMessage: vscode.l10n.t('Restarting kernel')
         };


### PR DESCRIPTION
This is the only place we see the tool being useful, so no need to take up space in the prompt.
