### PR TITLE
Add support for environment variable contributors in Jupyter kernel

### DIFF
--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { CancellationToken, ProviderResult, CancellationError, Event, Uri } from 'vscode';
+import type { CancellationToken, Disposable, ProviderResult, CancellationError, Event, Uri } from 'vscode';
 
 export interface Jupyter {
     /**
@@ -239,5 +239,37 @@ export interface Kernels {
      * Only kernels which have already been started by the user and belonging to Notebooks that are currently opened will be returned.
      */
     getKernel(uri: Uri): Thenable<Kernel | undefined>;
+    /**
+     * Registers a provider that can contribute additional environment variables
+     * to kernel processes.  The provider is called every time a kernel is
+     * started or restarted, receiving the notebook/resource URI so it can
+     * return per-notebook values.
+     *
+     * Variables returned by the provider are merged **after** all other
+     * sources (process.env, .env files, interpreter activation, kernelspec
+     * env), so they take highest priority.
+     */
+    registerEnvironmentVariablesProvider(
+        provider: KernelEnvironmentVariablesProvider
+    ): Disposable;
+}
+
+/**
+ * A provider that contributes environment variables to kernel processes.
+ */
+export interface KernelEnvironmentVariablesProvider {
+    /**
+     * Called before a kernel process is spawned.
+     *
+     * @param resource The URI of the notebook or interactive window that
+     *   owns the kernel, or `undefined` for kernels without a resource.
+     * @param token Cancellation token.
+     * @returns A map of environment variable names to values, or
+     *   `undefined`/`null` to contribute nothing.
+     */
+    provideEnvironmentVariables(
+        resource: Uri | undefined,
+        token?: CancellationToken
+    ): ProviderResult<Record<string, string>>;
 }
 // #endregion Kernels API

--- a/src/extension.node.ts
+++ b/src/extension.node.ts
@@ -120,7 +120,8 @@ export async function activate(context: IExtensionContext): Promise<IExtensionAp
             },
             kernels: {
                 getKernel: () => Promise.resolve(undefined),
-                onDidStart: () => ({ dispose: noop })
+                onDidStart: () => ({ dispose: noop }),
+                registerEnvironmentVariablesProvider: () => ({ dispose: noop })
             },
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             onDidChangePythonEnvironment: undefined as any,

--- a/src/extension.web.ts
+++ b/src/extension.web.ts
@@ -111,7 +111,8 @@ export async function activate(context: IExtensionContext): Promise<IExtensionAp
             createJupyterServerCollection: () => {
                 throw new Error('Not Implemented');
             },
-            kernels: { getKernel: () => Promise.resolve(undefined), onDidStart: () => ({ dispose: noop }) },
+            kernels: { getKernel: () => Promise.resolve(undefined), onDidStart: () => ({ dispose: noop }),
+                       registerEnvironmentVariablesProvider: () => ({ dispose: noop }) },
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             onDidChangePythonEnvironment: undefined as any,
             getPythonEnvironment: () => undefined

--- a/src/kernels/jupyter/session/jupyterKernelService.unit.test.ts
+++ b/src/kernels/jupyter/session/jupyterKernelService.unit.test.ts
@@ -24,6 +24,7 @@ import { ConfigurationService } from '../../../platform/common/configuration/ser
 import { JupyterSettings } from '../../../platform/common/configSettings';
 import { uriEquals } from '../../../test/datascience/helpers';
 import { KernelEnvironmentVariablesService } from '../../raw/launcher/kernelEnvVarsService.node';
+import { KernelEnvVarsContributorRegistry } from '../../raw/launcher/kernelEnvVarsContributor';
 import { IInterpreterService } from '../../../platform/interpreter/contracts';
 import { IEnvironmentActivationService } from '../../../platform/interpreter/activation/types';
 import { ICustomEnvironmentVariablesProvider } from '../../../platform/common/variables/types';
