### PR TITLE
Revert "Fix spawn calls to use Windows path quoting (#17020)"

### DIFF
--- a/src/platform/common/process/proc.node.ts
+++ b/src/platform/common/process/proc.node.ts
@@ -22,7 +22,6 @@ import {
 import { logProcess } from './logger.node';
 import { noop } from '../utils/misc';
 import { dispose } from '../utils/lifecycle';
-import { fileToCommandArgument } from '../helpers';
 
 export class BufferDecoder implements IBufferDecoder {
     public decode(buffers: Buffer[]): string {
@@ -81,7 +80,7 @@ export class ProcessService implements IProcessService {
 
     public execObservable(file: string, args: string[], options: SpawnOptions = {}): ObservableExecutionResult<string> {
         const spawnOptions = this.getDefaultOptions(options);
-        const proc = spawn(fileToCommandArgument(file), args, spawnOptions);
+        const proc = spawn(file, args, spawnOptions);
         let procExited = false;
         logger.ci(`Exec observable ${file}, ${args.join(' ')}`);
         const disposables: IDisposable[] = [];
@@ -156,7 +155,7 @@ export class ProcessService implements IProcessService {
     }
     public exec(file: string, args: string[], options: SpawnOptions = {}): Promise<ExecutionResult<string>> {
         const spawnOptions = this.getDefaultOptions(options);
-        const proc = spawn(fileToCommandArgument(file), args, spawnOptions);
+        const proc = spawn(file, args, spawnOptions);
         const deferred = createDeferred<ExecutionResult<string>>();
         const disposable: IDisposable = {
             dispose: () => {


### PR DESCRIPTION
This reverts commit 952a5f7212890e079373736cfb37719b1fad9b80.

Fixes https://github.com/microsoft/vscode-jupyter/issues/17042
