### PR TITLE
Fix "Restart Kernel and Run All Cells" not running cells

### DIFF
--- a/src/notebooks/notebookCommandListener.ts
+++ b/src/notebooks/notebookCommandListener.ts
@@ -111,6 +111,10 @@ export class NotebookCommandListener implements INotebookCommandHandler, IExtens
     private runAllCells() {
         if (window.activeNotebookEditor) {
             commands.executeCommand('notebook.execute').then(noop, noop);
+        } else {
+            // For interactive windows (Python files with # %% cells), use the
+            // interactive window's run all cells command via the code watcher.
+            commands.executeCommand(Commands.RunAllCells).then(noop, noop);
         }
     }
 

--- a/src/test/datascience/interactiveWindow.vscode.common.test.ts
+++ b/src/test/datascience/interactiveWindow.vscode.common.test.ts
@@ -592,6 +592,46 @@ ${actualCode}
         assert.equal(output.trim(), '1', 'original value should have been printed');
     });
 
+    test('Restart kernel and run all cells executes all cells (#17330)', async function () {
+        // https://github.com/microsoft/vscode-jupyter/issues/17330
+        const source = ['# %%', "print('cell1')", '# %%', "print('cell2')", ''].join('\n');
+        const tempFile = await createTemporaryFile({ contents: source, extension: '.py' });
+        disposables.push(tempFile);
+        const untitledPythonFile = await vscode.workspace.openTextDocument(tempFile.file);
+        await vscode.window.showTextDocument(untitledPythonFile);
+
+        // First run all cells to start the kernel and create the interactive window
+        const activeInteractiveWindow = (await interactiveWindowProvider.getOrCreate(
+            untitledPythonFile.uri
+        )) as InteractiveWindow;
+        const notebook = await waitForInteractiveWindow(activeInteractiveWindow);
+        await vscode.commands.executeCommand(Commands.RunAllCells, untitledPythonFile.uri);
+        await waitForLastCellToComplete(activeInteractiveWindow, -1, false);
+
+        const cellCountAfterFirstRun = notebook.getCells().filter((c) => c.kind === vscode.NotebookCellKind.Code).length;
+        assert.isAtLeast(cellCountAfterFirstRun, 2, 'Should have at least 2 code cells after first run');
+
+        // Now execute "Restart Kernel and Run All Cells"
+        // Focus the .py file (not the interactive window) to reproduce the bug
+        await vscode.window.showTextDocument(untitledPythonFile);
+        await vscode.commands.executeCommand(Commands.RestartKernelAndRunAllCells);
+
+        // Wait for new cells to appear after restart
+        await waitForCondition(
+            async () => {
+                const codeCells = notebook.getCells().filter((c) => c.kind === vscode.NotebookCellKind.Code);
+                return codeCells.length > cellCountAfterFirstRun;
+            },
+            defaultNotebookTestTimeout,
+            'Cells were not executed after Restart Kernel and Run All Cells'
+        );
+
+        // Verify the last cell executed successfully
+        const codeCells = notebook.getCells().filter((c) => c.kind === vscode.NotebookCellKind.Code);
+        const lastCell = codeCells[codeCells.length - 1];
+        await waitForExecutionCompletedSuccessfully(lastCell);
+    });
+
     test.skip('Get the notebook resource for the IW input box', async () => {
         const { activeInteractiveWindow, untitledPythonFile } = await runNewPythonFile(
             interactiveWindowProvider,


### PR DESCRIPTION
## Summary

Fixes #17330.

`runAllCells()` in `notebookCommandListener.ts` only dispatched via `notebook.execute`, which requires `window.activeNotebookEditor`. When invoked from a Python file with `# %%` cells (interactive window), `window.activeNotebookEditor` is null, so the call was silently a no-op.

**Fix:** Add an `else` branch in `runAllCells()` to dispatch to `Commands.RunAllCells` (the code watcher path) when there is no active notebook editor.

## Test plan

- [x] All 1168 unit tests pass
- [x] New integration test that failed before this change and passes now.
- [x] I manually compiled the code to a .vsix and installed it and verified that it fixes the bug.