### PR TITLE
feat: make magic command regex configurable in interactive window

### DIFF
--- a/package.json
+++ b/package.json
@@ -1699,6 +1699,12 @@
                     "default": false,
                     "description": "%jupyter.configuration.jupyter.magicCommandsAsComments.description%"
                 },
+                "jupyter.interactiveWindow.textEditor.magicCommandsRegex": {
+                    "type": "string",
+                    "default": "^#\\s*!",
+                    "markdownDescription": "Regular expression pattern to identify magic line comments in the interactive window text editor. The matched prefix is stripped when executing code. Default (`^#\\s*!`) handles standard `#!` style. Example for Databricks: `^#\\s*MAGIC\\s*`.",
+                    "scope": "resource"
+                },
                 "jupyter.pythonExportMethod": {
                     "type": "string",
                     "enum": [

--- a/src/interactive-window/editor-integration/cellFactory.ts
+++ b/src/interactive-window/editor-integration/cellFactory.ts
@@ -10,8 +10,17 @@ import { splitLines } from '../../platform/common/helpers';
 import { isSysInfoCell } from '../systemInfoCell';
 import { getCellMetadata } from '../../platform/common/utils';
 
-export function uncommentMagicCommands(line: string): string {
-    // Uncomment lines that are shell assignments (starting with #!),
+export function uncommentMagicCommands(line: string, settings?: Pick<IJupyterSettings, 'magicCommandsRegex'>): string {
+    // If a custom regex pattern is configured, use it to identify and strip the magic comment prefix.
+    // This supports alternative magic comment formats such as Databricks-style "# MAGIC %run".
+    if (settings?.magicCommandsRegex) {
+        const customPattern = new RegExp(settings.magicCommandsRegex);
+        if (customPattern.test(line)) {
+            return line.replace(customPattern, '');
+        }
+        return line;
+    }
+    // Default: uncomment lines that are shell assignments (starting with #!),
     // line magic (starting with #!%) or cell magic (starting with #!%%).
     if (/^#\s*!/.test(line)) {
         // If the regex test passes, it's either line or cell magic.

--- a/src/interactive-window/editor-integration/cellFactory.unit.test.ts
+++ b/src/interactive-window/editor-integration/cellFactory.unit.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { assert } from 'chai';
-import { generateCells } from './cellFactory';
+import { generateCells, uncommentMagicCommands } from './cellFactory';
 import { splitLines } from '../../platform/common/helpers';
 import { removeLinesFromFrontAndBack, stripComments } from '../../platform/common/utils';
 
@@ -228,5 +228,31 @@ test("dude")`;
         assert.equal(removed, expected4);
         removed = removeLinesFromFrontAndBack(entry5);
         assert.equal(removed, expected5);
+    });
+});
+
+suite('uncommentMagicCommands', () => {
+    test('leaves regular Python code unchanged', () => {
+        assert.equal(uncommentMagicCommands('x = 1'), 'x = 1');
+    });
+    test('uncomments shell assignment (#!)', () => {
+        assert.equal(uncommentMagicCommands('#! echo hello'), '! echo hello');
+    });
+    test('uncomments line magic (#!%)', () => {
+        assert.equal(uncommentMagicCommands('#!%timeit'), '%timeit');
+    });
+    test('uncomments cell magic (#!%%)', () => {
+        assert.equal(uncommentMagicCommands('#!%%bash'), '%%bash');
+    });
+    test('uses custom regex when provided (Databricks style)', () => {
+        const settings = { magicCommandsRegex: '^#\\s*MAGIC\\s*' };
+        assert.equal(uncommentMagicCommands('# MAGIC %run ./notebook', settings), '%run ./notebook');
+    });
+    test('leaves non-matching line unchanged with custom regex', () => {
+        const settings = { magicCommandsRegex: '^#\\s*MAGIC\\s*' };
+        assert.equal(uncommentMagicCommands('# regular comment', settings), '# regular comment');
+    });
+    test('falls back to default behavior when no settings provided', () => {
+        assert.equal(uncommentMagicCommands('#!%matplotlib inline'), '%matplotlib inline');
     });
 });

--- a/src/platform/common/configMigration.ts
+++ b/src/platform/common/configMigration.ts
@@ -18,6 +18,7 @@ export class ConfigMigration {
         sendSelectionToInteractiveWindow: 'interactiveWindow.textEditor.executeSelection',
         normalizeSelectionForInteractiveWindow: 'interactiveWindow.textEditor.normalizeSelection',
         magicCommandsAsComments: 'interactiveWindow.textEditor.magicCommandsAsComments',
+        magicCommandsRegex: 'interactiveWindow.textEditor.magicCommandsRegex',
         enableAutoMoveToNextCell: 'interactiveWindow.textEditor.autoMoveToNextCell',
         newCellOnRunLast: 'interactiveWindow.textEditor.autoAddNewCell',
         pythonCellFolding: 'interactiveWindow.textEditor.cellFolding',

--- a/src/platform/common/configSettings.ts
+++ b/src/platform/common/configSettings.ts
@@ -60,6 +60,7 @@ export class JupyterSettings implements IWatchableJupyterSettings {
     public debugpyDistPath: string = '';
     public stopOnFirstLineWhileDebugging: boolean = false;
     public magicCommandsAsComments: boolean = false;
+    public magicCommandsRegex: string = '^#\\s*!';
     public pythonExportMethod: 'direct' | 'commentMagics' | 'nbconvert' = 'direct';
     public stopOnError: boolean = false;
     public addGotoCodeLenses: boolean = false;

--- a/src/platform/common/types.ts
+++ b/src/platform/common/types.ts
@@ -67,6 +67,7 @@ export interface IJupyterSettings {
     readonly debugpyDistPath: string;
     readonly stopOnFirstLineWhileDebugging: boolean;
     readonly magicCommandsAsComments: boolean;
+    readonly magicCommandsRegex: string;
     readonly pythonExportMethod: 'direct' | 'commentMagics' | 'nbconvert';
     readonly stopOnError: boolean;
     readonly addGotoCodeLenses: boolean;


### PR DESCRIPTION
Fixes #16499

The magic command regex pattern (`^#\s*!`) used by `uncommentMagicCommands` is currently hardcoded, making it impossible to support alternative magic comment formats such as Databricks-style `# MAGIC %run ./notebook`.

## Changes
- Add `magicCommandsRegex` to `IJupyterSettings` interface and `JupyterSettings` class (default: `^#\s*!`, preserving existing behaviour)
- Register config migration key in `ConfigMigration`
- Add `jupyter.interactiveWindow.textEditor.magicCommandsRegex` setting to `package.json`
- Update `uncommentMagicCommands` to accept optional settings — backward-compatible, existing callers unaffected
- Add unit tests covering default and custom regex behaviour