@@ -447,7 +448,8 @@ suite('JupyterKernelService', () => {
             instance(appEnv),
             variablesService,
             instance(customEnvVars),
-            instance(configService)
+            instance(configService),
+            new KernelEnvVarsContributorRegistry()
         );
         testWorkspaceFolder = Uri.file(path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'datascience'));
         const jupyterPaths = mock<JupyterPaths>();

--- a/src/kernels/raw/launcher/kernelEnvVarsContributor.ts
+++ b/src/kernels/raw/launcher/kernelEnvVarsContributor.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { injectable } from 'inversify';
+import { CancellationToken, Disposable, Uri } from 'vscode';
+import { KernelEnvironmentVariablesProvider } from '../../../api';
+
+export const IKernelEnvVarsContributorRegistry = Symbol('IKernelEnvVarsContributorRegistry');
+
+export interface IKernelEnvVarsContributorRegistry {
+    register(provider: KernelEnvironmentVariablesProvider): Disposable;
+    getContributions(resource: Uri | undefined, token?: CancellationToken): Promise<Record<string, string>>;
+}
+
+@injectable()
+export class KernelEnvVarsContributorRegistry implements IKernelEnvVarsContributorRegistry {
+    private readonly providers = new Set<KernelEnvironmentVariablesProvider>();
+
+    public register(provider: KernelEnvironmentVariablesProvider): Disposable {
+        this.providers.add(provider);
+        return { dispose: () => this.providers.delete(provider) };
+    }
+
+    public async getContributions(
+        resource: Uri | undefined,
+        token?: CancellationToken
+    ): Promise<Record<string, string>> {
+        const merged: Record<string, string> = {};
+        const promises = [...this.providers].map(async (provider) => {
+            const vars = await Promise.resolve(provider.provideEnvironmentVariables(resource, token));
+            if (vars && !token?.isCancellationRequested) {
+                Object.assign(merged, vars);
+            }
+        });
+        await Promise.all(promises);
+        return merged;
+    }
+}

--- a/src/kernels/raw/launcher/kernelEnvVarsService.node.ts
+++ b/src/kernels/raw/launcher/kernelEnvVarsService.node.ts
@@ -18,6 +18,7 @@ import { IJupyterKernelSpec } from '../../types';
 import { CancellationToken, Uri } from 'vscode';
 import { PYTHON_LANGUAGE } from '../../../platform/common/constants';
 import { trackKernelResourceInformation } from '../../telemetry/helper';
