### PR TITLE
feat: add "Find..." browse option to notebook kernel picker

### DIFF
--- a/src/notebooks/controllers/kernelSource/localPythonKernelSelector.node.ts
+++ b/src/notebooks/controllers/kernelSource/localPythonKernelSelector.node.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { CancellationError, CancellationToken, NotebookDocument, commands, extensions, workspace } from 'vscode';
+import { CancellationError, CancellationToken, NotebookDocument, commands, extensions, window, workspace } from 'vscode';
 import { ServiceContainer } from '../../../platform/ioc/container';
 import { PythonKernelConnectionMetadata } from '../../../kernels/types';
 import { IInterpreterService } from '../../../platform/interpreter/contracts';
@@ -21,6 +21,7 @@ import { IPythonApiProvider, IPythonExtensionChecker } from '../../../platform/a
 import { PythonEnvironmentQuickPickItemProvider } from '../../../platform/interpreter/pythonEnvironmentQuickPickProvider.node';
 import { PythonEnvironmentFilter } from '../../../platform/interpreter/filter/filterService';
 import { noop } from '../../../platform/common/utils/misc';
+import { getOSType, OSType } from '../../../platform/common/utils/platform';
 import { findPreferredPythonEnvironment } from '../preferredKernelConnectionService.node';
 import { Commands } from '../../../platform/common/constants';
 import { createDeferred } from '../../../platform/common/utils/async';
@@ -58,6 +59,15 @@ export class LocalPythonKernelSelector extends DisposableBase {
                 DataScience.quickPickSelectPythonEnvironmentTitle
             )
         );
+        // Add "Find..." command to browse the filesystem for a Python interpreter.
+        this.pythonEnvPicker.addCommand(
+            {
+                label: `$(folder-opened) ${DataScience.browseForPythonInterpreter}`,
+                tooltip: DataScience.browseForPythonInterpreterTooltip
+            },
+            this.browseForPythonInterpreter.bind(this)
+        );
+
         let createEnvCommand: IDisposable | undefined;
         const addCreationCommand = () => {
             if (createEnvCommand) {
@@ -184,6 +194,37 @@ export class LocalPythonKernelSelector extends DisposableBase {
             interpreter: interpreter,
             id: getKernelId(spec, interpreter)
         });
+    }
+
+    private async browseForPythonInterpreter(): Promise<Environment | InputFlowAction | undefined> {
+        const uris = await window.showOpenDialog({
+            canSelectFiles: true,
+            canSelectFolders: false,
+            canSelectMany: false,
+            openLabel: DataScience.browseForPythonInterpreter,
+            filters: getOSType() === OSType.Windows ? { Python: ['exe'] } : undefined
+        });
+        if (!uris || uris.length === 0) {
+            // User cancelled the file dialog; return to the quick pick.
+            return undefined;
+        }
+        const selectedPath = uris[0].fsPath;
+        const apiProvider = ServiceContainer.instance.get<IPythonApiProvider>(IPythonApiProvider);
+        const api = await apiProvider.getNewApi();
+        if (!api) {
+            logger.warn('Python API not available when browsing for interpreter');
+            return undefined;
+        }
+        // Resolve the selected path through the Python extension API so it
+        // becomes a fully recognized Environment with an id.
+        const resolved = await api.environments.resolveEnvironment(selectedPath);
+        if (!resolved) {
+            logger.warn(`Could not resolve environment for path: ${selectedPath}`);
+            return undefined;
+        }
+        // resolveEnvironment returns a ResolvedEnvironment which extends Environment,
+        // so it can be returned directly and will be picked up by selectKernel().
+        return resolved;
     }
 
     private async createNewEnvironment(): Promise<Environment | InputFlowAction | undefined> {

--- a/src/platform/common/utils/localize.ts
+++ b/src/platform/common/utils/localize.ts
@@ -473,6 +473,10 @@ export namespace DataScience {
     export const createPythonEnvironmentInQuickPickTooltip = l10n.t(
         'Create an isolated Python Environment per workspace folder'
     );
+    export const browseForPythonInterpreter = l10n.t('Find...');
+    export const browseForPythonInterpreterTooltip = l10n.t(
+        'Browse the file system to find a Python interpreter'
+    );
 
     export const selectDifferentJupyterInterpreter = l10n.t('Change Interpreter');
     export const pandasTooOldForViewingFormat = (currentVersion: string, requiredVersion: string) =>


### PR DESCRIPTION
I realize that this was proposed and assigned in the issue referenced below. But I needed the solution sooner than later for my setup. I thought I should at least offer what I have in case it's useful.

Adds a file browser option to the Python environment kernel picker, allowing users to manually locate a Python interpreter on the filesystem. This addresses the gap where the Environments extension fails to detect all available environments, particularly for multi-project workspaces with virtual environments in subfolders or outside the workspace.

Fixes microsoft#17281
