### PR TITLE
Add Datalayer to be whitelisted as publisher to use API 

### DIFF
--- a/src/standalone/api/unstable/apiAccessService.ts
+++ b/src/standalone/api/unstable/apiAccessService.ts
@@ -25,7 +25,8 @@ export const TrustedExtensionPublishers = new Set([
     JVSC_EXTENSION_ID.split('.')[0],
     'rchiodo',
     'donjayamanne',
-    'SynapseVSCode'
+    'SynapseVSCode',
+    'datalayer'
 ]);
 
 // We dont want to expose this API to everyone, else we'll keep track of who has access to this.


### PR DESCRIPTION
Fixes #17267

Hello team! Thanks for the work on this awesome extension.

I make part of the https://datalayer.ai team and we would like to request access to use the API as stated on 

>Thanks for trying the Jupyter API. Please file an issue on our repo to use this API in production. This would prevent us from breaking your extension when updating the API (as it is still a work in progress).

Our extension is the following:

Marketplace: https://marketplace.visualstudio.com/items?itemName=datalayer.datalayer-jupyter-vscode
Source code here: https://github.com/datalayer/vscode-datalayer

Kind regards!
