### PR TITLE
remove installed by extension flag from internal tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -2051,7 +2051,6 @@
                 "displayName": "Start Notebook Kernel",
                 "modelDescription": "Selects a Python Kernel and starts it.",
                 "tags": [
-                    "extension_installed_by_tool",
                     "install python package",
                     "notebooks"
                 ],
@@ -2074,7 +2073,6 @@
                 "displayName": "Start Notebook Kernel",
                 "modelDescription": "Selects the Notebook Kernel and starts it.",
                 "tags": [
-                    "extension_installed_by_tool",
                     "jupyter",
                     "notebooks"
                 ],

--- a/src/standalone/chat/configureNotebook.other.node.ts
+++ b/src/standalone/chat/configureNotebook.other.node.ts
@@ -5,7 +5,8 @@ import {
     ensureKernelSelectedAndStarted,
     getPrimaryLanguageOfNotebook,
     getToolResponseForConfiguredNotebook,
-    hasKernelStartedOrIsStarting
+    hasKernelStartedOrIsStarting,
+    KernelStartTimeoutError
 } from './helper.node';
 import { IControllerRegistration } from '../../notebooks/controllers/types';
 import {
@@ -35,7 +36,18 @@ export class ConfigureNonPythonNotebookTool extends BaseTool<IBaseToolParams> {
         notebook: NotebookDocument,
         token: CancellationToken
     ) {
-        await ensureKernelSelectedAndStarted(notebook, this.controllerRegistration, token);
+        try {
+            await ensureKernelSelectedAndStarted(notebook, this.controllerRegistration, token);
+        } catch (ex) {
+            if (ex instanceof KernelStartTimeoutError) {
+                return new LanguageModelToolResult([
+                    new LanguageModelTextPart(
+                        'The kernel is taking longer than expected to start and is still starting in the background. Please try invoking this tool again in a few moments to check whether the kernel is ready.'
+                    )
+                ]);
+            }
+            throw ex;
+        }
 
         const selectedController = this.controllerRegistration.getSelected(notebook);
         const kernel = this.kernelProvider.get(notebook);

--- a/src/standalone/chat/configureNotebook.python.node.ts
+++ b/src/standalone/chat/configureNotebook.python.node.ts
@@ -5,6 +5,7 @@ import {
     ensureKernelSelectedAndStarted,
     getToolResponseForConfiguredNotebook,
     hasKernelStartedOrIsStarting,
+    KernelStartTimeoutError,
     selectKernelAndStart
 } from './helper.node';
 import { IControllerRegistration } from '../../notebooks/controllers/types';
@@ -69,7 +70,24 @@ export class ConfigurePythonNotebookTool extends BaseTool<IConfigurePythonNotebo
         }
 
         logger.trace(`ConfigurePythonNotebookTool: Start kernel for notebook ${getDisplayPath(notebook.uri)}`);
-        const kernel = await ensureKernelSelectedAndStarted(notebook, this.controllerRegistration, token);
+        let kernel;
+        try {
+            kernel = await ensureKernelSelectedAndStarted(notebook, this.controllerRegistration, token);
+        } catch (ex) {
+            if (ex instanceof KernelStartTimeoutError) {
+                logger.warn(
+                    `ConfigurePythonNotebookTool: Timed out waiting for kernel to start for notebook ${getDisplayPath(
+                        notebook.uri
+                    )}`
+                );
+                return new LanguageModelToolResult([
+                    new LanguageModelTextPart(
+                        'The kernel is taking longer than expected to start and is still starting in the background. Please try invoking this tool again in a few moments to check whether the kernel is ready.'
+                    )
+                ]);
+            }
+            throw ex;
+        }
         if (kernel) {
             logger.trace(
                 `ConfigurePythonNotebookTool: Kernel selected for notebook ${getDisplayPath(notebook.uri)}, status = ${

--- a/src/standalone/chat/helper.node.ts
+++ b/src/standalone/chat/helper.node.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { IKernel, KernelConnectionMetadata } from '../../kernels/types';
 import { execCodeInBackgroundThread } from '../api/kernels/backgroundExecution';
 import { getEnvExtApi } from '../../platform/api/python-envs/pythonEnvsApi';
-import { raceTimeout } from '../../platform/common/utils/async';
+import { raceTimeout, raceTimeoutError } from '../../platform/common/utils/async';
 import { IControllerRegistration, IVSCodeNotebookController } from '../../notebooks/controllers/types';
 import { raceCancellation } from '../../platform/common/cancellation';
 import { DisposableStore } from '../../platform/common/utils/lifecycle';
@@ -78,6 +78,24 @@ export async function installPackageThroughEnvsExtension(kernelUri: vscode.Uri, 
 
 export type packageDefinition = { name: string; version?: string };
 
+/**
+ * Maximum time (in ms) to wait for a kernel to start before returning to the caller.
+ * If the kernel hasn't started in this time, the tool returns a message to the LLM
+ * indicating the kernel is still starting (the kernel start itself continues in the background).
+ */
+export const KERNEL_START_TIMEOUT_MS = 20_000;
+
+/**
+ * Error thrown when a kernel start exceeds {@link KERNEL_START_TIMEOUT_MS}.
+ * The underlying kernel start is not cancelled and may still complete in the background.
+ */
+export class KernelStartTimeoutError extends Error {
+    constructor() {
+        super('Timed out waiting for the kernel to start');
+        this.name = 'KernelStartTimeoutError';
+    }
+}
+
 export async function ensureKernelSelectedAndStarted(
     notebook: vscode.NotebookDocument,
     controllerRegistration: IControllerRegistration,
@@ -120,7 +138,11 @@ export async function ensureKernelSelectedAndStarted(
     const controller = controllerRegistration.getSelected(notebook);
     if (controller) {
         logger.trace(`Kernel selected for notebook ${getDisplayPath(notebook.uri)}`);
-        return raceCancellation(token, controller.startKernel(notebook));
+        return raceTimeoutError(
+            KERNEL_START_TIMEOUT_MS,
+            new KernelStartTimeoutError(),
+            raceCancellation(token, controller.startKernel(notebook))
+        );
     } else {
         logger.warn(`No kernel controller selected for notebook ${getDisplayPath(notebook.uri)}`);
     }
@@ -165,7 +187,11 @@ export async function selectKernelAndStart(
 
     const controller = controllerRegistration.getSelected(notebook);
     if (controller && startKernel) {
-        return raceCancellation(token, controller.startKernel(notebook));
+        return raceTimeoutError(
+            KERNEL_START_TIMEOUT_MS,
+            new KernelStartTimeoutError(),
+            raceCancellation(token, controller.startKernel(notebook))
+        );
     }
 }
 

--- a/src/test/standardTest.node.ts
+++ b/src/test/standardTest.node.ts
@@ -96,6 +96,29 @@ async function createTempDir() {
 }
 
 /**
+ * Creates a temporary user data directory with extension signature verification disabled.
+ * This is needed in CI environments (e.g. macOS ARM64 with VS Code Insiders) where the
+ * extension signature verification service may be unreachable, causing all extension
+ * installations to fail with 'Signature verification failed with UnknownError'.
+ */
+async function createInstallUserDataDir(): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+        tmp.dir({ unsafeCleanup: true }, (err, dir) => {
+            if (err) {
+                return reject(err);
+            }
+            const settingsDir = path.join(dir, 'User');
+            fs.mkdirSync(settingsDir, { recursive: true });
+            fs.writeFileSync(
+                path.join(settingsDir, 'settings.json'),
+                JSON.stringify({ 'extensions.verifySignature': false })
+            );
+            resolve(dir);
+        });
+    });
+}
+
+/**
  * Smoke tests & tests running in VSCode require Python extension to be installed.
  */
 async function installPythonExtension(vscodeExecutablePath: string, extensionsDir: string, platform: DownloadPlatform) {
@@ -104,13 +127,18 @@ async function installPythonExtension(vscodeExecutablePath: string, extensionsDi
         return;
     }
     const cliPath = resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath, platform);
-    await installExtension(PythonExtension, cliPath, extensionsDir, ['--pre-release']);
+    // Use a dedicated user data dir with signature verification disabled to avoid
+    // failures caused by the VS Code extension signature verification service being
+    // unreachable in CI environments.
+    const installUserDataDir = await createInstallUserDataDir();
+    const installArgs = ['--user-data-dir', installUserDataDir];
+    await installExtension(PythonExtension, cliPath, extensionsDir, ['--pre-release', ...installArgs]);
 
     // Make sure pylance is there too as we'll use it for intellisense tests
-    await installExtension(PylanceExtension, cliPath, extensionsDir);
+    await installExtension(PylanceExtension, cliPath, extensionsDir, installArgs);
 
     // Make sure renderers is there too as we'll use it for widget tests
-    await installExtension(RendererExtension, cliPath, extensionsDir);
+    await installExtension(RendererExtension, cliPath, extensionsDir, installArgs);
 }
 
 // Make sure renderers is there too as we'll use it for widget tests
@@ -131,9 +159,8 @@ async function installExtension(extension: string, cliPath: string, extensionsDi
     if (output.error) {
         throw output.error;
     }
-    if (output.stderr) {
-        console.error(`Error installing ${extension} Extension to ${extensionsDir}`);
-        console.error(output.stderr);
+    if (output.status !== 0) {
+        throw new Error(`Failed to install extension ${extension} (exit code ${output.status})`);
     }
 }
 
@@ -188,6 +215,8 @@ async function getExtensionsDir(): Promise<string> {
 }
 
 async function start() {
+    // Ensure temp directories created by `tmp` are cleaned up when the process exits.
+    tmp.setGracefulCleanup();
     const platform = computePlatform();
     const vscodeExecutablePath = await downloadAndUnzipVSCode(channel, platform);
     const baseLaunchArgs = requiresPythonExtensionToBeInstalled() ? [] : ['--disable-extensions'];


### PR DESCRIPTION
Removed the `extension_installed_by_tool` tag from `configure_python_notebook` and `configure_non_python_notebook`

Both tools are registered with `when: "false"` because they're internal helpers — the public `configure_notebook` tool invokes them after doing important setup (Python extension activation, recommended-environment discovery, retry-on-failure orchestration). They were never meant to be called by the model directly.

However, copilot-chat's tool filter has a fallback that auto-enables any tool tagged `extension_installed_by_tool` if it isn't otherwise in the user's tool picker selection. That tag was overriding our `when: "false"` and exposing these internal tools to the model. When the model called `configure_python_notebook` directly, it skipped all of the orchestration the public tool provides — including the implicit warm-up time that lets a still-loading notebook finish initializing — leading to cancellation of the tool and ending the request prematurely.

we've also seen the agent stall out forever on the kernel startup, and this PR add in a timeout for the helpers that try to start and wait for the kernel.