### PR TITLE
fix: ensure exact controller ownership on dispose

### DIFF
--- a/src/notebooks/controllers/vscodeNotebookController.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.ts
@@ -338,8 +338,8 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
         // If the kernel is associated with this document, and the controller is being disposed,
         // then the kernel for this document must be disposed.
         workspace.notebookDocuments
-            .map((doc) => (this.associatedDocuments.has(doc) ? this.kernelProvider.get(doc) : undefined))
-            .filter((kernel) => kernel?.kernelConnectionMetadata.id === this.kernelConnection.id)
+            .map((doc) => this.notebookKernels.get(doc))
+            .filter((kernel) => kernel?.controller.id === this.id)
             .forEach((kernel) => (kernel ? kernel.dispose().catch(noop) : undefined));
         this._onNotebookControllerSelectionChanged.dispose();
         this._onConnecting.dispose();
@@ -413,8 +413,8 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
         if (!event.selected) {
             // If user has selected another controller, then kill the current kernel.
             // Possible user selected a controller that's not contributed by us at all.
-            const kernel = this.kernelProvider.get(event.notebook);
-            if (kernel?.kernelConnectionMetadata.id === this.kernelConnection.id) {
+            const kernel = this.notebookKernels.get(event.notebook);
+            if (kernel?.controller.id === this.id) {
                 logger.info(
                     `Disposing kernel ${this.kernelConnection.id} for notebook ${getDisplayPath(
                         event.notebook.uri
@@ -668,13 +668,15 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
     private async connectToKernel(doc: NotebookDocument, options: IDisplayOptions): Promise<IKernel> {
         const tracker = getNotebookTelemetryTracker(doc)?.startKernel();
         this._onConnecting.fire();
-        return KernelConnector.connectToNotebookKernel(
+        const kernel = await KernelConnector.connectToNotebookKernel(
             this.kernelConnection,
             this.serviceContainer,
             { resource: doc.uri, notebook: doc, controller: this.controller },
             options,
             this.disposables
         ).finally(() => tracker?.stop());
+        this.updateKernelInfoInNotebookWhenAvailable(kernel, doc);
+        return kernel;
     }
 
     private updateKernelInfoInNotebookWhenAvailable(kernel: IKernel, doc: NotebookDocument) {
@@ -755,6 +757,7 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
             controller: this.controller,
             resourceUri: document.uri // In the case of interactive window, we cannot pass the Uri of notebook, it must be the Py file or undefined.
         });
+        this.updateKernelInfoInNotebookWhenAvailable(newKernel, document);
         logger.debug(`KernelProvider switched kernel to id = ${newKernel.kernelConnectionMetadata.id}`);
 
         // If this is a Python notebook and Python isn't installed, then don't auto-start the kernel.

--- a/src/notebooks/controllers/vscodeNotebookController.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.ts
@@ -338,7 +338,7 @@ export class VSCodeNotebookController implements Disposable, IVSCodeNotebookCont
         // If the kernel is associated with this document, and the controller is being disposed,
         // then the kernel for this document must be disposed.
         workspace.notebookDocuments
-            .map((doc) => this.notebookKernels.get(doc))
+            .map((doc) => this.notebookKernels.get(doc) || this.kernelProvider.get(doc))
             .filter((kernel) => kernel?.controller.id === this.id)
             .forEach((kernel) => (kernel ? kernel.dispose().catch(noop) : undefined));
         this._onNotebookControllerSelectionChanged.dispose();

--- a/src/notebooks/controllers/vscodeNotebookController.unit.test.ts
+++ b/src/notebooks/controllers/vscodeNotebookController.unit.test.ts
@@ -11,6 +11,7 @@ import { NotebookDocument, EventEmitter, NotebookController, Uri, Disposable } f
 import { VSCodeNotebookController, warnWhenUsingOutdatedPython } from './vscodeNotebookController';
 import {
     IKernel,
+    IKernelController,
     IKernelProvider,
     KernelConnectionMetadata,
     LiveRemoteKernelConnectionMetadata,
@@ -80,6 +81,7 @@ suite(`Notebook Controller`, function () {
         kernelProvider = mock<IKernelProvider>();
         extensionChecker = mock<IPythonExtensionChecker>();
         controller = mock<NotebookController>();
+        when(controller.id).thenReturn('1');
         kernel = mock<IKernel>();
         onDidChangeSelectedNotebooks = new EventEmitter<{
             readonly notebook: NotebookDocument;
@@ -278,6 +280,58 @@ suite(`Notebook Controller`, function () {
 
         verify(mockedVSCodeNamespaces.workspace.applyEdit(anything())).once();
     });
+    suite('Deselect Controller', () => {
+        setup(() => {
+            new VSCodeNotebookController(
+                instance(kernelConnection),
+                '1',
+                'jupyter-notebook',
+                instance(kernelProvider),
+                instance(context),
+                disposables,
+                instance(languageService),
+                instance(configService),
+                instance(extensionChecker),
+                instance(serviceContainer),
+                displayDataProvider
+            );
+            notebook = new TestNotebookDocument(undefined, 'jupyter-notebook');
+        });
+        test('Disposes the kernel if it belongs to this controller when deselected', async function () {
+            const mockKernel = mock<IKernel>();
+            when(mockKernel.dispose()).thenResolve();
+            when(kernelProvider.getOrCreate(notebook, anything())).thenReturn(instance(mockKernel));
+
+            const mockKernelController = mock<IKernelController>();
+            when(mockKernelController.id).thenReturn('1');
+            when(mockKernel.controller).thenReturn(instance(mockKernelController));
+
+            // Select then deselect
+            onDidChangeSelectedNotebooks.fire({ notebook, selected: true });
+            await clock.runAllAsync();
+            onDidChangeSelectedNotebooks.fire({ notebook, selected: false });
+            await clock.runAllAsync();
+
+            verify(mockKernel.dispose()).once();
+        });
+        test('Does not dispose the kernel if it belongs to a different controller when deselected', async function () {
+            const mockKernel = mock<IKernel>();
+            when(mockKernel.dispose()).thenResolve();
+            when(kernelProvider.getOrCreate(notebook, anything())).thenReturn(instance(mockKernel));
+
+            const mockKernelController = mock<IKernelController>();
+            when(mockKernelController.id).thenReturn('different-controller');
+            when(mockKernel.controller).thenReturn(instance(mockKernelController));
+
+            // Select then deselect
+            onDidChangeSelectedNotebooks.fire({ notebook, selected: true });
+            await clock.runAllAsync();
+            onDidChangeSelectedNotebooks.fire({ notebook, selected: false });
+            await clock.runAllAsync();
+
+            verify(mockKernel.dispose()).never();
+        });
+    });
     suite('dispose', () => {
         let controllerInstance: VSCodeNotebookController;
         setup(() => {
@@ -304,10 +358,14 @@ suite(`Notebook Controller`, function () {
             const notebook1 = new TestNotebookDocument();
             const notebook2 = new TestNotebookDocument();
             when(mockedVSCodeNamespaces.workspace.notebookDocuments).thenReturn([notebook1, notebook2]);
-            when(kernelProvider.get(notebook1)).thenReturn(instance(kernel1));
-            when(kernelProvider.get(notebook2)).thenReturn(instance(kernel2));
-            when(kernel1.kernelConnectionMetadata).thenReturn(instance(kernelConnection));
-            when(kernel2.kernelConnectionMetadata).thenReturn(instance(kernelConnection));
+            when(kernelProvider.getOrCreate(notebook1, anything())).thenReturn(instance(kernel1));
+            when(kernelProvider.getOrCreate(notebook2, anything())).thenReturn(instance(kernel2));
+            const mockKernelController1 = mock<IKernelController>();
+            const mockKernelController2 = mock<IKernelController>();
+            when(mockKernelController1.id).thenReturn('1');
+            when(mockKernelController2.id).thenReturn('1');
+            when(kernel1.controller).thenReturn(instance(mockKernelController1));
+            when(kernel2.controller).thenReturn(instance(mockKernelController2));
 
             // Associate the controller with notebook1
             onDidChangeSelectedNotebooks.fire({ notebook: notebook1, selected: true });
@@ -328,10 +386,14 @@ suite(`Notebook Controller`, function () {
             const notebook1 = new TestNotebookDocument();
             const notebook2 = new TestNotebookDocument();
             when(mockedVSCodeNamespaces.workspace.notebookDocuments).thenReturn([notebook1, notebook2]);
-            when(kernelProvider.get(notebook1)).thenReturn(instance(kernel1));
-            when(kernelProvider.get(notebook2)).thenReturn(instance(kernel2));
-            when(kernel1.kernelConnectionMetadata).thenReturn(instance(kernelConnection));
-            when(kernel2.kernelConnectionMetadata).thenReturn(instance(kernelConnection));
+            when(kernelProvider.getOrCreate(notebook1, anything())).thenReturn(instance(kernel1));
+            when(kernelProvider.getOrCreate(notebook2, anything())).thenReturn(instance(kernel2));
+            const mockKernelController1 = mock<IKernelController>();
+            const mockKernelController2 = mock<IKernelController>();
+            when(mockKernelController1.id).thenReturn('1');
+            when(mockKernelController2.id).thenReturn('1');
+            when(kernel1.controller).thenReturn(instance(mockKernelController1));
+            when(kernel2.controller).thenReturn(instance(mockKernelController2));
 
             // Associate the controller with both notebooks
             onDidChangeSelectedNotebooks.fire({ notebook: notebook1, selected: true });
@@ -344,6 +406,27 @@ suite(`Notebook Controller`, function () {
             // Verify that both kernels are disposed
             verify(kernel1.dispose()).once();
             verify(kernel2.dispose()).once();
+        });
+        test('Does not dispose the kernel if it belongs to a different controller', async function () {
+            const kernel1 = mock<IKernel>();
+            when(kernel1.dispose()).thenResolve();
+            const notebook1 = new TestNotebookDocument();
+            when(mockedVSCodeNamespaces.workspace.notebookDocuments).thenReturn([notebook1]);
+            when(kernelProvider.getOrCreate(notebook1, anything())).thenReturn(instance(kernel1));
+
+            const mockKernelController1 = mock<IKernelController>();
+            when(mockKernelController1.id).thenReturn('different-controller-id');
+            when(kernel1.controller).thenReturn(instance(mockKernelController1));
+
+            // Associate the controller with notebook1
+            onDidChangeSelectedNotebooks.fire({ notebook: notebook1, selected: true });
+            await clock.runAllAsync();
+
+            // Dispose the controller
+            controllerInstance.dispose();
+
+            // Verify that the kernel is NOT disposed because it belongs to a different controller
+            verify(kernel1.dispose()).never();
         });
     });
     suite('Unsupported Python Versions', () => {


### PR DESCRIPTION
- Fixes: https://github.com/microsoft/vscode-jupyter/issues/17094 (Addresses the root cause)
- Context: https://github.com/microsoft/vscode-jupyter/pull/17097

In https://github.com/microsoft/vscode-jupyter/pull/17097, we introduced logic to tear down active kernels when a notebook controller is deselected or disposed. The [final commit](https://github.com/microsoft/vscode-jupyter/commit/d3e7deac524607b42d0b5a1e90b7b71011a7429a) in that PR (contributed by https://github.com/DonJayamanne) used the following check:
`kernel?.kernelConnectionMetadata.id === this.kernelConnection.id`. This didn't actually fix the issue.

Admittedly, the lifecycle of all of this is a bit confusing to me. But by shifting the disposal logic to rely on strict controller ownership, it works as expected. Every `IKernel` instantiated in the extension is explicitly assigned to its originating `IKernelController` via the controller property.

* Updated Disposal Logic: Changed the condition in `dispose()` and `onDidChangeSelectedNotebooks` to check `kernel?.controller.id === this.id`.
* State Tracking: Enhanced `this.notebookKernels` tracking to ensure the controller always has an accurate map of documents to their active kernels.
* Result: A controller will now only dispose of a kernel if it explicitly spawned it.

Testing
* Updated existing tests to reflect the new strict ownership paradigm.
* Added new positive/negative unit tests in vscodeNotebookController.unit.test.ts to explicitly verify that:
    * A controller successfully disposes of kernels it owns when deselected or disposed.
    * A controller safely ignores and does not dispose of kernels owned by other controllers, preventing cross-controller interference.
* Manual testing using the _Colab_ extension following the repro steps as reported in https://github.com/microsoft/vscode-jupyter/issues/17094.