+import { IKernelEnvVarsContributorRegistry } from './kernelEnvVarsContributor';
 
 /**
  * Class used to fetch environment variables for a kernel.
@@ -30,7 +31,9 @@ export class KernelEnvironmentVariablesService {
         @inject(IEnvironmentVariablesService) private readonly envVarsService: IEnvironmentVariablesService,
         @inject(ICustomEnvironmentVariablesProvider)
         private readonly customEnvVars: ICustomEnvironmentVariablesProvider,
-        @inject(IConfigurationService) private readonly configService: IConfigurationService
+        @inject(IConfigurationService) private readonly configService: IConfigurationService,
+        @inject(IKernelEnvVarsContributorRegistry)
+        private readonly envVarsContributors: IKernelEnvVarsContributorRegistry
     ) {}
     /**
      * Generates the environment variables for the kernel.
@@ -143,6 +146,15 @@ export class KernelEnvironmentVariablesService {
         // env variables in kernelSpecs can contain variables that need to be substituted
         for (const [key, value] of Object.entries(kernelSpecVariablesRequiringSubstitution)) {
             mergedVars[key] = substituteEnvVars(key, value, mergedVars);
+        }
+
+        // Let other extensions contribute additional environment variables.
+        // These are merged last so they take highest priority.
+        const contributed = await this.envVarsContributors.getContributions(resource, token);
+        Object.assign(mergedVars, contributed);
+
+        if (token?.isCancellationRequested) {
+            return;
         }
 
         return mergedVars;

--- a/src/kernels/raw/launcher/kernelEnvVarsService.unit.test.ts
+++ b/src/kernels/raw/launcher/kernelEnvVarsService.unit.test.ts
@@ -13,6 +13,7 @@ import { IInterpreterService } from '../../../platform/interpreter/contracts';
 import { EnvironmentType, PythonEnvironment } from '../../../platform/pythonEnvironments/info';
 import { anything, instance, mock, when } from 'ts-mockito';
 import { KernelEnvironmentVariablesService } from './kernelEnvVarsService.node';
+import { IKernelEnvVarsContributorRegistry, KernelEnvVarsContributorRegistry } from './kernelEnvVarsContributor';
 import { IJupyterKernelSpec } from '../../types';
 import { Uri } from 'vscode';
 import { IConfigurationService, IWatchableJupyterSettings, type ReadWrite } from '../../../platform/common/types';
@@ -29,6 +30,7 @@ suite('Kernel Environment Variables Service', () => {
     let interpreterService: IInterpreterService;
     let configService: IConfigurationService;
     let settings: IWatchableJupyterSettings;
+    let envVarsContributors: IKernelEnvVarsContributorRegistry;
     const pathFile = Uri.joinPath(Uri.file('foobar'), 'bar');
     const interpreter: PythonEnvironment = {
         uri: pathFile,
@@ -53,13 +55,15 @@ suite('Kernel Environment Variables Service', () => {
         variablesService = new EnvironmentVariablesService(instance(fs));
         configService = mock<IConfigurationService>();
         settings = mock(JupyterSettings);
+        envVarsContributors = new KernelEnvVarsContributorRegistry();
         when(configService.getSettings(anything())).thenReturn(instance(settings));
         kernelVariablesService = new KernelEnvironmentVariablesService(
             instance(interpreterService),
             instance(envActivation),
             variablesService,
             instance(customVariablesService),
-            instance(configService)
+            instance(configService),
+            envVarsContributors
         );
         if (process.platform === 'win32') {
             // Win32 will generate upper case all the time
@@ -228,6 +232,43 @@ suite('Kernel Environment Variables Service', () => {
         assert.strictEqual(vars!['TWO'], `2`);
         assert.strictEqual(vars!['THREE'], `HELLO_1`);
         assert.strictEqual(vars!['PATH'], `some_path;pathInInterpreterEnv;1`);
+    });
+
+    test('Contributed env vars are merged with highest priority', async () => {
+        process.env['HELLO_VAR'] = 'original';
+        delete kernelSpec.interpreterPath;
+        when(customVariablesService.getCustomEnvironmentVariables(anything(), anything(), anything())).thenResolve({
+            HELLO_VAR: 'from_dotenv'
+        });
+        const resource = Uri.file('/path/to/notebook.ipynb');
+        envVarsContributors.register({
+            provideEnvironmentVariables(res) {
+                return { HELLO_VAR: 'from_contributor', NOTEBOOK_PATH: res?.fsPath || '' };
+            }
+        });
+
+        const vars = await kernelVariablesService.getEnvironmentVariables(resource, undefined, kernelSpec);
+
+        assert.strictEqual(vars!['HELLO_VAR'], 'from_contributor');
+        assert.strictEqual(vars!['NOTEBOOK_PATH'], '/path/to/notebook.ipynb');
+    });
+
+    test('Contributed env vars disposable unregisters the provider', async () => {
+        delete kernelSpec.interpreterPath;
+        when(customVariablesService.getCustomEnvironmentVariables(anything(), anything(), anything())).thenResolve();
+        const disposable = envVarsContributors.register({
+            provideEnvironmentVariables() {
+                return { MY_VAR: 'hello' };
+            }
+        });
+
+        let vars = await kernelVariablesService.getEnvironmentVariables(undefined, undefined, kernelSpec);
+        assert.strictEqual(vars!['MY_VAR'], 'hello');
+
+        disposable.dispose();
+
+        vars = await kernelVariablesService.getEnvironmentVariables(undefined, undefined, kernelSpec);
+        assert.isUndefined(vars!['MY_VAR']);
     });
 
     async function testPYTHONNOUSERSITE(_envType: EnvironmentType, shouldBeSet: boolean) {

--- a/src/kernels/serviceRegistry.node.ts
+++ b/src/kernels/serviceRegistry.node.ts
@@ -29,6 +29,7 @@ import { LocalPythonAndRelatedNonPythonKernelSpecFinder } from './raw/finder/loc
 import { PythonKernelInterruptDaemon } from './raw/finder/pythonKernelInterruptDaemon.node';
 import { TrustedKernelPaths } from './raw/finder/trustedKernelPaths.node';
 import { ITrustedKernelPaths } from './raw/finder/types';
+import { IKernelEnvVarsContributorRegistry, KernelEnvVarsContributorRegistry } from './raw/launcher/kernelEnvVarsContributor';
 import { KernelEnvironmentVariablesService } from './raw/launcher/kernelEnvVarsService.node';
 import { KernelLauncher } from './raw/launcher/kernelLauncher.node';
 import { RawKernelSessionFactory } from './raw/session/rawKernelSessionFactory.node';
@@ -65,6 +66,10 @@ export function registerTypes(serviceManager: IServiceManager, isDevMode: boolea
     serviceManager.addSingleton<KernelEnvironmentVariablesService>(
         KernelEnvironmentVariablesService,
         KernelEnvironmentVariablesService
+    );
+    serviceManager.addSingleton<IKernelEnvVarsContributorRegistry>(
+        IKernelEnvVarsContributorRegistry,
+        KernelEnvVarsContributorRegistry
     );
     serviceManager.addSingleton<IKernelFinder>(IKernelFinder, KernelFinder);
     serviceManager.addSingleton<IExtensionSyncActivationService>(

--- a/src/standalone/api/kernels/index.ts
+++ b/src/standalone/api/kernels/index.ts
@@ -2,9 +2,10 @@
 // Licensed under the MIT License.
 
 import { Uri, workspace, EventEmitter, CancellationToken } from 'vscode';
-import { Kernel, Kernels } from '../../../api';
+import { Kernel, KernelEnvironmentVariablesProvider, Kernels } from '../../../api';
 import { ServiceContainer } from '../../../platform/ioc/container';
 import { IKernel, IKernelProvider } from '../../../kernels/types';
+import { IKernelEnvVarsContributorRegistry } from '../../../kernels/raw/launcher/kernelEnvVarsContributor';
 import { createKernelApiForExtension as createKernelApiForExtension } from './kernel';
 import { Telemetry, sendTelemetryEvent } from '../../../telemetry';
 import {
@@ -138,6 +139,12 @@ export function getKernelsApi(extensionId: string): Kernels {
             }
 
             return extensionAPI.onDidStart.event;
+        },
+        registerEnvironmentVariablesProvider(provider: KernelEnvironmentVariablesProvider) {
+            const registry =
+                ServiceContainer.instance.get<IKernelEnvVarsContributorRegistry>(IKernelEnvVarsContributorRegistry);
+            logger.debug(`Extension ${extensionId} registered a KernelEnvironmentVariablesProvider`);
+            return registry.register(provider);
         }
     };
 }


### PR DESCRIPTION
- Introduced `KernelEnvVarsContributorRegistry` to manage environment variable providers.
- Updated `KernelEnvironmentVariablesService` to merge contributed environment variables with existing ones.
- Added registerEnvironmentVariablesProvider to Jupyter API to allow registration of environment variable providers.
- Added tests to verify the correct merging of environment variables from contributors.


Motivation: The kernel in our organization needs to know the notebook filename on startup. In Jupyter project, this is passed in the connection file in field `jupyter_session`. In vscode, this is impossible without modifying the vscode-jupyter extension.