### PR TITLE
Fix: Clarify 'no pip' error with hint about spaces in path

### DIFF
--- a/src/platform/common/utils/localize.ts
+++ b/src/platform/common/utils/localize.ts
@@ -837,7 +837,7 @@ export namespace Installer {
     export const noCondaOrPipInstaller = l10n.t(
         'There is no Conda or Pip installer available in the selected environment.'
     );
-    export const noPipInstaller = l10n.t('There is no Pip installer available in the selected environment.');
+    export const noPipInstaller = l10n.t('There is no Pip installer available in the selected environment.This may be caused by spaces or special characters in the workspace path, or an environment misconfiguration.');
     export const searchForHelp = l10n.t('Search for help');
 }
 


### PR DESCRIPTION
Currently, when a user's project is in a folder path (e.g Z:\AI for Industrial Applications\3rd Semester\Machine Learning)  with spaces, kernel discovery can fail with the error "There is no Pip installer available in the selected environment." This message is misleading as it suggests a problem with the Python environment itself, rather than the file path. This leads to frustrating and time-consuming troubleshooting.

This change directly amends the error string to add a helpful tip. It informs the user that the issue may be caused by spaces or special characters in their workspace path, guiding them toward a common but difficult-to-diagnose solution.

Related Issue 
Fixes #17057