### PR TITLE
Downgrade VS Code engine version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "theme": "light"
     },
     "engines": {
-        "vscode": "^1.105.0"
+        "vscode": "^1.104.0"
     },
     "l10n": "./l10n",
     "extensionKind": [


### PR DESCRIPTION
Since there's a bug that VSCode install a very old Jupyter version, and the fix is on VSCode 1.105 that is not yet fully released, we need to have the latest version to support the katest released of VSCode

related bugs:
https://github.com/microsoft/vscode-jupyter/issues/16977 https://github.com/microsoft/vscode-jupyter/issues/16973 https://github.com/microsoft/vscode/issues/270285

Fixes #
