### PR TITLE
solving hang "Connecting to kernel: Python 3.14.0: Connecting to kernel: Python 3.14.0" forever

### DIFF
--- a/src/platform/interpreter/globalPythonExePathService.node.ts
+++ b/src/platform/interpreter/globalPythonExePathService.node.ts
@@ -75,7 +75,7 @@ export class GlobalPythonExecutablePathService {
         // Add delimiters as sometimes, the python runtime can spit out warning/information messages as well.
         const { stdout } = await processService.exec(executable.fsPath, [
             '-c',
-            `import site;print("${delimiter}");print(site.${valueToUse});print("${delimiter}");`
+            `import site;print('${delimiter}');print(site.${valueToUse});print('${delimiter}');`
         ]);
         if (stdout.includes(delimiter)) {
             const output = stdout


### PR DESCRIPTION
Fixes #17087
