### PR TITLE
make note that kernel state is empty after restart

### DIFF
--- a/src/standalone/chat/restartKernelTool.node.ts
+++ b/src/standalone/chat/restartKernelTool.node.ts
@@ -33,7 +33,7 @@ export class RestartKernelTool implements vscode.LanguageModelTool<RestartKernel
         const uri = vscode.Uri.file(options.input.filePath);
         sendLMToolCallTelemetry(RestartKernelTool.toolName, uri);
         await vscode.commands.executeCommand('jupyter.restartkernel', uri);
-        const finalMessageString = `The kernel for the notebook at ${options.input.filePath} has been restarted.`;
+        const finalMessageString = `The kernel for the notebook at ${options.input.filePath} has been restarted and any state from previous cell executions has been cleared.`;
         return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(finalMessageString)]);
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-copilot/issues/18003

Another option is to push it to use the summary tool, but hopefully this can take care of it without needing that extra tool call.
